### PR TITLE
DPC-69: FHIR endpoints now reject invalid content types

### DIFF
--- a/dpc-web/src/main/java/gov/cms/dpc/web/DPCWebApplication.java
+++ b/dpc-web/src/main/java/gov/cms/dpc/web/DPCWebApplication.java
@@ -4,6 +4,7 @@ import ca.mestevens.java.configuration.bundle.TypesafeConfigurationBundle;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import gov.cms.dpc.attribution.AttributionModule;
 import gov.cms.dpc.queue.JobQueueModule;
+import gov.cms.dpc.web.features.FHIRRequestFeature;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -32,6 +33,7 @@ public class DPCWebApplication extends Application<DPWebConfiguration> {
     @Override
     public void run(final DPWebConfiguration configuration,
                     final Environment environment) {
-        // TODO: implement application
+        // Add FHIR filters
+        environment.jersey().register(FHIRRequestFeature.class);
     }
 }

--- a/dpc-web/src/main/java/gov/cms/dpc/web/core/FHIRMediaTypes.java
+++ b/dpc-web/src/main/java/gov/cms/dpc/web/core/FHIRMediaTypes.java
@@ -1,0 +1,24 @@
+package gov.cms.dpc.web.core;
+
+import javax.ws.rs.core.MediaType;
+
+public class FHIRMediaTypes {
+
+    public static final String FHIR_JSON = "application/fhir+json";
+    public static final String FHIR_NDJSON = "application/fhir+ndjson";
+
+    private static final MediaType FHIR_JSON_MT = MediaType.valueOf(FHIR_JSON);
+    private static final MediaType FHIR_NDJSON_MT = MediaType.valueOf(FHIR_NDJSON);
+
+    /**
+     * Validates whether or not the given content type is of type FHIR
+     * String can be null or empty
+     * @param mediaType - {@link String} value from {@link javax.ws.rs.core.HttpHeaders#CONTENT_TYPE} header.
+     * @return - {@code true} content type is FHIR. {@code false} content type is not FHIR
+     */
+    public static boolean isFHIRContent(MediaType mediaType) {
+
+        return mediaType.isCompatible(MediaType.valueOf(FHIR_JSON)) ||
+                mediaType.isCompatible(MediaType.valueOf(FHIR_NDJSON));
+    }
+}

--- a/dpc-web/src/main/java/gov/cms/dpc/web/core/annotations/FHIR.java
+++ b/dpc-web/src/main/java/gov/cms/dpc/web/core/annotations/FHIR.java
@@ -1,0 +1,20 @@
+package gov.cms.dpc.web.core.annotations;
+
+import gov.cms.dpc.web.core.FHIRMediaTypes;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import java.lang.annotation.*;
+
+
+/**
+ * Marks the endpoint as complying with the FHIR specification.
+ * Automatically adds the {@link Consumes}, and {@link Produces} annotations to restrict the possible inputs/outputs to the API
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Consumes({FHIRMediaTypes.FHIR_JSON})
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Produces({FHIRMediaTypes.FHIR_JSON})
+@Inherited
+public @interface FHIR {
+}

--- a/dpc-web/src/main/java/gov/cms/dpc/web/features/FHIRRequestFeature.java
+++ b/dpc-web/src/main/java/gov/cms/dpc/web/features/FHIRRequestFeature.java
@@ -1,0 +1,18 @@
+package gov.cms.dpc.web.features;
+
+import gov.cms.dpc.web.core.annotations.FHIR;
+import gov.cms.dpc.web.filters.FHIRRequestFilter;
+
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+
+public class FHIRRequestFeature implements DynamicFeature {
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        if (resourceInfo.getResourceMethod().getAnnotation(FHIR.class) != null || resourceInfo.getResourceClass().getAnnotation(FHIR.class) != null) {
+            context.register(FHIRRequestFilter.class);
+        }
+    }
+}

--- a/dpc-web/src/main/java/gov/cms/dpc/web/filters/FHIRRequestFilter.java
+++ b/dpc-web/src/main/java/gov/cms/dpc/web/filters/FHIRRequestFilter.java
@@ -1,0 +1,31 @@
+package gov.cms.dpc.web.filters;
+
+import gov.cms.dpc.web.core.FHIRMediaTypes;
+import org.eclipse.jetty.server.Response;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.MediaType;
+import java.util.List;
+
+public class FHIRRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        final List<MediaType> contentHeader = requestContext.getAcceptableMediaTypes();
+
+        boolean valid = false;
+
+        for (MediaType header : contentHeader) {
+            valid = FHIRMediaTypes.isFHIRContent(header);
+            if (valid)
+                break;
+        }
+
+        if (!valid) {
+            final IllegalArgumentException cause = new IllegalArgumentException("Must specify valid FHIR content type");
+            throw new WebApplicationException(cause, Response.SC_UNSUPPORTED_MEDIA_TYPE);
+        }
+    }
+}

--- a/dpc-web/src/main/java/gov/cms/dpc/web/resources/AbstractGroupResource.java
+++ b/dpc-web/src/main/java/gov/cms/dpc/web/resources/AbstractGroupResource.java
@@ -1,12 +1,14 @@
 package gov.cms.dpc.web.resources;
 
+import gov.cms.dpc.web.core.annotations.FHIR;
+
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
-@Produces("application/fhir+json")
+@FHIR
 @Path("/Group")
 public abstract class AbstractGroupResource {
 
@@ -16,5 +18,5 @@ public abstract class AbstractGroupResource {
 
     @Path("/{providerID}/$export")
     @GET
-    public abstract Response export(@PathParam("providerID") String groupID);
+    public abstract Response export(@PathParam("providerID") String groupID, HttpServletRequest req);
 }

--- a/dpc-web/src/main/java/gov/cms/dpc/web/resources/v1/GroupResource.java
+++ b/dpc-web/src/main/java/gov/cms/dpc/web/resources/v1/GroupResource.java
@@ -3,17 +3,20 @@ package gov.cms.dpc.web.resources.v1;
 import ca.uhn.fhir.parser.IParser;
 import gov.cms.dpc.common.models.JobModel;
 import gov.cms.dpc.queue.JobQueue;
+import gov.cms.dpc.web.core.FHIRMediaTypes;
+import gov.cms.dpc.web.core.annotations.FHIR;
 import gov.cms.dpc.web.resources.AbstractGroupResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.UUID;
+
 
 public class GroupResource extends AbstractGroupResource {
 
@@ -34,12 +37,13 @@ public class GroupResource extends AbstractGroupResource {
      * The `Content-Location` header contains the URI to call when
      *
      * @param providerID {@link String} ID of provider to retrieve data for
+     * @param req
      * @return - {@link org.hl7.fhir.r4.model.OperationOutcome} specifying whether or not the request was successful.
      */
     @Override
     @Path("/{providerID}/$export")
     @GET // Need this here, since we're using a path param
