### PR TITLE
DPC-216: Fix failing AWS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ before_install:
 
 script:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - mvn test -B -V
   # Format the test results and copy to a new directory
-  - mkdir reports
   - mvn jacoco:report
+  - mkdir reports
   - |
     for module in dpc-aggregation dpc-api dpc-attribution dpc-queue
     do

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ script:
   # Format the test results and copy to a new directory
   - mkdir reports
   - mvn jacoco:report
-    - |
+  - |
     for module in dpc-aggregation dpc-api dpc-attribution dpc-queue
     do
-    JACOCO_SOURCE_PATH=./$module/src/main/java ./cc-test-reporter format-coverage ./$module/target/site/jacoco/jacoco.xml --input-type jacoco -o reports/codeclimate.unit.$module.json
+      JACOCO_SOURCE_PATH=./$module/src/main/java ./cc-test-reporter format-coverage ./$module/target/site/jacoco/jacoco.xml --input-type jacoco -o reports/codeclimate.unit.$module.json
     done
   - ls reports
   - docker-compose down
@@ -42,9 +42,8 @@ script:
   - |
     for module in dpc-aggregation dpc-api dpc-attribution dpc-queue
     do
-        JACOCO_SOURCE_PATH=./$module/src/main/java ./cc-test-reporter format-coverage ./$module/target/site/jacoco/jacoco.xml --input-type jacoco -o reports/codeclimate.integration.$module.json
+      JACOCO_SOURCE_PATH=./$module/src/main/java ./cc-test-reporter format-coverage ./$module/target/site/jacoco/jacoco.xml --input-type jacoco -o reports/codeclimate.integration.$module.json
     done
-
   - ./cc-test-reporter sum-coverage reports/codeclimate.* -o coverage/codeclimate.json
   - ./cc-test-reporter upload-coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_install:
 #before_script:
 #  - psql -c 'create database dpc_attribution;' -U postgres
 
-after_script:
+script:
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
   # Format the test results and copy to a new directory
   - mkdir reports
   - mvn jacoco:report

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "5432:5432"
 
   aggregation:
-    image: dpc-aggregation
+    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc}:dpc-aggregation
     ports:
       - "8088:8081"
     environment:
@@ -28,7 +28,7 @@ services:
       - export-volume:/app/data
 
   attribution:
-    image: dpc-attribution
+    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc}:dpc-attribution
     depends_on:
       - db
     environment:
@@ -38,7 +38,7 @@ services:
       - "9901:9900"
 
   api:
-    image: dpc-api
+    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc}:dpc-api
     ports:
       - "3002:3002"
     environment:

--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -163,7 +163,10 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <to>
-                        <image>${project.artifactId}</image>
+                        <image>${jib.ecr.root}</image>
+                        <tags>
+                            <tag>dpc-aggregation</tag>
+                        </tags>
                     </to>
                     <extraDirectory>
                         <path>${project.basedir}/../bbcerts</path>

--- a/dpc-aggregation/src/main/resources/sbx.application.conf
+++ b/dpc-aggregation/src/main/resources/sbx.application.conf
@@ -1,0 +1,19 @@
+# Override the keystore location to point to correct location when run within docker environment
+dpc.aggregation {
+  database {
+    driverClass = org.postgresql.Driver
+    url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_attribution"
+    user = postgres
+    password = postgres
+    properties = {
+      "hibernate.hbm2ddl.auto" = update
+    }
+  }
+  bbclient.keyStore.location = "/bb.keystore"
+  queue {
+    singleServerConfig {
+      address = "redis://redis.dpc-dev.local:6379"
+    }
+  }
+  exportPath = "/app/data"
+}

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -154,7 +154,10 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <to>
-                        <image>${project.artifactId}</image>
+                        <image>${jib.ecr.root}</image>
+                        <tags>
+                            <tag>dpc-api</tag>
+                        </tags>
                     </to>
                     <container>
                         <args>

