### PR TITLE
DPC-169: Implement typesafe SQL

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,10 +1,10 @@
-version: 2
+version: "2"
 checks:
   # IntelliJ generates suspicious equals/hashcode methods.
   # So we bump the complexity metric to 9, which should weed them out
   method-complexity:
-    enabled: true
-    threshold: 9
+    config:
+      threshold: 9
   # Disabled because IntelliJ generates suspicious equals/hashcode methods.
   identical-code:
     enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ jdk:
 services:
   - postgresql
 
+cache:
+  directories:
+    - $HOME/.m2
+
 # Setup the postgres database for testing
 before_script:
   - psql -c 'create database dpc_attribution;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 # Setup the postgres database for testing
 before_script:
-  - psql -c 'create database dpc-attribution;' -U postgres
+  - psql -c 'create database dpc_attribution;' -U postgres
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_ebb4f1b65c80_key -iv $encrypted_ebb4f1b65c80_iv -in bbcerts/bb.keystore.enc -out bbcerts/bb.keystore -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     image: postgres
     environment:
-      - POSTGRES_DB=dpc-attribution
+      - POSTGRES_DB=dpc_attribution
       - POSTGRES_PASSWORD=dpc-safe
     ports:
       - "5432:5432"

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -14,6 +14,8 @@
 
     <properties>
         <mainClass>gov.cms.dpc.attribution.DPCAttributionService</mainClass>
+        <jooq.version>3.11.10</jooq.version>
+        <pgsql.version>42.2.5</pgsql.version>
     </properties>
 
     <dependencies>
