### PR TITLE
DPC-168: Remove support for H2 database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ language: java
 jdk:
   - oraclejdk11
 
+services:
+  - postgresql
+
+# Setup the postgres database for testing
+before_script:
+  - psql -c 'create database dpc-attribution;' -U postgres
+
 before_install:
   - openssl aes-256-cbc -K $encrypted_ebb4f1b65c80_key -iv $encrypted_ebb4f1b65c80_iv -in bbcerts/bb.keystore.enc -out bbcerts/bb.keystore -d
   - wget https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 -O ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 # Setup the postgres database for testing
 before_script:
-  - psql -c 'create database dpc-attribution;' -U postgres
+  - psql -c 'create database dpc_attribution;' -U postgres
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_ebb4f1b65c80_key -iv $encrypted_ebb4f1b65c80_iv -in bbcerts/bb.keystore.enc -out bbcerts/bb.keystore -d

--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ How to start the DPC Services
 This will also construct the *Docker* images for the API and Aggregation services.
 To skip the Docker build pass -Djib.skip=True
 
+*DPC* requires a running Postgres database.
+The `docker-compose` file includes the necessary application and configurations, and can be started like so: 
+
+```bash
+docker-compose up db
+```
+
+By default, the application attempts to connect to the `dpc_atrribution` database on the localhost as the `postgres` user.
+This can be overridden in the configuration files.
+For example, modifying the `dpc-attribution` configuration:
+
+```yaml
+dpc.attribution {
+  database = {
+    driverClass = org.postgresql.Driver
+    url = "jdbc:postgresql://localhost:5432/dpc-dev"
+    user = postgres
+  }
+}
+``` 
+
 Once the JARs are built, they can be run in two ways.
 
 1. Executed using *Docker Compose* `docker-compose up`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres
     environment:
-      - POSTGRES_DB=dpc-attribution
+      - POSTGRES_DB=dpc_attribution
       - POSTGRES_PASSWORD=dpc-safe
     ports:
       - "5432:5432"

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -29,11 +29,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-hibernate</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <version>1.4.197</version>
-        </dependency>
         <!--No longer shipped with Java 11, so we need to include it manually-->
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
@@ -46,7 +46,7 @@ public class DPCAttributionService extends Application<DPCAttributionConfigurati
             }
         });
 
-        bootstrap.addCommand(new SeedCommand());
+        bootstrap.addCommand(new SeedCommand(bootstrap.getApplication()));
     }
 
     @Override

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -47,7 +47,6 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
     protected void run(Environment environment, Namespace namespace, DPCAttributionConfiguration configuration) throws Exception {
         // Get the db factory
         final PooledDataSourceFactory dataSourceFactory = configuration.getDatabase();
-//        dataSourceFactory.asSingleConnectionPool();
         final ManagedDataSource dataSource = dataSourceFactory.build(environment.metrics(), "attribution-seeder");
 
         // Read in the seeds file and write things

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -2,7 +2,7 @@ dpc.attribution {
   database = {
     driverClass = org.postgresql.Driver
     url = "jdbc:postgresql://localhost:5432/dpc_attribution"
-    user = travis
+    user = postgres
   }
 
   logging {

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -2,8 +2,7 @@ dpc.attribution {
   database = {
     driverClass = org.postgresql.Driver
     url = "jdbc:postgresql://localhost:5432/dpc-attribution"
-    user = postgres
-    password = dpc-safe
+    user = travis
   }
 
   logging {

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -1,7 +1,9 @@
 dpc.attribution {
   database = {
     driverClass = org.postgresql.Driver
-    url = "jdbc:postgresql://localhost/dpc-dev"
+    url = "jdbc:postgresql://localhost:5432/dpc-attribution"
+    user = postgres
+    password = dpc-safe
   }
 
   logging {

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 dpc.attribution {
   database = {
-    driverClass = org.h2.Driver
-    url = "jdbc:h2:file:./h2/app_db;DB_CLOSE_ON_EXIT=FALSE"
+    driverClass = org.postgresql.Driver
+    url = "jdbc:postgresql://localhost/dpc-dev"
   }
 
   logging {

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 dpc.attribution {
   database = {
     driverClass = org.postgresql.Driver
-    url = "jdbc:postgresql://localhost:5432/dpc-attribution"
+    url = "jdbc:postgresql://localhost:5432/dpc_attribution"
     user = travis
   }
 

--- a/dpc-attribution/src/main/resources/dev.application.conf
+++ b/dpc-attribution/src/main/resources/dev.application.conf
@@ -1,7 +1,7 @@
 dpc.attribution {
   database = {
     driverClass = org.postgresql.Driver
-    url = "jdbc:postgresql://db:5432/dpc-attribution"
+    url = "jdbc:postgresql://db:5432/dpc_attribution"
     user = postgres
     password = dpc-safe
   }


### PR DESCRIPTION
We no longer support using the H2 database for local testing. We now require a local Postgres installation, which simplifies the setup and configuration process.

This also resolves DPC-172 in which the application was leaking database connections because the SessionFactory was not being injected as a singleton.

When running in TravisCI, we need to add a `postgres` service to the .yml file, in order to have something local to test against. Eventually, this will probably go away and get moved into the docker compose file, but we'll rely on the builtin services for now.