### PR TITLE
DPC-23: Add ability to resubmit roster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ language: java
 jdk:
   - oraclejdk11
 
+addons:
+  postgresql: "9.6"
+
 services:
   - postgresql
   - redis-server

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Required services
 
 DPC requires two external services to be running. *Postgres* and *Redis*
 
+Any version of Redis should suffice, but we require at least Postgres *9.5*.
+
 The `docker-compose` file includes the necessary applications and configurations, and can be started like so: 
 
 ```bash

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -191,12 +191,13 @@
                                         </property>
                                         <property>
                                             <key>dialect</key>
-                                            <value>org.hibernate.dialect.PostgreSQL9Dialect</value>
+                                            <value>org.hibernate.dialect.PostgreSQL10Dialect</value>
                                         </property>
                                     </properties>
                                     <includes>.*</includes>
                                 </database>
                                 <generate>
+                                    <javaTimeTypes>true</javaTimeTypes>
                                 </generate>
                                 <target>
                                     <packageName>gov.cms.dpc.attribution.dao</packageName>

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
@@ -21,6 +21,7 @@ import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.sql.SQLException;
 import java.time.Duration;
 
@@ -66,11 +67,8 @@ class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfigura
     }
 
     @Provides
-    DSLContext provideDSL(DPCAttributionConfiguration config) {
-        final DataSourceFactory factory = config.getDatabase();
-        final ManagedDataSource dataSource = factory.build(getEnvironment().metrics(), "tested-things");
+    DSLContext provideDSL(ManagedDataSource dataSource) {
         final Settings settings = new Settings().withRenderNameStyle(RenderNameStyle.AS_IS);
-
         try {
             return DSL.using(dataSource.getConnection(), settings);
         } catch (SQLException e) {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
@@ -5,6 +5,7 @@ import com.google.inject.Provides;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import gov.cms.dpc.attribution.jdbi.ProviderDAO;
 import gov.cms.dpc.attribution.jdbi.RelationshipDAO;
+import gov.cms.dpc.attribution.jdbi.RosterEngine;
 import gov.cms.dpc.attribution.resources.v1.GroupResource;
 import gov.cms.dpc.attribution.resources.v1.V1AttributionResource;
 import gov.cms.dpc.common.hibernate.DPCHibernateBundle;
@@ -34,7 +35,7 @@ class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfigura
     @Override
     public void configure(Binder binder) {
         binder.bind(ProviderDAO.class);
-        binder.bind(AttributionEngine.class).to(ProviderDAO.class);
+        binder.bind(AttributionEngine.class).to(RosterEngine.class);
         binder.bind(V1AttributionResource.class);
     }
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionException.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionException.java
@@ -1,8 +1,0 @@
-package gov.cms.dpc.attribution;
-
-public class AttributionException extends RuntimeException {
-
-    public AttributionException(String message) {
-        super(message);
-    }
-}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionException.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionException.java
@@ -1,0 +1,8 @@
+package gov.cms.dpc.attribution;
+
+public class AttributionException extends RuntimeException {
+
+    public AttributionException(String message) {
+        super(message);
+    }
+}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -3,12 +3,7 @@ package gov.cms.dpc.attribution.cli;
 import gov.cms.dpc.attribution.DPCAttributionConfiguration;
 import gov.cms.dpc.attribution.dao.tables.Patients;
 import gov.cms.dpc.attribution.dao.tables.Providers;
-import gov.cms.dpc.attribution.dao.tables.records.AttributionsRecord;
-import gov.cms.dpc.attribution.dao.tables.records.PatientsRecord;
-import gov.cms.dpc.attribution.dao.tables.records.ProvidersRecord;
-import gov.cms.dpc.common.entities.AttributionRelationship;
-import gov.cms.dpc.common.entities.PatientEntity;
-import gov.cms.dpc.common.entities.ProviderEntity;
+import gov.cms.dpc.attribution.jdbi.RosterUtils;
 import gov.cms.dpc.common.utils.SeedProcessor;
 import io.dropwizard.Application;
 import io.dropwizard.cli.EnvironmentCommand;
@@ -17,10 +12,6 @@ import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Environment;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Practitioner;
-import org.hl7.fhir.dstu3.model.ResourceType;
 import org.jooq.DSLContext;
 import org.jooq.conf.RenderNameStyle;
 import org.jooq.conf.Settings;
@@ -31,9 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.MissingResourceException;
-import java.util.UUID;
 
 public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration> {
 
@@ -88,40 +77,7 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
                     .entrySet()
                     .stream()
                     .map(this.seedProcessor::generateRosterBundle)
-                    .forEach(bundle -> {
-                        // Insert the provider , patients, and the attribution relationships
-                        final Practitioner provider = (Practitioner) bundle.getEntryFirstRep().getResource();
-
-                        final ProviderEntity providerEntity = ProviderEntity.fromFHIR(provider);
-                        providerEntity.setProviderID(UUID.randomUUID());
-
-                        logger.info("Adding provider {}", providerEntity.getProviderNPI());
-
-                        final ProvidersRecord pr = context.newRecord(Providers.PROVIDERS, providerEntity);
-                        pr.setId(UUID.randomUUID());
-                        context.executeInsert(pr);
-
-                        bundle
-                                .getEntry()
-                                .stream()
-                                .map(Bundle.BundleEntryComponent::getResource)
-                                .filter((resource -> resource.getResourceType() == ResourceType.Patient))
-                                .map(patient -> PatientEntity.fromFHIR((Patient) patient))
-                                .forEach(patientEntity -> {
-                                    // Create a new record from the patient entity
-                                    patientEntity.setPatientID(UUID.randomUUID());
-                                    final PatientsRecord patient = context.newRecord(Patients.PATIENTS, patientEntity);
-                                    patient.setId(UUID.randomUUID());
-                                    context.executeInsert(patient);
-
-                                    // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
-                                    final AttributionsRecord attr = new AttributionsRecord();
-                                    attr.setProviderId(pr.getId());
-                                    attr.setPatientId(patient.getId());
-                                    attr.setCreatedAt(creationTimestamp);
-                                    context.executeInsert(attr);
-                                });
-                    });
+                    .forEach(bundle -> RosterUtils.handleAttributionBundle(bundle, context, creationTimestamp));
             logger.info("Finished loading seeds");
         }
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.MissingResourceException;
 
 public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration> {
@@ -61,7 +62,7 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
         final PooledDataSourceFactory dataSourceFactory = configuration.getDatabase();
         final ManagedDataSource dataSource = dataSourceFactory.build(environment.metrics(), "attribution-seeder");
 
-        final Timestamp creationTimestamp = generateTimestamp(namespace);
+        final OffsetDateTime creationTimestamp = generateTimestamp(namespace);
 
         // Read in the seeds file and write things
         logger.info("Seeding attributions at time {}", creationTimestamp.toLocalDateTime());
@@ -77,16 +78,16 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
                     .entrySet()
                     .stream()
                     .map(this.seedProcessor::generateRosterBundle)
-                    .forEach(bundle -> RosterUtils.handleAttributionBundle(bundle, context, creationTimestamp));
+                    .forEach(bundle -> RosterUtils.submitAttributionBundle(bundle, context, creationTimestamp));
             logger.info("Finished loading seeds");
         }
     }
 
-    private static Timestamp generateTimestamp(Namespace namespace) {
+    private static OffsetDateTime generateTimestamp(Namespace namespace) {
         final String timestamp = namespace.getString("timestamp");
         if (timestamp == null) {
-            return Timestamp.from(Instant.now());
+            return OffsetDateTime.now();
         }
-        return Timestamp.valueOf(timestamp);
+        return OffsetDateTime.parse(timestamp.trim());
     }
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/AbstractRecordUpserter.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/AbstractRecordUpserter.java
@@ -1,0 +1,132 @@
+package gov.cms.dpc.attribution.jdbi;
+
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.TableField;
+import org.jooq.impl.UpdatableRecordImpl;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract class for adding custom handling of {@link org.jooq.Record} insertion or updating.
+ * This allows the user to specify how conflicts in the database should be handled.
+ * <p>
+ * When overriding, the user specifies which columns should be included when determining whether or not a conflict occurs.
+ * The user then specifies which fields to EXCLUDE from updating with the new record.
+ * Finally, any specific return fields are listed. If no fields are given, the entire record is returned.
+ * <p>
+ * If there is no conflicting data in the database, the {@link org.jooq.Record} is inserted without modification.
+ *
+ * @param <R> - Generic record type which extends {@link UpdatableRecordImpl}.
+ */
+public abstract class AbstractRecordUpserter<R extends UpdatableRecordImpl<R>> {
+
+    private final DSLContext ctx;
+    private final R record;
+
+    AbstractRecordUpserter(DSLContext ctx, R record) {
+        this.ctx = ctx;
+        this.record = record;
+    }
+
+    /**
+     * Specify which {@link TableField}s for the given {@link org.jooq.Record} should be considered when determining a conflict occurs.
+     * If no fields are specified, then conflict handling will not be implemented.
+     *
+     * @return - {@link List} of {@link TableField} from the given {@link org.jooq.Record} to consider for conflict detection.
+     */
+    abstract List<TableField<R, ?>> getConflictFields();
+
+    /**
+     * Specify which {@link TableField}s should NOT be updated with the new record values.
+     * At the very least, this should always include the record's primary key.
+     *
+     * @return - {@link List} of {@link TableField} from the given {@link org.jooq.Record} to exclude from updating with the new values.
+     */
+    abstract List<TableField<R, ?>> getExcludedFields();
+
+
+    /**
+     * Specify which {@link TableField}s should be returned from the database.
+     * If no fields are specified, the entire {@link org.jooq.Record} is returned.
+     *
+     * @return - {@link List} of {@link TableField} from the given {@link org.jooq.Record} to return after the upsert
+     */
+    abstract List<TableField<R, ?>> getReturnFields();
+
+    /**
+     * Return the underlying record
+     *
+     * @return - {@link R} record to be upserted
+     */
+    public R getRecord() {
+        return this.record;
+    }
+
+    /**
+     * {@link Map} of {@link String} {@link Object} values which represent the {@link TableField} and values to update for the underlying record.
+     * This always includes the values returned by {@link AbstractRecordUpserter#getExcludedFields()}, and optionally includes the values from {@link AbstractRecordUpserter#getConflictFields()} as well.
+     *
+     * @param excludeConflictFields - {@code true} exclude conflicting fields from the update. {@link false} update conflicting fields.
+     * @return - {@link Map} of {@link String} {@link Object} values which will be updated when a conflict occurs.
+     */
+    public Map<String, Object> getUpdateMap(boolean excludeConflictFields) {
+        final Map<String, Object> recordMap = this.record.intoMap();
+        this.excludeMapFields(recordMap, getExcludedFields());
+
+        // Always exclude primary keys
+
+        if (excludeConflictFields) {
+            this.excludeMapFields(recordMap, getConflictFields());
+        }
+
+        return recordMap;
+    }
+
+    /**
+     * Upsert the record, using the {@link Map} returned by {@link AbstractRecordUpserter#getUpdateMap(boolean)}.
+     * This defaults to excluding conflict fields from the update.
+     * <p>
+     * This also defaults to returning a {@link org.jooq.Record} which only includes the fields specified by {@link AbstractRecordUpserter#getReturnFields()}.
+     *
+     * @return - {@link R} containing only the fields specified by {@link AbstractRecordUpserter#getReturnFields()}
+     */
+    public R upsert() {
+        return upsert(getReturnFields(), true);
+    }
+
+    /**
+     * Upsert the record, using the {@link Map} returned by {@link AbstractRecordUpserter#getUpdateMap(boolean)}.
+     * Allows the user to specify whether or not to exclude conflict fields from the update.
+     *
+     * @param returnFields          - {@link Collection} of {@link TableField} which specifies which values to return from the database
+     * @param excludeConflictFields - {@code true} exclude conflicting fields from the update. {@link false} update conflicting fields.
+     * @return - {@link R} containing only the fields specified by {@code returnFields}
+     */
+    public R upsert(Collection<TableField<R, ?>> returnFields, boolean excludeConflictFields) {
+        var insertStep = ctx.insertInto(record.getTable())
+                .set(record)
+                .onConflict(getConflictFields())
+                .doUpdate()
+                .set(getUpdateMap(excludeConflictFields));
+
+        if (returnFields.isEmpty()) {
+            return insertStep
+                    .returning()
+                    .fetchOne();
+        } else {
+            return insertStep
+                    .returning(returnFields)
+                    .fetchOne();
+        }
+    }
+
+    private void excludeMapFields(Map<String, Object> recordMap, List<TableField<R, ?>> fields) {
+        fields
+                .stream()
+                .map(Field::getName)
+                .forEach(recordMap::remove);
+    }
+}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/AbstractRecordUpserter.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/AbstractRecordUpserter.java
@@ -69,7 +69,7 @@ public abstract class AbstractRecordUpserter<R extends UpdatableRecordImpl<R>> {
      * {@link Map} of {@link String} {@link Object} values which represent the {@link TableField} and values to update for the underlying record.
      * This always includes the values returned by {@link AbstractRecordUpserter#getExcludedFields()}, and optionally includes the values from {@link AbstractRecordUpserter#getConflictFields()} as well.
      *
-     * @param excludeConflictFields - {@code true} exclude conflicting fields from the update. {@link false} update conflicting fields.
+     * @param excludeConflictFields - {@code true} exclude conflicting fields from the update. {@code false} update conflicting fields.
      * @return - {@link Map} of {@link String} {@link Object} values which will be updated when a conflict occurs.
      */
     public Map<String, Object> getUpdateMap(boolean excludeConflictFields) {
@@ -102,7 +102,7 @@ public abstract class AbstractRecordUpserter<R extends UpdatableRecordImpl<R>> {
      * Allows the user to specify whether or not to exclude conflict fields from the update.
      *
      * @param returnFields          - {@link Collection} of {@link TableField} which specifies which values to return from the database
-     * @param excludeConflictFields - {@code true} exclude conflicting fields from the update. {@link false} update conflicting fields.
+     * @param excludeConflictFields - {@code true} exclude conflicting fields from the update. {@code false} update conflicting fields.
      * @return - {@link R} containing only the fields specified by {@code returnFields}
      */
     public R upsert(Collection<TableField<R, ?>> returnFields, boolean excludeConflictFields) {
@@ -124,8 +124,7 @@ public abstract class AbstractRecordUpserter<R extends UpdatableRecordImpl<R>> {
     }
 
     private void excludeMapFields(Map<String, Object> recordMap, List<TableField<R, ?>> fields) {
-        fields
-                .stream()
+        fields.stream()
                 .map(Field::getName)
                 .forEach(recordMap::remove);
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/PatientRecordUpserter.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/PatientRecordUpserter.java
@@ -1,0 +1,35 @@
+package gov.cms.dpc.attribution.jdbi;
+
+import gov.cms.dpc.attribution.dao.tables.records.PatientsRecord;
+import org.jooq.DSLContext;
+import org.jooq.TableField;
+
+import java.util.Collections;
+import java.util.List;
+
+import static gov.cms.dpc.attribution.dao.tables.Patients.PATIENTS;
+
+/**
+ * Implementation of {@link AbstractRecordUpserter}, specialized for {@link PatientsRecord}
+ */
+public class PatientRecordUpserter extends AbstractRecordUpserter<PatientsRecord> {
+
+    PatientRecordUpserter(DSLContext ctx, PatientsRecord record) {
+        super(ctx, record);
+    }
+
+    @Override
+    List<TableField<PatientsRecord, ?>> getConflictFields() {
+        return Collections.singletonList(PATIENTS.BENEFICIARY_ID);
+    }
+
+    @Override
+    List<TableField<PatientsRecord, ?>> getExcludedFields() {
+        return Collections.singletonList(PATIENTS.ID);
+    }
+
+    @Override
+    List<TableField<PatientsRecord, ?>> getReturnFields() {
+        return Collections.singletonList(PATIENTS.ID);
+    }
+}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
@@ -69,17 +69,19 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> implements Attribut
 
         // Get the patients and create the attribution
 
-        final List<PatientEntity> patients = attributionBundle
+        attributionBundle
                 .getEntry()
                 .stream()
                 .filter(Bundle.BundleEntryComponent::hasResource)
                 .map(Bundle.BundleEntryComponent::getResource)
                 .filter((resource -> resource.getResourceType() == ResourceType.Patient))
                 .map(patient -> PatientEntity.fromFHIR((Patient) patient))
-                .collect(Collectors.toList());
+                .map((pEntity) -> new AttributionRelationship(provider, pEntity))
+                .forEach(this.rDAO::addAttributionRelationship);
 
-        provider.setAttributedPatients(patients);
-        persist(provider);
+//        provider.setAttributedPatients(patients);
+//        currentSession().saveOrUpdate(provider);
+//        persist(provider);
     }
 
     @Override

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
@@ -68,7 +68,6 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> implements Attribut
         final ProviderEntity provider = ProviderEntity.fromFHIR(practitioner);
 
         // Get the patients and create the attribution
-
         attributionBundle
                 .getEntry()
                 .stream()
@@ -78,10 +77,6 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> implements Attribut
                 .map(patient -> PatientEntity.fromFHIR((Patient) patient))
                 .map((pEntity) -> new AttributionRelationship(provider, pEntity))
                 .forEach(this.rDAO::addAttributionRelationship);
-
-//        provider.setAttributedPatients(patients);
-//        currentSession().saveOrUpdate(provider);
-//        persist(provider);
     }
 
     @Override

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderRecordUpserter.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderRecordUpserter.java
@@ -1,0 +1,35 @@
+package gov.cms.dpc.attribution.jdbi;
+
+import gov.cms.dpc.attribution.dao.tables.records.ProvidersRecord;
+import org.jooq.DSLContext;
+import org.jooq.TableField;
+
+import java.util.Collections;
+import java.util.List;
+
+import static gov.cms.dpc.attribution.dao.tables.Providers.PROVIDERS;
+
+/**
+ * Implementation of {@link AbstractRecordUpserter}, specialized for {@link ProvidersRecord}
+ */
+public class ProviderRecordUpserter extends AbstractRecordUpserter<ProvidersRecord> {
+
+    public ProviderRecordUpserter(DSLContext ctx, ProvidersRecord record) {
+        super(ctx, record);
+    }
+
+    @Override
+    List<TableField<ProvidersRecord, ?>> getConflictFields() {
+        return Collections.singletonList(PROVIDERS.PROVIDER_ID);
+    }
+
+    @Override
+    List<TableField<ProvidersRecord, ?>> getExcludedFields() {
+        return Collections.singletonList(PROVIDERS.ID);
+    }
+
+    @Override
+    List<TableField<ProvidersRecord, ?>> getReturnFields() {
+        return Collections.singletonList(PROVIDERS.ID);
+    }
+}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
@@ -53,6 +53,10 @@ public class RelationshipDAO extends AbstractDAO<AttributionRelationship> {
         return relationship;
     }
 
+    public void addAttributionRelationship(AttributionRelationship relationship) {
+        persist(relationship);
+    }
+
     /**
      * Remove the given attribution relationship
      *

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
@@ -1,6 +1,5 @@
 package gov.cms.dpc.attribution.jdbi;
 
-import gov.cms.dpc.attribution.AttributionException;
 import gov.cms.dpc.attribution.dao.tables.records.AttributionsRecord;
 import gov.cms.dpc.attribution.dao.tables.records.PatientsRecord;
 import gov.cms.dpc.attribution.dao.tables.records.ProvidersRecord;

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
@@ -1,0 +1,142 @@
+package gov.cms.dpc.attribution.jdbi;
+
+import gov.cms.dpc.attribution.dao.tables.records.AttributionsRecord;
+import gov.cms.dpc.attribution.dao.tables.records.PatientsRecord;
+import gov.cms.dpc.attribution.dao.tables.records.ProvidersRecord;
+import gov.cms.dpc.common.entities.PatientEntity;
+import gov.cms.dpc.common.entities.ProviderEntity;
+import gov.cms.dpc.common.interfaces.AttributionEngine;
+import gov.cms.dpc.fhir.FHIRExtractors;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Practitioner;
+import org.hl7.fhir.dstu3.model.ResourceType;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+
+import javax.inject.Inject;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static gov.cms.dpc.attribution.dao.tables.Attributions.ATTRIBUTIONS;
+import static gov.cms.dpc.attribution.dao.tables.Patients.PATIENTS;
+import static gov.cms.dpc.attribution.dao.tables.Providers.PROVIDERS;
+
+public class RosterEngine implements AttributionEngine {
+
+    private final DSLContext context;
+
+    @Inject
+    RosterEngine(DSLContext context) {
+        this.context = context;
+    }
+
+
+    @Override
+    public Optional<List<String>> getAttributedPatientIDs(Practitioner provider) {
+
+        try {
+            return Optional.of(context.select()
+                    .from(PROVIDERS)
+                    .join(ATTRIBUTIONS).on(ATTRIBUTIONS.PROVIDER_ID.eq(PROVIDERS.ID))
+                    .join(PATIENTS).on((ATTRIBUTIONS.PATIENT_ID).eq(PATIENTS.ID))
+                    .where(PROVIDERS.PROVIDER_ID.eq(FHIRExtractors.getProviderNPI(provider)))
+                    .fetch().getValues(PATIENTS.BENEFICIARY_ID));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void addAttributionRelationship(Practitioner provider, Patient patient) {
+
+        context.transaction(config -> {
+
+            final DSLContext ctx = DSL.using(config);
+
+
+            final PatientsRecord patientRecord = ctx.newRecord(PATIENTS, patient);
+            final ProvidersRecord providerRecord = ctx.newRecord(PROVIDERS, provider);
+            ctx.executeInsert(patientRecord);
+            ctx.executeInsert(providerRecord);
+
+            // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
+            final AttributionsRecord attr = new AttributionsRecord();
+            attr.setProviderId(providerRecord.getId());
+            attr.setPatientId(patientRecord.getId());
+            attr.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
+
+            ctx.executeInsert(attr);
+        });
+    }
+
+    @Override
+    public void addAttributionRelationships(Bundle attributionBundle) {
+        context.transaction(config -> {
+
+            final DSLContext ctx = DSL.using(config);
+
+            final Timestamp creationTimestamp = Timestamp.from(Instant.now());
+            // Insert the provider , patients, and the attribution relationships
+            final Practitioner provider = (Practitioner) attributionBundle.getEntryFirstRep().getResource();
+
+            final ProviderEntity providerEntity = ProviderEntity.fromFHIR(provider);
+            providerEntity.setProviderID(UUID.randomUUID());
+
+//            logger.info("Adding provider {}", providerEntity.getProviderNPI());
+
+            final ProvidersRecord pr = ctx.newRecord(PROVIDERS, providerEntity);
+            pr.setId(UUID.randomUUID());
+            ctx.executeInsert(pr);
+
+            attributionBundle
+                    .getEntry()
+                    .stream()
+                    .map(Bundle.BundleEntryComponent::getResource)
+                    .filter((resource -> resource.getResourceType() == ResourceType.Patient))
+                    .map(patient -> PatientEntity.fromFHIR((Patient) patient))
+                    .forEach(patientEntity -> {
+                        // Create a new record from the patient entity
+                        patientEntity.setPatientID(UUID.randomUUID());
+                        final PatientsRecord patient = ctx.newRecord(PATIENTS, patientEntity);
+                        patient.setId(UUID.randomUUID());
+                        ctx.executeInsert(patient);
+
+                        // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
+                        final AttributionsRecord attr = new AttributionsRecord();
+                        attr.setProviderId(pr.getId());
+                        attr.setPatientId(patient.getId());
+                        attr.setCreatedAt(creationTimestamp);
+                        ctx.executeInsert(attr);
+                    });
+        });
+    }
+
+    @Override
+    public void removeAttributionRelationship(Practitioner provider, Patient patient) {
+        // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
+        final AttributionsRecord attr = new AttributionsRecord();
+        attr.setProviderId(UUID.fromString(FHIRExtractors.getProviderNPI(provider)));
+        attr.setPatientId(UUID.fromString(FHIRExtractors.getPatientMPI(patient)));
+        attr.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
+
+        context.executeInsert(attr);
+    }
+
+    @Override
+    public boolean isAttributed(Practitioner provider, Patient patient) {
+//        return true;
+        return context.fetchExists(context.selectOne()
+                .from(ATTRIBUTIONS)
+                .join(PATIENTS).on(PATIENTS.ID.eq(ATTRIBUTIONS.PATIENT_ID))
+                .join(PROVIDERS).on(PROVIDERS.ID.eq(ATTRIBUTIONS.PROVIDER_ID))
+                .where(PATIENTS.BENEFICIARY_ID
+                        .eq(FHIRExtractors.getPatientMPI(patient))
+                        .and(PROVIDERS.PROVIDER_ID
+                                .eq(FHIRExtractors.getProviderNPI(provider)))));
+    }
+}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
@@ -119,12 +119,9 @@ public class RosterEngine implements AttributionEngine {
             final AttributionsRecord attributionsRecord = attributionsRecords.get(0);
 
             // Remove all the records
-            int removed = 0;
-            removed += ctx.deleteFrom(ATTRIBUTIONS).where(ATTRIBUTIONS.ID.eq(attributionsRecord.getId())).execute();
-            removed += ctx.deleteFrom(PATIENTS).where(PATIENTS.ID.eq(attributionsRecord.getPatientId())).execute();
-            removed += ctx.deleteFrom(PROVIDERS).where(PROVIDERS.ID.eq(attributionsRecord.getPatientId())).execute();
+            final int removed = ctx.deleteFrom(ATTRIBUTIONS).where(ATTRIBUTIONS.ID.eq(attributionsRecord.getId())).execute();
 
-            if (removed != 3) {
+            if (removed != 1) {
                 throw new IllegalStateException("Failure removing attribution relationship. Row leftover");
             }
         });
@@ -132,7 +129,6 @@ public class RosterEngine implements AttributionEngine {
 
     @Override
     public boolean isAttributed(Practitioner provider, Patient patient) {
-//        return true;
         return context.fetchExists(context.selectOne()
                 .from(ATTRIBUTIONS)
                 .join(PATIENTS).on(PATIENTS.ID.eq(ATTRIBUTIONS.PATIENT_ID))

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
@@ -15,9 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -73,7 +71,7 @@ public class RosterEngine implements AttributionEngine {
             final AttributionsRecord attr = new AttributionsRecord();
             attr.setProviderId(providerRecord.getId());
             attr.setPatientId(patientRecord.getId());
-            attr.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
+            attr.setCreatedAt(OffsetDateTime.now());
 
             final int updated = ctx.executeInsert(attr);
             if (updated != 1) {
@@ -87,8 +85,7 @@ public class RosterEngine implements AttributionEngine {
         context.transaction(config -> {
 
             final DSLContext ctx = DSL.using(config);
-            final Timestamp creationTimestamp = Timestamp.from(Instant.now());
-            RosterUtils.handleAttributionBundle(attributionBundle, ctx, creationTimestamp);
+            RosterUtils.submitAttributionBundle(attributionBundle, ctx, OffsetDateTime.now());
         });
     }
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
@@ -112,7 +112,7 @@ public class RosterEngine implements AttributionEngine {
                     .fetchInto(ATTRIBUTIONS);
 
             if (attributionsRecords.isEmpty()) {
-                logger.warn("Cannot find attribution relationship between {} and {}.");
+                logger.warn("Cannot find attribution relationship between {} and {}.", providerNPI, patientMPI);
             }
 
             // Just get the first one, because we know they're unique

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
@@ -45,7 +45,9 @@ public class RosterUtils {
         }
 
         logger.debug("Adding provider {}", providerEntity.getProviderNPI());
-        final ProvidersRecord providerRecord = new ProviderRecordUpserter(ctx, ctx.newRecord(PROVIDERS, providerEntity)).upsert();
+        final ProvidersRecord providerRecord = ctx.newRecord(PROVIDERS, providerEntity);
+        // Upsert the record and get the new ID
+        providerRecord.setId(new ProviderRecordUpserter(ctx, providerRecord).upsert().getId());
 
         attributionBundle
                 .getEntry()
@@ -64,7 +66,7 @@ public class RosterUtils {
         final PatientRecordUpserter patientRecordUpserter = new PatientRecordUpserter(ctx, ctx.newRecord(PATIENTS, patientEntity));
         final PatientsRecord patient = patientRecordUpserter.upsert();
 
-        logger.debug("Attribution patient {} to provider {}.", patient.getBeneficiaryId(), providerRecord.getProviderId());
+        logger.debug("Attributing patient {} to provider {}.", patientEntity.getBeneficiaryID(), providerRecord.getProviderId());
 
         // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
         final AttributionsRecord attr = new AttributionsRecord();

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Timestamp;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import static gov.cms.dpc.attribution.dao.tables.Patients.PATIENTS;
@@ -29,12 +30,13 @@ public class RosterUtils {
 
     /**
      * Helper method for adding a roster {@link Bundle} to the RDBMS backend
+     * When submitting the bundle, the values in the provided {@link Bundle} are merged with any existing values in the database.
      *
      * @param attributionBundle - Roster {@link Bundle} to add/update
      * @param ctx               - {@link DSLContext} DB context to utilize
      * @param creationTimestamp - {@link Timestamp} of when the attribution relationships were updated
      */
-    public static void handleAttributionBundle(Bundle attributionBundle, DSLContext ctx, Timestamp creationTimestamp) {
+    public static void submitAttributionBundle(Bundle attributionBundle, DSLContext ctx, OffsetDateTime creationTimestamp) {
 
         // Insert the provider, patient, and attribution relationships
         final Practitioner provider = (Practitioner) attributionBundle.getEntryFirstRep().getResource();
@@ -58,7 +60,7 @@ public class RosterUtils {
                 .forEach(patientEntity -> RosterUtils.createUpdateAttributionRelationship(ctx, patientEntity, providerRecord, creationTimestamp));
     }
 
-    private static void createUpdateAttributionRelationship(DSLContext ctx, PatientEntity patientEntity, ProvidersRecord providerRecord, Timestamp creationTimestamp) {
+    private static void createUpdateAttributionRelationship(DSLContext ctx, PatientEntity patientEntity, ProvidersRecord providerRecord, OffsetDateTime creationTimestamp) {
         // Create a new record from the patient entity
         if (patientEntity.getPatientID() == null) {
             patientEntity.setPatientID(UUID.randomUUID());

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
@@ -23,6 +23,10 @@ public class RosterUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(RosterUtils.class);
 
+    private RosterUtils() {
+        // Not used
+    }
+
     /**
      * Helper method for adding a roster {@link Bundle} to the RDBMS backend
      *

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
@@ -1,0 +1,65 @@
+package gov.cms.dpc.attribution.jdbi;
+
+import gov.cms.dpc.attribution.dao.tables.records.AttributionsRecord;
+import gov.cms.dpc.attribution.dao.tables.records.PatientsRecord;
+import gov.cms.dpc.attribution.dao.tables.records.ProvidersRecord;
+import gov.cms.dpc.common.entities.PatientEntity;
+import gov.cms.dpc.common.entities.ProviderEntity;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Practitioner;
+import org.hl7.fhir.dstu3.model.ResourceType;
+import org.jooq.DSLContext;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+import static gov.cms.dpc.attribution.dao.tables.Patients.PATIENTS;
+import static gov.cms.dpc.attribution.dao.tables.Providers.PROVIDERS;
+
+public class RosterUtils {
+
+    /**
+     * Helper method for adding a roster {@link Bundle} to the RDBMS backend
+     *
+     * @param attributionBundle - Roster {@link Bundle} to add/update
+     * @param ctx               - {@link DSLContext} DB context to utilize
+     * @param creationTimestamp - {@link Timestamp} of when the attribution relationships were updated
+     */
+    public static void handleAttributionBundle(Bundle attributionBundle, DSLContext ctx, Timestamp creationTimestamp) {
+
+        // Insert the provider , patients, and the attribution relationships
+        final Practitioner provider = (Practitioner) attributionBundle.getEntryFirstRep().getResource();
+
+        final ProviderEntity providerEntity = ProviderEntity.fromFHIR(provider);
+        providerEntity.setProviderID(UUID.randomUUID());
+
+//            logger.info("Adding provider {}", providerEntity.getProviderNPI());
+
+        final ProvidersRecord providerRecord = ctx.newRecord(PROVIDERS, providerEntity);
+        providerRecord.setId(UUID.randomUUID());
+        new ProviderRecordUpserter(ctx, providerRecord).upsert();
+
+        attributionBundle
+                .getEntry()
+                .stream()
+                .map(Bundle.BundleEntryComponent::getResource)
+                .filter((resource -> resource.getResourceType() == ResourceType.Patient))
+                .map(patient -> PatientEntity.fromFHIR((Patient) patient))
+                .forEach(patientEntity -> RosterUtils.createUpdateAttributionRelationship(ctx, patientEntity, providerRecord, creationTimestamp));
+    }
+
+    private static void createUpdateAttributionRelationship(DSLContext ctx, PatientEntity patientEntity, ProvidersRecord providerRecord, Timestamp creationTimestamp) {
+        // Create a new record from the patient entity
+        patientEntity.setPatientID(UUID.randomUUID());
+        final PatientRecordUpserter patientRecordUpserter = new PatientRecordUpserter(ctx, ctx.newRecord(PATIENTS, patientEntity));
+        final PatientsRecord patient = patientRecordUpserter.upsert();
+
+        // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
+        final AttributionsRecord attr = new AttributionsRecord();
+        attr.setProviderId(providerRecord.getId());
+        attr.setPatientId(patient.getId());
+        attr.setCreatedAt(creationTimestamp);
+        ctx.executeInsert(attr);
+    }
+}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jobs/ExpireAttributions.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jobs/ExpireAttributions.java
@@ -12,7 +12,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -49,7 +48,7 @@ public class ExpireAttributions extends Job {
         try {
             final int removed = context
                     .delete(Attributions.ATTRIBUTIONS)
-                    .where(Attributions.ATTRIBUTIONS.CREATED_AT.le(Timestamp.from(this.expirationTemporal.toInstant())))
+                    .where(Attributions.ATTRIBUTIONS.CREATED_AT.le(this.expirationTemporal))
                     .execute();
             logger.debug("Expired {} attribution relationships.", removed);
         } finally {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractGroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractGroupResource.java
@@ -8,7 +8,6 @@ import javax.ws.rs.core.Response;
 import java.util.List;
 
 @Path("/Group")
-@FHIR
 public abstract class AbstractGroupResource {
 
     protected AbstractGroupResource() {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -4,7 +4,6 @@ import gov.cms.dpc.attribution.resources.AbstractGroupResource;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
 import gov.cms.dpc.fhir.FHIRBuilders;
 import gov.cms.dpc.fhir.annotations.FHIR;
-import io.dropwizard.hibernate.UnitOfWork;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.slf4j.Logger;
@@ -29,7 +28,6 @@ public class GroupResource extends AbstractGroupResource {
 
     @POST
     @FHIR
-    @UnitOfWork
     public Response submitRoster(Bundle providerBundle) {
         logger.debug("API request to submit roster");
         this.engine.addAttributionRelationships(providerBundle);
@@ -40,7 +38,6 @@ public class GroupResource extends AbstractGroupResource {
     @Path("/{groupID}")
     @GET
     @Override
-    @UnitOfWork
     public List<String> getAttributedPatients(@PathParam("groupID") String groupID) {
         logger.debug("API request to retrieve attributed patients for {}", groupID);
 
@@ -61,7 +58,6 @@ public class GroupResource extends AbstractGroupResource {
 
     @Path("/{groupID}/{patientID}")
     @GET
-    @UnitOfWork
     @Override
     public boolean isAttributed(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to determine attribution between {} and {}", groupID, patientID);
@@ -76,7 +72,6 @@ public class GroupResource extends AbstractGroupResource {
 
     @Path("/{groupID}/{patientID}")
     @PUT
-    @UnitOfWork
     @Override
     public void attributePatient(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to add attribution between {} and {}", groupID, patientID);
@@ -91,7 +86,6 @@ public class GroupResource extends AbstractGroupResource {
     }
 
     @Path("/{groupID}/{patientID}")
-    @UnitOfWork
     @Override
     @DELETE
     public void removeAttribution(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -43,12 +43,19 @@ public class GroupResource extends AbstractGroupResource {
     @UnitOfWork
     public List<String> getAttributedPatients(@PathParam("groupID") String groupID) {
         logger.debug("API request to retrieve attributed patients for {}", groupID);
-        // Create a practitioner resource for retrieval
-        final Optional<List<String>> attributedBeneficiaries = engine.getAttributedPatientIDs(FHIRBuilders.buildPractitionerFromNPI(groupID));
+        
+        Optional<List<String>> attributedBeneficiaries;
+        try {
+            // Create a practitioner resource for retrieval
+            attributedBeneficiaries = engine.getAttributedPatientIDs(FHIRBuilders.buildPractitionerFromNPI(groupID));
+        } catch (Exception e) {
+            logger.error("Cannot get attributed patients for {}", groupID, e);
+            throw new WebApplicationException(String.format("Unable to retrieve attributed patients for: %s", groupID), Response.Status.INTERNAL_SERVER_ERROR);
+        }
+
         if (attributedBeneficiaries.isEmpty()) {
             throw new WebApplicationException(String.format("Unable to find provider: %s", groupID), Response.Status.NOT_FOUND);
         }
-
         return attributedBeneficiaries.get();
     }
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -43,7 +43,7 @@ public class GroupResource extends AbstractGroupResource {
     @UnitOfWork
     public List<String> getAttributedPatients(@PathParam("groupID") String groupID) {
         logger.debug("API request to retrieve attributed patients for {}", groupID);
-        
+
         Optional<List<String>> attributedBeneficiaries;
         try {
             // Create a practitioner resource for retrieval

--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -33,7 +33,7 @@
         <createIndex tableName="PROVIDERS" indexName="providers_id_idx">
             <column name="provider_id"/>
         </createIndex>
-        
+
         <createTable tableName="PATIENTS">
             <column name="id" type="UUID">
                 <constraints primaryKey="true" nullable="false"/>
@@ -52,7 +52,7 @@
             <column name="beneficiary_id"/>
         </createIndex>
     </changeSet>
-    
+
     <changeSet id="add-attribution-fk" author="nickrobison-usds">
         <addForeignKeyConstraint
                 baseTableName="ATTRIBUTIONS"
@@ -67,6 +67,11 @@
                 constraintName="fk_attribution_patients"
                 referencedTableName="PATIENTS"
                 referencedColumnNames="id"/>
+    </changeSet>
+
+    <changeSet id="add-unique-constraints" author="nickrobison-usds">
+        <addUniqueConstraint tableName="providers" columnNames="provider_id"/>
+        <addUniqueConstraint tableName="patients" columnNames="beneficiary_id"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -74,4 +74,8 @@
         <addUniqueConstraint tableName="patients" columnNames="beneficiary_id"/>
     </changeSet>
 
+    <changeSet id="migrate-to-timezone" author="nickrobison-usds">
+        <modifyDataType tableName="attributions" columnName="created_at" newDataType="TIMESTAMP WITH TIME ZONE"/>
+    </changeSet>
+
 </databaseChangeLog>

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
@@ -21,7 +21,6 @@ import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.jupiter.api.*;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
@@ -122,37 +121,37 @@ public class AttributionFHIRTest {
                 assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
             }
 
-//            // Add an additional patient
-//            // Create a new bundle with extra patients to attribute
-//            final String newPatientID = "test-new-patient-id";
-//            final Bundle updateBundle = createAttributionBundle(providerID, newPatientID);
-//
-//            // Submit the bundle
-//            final HttpPost submitUpdate = new HttpPost("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group");
-//            submitUpdate.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
-//            submitUpdate.setEntity(new StringEntity(ctx.newJsonParser().encodeResourceToString(updateBundle)));
-//
-//            try (CloseableHttpResponse response = client.execute(submitUpdate)) {
-//                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have succeeded");
-//            }
-//
-//            // Check how many are attributed
-//
-//            try (CloseableHttpResponse response = client.execute(getPatients)) {
-//                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
-//                final List<String> patients = mapper.readValue(EntityUtils.toString(response.getEntity()), new TypeReference<List<String>>() {
-//                });
-//                // Since the practitioner is not
-//                assertEquals(bundle.getEntry().size(), patients.size(), "Should have an additional patient");
-//            }
-//
-//            // Check that a specific patient is attributed
-//            final HttpGet updatedAttributed = new HttpGet(String.format("http://localhost:%d/v1/Group/%s/%s", APPLICATION.getLocalPort(), providerID, newPatientID));
-//            updatedAttributed.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
-//
-//            try (CloseableHttpResponse response = client.execute(updatedAttributed)) {
-//                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
-//            }
+            // Add an additional patient
+            // Create a new bundle with extra patients to attribute
+            final String newPatientID = "test-new-patient-id";
+            final Bundle updateBundle = createAttributionBundle(providerID, newPatientID);
+
+            // Submit the bundle
+            final HttpPost submitUpdate = new HttpPost("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group");
+            submitUpdate.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
+            submitUpdate.setEntity(new StringEntity(ctx.newJsonParser().encodeResourceToString(updateBundle)));
+
+            try (CloseableHttpResponse response = client.execute(submitUpdate)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have succeeded");
+            }
+
+            // Check how many are attributed
+
+            try (CloseableHttpResponse response = client.execute(getPatients)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
+                final List<String> patients = mapper.readValue(EntityUtils.toString(response.getEntity()), new TypeReference<List<String>>() {
+                });
+                // Since the practitioner is not
+                assertEquals(bundle.getEntry().size(), patients.size(), "Should have an additional patient");
+            }
+
+            // Check that a specific patient is attributed
+            final HttpGet updatedAttributed = new HttpGet(String.format("http://localhost:%d/v1/Group/%s/%s", APPLICATION.getLocalPort(), providerID, newPatientID));
+            updatedAttributed.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
+
+            try (CloseableHttpResponse response = client.execute(updatedAttributed)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
+            }
 
 
 //             Remove the patient and try again

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
@@ -19,7 +19,10 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.Practitioner;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 import java.io.InputStream;
 import java.util.HashMap;
@@ -58,12 +61,8 @@ public class AttributionFHIRTest {
         groupedPairs = seedProcessor.extractProviderMap();
     }
 
-    @BeforeEach
-    public void initDB() throws Exception {
-    }
-
     @AfterAll
-    public static void shutdown() throws Exception {
+    public static void shutdown() {
         APPLICATION.after();
     }
 
@@ -82,9 +81,6 @@ public class AttributionFHIRTest {
     }
 
     private void submitRoster(Bundle bundle) throws Exception {
-
-        // Manually call lifecycle hooks
-        initDB();
 
         final String providerID = ((Practitioner) bundle.getEntryFirstRep().getResource()).getIdentifierFirstRep().getValue();
         final String patientID = ((Patient) bundle.getEntry().get(1).getResource()).getIdentifierFirstRep().getValue();
@@ -109,7 +105,6 @@ public class AttributionFHIRTest {
                 assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
                 List<String> beneies = mapper.readValue(EntityUtils.toString(response.getEntity()), new TypeReference<List<String>>() {
                 });
-                // Since the practitioner is not
                 assertEquals(bundle.getEntry().size() - 1, beneies.size(), "Should have the same number of beneies");
             }
 
@@ -152,9 +147,6 @@ public class AttributionFHIRTest {
             try (CloseableHttpResponse response = client.execute(updatedAttributed)) {
                 assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
             }
-
-
-//             Remove the patient and try again
         }
     }
 

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/SharedMethods.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/SharedMethods.java
@@ -2,8 +2,14 @@ package gov.cms.dpc.attribution;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpEntity;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Practitioner;
 
 import java.io.IOException;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
 
 public class SharedMethods {
@@ -13,5 +19,29 @@ public class SharedMethods {
         final ObjectMapper mapper = new ObjectMapper();
 
         return (List<T>) mapper.readValue(entity.getContent(), List.class);
+    }
+
+    public static Bundle createAttributionBundle(String providerID, String patientID) {
+        final Bundle bundle = new Bundle();
+        bundle.setId(new IdType("Roster", "bundle-update"));
+        bundle.setType(Bundle.BundleType.COLLECTION);
+
+        // Create the provider with the necessary fields
+        final Practitioner practitioner = new Practitioner();
+        practitioner.addIdentifier().setValue(providerID);
+        practitioner.addName().addGiven("Test").setFamily("Provider");
+        bundle.addEntry().setResource(practitioner).setFullUrl("http://something.gov/" + practitioner.getIdentifierFirstRep().getValue());
+
+        // Add some random values to the patient
+        final Patient patient = new Patient();
+        patient.addIdentifier().setValue(patientID);
+        patient.addName().addGiven("New Test Patient");
+        patient.setBirthDate(new GregorianCalendar(2019, Calendar.MARCH, 1).getTime());
+        final Bundle.BundleEntryComponent component = new Bundle.BundleEntryComponent();
+        component.setResource(patient);
+        component.setFullUrl("http://something.gov/" + patient.getIdentifierFirstRep().getValue());
+        bundle.addEntry(component);
+
+        return bundle;
     }
 }

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
@@ -11,6 +11,10 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.eclipse.jetty.http.HttpStatus;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +25,10 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.UUID;
 
 import static gov.cms.dpc.attribution.SharedMethods.UnmarshallResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class ExpirationJobTest {
 
     private static final DropwizardTestSupport<DPCAttributionConfiguration> APPLICATION = new DropwizardTestSupport<>(DPCAttributionService.class, null, ConfigOverride.config("server.applicationConnectors[0].port", "3727"));
+    private static final String PROVIDER_ID = "0c527d2e-2e8a-4808-b11d-0fa06baf8254";
     private Client client;
 
     @BeforeEach
@@ -55,6 +63,7 @@ class ExpirationJobTest {
 
     @Test
     void test() throws IOException, InterruptedException {
+
         this.startJob(this.client, "ExpireAttributions");
 
         this.stopJob(this.client, "ExpireAttributions");
@@ -65,7 +74,7 @@ class ExpirationJobTest {
         // Check how many are left
         try (final CloseableHttpClient client = HttpClients.createDefault()) {
 
-            final HttpGet httpGet = new HttpGet("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group/0c527d2e-2e8a-4808-b11d-0fa06baf8254");
+            final HttpGet httpGet = new HttpGet("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group/" + PROVIDER_ID);
             httpGet.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
 
             try (final CloseableHttpResponse response = client.execute(httpGet)) {

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
@@ -49,8 +49,7 @@ class ExpirationJobTest {
         APPLICATION.before();
         APPLICATION.getApplication().run("db", "migrate");
         // Seed the database, but use a really early time
-        APPLICATION.getApplication().run("seed", "-t 2015-01-01 12:12:12");
-        // TODO: Add additional attributions created after the expiration threshold (DPC-186)
+        APPLICATION.getApplication().run("seed", "-t 2015-01-01T12:12:12Z");
 
         this.client = new JerseyClientBuilder(APPLICATION.getEnvironment()).build("test");
     }

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.jobs;
 
+import ca.uhn.fhir.context.FhirContext;
 import gov.cms.dpc.attribution.DPCAttributionConfiguration;
 import gov.cms.dpc.attribution.DPCAttributionService;
 import gov.cms.dpc.fhir.FHIRMediaTypes;
@@ -8,13 +9,12 @@ import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.IdType;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,12 +25,10 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.UUID;
 
 import static gov.cms.dpc.attribution.SharedMethods.UnmarshallResponse;
+import static gov.cms.dpc.attribution.SharedMethods.createAttributionBundle;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -42,6 +40,7 @@ class ExpirationJobTest {
 
     private static final DropwizardTestSupport<DPCAttributionConfiguration> APPLICATION = new DropwizardTestSupport<>(DPCAttributionService.class, null, ConfigOverride.config("server.applicationConnectors[0].port", "3727"));
     private static final String PROVIDER_ID = "0c527d2e-2e8a-4808-b11d-0fa06baf8254";
+    private static final FhirContext ctx = FhirContext.forDstu3();
     private Client client;
 
     @BeforeEach
@@ -64,6 +63,22 @@ class ExpirationJobTest {
     @Test
     void test() throws IOException, InterruptedException {
 
+        // Manually add a new relationship with a current creation timestamp
+        final String newPatientID = "test-new-patient-id";
+        final Bundle updateBundle = createAttributionBundle(PROVIDER_ID, newPatientID);
+
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+
+            // Submit the bundle
+            final HttpPost submitUpdate = new HttpPost("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group");
+            submitUpdate.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
+            submitUpdate.setEntity(new StringEntity(ctx.newJsonParser().encodeResourceToString(updateBundle)));
+
+            try (CloseableHttpResponse response = client.execute(submitUpdate)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have succeeded");
+            }
+        }
+
         this.startJob(this.client, "ExpireAttributions");
 
         this.stopJob(this.client, "ExpireAttributions");
@@ -80,7 +95,7 @@ class ExpirationJobTest {
             try (final CloseableHttpResponse response = client.execute(httpGet)) {
                 assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have succeeded");
                 List<String> beneficiaries = UnmarshallResponse(response.getEntity());
-                assertEquals(0, beneficiaries.size(), "Should have no beneficiaries");
+                assertEquals(1, beneficiaries.size(), "Should have only have a single relationship");
             }
         }
     }

--- a/dpc-attribution/src/test/resources/application.conf
+++ b/dpc-attribution/src/test/resources/application.conf
@@ -1,8 +1,0 @@
-dpc.attribution {
-  logging {
-    loggers {
-      "gov.cms.dpc" = INFO
-      "org.hibernate" = TRACE
-    }
-  }
-}

--- a/dpc-attribution/src/test/resources/application.conf
+++ b/dpc-attribution/src/test/resources/application.conf
@@ -1,0 +1,8 @@
+dpc.attribution {
+  logging {
+    loggers {
+      "gov.cms.dpc" = INFO
+      "org.hibernate" = TRACE
+    }
+  }
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
@@ -15,6 +15,9 @@ import java.util.Objects;
                 "inner join patients as pat on a.patient = pat.patientID " +
                 "where prov.providerNPI = :provID and pat.beneficiaryID = :patID")
 })
+@Table(name = "attributions",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"patient_id", "provider_id"})}
+)
 public class AttributionRelationship {
 
     @Id

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
@@ -22,7 +22,7 @@ public class AttributionRelationship {
     @Column(name = "id", updatable = false, nullable = false)
     private Long attributionID;
 
-    @ManyToOne(cascade = CascadeType.PERSIST)
+    @ManyToOne(cascade = CascadeType.MERGE)
     private ProviderEntity provider;
 
     @ManyToOne(cascade = CascadeType.PERSIST)

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
@@ -31,7 +31,7 @@ public class AttributionRelationship {
     @ManyToOne(cascade = CascadeType.PERSIST)
     private PatientEntity patient;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
     @CreationTimestamp
     private OffsetDateTime created;
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
@@ -21,7 +21,7 @@ public class PatientEntity {
     private UUID patientID;
 
     @NotEmpty
-    @Column(name = "beneficiary_id")
+    @Column(name = "beneficiary_id", unique = true)
     private String beneficiaryID;
 
     @Column(name = "first_name")

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
@@ -25,7 +25,7 @@ public class ProviderEntity {
     @Column(name = "id", updatable = false, nullable = false, columnDefinition = "uuid")
     private UUID providerID;
 
-    @Column(name = "provider_id")
+    @Column(name = "provider_id", unique = true)
     private String providerNPI;
     @Column(name = "first_name")
     private String providerFirstName;

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.common.entities;
 
 import gov.cms.dpc.fhir.FHIRExtractors;
+import org.hibernate.annotations.SQLInsert;
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.Practitioner;
 
@@ -10,10 +11,13 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Entity(name = "providers")
-@NamedQueries({
+@NamedQueries(value = {
         @NamedQuery(name = "getProvider", query = "select 1 from providers a where a.providerNPI = :provID"),
         @NamedQuery(name = "findByProvider", query = "from providers a where a.providerNPI = :id")
 })
+@SQLInsert(sql = "INSERT INTO providers(first_name, last_name, provider_id, id) VALUES(?, ?, ?, ?)" +
+        " ON CONFLICT (provider_id) DO UPDATE SET last_name = EXCLUDED.last_name," +
+        " first_name = EXCLUDED.first_name")
 public class ProviderEntity {
 
     @Id

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
@@ -5,6 +5,8 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
+import io.dropwizard.db.ManagedDataSource;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 
@@ -34,6 +36,13 @@ public class DPCHibernateModule<T extends Configuration & IDPCDatabase> extends 
             throw new IllegalStateException(e);
         }
         return hibernate.getSessionFactory();
+    }
+
+    @Provides
+    @Singleton
+    ManagedDataSource provideDataSource() {
+        final DataSourceFactory factory = getConfiguration().getDatabase();
+        return factory.build(getEnvironment().metrics(), "tested-things");
     }
 
     @Provides

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,10 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <!--Exclude generated sources, such as Jooq-->
+                            <excludePackageNames>gov.cms.dpc.attribution.dao</excludePackageNames>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
**Why**

This PR adds the ability for vendors to add/remove attribution relationships to their existing rosters. Duplicate records are handled using an *upsert* methodology, where new records are inserted as they are, conflicting records are merged using a user defined function.

**What changed**

The external API did not change much at all. No additional endpoints were created. The majority of the changes are internal, with largest being that I replaced the existing Roster logic (which was using Hibernate) to an alternative implementation using JOOQ. This allows for a much cleaner implementation and type-safe SQL, which is generated from the Hibernate entities.
This also adds logic for merging new data into existing records, in order to do this, I've created an `AbstractRecordUpserter` class that allows specializations for specific record types (e.g. Patients, Providers, etc). It mainly allows you to specify which columns to *exclude* for updating.

**Choices Made**
Moved away from Hibernate because it's not really designed to support the more complex querying that we need to do. It was also proving to be really brittle when trying to retrieve related entities from different projections. JOOQ makes it much cleaner and simpler. Hibernate still has value so we won't entirely get rid of it, but it definitely has query limitations.

**Testing Done**
 - Attribution Service integration tests have been expanded to test roster updating
- Manually verified that relationships are indeed updated.
- Updated expiration test to add a new attribution relationship and ensure it gets left around

**Future work**
- Operations are wrapped within atomic transactions but each operation is executed as a separate SQL statement. This may cause an issue with large attribution lists, in the future we may want to look into SQL batch operations to reduce the size of the transaction log.
- We should add the ability to retrieve rosters and individual patient/provider records. At the very least, this will help with debugging/administration but my be useful to expose externally.

**Tickets closed**
- DPC-23: Ticket for this PR
- DPC-170: We now handle duplicate relationships and patient/provider records
- DPC-186: Verified that expiration job only expires job older than the cutoff value.