### PR TITLE
Initial support for generating FHIR capability statements.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,12 @@
             <artifactId>dropwizard-guicier</artifactId>
             <version>1.3.5.1</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-structures-r4 -->
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-structures-r4</artifactId>
+            <version>3.6.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/gov/cms/dpc/DPCAppModule.java
+++ b/src/main/java/gov/cms/dpc/DPCAppModule.java
@@ -1,13 +1,29 @@
 package gov.cms.dpc;
 
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
 import com.google.inject.Binder;
+import com.google.inject.Provides;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
-import gov.cms.dpc.resources.BaseResource;
+import gov.cms.dpc.resources.TestResource;
+import gov.cms.dpc.resources.V1BaseResource;
 
 public class DPCAppModule extends DropwizardAwareModule<DPCAppConfiguration> {
 
+    private final FhirContext context;
+
+    DPCAppModule() {
+        this.context = FhirContext.forR4();
+    }
+
     @Override
     public void configure(Binder binder) {
-        binder.bind(BaseResource.class);
+        binder.bind(TestResource.class);
+        binder.bind(V1BaseResource.class);
+    }
+
+    @Provides
+    IParser getJsonParser() {
+        return this.context.newJsonParser();
     }
 }

--- a/src/main/java/gov/cms/dpc/core/AbstractApplicationRoutes.java
+++ b/src/main/java/gov/cms/dpc/core/AbstractApplicationRoutes.java
@@ -1,0 +1,29 @@
+package gov.cms.dpc.core;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+public abstract class AbstractApplicationRoutes {
+
+    public AbstractApplicationRoutes() {
+//        Not used
+    }
+
+    /**
+     * Returns the current API version
+     * @return - {@link String} version number
+     */
+    @Path("/version")
+    @GET
+    public abstract String version();
+
+    /**
+     * Returns the FHIR capabilities statement
+     * @return {@link String} capabilities statement
+     */
+    @Path("/metadata")
+    @GET
+    @Produces("application/json")
+    public abstract String metadata();
+}

--- a/src/main/java/gov/cms/dpc/core/Capabilities.java
+++ b/src/main/java/gov/cms/dpc/core/Capabilities.java
@@ -1,0 +1,36 @@
+package gov.cms.dpc.core;
+
+import org.hl7.fhir.r4.model.CapabilityStatement;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Enumerations;
+
+import java.util.Arrays;
+
+public class Capabilities {
+
+    private Capabilities() {
+//        Should not use
+    }
+
+    public static CapabilityStatement buildCapabilities() {
+        DateTimeType releaseDate = DateTimeType.now();
+
+        CapabilityStatement.CapabilityStatementSoftwareComponent softwareElement = new CapabilityStatement.CapabilityStatementSoftwareComponent()
+                .setName("Data @ Point of Care API")
+                .setVersion("0.0.1")
+                .setReleaseDateElement(releaseDate);
+
+        CapabilityStatement capabilityStatement = new CapabilityStatement();
+
+        capabilityStatement
+                .setStatus(Enumerations.PublicationStatus.ACTIVE)
+                .setDateElement(releaseDate)
+                .setPublisher("Centers for Medicare and Medicaid Services")
+                .setFhirVersion("4.0.0")
+                .setSoftware(softwareElement)
+                .setFormat(Arrays.asList(new CodeType("application/json"), new CodeType("application/fhir+json")));
+
+        return capabilityStatement;
+    }
+}

--- a/src/main/java/gov/cms/dpc/resources/TestResource.java
+++ b/src/main/java/gov/cms/dpc/resources/TestResource.java
@@ -9,10 +9,10 @@ import javax.ws.rs.core.Response;
 
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
-public class BaseResource {
+public class TestResource {
 
     @Inject
-    public BaseResource() {
+    public TestResource() {
         // Not used
     }
 

--- a/src/main/java/gov/cms/dpc/resources/V1BaseResource.java
+++ b/src/main/java/gov/cms/dpc/resources/V1BaseResource.java
@@ -1,0 +1,31 @@
+package gov.cms.dpc.resources;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import gov.cms.dpc.core.AbstractApplicationRoutes;
+import gov.cms.dpc.core.Capabilities;
+import org.hl7.fhir.r4.model.CapabilityStatement;
+
+import javax.inject.Inject;
+import javax.ws.rs.Path;
+
+@Path("/v1")
+public class V1BaseResource extends AbstractApplicationRoutes {
+
+    private final IParser parser;
+
+    @Inject
+    public V1BaseResource(IParser jsonParser) {
+        this.parser = jsonParser;
+    }
+
+    @Override
+    public String version() {
+        return "Version 1";
+    }
+
+    @Override
+    public String metadata() {
+        return parser.encodeResourceToString(Capabilities.buildCapabilities());
+    }
+}


### PR DESCRIPTION
Addresses DPC-31 and adds initial support for generating a FHIR capabilities statement.

This is required by the FHIR spec and should include information regarding the various endpoints and their parameters. Right now, we only have the plumbing in place, but we'll add the endpoints as we go along.