### PR TITLE
DPC-94: Unified Dropwizard configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ docker-compose up db redis
 By default, the application attempts to connect to the `dpc_atrribution` database on the localhost as the `postgres` user.
 This database needs to be manually created, but table setup and data migration will be handled by the DPC services.
 
-For Redis, we assume the server is running on the localhost, with the default port. 
+For Redis, we assume the server is running on the localhost, with the default port.
 
 The defaults can be overridden in the configuration files.
+Common configuration options (such as database connection strings) are stored in the `server.conf` file within the `src/main/resources` directory.
+These settings are included in the various modules via the `include "server.conf"` attribute in module application config files.
+See the `dpc-attribution` [application.conf](dpc-attribution/src/main/resources/application.conf) for an example.
+
+Default settings can be overridden either directly in the module configurations, or via an `application.local.conf` file in the project root directory. 
 For example, modifying the `dpc-attribution` configuration:
 
 ```yaml
@@ -45,6 +50,12 @@ dpc.attribution {
     }
 }
 ```
+
+#### Note:
+
+On startup, the services look for a local override file (application.local.conf) in the root of their *current* working directory.
+This can create an issue when running tests with IntelliJ which by default sets the working directory to be the module root, which means any local overrides are ignored.
+This can be fixed by setting the working directory to the project root, but needs to done manually. 
 
 Running DPC
 --- 

