### PR TITLE
Fix default url in demo seeder

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
@@ -52,7 +52,7 @@ public class DemoCommand extends Command {
                 .addArgument("--host")
                 .dest("hostname")
                 .type(String.class)
-                .setDefault("http://localhost:3002")
+                .setDefault("localhost:3002")
                 .help("Set the hostname (including port number) for running the Demo against");
     }
 


### PR DESCRIPTION
Hi @nickrobison-usds @RickHawesUSDS 
Was running the demo seeder to build a suitable environment for my demo app and found a small bug. Opening a PR with a suggested fix!

**Why**
To fix the following error in the dpc-api jar demo command:
```
$ java -jar dpc-api/target/dpc-api-0.2.0-SNAPSHOT.jar demo
WARN  [2019-05-09 16:03:10,768] com.squarespace.jersey2.guice.JerseyGuiceUtils: It appears jersey2-guice-spi is either not present or in conflict with some other Jar: ServiceLocatorGeneratorImpl(hk2-locator, 1332691311)
Running demo!
ca.uhn.fhir.rest.client.exceptions.FhirClientConnectionException: Failed to retrieve the server metadata statement during client initialization. URL used was http://http://localhost:3002/v1/metadata
```
Making the demo command work will enable [the example client app](https://github.com/isears/DpcFlaskExample) I'm building to run 100% locally.

**What Changed**
Removed the repeated `http://` prefix in the default configuration