--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
@@ -47,12 +47,19 @@ public class DemoCommand extends Command {
                 .type(String.class)
                 .setDefault(ClientUtils.PROVIDER_ID)
                 .help("Execute as a specific provider");
+
+        subparser
+                .addArgument("--host")
+                .dest("hostname")
+                .type(String.class)
+                .setDefault("http://localhost:3002")
+                .help("Set the hostname (including port number) for running the Demo against");
     }
 
     @Override
     public void run(Bootstrap<?> bootstrap, Namespace namespace) throws Exception {
         System.out.println("Running demo!");
-        final String baseURL = "http://localhost:3002/v1/";
+        final String baseURL = buildBaseURL(namespace);
 
         // Make the initial export request
         // If it's a 404, that's fine, for anything else, fail
@@ -63,7 +70,7 @@ public class DemoCommand extends Command {
             System.out.println("Provider is not registered with the system");
         }
 
-        // Sleep for 2 seconds, for presentation reasons
+//         Sleep for 2 seconds, for presentation reasons
         Thread.sleep(2000);
 
         this.uploadBundle(namespace, baseURL);
@@ -75,7 +82,7 @@ public class DemoCommand extends Command {
         final JobCompletionModel jobResponse = monitorExportRequest(exportOperation);
 
         System.out.print("\n\nExport job completed successfully.%n%nAvailable files:%n");
-        jobResponse.getOutput().forEach(System.out::println);
+        jobResponse.getOutput().forEach(entry -> System.out.println(entry.getUrl()));
 
         System.exit(0);
     }
@@ -128,5 +135,9 @@ public class DemoCommand extends Command {
 
     private static String getSeedsFile(Namespace namespace) {
         return namespace.getString("seed-file");
+    }
+
+    private static String buildBaseURL(Namespace namespace) {
+        return "http://" + namespace.getString("hostname") + "/v1/";
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/models/JobCompletionModel.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/models/JobCompletionModel.java
@@ -28,6 +28,10 @@ public class JobCompletionModel {
          */
         private String url;
 
+        public OutputEntry() {
+            // Jackson Required
+        }
+
         public OutputEntry(ResourceType type, String url) {
             this.type = type;
             this.url = url;
@@ -58,6 +62,10 @@ public class JobCompletionModel {
     // FIXME(rickhawes): DPC-205 will fill in this array.
     private final List<String> error = new ArrayList<>();
     private Map<String, Object> encryptionParameters;
+
+    public JobCompletionModel() {
+        // Jackson requireds
+    }
 
     public JobCompletionModel(OffsetDateTime transactionTime, String request, List<OutputEntry> output) {
         this.transactionTime = transactionTime;

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
@@ -9,6 +9,8 @@ import gov.cms.dpc.queue.exceptions.JobQueueFailure;
 import gov.cms.dpc.queue.models.JobModel;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.ResourceType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -24,6 +26,8 @@ import java.util.stream.Collectors;
  * See https://github.com/smart-on-fhir/fhir-bulk-data-docs/blob/master/export.md for details.
  */
 public class JobResource extends AbstractJobResource {
+
+    private static final Logger logger = LoggerFactory.getLogger(JobResource.class);
 
     private final JobQueue queue;
     private final String baseURL;
@@ -43,6 +47,7 @@ public class JobResource extends AbstractJobResource {
 
         // Return a response based on status
         return maybeJob.map(job -> {
+            logger.debug("Fetched Job: {}", job);
             if (!job.isValid()) {
                 throw new JobQueueFailure(jobUUID, "Fetched an invalid job model");
             }

--- a/dpc-api/src/main/resources/sbx.application.conf
+++ b/dpc-api/src/main/resources/sbx.application.conf
@@ -1,0 +1,21 @@
+# Override the keystore location to point to correct location when run within docker environment
+dpc.api {
+  database {
+    driverClass = org.postgresql.Driver
+    url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_attribution"
+    user = postgres
+    password = postgres
+    properties = {
+      "hibernate.hbm2ddl.auto" = update
+    }
+  }
+  bbclient.keyStore.location = "/bb.keystore"
+  queue {
+    singleServerConfig {
+      address = "redis://redis.dpc-dev.local:6379"
+    }
+  }
+
+  attributionURL = "http://backend.dpc-dev.local:8080/v1/"
+  exportPath = "/app/data"
+}

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -145,7 +145,10 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <to>
-                        <image>${project.artifactId}</image>
+                        <image>${jib.ecr.root}</image>
+                        <tags>
+                            <tag>dpc-attribution</tag>
+                        </tags>
                     </to>
                     <container>
                         <args>

--- a/dpc-attribution/src/main/resources/sbx.application.conf
+++ b/dpc-attribution/src/main/resources/sbx.application.conf
@@ -1,0 +1,15 @@
+dpc.attribution {
+  database = {
+    driverClass = org.postgresql.Driver
+    url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_attribution"
+    user = postgres
+    password = postgres
+  }
+
+  server {
+    applicationConnectors = [{
+      type = http
+      port = 8080
+    }]
+  }
+}

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
@@ -11,12 +11,11 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /**
  * Implements a distributed {@link JobQueue} using Redis and Postgres
@@ -24,7 +23,6 @@ import java.util.function.Function;
 public class DistributedQueue implements JobQueue {
 
     private static final Logger logger = LoggerFactory.getLogger(DistributedQueue.class);
-    private static final Double MILLIS_PER_SECOND = 1000.0;
 
     private final Queue<UUID> queue;
     private final Session session;
@@ -37,9 +35,13 @@ public class DistributedQueue implements JobQueue {
 
     @Override
     public void submitJob(UUID jobID, JobModel data) {
-        assert(jobID == data.getJobID() && data.getStatus() == JobStatus.QUEUED);
-        logger.debug("Adding jobID {} to the queue with for provider {}.", jobID, data.getProviderID());
-        data.setSubmitTime(OffsetDateTime.now());
+        assert (jobID == data.getJobID() && data.getStatus() == JobStatus.QUEUED);
+        final OffsetDateTime submitTime = OffsetDateTime.now();
+        logger.debug("Adding jobID {} to the queue at {} with for provider {}.",
+                jobID,
+                submitTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                data.getProviderID());
+        data.setSubmitTime(submitTime);
         // Persist the job in postgres
         final Transaction tx = this.session.beginTransaction();
         try {
@@ -87,37 +89,44 @@ public class DistributedQueue implements JobQueue {
         if (jobID == null) {
             return Optional.empty();
         }
+        final OffsetDateTime startTime = OffsetDateTime.now();
         final JobModel updatedJob = updateModel(jobID, (JobModel job) -> {
             // Verify that the job is in progress, otherwise fail
             if (job.getStatus() != JobStatus.QUEUED) {
                 throw new JobQueueFailure(jobID, String.format("Cannot work job in state: %s", job.getStatus()));
             }
-
             // Update the status and start time
             job.setStatus(JobStatus.RUNNING);
-            job.setStartTime(OffsetDateTime.now());
+            job.setStartTime(startTime);
         });
-        final var delay = Duration.between(updatedJob.getSubmitTime().get(), updatedJob.getStartTime().get()).toMillis()/MILLIS_PER_SECOND;
-        logger.debug("Started work job {}, waited in queue for {} seconds", jobID, delay);
+        final var delay = Duration.between(updatedJob.getSubmitTime().get(), updatedJob.getStartTime().get());
+        logger.debug("Started job {} at {}, waited in queue for {} seconds",
+                jobID,
+                startTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                delay.toSeconds());
 
         return Optional.of(new Pair(jobID, updatedJob));
     }
 
     @Override
     public void completeJob(UUID jobID, JobStatus status) {
-        assert(status == JobStatus.COMPLETED || status == JobStatus.FAILED);
+        assert (status == JobStatus.COMPLETED || status == JobStatus.FAILED);
+        final OffsetDateTime completionTime = OffsetDateTime.now();
         final JobModel updatedJob = updateModel(jobID, (JobModel job) -> {
             // Verify that the job is running
             if (job.getStatus() != JobStatus.RUNNING) {
                 throw new JobQueueFailure(jobID, String.format("Cannot complete job in state: %s", job.getStatus()));
             }
-
-            // Set the status and the complete time
+            // Set the status and the completion time
             job.setStatus(status);
-            job.setCompleteTime(OffsetDateTime.now());
+            job.setCompleteTime(completionTime);
         });
-        final var workDuration = Duration.between(updatedJob.getStartTime().get(), updatedJob.getCompleteTime().get()).toMillis()/MILLIS_PER_SECOND;
-        logger.debug("Completed job {} with status {} and duration {} seconds", jobID, status, workDuration);
+        final Duration workDuration = Duration.between(updatedJob.getStartTime().get(), updatedJob.getCompleteTime().get());
+        logger.debug("Completed job {} at {} with status {} and duration {} seconds",
+                jobID,
+                completionTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                status,
+                workDuration.toSeconds());
     }
 
     @Override
@@ -133,7 +142,7 @@ public class DistributedQueue implements JobQueue {
     /**
      * Fetch the job from the database, call the mutator function to update the job, and save the update in the database.
      *
-     * @param jobID - The jobID to fetch from the database.
+     * @param jobID   - The jobID to fetch from the database.
      * @param mutator - Function called to update the job. If the mutator throws, rollback the transaction.
      * @return the {@link JobModel} after the a successful
      */

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
@@ -38,8 +38,7 @@ public class DistributedQueue implements JobQueue {
         assert (jobID == data.getJobID() && data.getStatus() == JobStatus.QUEUED);
         final OffsetDateTime submitTime = OffsetDateTime.now();
         logger.debug("Adding jobID {} to the queue at {} with for provider {}.",
-                jobID,
-                submitTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+                jobID, submitTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                 data.getProviderID());
         data.setSubmitTime(submitTime);
         // Persist the job in postgres

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
@@ -10,10 +10,7 @@ import org.hl7.fhir.dstu3.model.ResourceType;
 import javax.persistence.*;
 import java.security.interfaces.RSAPublicKey;
 import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 @Entity(name = "job_queue")
 public class JobModel {
@@ -231,5 +228,20 @@ public class JobModel {
     @Override
     public int hashCode() {
         return Objects.hash(jobID, resourceTypes, providerID, patients, status, submitTime, startTime, completeTime);
+    }
+
+    @Override
+    public String toString() {
+        return "JobModel{" +
+                "jobID=" + jobID +
+                ", resourceTypes=" + resourceTypes +
+                ", providerID='" + providerID + '\'' +
+                ", patients=" + patients +
+                ", status=" + status +
+                ", rsaPublicKey=" + Arrays.toString(rsaPublicKey) +
+                ", submitTime=" + submitTime +
+                ", startTime=" + startTime +
+                ", completeTime=" + completeTime +
+                '}';
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <pgsql.version>42.2.5</pgsql.version>
         <java.version>11</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>
+        <jib.ecr.root>430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc</jib.ecr.root>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Why**
This ticket was originally opened because the JobModel serialization as failing in the AWS environments. On digging into it further, it turned out the issue was due to an older copy of code running in the environment which did not have DPC-110 included. This was causing things to fail when running the EndToEnd tests locally.

**What Changed**
No changes were made for the originally reported issue, except for some additional logging being added to make tracking job states a bit easier.

While working on this ticket a couple of other issues were discovered.

1. Travis CI was not correctly handling integration test failures.
Due to the stage in which we were running the integration tests, Travis was happy to continue even if one of the commands reported an error. The fix was to simply change the stage from `after_script` to `script` in order to make the entire test suite run in a single stage.

1. The travis build was actually failing because the `EndToEndRequestTest` was failing to deserialize the `JobCompletionModel` correctly. This was due to missing no-arge constructors that are required by Jackson. This was due to the code review failure of @nickrobison-usds. 

**Future Work:**
Lots of work to continue to improvement build and deployment process so that this doesn't happen in the future. No immediate followup tickets.

**Tickets closed:**
DPC-216: Invalid error, so we'll close this ticket and move on.
DPC-221: Docker images are now tagged using the ECR repository address.