### PR TITLE
DPC-206: Fix failing compilation in endtoend tests

### DIFF
--- a/dpc-api/src/test/java/gov/cms/dpc/api/EndToEndRequestTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/EndToEndRequestTest.java
@@ -82,7 +82,7 @@ public class EndToEndRequestTest extends AbstractApplicationTest {
         assertEquals(1, jobResponse.getOutput().size(), "Should have 1 file");
 
         // Get the first file and download it.
-        final String fileID = jobResponse.getOutput().get(0);
+        final String fileID = jobResponse.getOutput().get(0).getUrl();
         final File tempFile = ClientUtils.fetchExportedFiles(fileID);
 
         // Read the file back in and parse the patients


### PR DESCRIPTION
DPC-110 and DPC-206 had some interactions with each other.
When merging DPC-206, I neglected to re-run the tests against the latest master.
This is a small tweak to get things building and passing again.