-    public Response export(@PathParam("providerID") String providerID) {
+    public Response export(@PathParam("providerID") String providerID, @Context HttpServletRequest req) {
         logger.debug("Exporting data for provider: {}", providerID);
 
         // Generate a job ID and submit it to the queue

--- a/dpc-web/src/test/java/gov/cms/dpc/web/FHIRSubmissionTest.java
+++ b/dpc-web/src/test/java/gov/cms/dpc/web/FHIRSubmissionTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import static gov.cms.dpc.web.core.FHIRMediaTypes.FHIR_JSON;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
@@ -28,14 +29,13 @@ import static org.mockito.Mockito.reset;
 @ExtendWith(DropwizardExtensionsSupport.class)
 public class FHIRSubmissionTest {
     private static final IParser parser = mock(IParser.class);
-    public static final String FHIR_JSON = "application/fhir+json";
     private final JobQueue queue = new MemoryQueue();
     private ResourceExtension groupResource = ResourceExtension.builder().addResource(new GroupResource(parser, queue)).build();
     private ResourceExtension jobResource = ResourceExtension.builder().addResource(new JobResource(queue)).build();
 
 
     // This is required for Guice to load correctly. Not entirely sure why
-    // https://github.com/dropwizard/dropwizard/issues/1772
+//     https://github.com/dropwizard/dropwizard/issues/1772
     @BeforeAll
     public static void setup() {
         JerseyGuiceUtils.reset();
@@ -59,7 +59,7 @@ public class FHIRSubmissionTest {
 
         String jobURL = response.getHeaderString("Content-Location").replace("http://localhost:3002/v1", "");
         WebTarget jobTarget = jobResource.client().target(jobURL);
-        Response jobResp = jobTarget.request().accept("application/fhir+json").get();
+        Response jobResp = jobTarget.request().accept(FHIR_JSON).get();
         assertEquals(HttpStatus.ACCEPTED_202, jobResp.getStatus(), "Job should be in progress");
 
         // Finish the job and check again
@@ -67,7 +67,7 @@ public class FHIRSubmissionTest {
         queue.completeJob(queue.workJob().orElseThrow(() -> new IllegalStateException("Should have a job")).getLeft(), JobStatus.COMPLETED);
 
         jobTarget = jobResource.client().target(jobURL);
-        jobResp = jobTarget.request().accept("application/fhir+json").get();
+        jobResp = jobTarget.request().accept(FHIR_JSON).get();
         assertEquals(HttpStatus.OK_200, jobResp.getStatus(), "Job should be done");
 
 

--- a/dpc-web/src/test/java/gov/cms/dpc/web/GroupIntegrationTest.java
+++ b/dpc-web/src/test/java/gov/cms/dpc/web/GroupIntegrationTest.java
@@ -1,0 +1,40 @@
+package gov.cms.dpc.web;
+
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.exceptions.NonFhirResponseException;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
+import ca.uhn.fhir.rest.server.exceptions.UnclassifiedServerFailureException;
+import org.hl7.fhir.r4.model.Parameters;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Simple integration tests for Group resource
+ */
+public class GroupIntegrationTest extends AbstractApplicationTest {
+
+    /**
+     * Test that the group resource correctly accepts/rejects invalid content types.
+     */
+    @Test
+    public void testMediaTypes() {
+
+        // Verify that FHIR is accepted
+        final IGenericClient client = ctx.newRestfulGenericClient("http://localhost:" + APPLICATION.getLocalPort() + "/v1/");
+
+        final IOperationUntypedWithInput<Parameters> execute = client
+                .operation()
+                .onInstanceVersion(new IdDt("Group", "1"))
+                .named("$export")
+                .withNoParameters(Parameters.class)
+                .useHttpGet();
+
+
+        assertThrows(NonFhirResponseException.class, execute::execute, "Should throw exception, but accept JSON request");
+
+        // Try again, but use a different encoding
+        assertThrows(UnclassifiedServerFailureException.class, () -> execute.encodedXml().execute(), "Should not accept XML encoding");
+    }
+}


### PR DESCRIPTION
We now have `FHIR` annotation, which allows us to mark FHIR endpoints and apply the appropriate interceptors.

We may have to revert at least a portion of these changes if it turns out that it’s too difficult for clients to set the necessary header.

Closes DPC-69