--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -104,6 +104,17 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/../src/resources</directory>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/../src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/dpc-aggregation/src/main/resources/application.conf
+++ b/dpc-aggregation/src/main/resources/application.conf
@@ -1,6 +1,13 @@
 dpc.aggregation {
   include "server.conf"
 
+  database {
+    #
+    properties = {
+      "hibernate.hbm2ddl.auto" = update
+    }
+  }
+
   bbclient {
     keyStore {
       type = "JKS"

--- a/dpc-aggregation/src/main/resources/application.conf
+++ b/dpc-aggregation/src/main/resources/application.conf
@@ -1,4 +1,6 @@
 dpc.aggregation {
+  include "server.conf"
+
   bbclient {
     keyStore {
       type = "JKS"
@@ -7,28 +9,6 @@ dpc.aggregation {
     }
 
     serverBaseUrl = "https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/"
-  }
-
-  database {
-    driverClass = org.postgresql.Driver
-    url = "jdbc:postgresql://localhost:5432/dpc_attribution"
-    user = postgres
-    password = dpc-safe
-    properties = {
-      "hibernate.hbm2ddl.auto" = update
-    }
-  }
-
-  server {
-    registerDefaultExceptionMappers = false
-    applicationConnectors = [{
-      type = http
-      port = 8080
-    }]
-    adminConnectors = [{
-      type = http
-      port = 9999
-    }]
   }
 
   exportPath = "/tmp"

--- a/dpc-aggregation/src/main/resources/application.conf
+++ b/dpc-aggregation/src/main/resources/application.conf
@@ -1,13 +1,6 @@
 dpc.aggregation {
   include "server.conf"
 
-  database {
-    #
-    properties = {
-      "hibernate.hbm2ddl.auto" = update
-    }
-  }
-
   bbclient {
     keyStore {
       type = "JKS"

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -96,6 +96,14 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/../src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
         <!--Pull in the attribution seeds so we can use them for the integration tests.-->
         <testResources>
             <testResource>

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
@@ -16,10 +16,8 @@ import java.io.IOException;
 
 public class DPCAPIConfiguration extends TypesafeConfiguration implements IDPCDatabase, DPCQueueConfig {
 
-    private String testValue;
     @NotEmpty
     private String exportPath;
-
     @Valid
     @NotNull
     @JsonProperty
@@ -40,14 +38,6 @@ public class DPCAPIConfiguration extends TypesafeConfiguration implements IDPCDa
 
     DPCAPIConfiguration() {
 //        Not used;
-    }
-
-    public String getTestValue() {
-        return this.testValue;
-    }
-
-    public void setTestValue(String testValue) {
-        this.testValue = testValue;
     }
 
     public JerseyClientConfiguration getHttpClient() {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
@@ -32,7 +32,7 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
                 .build();
 
         bootstrap.addBundle(guiceBundle);
-        bootstrap.addBundle(new TypesafeConfigurationBundle());
+        bootstrap.addBundle(new TypesafeConfigurationBundle("dpc.api"));
     }
 
     @Override

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -1,23 +1,11 @@
 dpc.api {
   include "server.conf"
 
-  database {
-    properties = {
-      "hibernate.hbm2ddl.auto" = update
-    }
-  }
-
   attributionURL = "http://localhost:3500/v1/"
   exportPath = "/tmp"
 
   httpClient {
     timeout: 5s
     connectionRequestTimeout: 5s
-  }
-
-  queue {
-    singleServerConfig {
-      address = "redis://localhost:6379"
-    }
   }
 }

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -1,36 +1,17 @@
-logging {
-  level = INFO
-}
+dpc.api {
+  include "server.conf"
 
-server {
-  registerDefaultExceptionMappers = false
-  applicationConnectors = [{
-    type = http
-    port = 3002
-  }]
-  adminConnectors =  [{
-    type = http
-    port = 9900
-  }]
-}
+  attributionURL = "http://localhost:3500/v1/"
+  exportPath = "/tmp"
 
-httpClient {
-  timeout: 5s
-  connectionRequestTimeout: 5s
-}
-
-queue {
-  singleServerConfig {
-    address = "redis://localhost:6379"
+  httpClient {
+    timeout: 5s
+    connectionRequestTimeout: 5s
   }
-}
 
-database {
-  driverClass = org.postgresql.Driver
-  url = "jdbc:postgresql://localhost:5432/dpc_attribution"
-  user = postgres
-  password = dpc-safe
-  properties = {
-    "hibernate.hbm2ddl.auto" = update
+  queue {
+    singleServerConfig {
+      address = "redis://localhost:6379"
+    }
   }
 }

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -1,6 +1,12 @@
 dpc.api {
   include "server.conf"
 
+  database {
+    properties = {
+      "hibernate.hbm2ddl.auto" = update
+    }
+  }
+
   attributionURL = "http://localhost:3500/v1/"
   exportPath = "/tmp"
 

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -92,6 +92,9 @@
                 <directory>${project.basedir}/../src/resources</directory>
             </resource>
             <resource>
+                <directory>${project.basedir}/../src/main/resources</directory>
+            </resource>
+            <resource>
                 <directory>src/main/resources</directory>
             </resource>
         </resources>

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -1,28 +1,6 @@
 dpc.attribution {
-  database {
-    driverClass = org.postgresql.Driver
-    url = "jdbc:postgresql://localhost:5432/dpc_attribution"
-    user = postgres
-    password = dpc-safe
-  }
 
-  logging {
-    loggers {
-      "gov.cms.dpc" = DEBUG
-    }
-  }
-
-  server {
-    registerDefaultExceptionMappers = false
-    applicationConnectors = [{
-      type = http
-      port = 3500
-    }]
-    adminConnectors = [{
-      type = http
-      port = 9999
-    }]
-  }
+  include "server.conf"
 
   expirationThreshold = 90 // In days
   sundial {

--- a/dpc-queue/src/main/resources/reference.conf
+++ b/dpc-queue/src/main/resources/reference.conf
@@ -1,0 +1,6 @@
+queue {
+  # Default to connecting to redis only on the localhost
+  singleServerConfig {
+    address = "redis://localhost:6379"
+  }
+}

--- a/dpc-queue/src/main/resources/reference.conf
+++ b/dpc-queue/src/main/resources/reference.conf
@@ -4,3 +4,10 @@ queue {
     address = "redis://localhost:6379"
   }
 }
+
+database {
+  properties = {
+    # Use Hibernate to setup the Job table in Postgres, this will eventually need to be removed
+    "hibernate.hbm2ddl.auto" = update
+  }
+}

--- a/dpc-queue/src/test/resources/hibernate.cfg.xml
+++ b/dpc-queue/src/test/resources/hibernate.cfg.xml
@@ -10,7 +10,7 @@
         <property name="hibernate.connection.driver_class">org.postgresql.Driver</property>
         <property name="hibernate.connection.url">jdbc:postgresql://localhost:5432/dpc_attribution</property>
         <property name="hibernate.connection.username">postgres</property>
-        <property name="hibernate.connection.password">postgres</property>
+        <property name="hibernate.connection.password">dpc-safe</property>
 
         <!-- SQL dialect -->
         <property name="hibernate.dialect">org.hibernate.dialect.PostgreSQL10Dialect</property>

--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -1,0 +1,23 @@
+# Default configuration for DPC Dropwizard services
+
+database {
+  driverClass = org.postgresql.Driver
+  url = "jdbc:postgresql://localhost:5432/dpc_attribution"
+  user = postgres
+  password = dpc-safe
+  properties = {
+    "hibernate.hbm2ddl.auto" = update
+  }
+}
+
+server {
+  registerDefaultExceptionMappers = false
+  applicationConnectors = [{
+    type = http
+    port = 3002
+  }]
+  adminConnectors = [{
+    type = http
+    port = 9900
+  }]
+}

--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -5,9 +5,6 @@ database {
   url = "jdbc:postgresql://localhost:5432/dpc_attribution"
   user = postgres
   password = dpc-safe
-  properties = {
-    "hibernate.hbm2ddl.auto" = update
-  }
 }
 
 server {


### PR DESCRIPTION
This PR is mainly around reworking the configuration files so that we have single points of contact for making changes.

Each service now has its options isolated into its own namespace (e.g. `dpc.attribution{}`), which means we can override settings for each service as we need to.

In order to reduce config duplication, most of the common settings (e.g. service ports, database connection properties, logging, etc) have been moved into a `server.conf` file in the `src/main/resources` directory. Each service can then `include "server.conf" within its namespace and inherit the default settings, which it is free to override as it sees fit.
In order for this to work correctly, each service needs to include the `src/main/resources` directory in its build, which is accomplished by adding:

```xml
<resources>
  <resource>
    <directory>${project.basedir}/../src/main/resources</directory>
   </resource>
</resources>
```

under the `<build>` key of the pom.

Likewise, the `dpc-queue` module now ships its own `reference.conf` file which includes its default values as well. 