### PR TITLE
DPC-87: Fixed seed resource path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 application.local.conf
 target/
+dependency-reduced-*.xml

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/TestSeeder.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/TestSeeder.java
@@ -13,7 +13,7 @@ import java.util.MissingResourceException;
 
 public class TestSeeder implements AttributionSeeder {
 
-    private static final String CSV = "./test_associations.csv";
+    private static final String CSV = "test_associations.csv";
     private final Logger logger = LoggerFactory.getLogger(TestSeeder.class);
 
     private final AttributionEngine engine;


### PR DESCRIPTION
JAR resource paths need to be based on their position from the root of the JAR. Making the path absolute causes the class loader to look from the path where the class file resides.

Closes DPC-87.