@@ -47,9 +49,14 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
+            <version>${jooq.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.5</version>
+            <version>${pgsql.version}</version>
         </dependency>
         <dependency>
             <groupId>gov.cms.dpc</groupId>
@@ -152,6 +159,57 @@
                         </permissions>
                     </extraDirectory>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jooq</groupId>
+                <artifactId>jooq-codegen-maven</artifactId>
+                <version>${jooq.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-postgres-jpa</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <generator>
+                                <database>
+                                    <name>org.jooq.meta.extensions.jpa.JPADatabase</name>
+                                    <properties>
+                                        <property>
+                                            <key>packages</key>
+                                            <value>gov.cms.dpc.attribution.models</value>
+                                        </property>
+                                        <property>
+                                            <key>dialect</key>
+                                            <value>MYSQl</value>
+                                        </property>
+                                    </properties>
+                                    <includes>.*</includes>
+                                </database>
+                                <generate>
+                                </generate>
+                                <target>
+                                    <packageName>gov.cms.dpc.attribution.dao</packageName>
+                                    <directory>target/generated-sources/jooq</directory>
+                                </target>
+                            </generator>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>${pgsql.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.jooq</groupId>
+                        <artifactId>jooq-meta-extensions</artifactId>
+                        <version>${jooq.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -179,11 +179,11 @@
                                     <properties>
                                         <property>
                                             <key>packages</key>
-                                            <value>gov.cms.dpc.attribution.models</value>
+                                            <value>gov.cms.dpc.common.entities</value>
                                         </property>
                                         <property>
                                             <key>dialect</key>
-                                            <value>MYSQl</value>
+                                            <value>org.hibernate.dialect.PostgreSQL9Dialect</value>
                                         </property>
                                     </properties>
                                     <includes>.*</includes>
@@ -199,11 +199,6 @@
                     </execution>
                 </executions>
                 <dependencies>
-                    <dependency>
-                        <groupId>org.postgresql</groupId>
-                        <artifactId>postgresql</artifactId>
-                        <version>${pgsql.version}</version>
-                    </dependency>
                     <dependency>
                         <groupId>org.jooq</groupId>
                         <artifactId>jooq-meta-extensions</artifactId>

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
@@ -72,7 +72,7 @@ class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfigura
     public static class AttributionHibernateModule extends HibernateBundle<DPCAttributionConfiguration> implements ConfiguredBundle<DPCAttributionConfiguration> {
 
         private static final Logger logger = LoggerFactory.getLogger(AttributionHibernateModule.class);
-        public static String PREFIX_STRING = "gov.cms.dpc.attribution.models";
+        public static String PREFIX_STRING = "gov.cms.dpc.common.entities";
 
         @Inject
         public AttributionHibernateModule() {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -1,9 +1,11 @@
 package gov.cms.dpc.attribution.cli;
 
 import gov.cms.dpc.attribution.DPCAttributionConfiguration;
-import gov.cms.dpc.attribution.models.AttributionRelationship;
-import gov.cms.dpc.attribution.models.PatientEntity;
-import gov.cms.dpc.attribution.models.ProviderEntity;
+import gov.cms.dpc.attribution.dao.tables.Providers;
+import gov.cms.dpc.attribution.dao.tables.records.ProvidersRecord;
+import gov.cms.dpc.common.entities.AttributionRelationship;
+import gov.cms.dpc.common.entities.PatientEntity;
+import gov.cms.dpc.common.entities.ProviderEntity;
 import gov.cms.dpc.common.utils.SeedProcessor;
 import io.dropwizard.Application;
 import io.dropwizard.cli.EnvironmentCommand;
@@ -15,8 +17,10 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.ResourceType;
+import org.jooq.DSLContext;
 import org.jooq.conf.RenderNameStyle;
 import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,10 +86,10 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
 
                         logger.info("Adding provider {}", providerEntity.getProviderNPI());
 
-//                        try (DSLContext context = DSL.using(connection, this.settings)) {
-//                            final ProvidersRecord providersRecord = context.newRecord(Providers.PROVIDERS, providerEntity);
-//                            context.executeInsert(providersRecord);
-//                        }
+                        try (DSLContext context = DSL.using(connection, this.settings)) {
+                            final ProvidersRecord providersRecord = context.newRecord(Providers.PROVIDERS, providerEntity);
+                            context.executeInsert(providersRecord);
+                        }
 //                        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO providers (id, provider_id, first_name, last_name) VALUES (?, ?, ?, ?)")) {
 //                            statement.setObject(1, providerEntity.getProviderID());
 //                            statement.setObject(2, providerEntity.getProviderNPI());

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -47,7 +47,6 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
     protected void run(Environment environment, Namespace namespace, DPCAttributionConfiguration configuration) throws Exception {
         // Get the db factory
         final PooledDataSourceFactory dataSourceFactory = configuration.getDatabase();
-//        dataSourceFactory.asSingleConnectionPool();
         final ManagedDataSource dataSource = dataSourceFactory.build(environment.metrics(), "attribution-seeder");
 
         // Read in the seeds file and write things

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -15,6 +15,8 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.ResourceType;
+import org.jooq.conf.RenderNameStyle;
+import org.jooq.conf.Settings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +33,7 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
     private static final String CSV = "test_associations.csv";
 
     private final SeedProcessor seedProcessor;
+    private final Settings settings;
 
 
     public SeedCommand(Application<DPCAttributionConfiguration> application) {
@@ -41,6 +44,8 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
             throw new MissingResourceException("Can not find seeds file", this.getClass().getName(), CSV);
         }
         this.seedProcessor = new SeedProcessor(resource);
+
+        this.settings = new Settings().withRenderNameStyle(RenderNameStyle.AS_IS);
     }
 
     @Override
@@ -77,15 +82,19 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
 
                         logger.info("Adding provider {}", providerEntity.getProviderNPI());
 
-                        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO providers (id, provider_id, first_name, last_name) VALUES (?, ?, ?, ?)")) {
-                            statement.setObject(1, providerEntity.getProviderID());
-                            statement.setObject(2, providerEntity.getProviderNPI());
-                            statement.setString(3, providerEntity.getProviderFirstName());
-                            statement.setString(4, providerEntity.getProviderLastName());
-                            statement.execute();
-                        } catch (SQLException e) {
-                            throw new IllegalStateException(e);
-                        }
+//                        try (DSLContext context = DSL.using(connection, this.settings)) {
+//                            final ProvidersRecord providersRecord = context.newRecord(Providers.PROVIDERS, providerEntity);
+//                            context.executeInsert(providersRecord);
+//                        }
+//                        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO providers (id, provider_id, first_name, last_name) VALUES (?, ?, ?, ?)")) {
+//                            statement.setObject(1, providerEntity.getProviderID());
+//                            statement.setObject(2, providerEntity.getProviderNPI());
+//                            statement.setString(3, providerEntity.getProviderFirstName());
+//                            statement.setString(4, providerEntity.getProviderLastName());
+//                            statement.execute();
+//                        } catch (SQLException e) {
+//                            throw new IllegalStateException(e);
+//                        }
                         bundle
                                 .getEntry()
                                 .stream()

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
@@ -1,8 +1,8 @@
 package gov.cms.dpc.attribution.jdbi;
 
-import gov.cms.dpc.attribution.models.AttributionRelationship;
-import gov.cms.dpc.attribution.models.PatientEntity;
-import gov.cms.dpc.attribution.models.ProviderEntity;
+import gov.cms.dpc.common.entities.AttributionRelationship;
+import gov.cms.dpc.common.entities.PatientEntity;
+import gov.cms.dpc.common.entities.ProviderEntity;
 import gov.cms.dpc.common.exceptions.UnknownRelationship;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
 import gov.cms.dpc.fhir.FHIRExtractors;

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
@@ -1,6 +1,6 @@
 package gov.cms.dpc.attribution.jdbi;
 
-import gov.cms.dpc.attribution.models.AttributionRelationship;
+import gov.cms.dpc.common.entities.AttributionRelationship;
 import gov.cms.dpc.common.exceptions.UnknownRelationship;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import io.dropwizard.hibernate.AbstractDAO;

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/models/ProviderEntity.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/models/ProviderEntity.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.attribution.models;
 
 import gov.cms.dpc.fhir.FHIRExtractors;
+import org.hibernate.annotations.Type;
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.Practitioner;
 
@@ -19,6 +20,7 @@ public class ProviderEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "id", updatable = false, nullable = false)
+//    @Type(type="org.hibernate.type.PostgresUUIDType")
     private UUID providerID;
 
     @Column(name = "provider_id")

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -1,8 +1,8 @@
 dpc.attribution {
-  database = {
+  database {
     driverClass = org.postgresql.Driver
     url = "jdbc:postgresql://localhost:5432/dpc_attribution"
-    user = travis
+    user = postgres
   }
 
   logging {

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 dpc.attribution {
   database = {
     driverClass = org.postgresql.Driver
-    url = "jdbc:postgresql://localhost:5432/dpc-attribution"
+    url = "jdbc:postgresql://localhost:5432/dpc_attribution"
     user = travis
   }
 

--- a/dpc-attribution/src/main/resources/dev.application.conf
+++ b/dpc-attribution/src/main/resources/dev.application.conf
@@ -1,7 +1,7 @@
 dpc.attribution {
   database = {
     driverClass = org.postgresql.Driver
-    url = "jdbc:postgresql://db:5432/dpc-attribution"
+    url = "jdbc:postgresql://db:5432/dpc_attribution"
     user = postgres
     password = dpc-safe
   }

--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -34,5 +34,10 @@
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>5.2.15.Final</version>
+        </dependency>
     </dependencies>
 </project>

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
@@ -23,7 +23,6 @@ public class AttributionRelationship {
     @ManyToOne(cascade = CascadeType.PERSIST)
     private ProviderEntity provider;
 
-//    @Column(name = "patient_id")
     @ManyToOne(cascade = CascadeType.PERSIST)
     private PatientEntity patient;
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
@@ -1,4 +1,4 @@
-package gov.cms.dpc.attribution.models;
+package gov.cms.dpc.common.entities;
 
 import org.hibernate.annotations.CreationTimestamp;
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
@@ -1,4 +1,4 @@
-package gov.cms.dpc.attribution.models;
+package gov.cms.dpc.common.entities;
 
 import org.hibernate.validator.constraints.NotEmpty;
 import org.hl7.fhir.dstu3.model.HumanName;
@@ -17,7 +17,7 @@ public class PatientEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "id", updatable = false, nullable = false)
+    @Column(name = "id", updatable = false, nullable = false, columnDefinition = "uuid")
     private UUID patientID;
 
     @NotEmpty

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
@@ -1,7 +1,6 @@
-package gov.cms.dpc.attribution.models;
+package gov.cms.dpc.common.entities;
 
 import gov.cms.dpc.fhir.FHIRExtractors;
-import org.hibernate.annotations.Type;
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.Practitioner;
 
@@ -19,8 +18,7 @@ public class ProviderEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "id", updatable = false, nullable = false)
-//    @Type(type="org.hibernate.type.PostgresUUIDType")
+    @Column(name = "id", updatable = false, nullable = false, columnDefinition = "uuid")
     private UUID providerID;
 
     @Column(name = "provider_id")


### PR DESCRIPTION
Added support for the JOOQ SQL framework, which means we now have a clean, typesafe interface for executing custom SQL queries.

This is primarily used in the `SeedCommand` class, since we can't inject the Hibernate context in a `Command` because it's not configured yet. This lets us remove a bunch of code and much more cleanly express our intent.

The Java classes are generated by JOOQ, based on our JPA entities. Due to the order of compilation, we had to move the entities in the `dpc-common` module, so that they would be available for JOOQ to parse. This add a step to the `generate-sources` phase of maven, but it should be handled automatically. The resulting classes are generated in the `target/` directory, so there's nothing for us to commit to git.