### PR TITLE
DPC-177: Address Build Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 #  - psql -c 'create database dpc_attribution;' -U postgres
 
 script:
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -Perror-prone -B -V
   - mvn test -B -V
   # Format the test results and copy to a new directory
   - mvn jacoco:report

--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -76,11 +76,6 @@
             <groupId>com.hubspot.dropwizard</groupId>
             <artifactId>dropwizard-guicier</artifactId>
         </dependency>
-        <!--No longer shipped with Java 11, so we need to include it manually-->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationService.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationService.java
@@ -25,7 +25,7 @@ public class DPCAggregationService extends Application<DPCAggregationConfigurati
     public void initialize(Bootstrap<DPCAggregationConfiguration> bootstrap) {
         JerseyGuiceUtils.reset();
         GuiceBundle<DPCAggregationConfiguration> guiceBundle = GuiceBundle.defaultBuilder(DPCAggregationConfiguration.class)
-                .modules(new DPCHibernateModule(), new AggregationAppModule(), new BlueButtonClientModule(), new JobQueueModule())
+                .modules(new DPCHibernateModule<>(), new AggregationAppModule(), new BlueButtonClientModule(), new JobQueueModule<>())
                 .build();
 
         bootstrap.addBundle(guiceBundle);

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/bbclient/BlueButtonClientSetupException.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/bbclient/BlueButtonClientSetupException.java
@@ -2,6 +2,8 @@ package gov.cms.dpc.aggregation.bbclient;
 
 public class BlueButtonClientSetupException extends RuntimeException {
 
+    public static final long serialVersionUID = 42L;
+
     public BlueButtonClientSetupException(String message, Throwable cause){
         super(message, cause);
     }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/bbclient/DefaultBlueButtonClient.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/bbclient/DefaultBlueButtonClient.java
@@ -26,6 +26,7 @@ public class DefaultBlueButtonClient implements BlueButtonClient {
      * @return {@link Patient} A FHIR Patient resource
      * @throws ResourceNotFoundException when no such patient with the provided ID exists
      */
+    @Override
     public Patient requestPatientFromServer(String patientID) throws ResourceNotFoundException {
         logger.debug("Attempting to fetch patient ID {} from baseURL: {}", patientID, client.getServerBase());
         return client.read().resource(Patient.class).withId(patientID).execute();
@@ -49,6 +50,7 @@ public class DefaultBlueButtonClient implements BlueButtonClient {
      * @return {@link Bundle} Containing a number (possibly 0) of {@link ExplanationOfBenefit} objects
      * @throws ResourceNotFoundException when the requested patient does not exist
      */
+    @Override
     public Bundle requestEOBBundleFromServer(String patientID) throws ResourceNotFoundException {
         // TODO: need to implement some kind of pagination? EOB bundles can be HUGE
         logger.debug("Attempting to fetch EOBs for patient ID {} from baseURL: {}", patientID, client.getServerBase());

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/bbclient/MockBlueButtonClient.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/bbclient/MockBlueButtonClient.java
@@ -19,11 +19,13 @@ public class MockBlueButtonClient implements BlueButtonClient {
 
     }
 
+    @Override
     public Patient requestPatientFromServer(String patientID) {
         final var path = SAMPLE_PATIENT_PATH_PREFIX + patientID + ".xml";
         return requestFromServer(Patient.class, path);
     }
 
+    @Override
     public Bundle requestEOBBundleFromServer(String patientID) {
         final var path = SAMPLE_EOB_PATH_PREFIX + patientID + ".xml";
         return requestFromServer(Bundle.class, path);

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngine.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngine.java
@@ -76,7 +76,7 @@ public class EncryptingAggregationEngine extends AggregationEngine {
 
         try {
             // Generate Key
-            KeyGenerator keyGenerator = KeyGenerator.getInstance(symmetricCipher.split("/")[0]);
+            KeyGenerator keyGenerator = KeyGenerator.getInstance(symmetricCipher.split("/", -1)[0]);
             keyGenerator.init(keyBits);
             SecretKey secretKey = keyGenerator.generateKey();
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/qclient/AbstractMockQueueClient.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/qclient/AbstractMockQueueClient.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public abstract class AbstractMockQueueClient implements JobQueue {
+    @Override
     public void submitJob(UUID jobId, JobModel data) {
         // TODO
 
@@ -18,10 +19,12 @@ public abstract class AbstractMockQueueClient implements JobQueue {
         return Optional.of(JobStatus.COMPLETED);
     }
 
+    @Override
     public Optional<JobModel> getJob(UUID jobID) {
         return Optional.empty();
     }
 
+    @Override
     public void completeJob(UUID uuid, JobStatus jobStatus) {
         // TODO
     }
@@ -30,6 +33,7 @@ public abstract class AbstractMockQueueClient implements JobQueue {
         // TODO
     }
 
+    @Override
     public long queueSize() {
         // TODO
         return -1;

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/qclient/MockEmptyQueueClient.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/qclient/MockEmptyQueueClient.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 public class MockEmptyQueueClient extends AbstractMockQueueClient {
 
+    @Override
     public Optional<Pair<UUID, JobModel>> workJob() {
         return Optional.empty();
     }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/qclient/MockFullQueueClient.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/qclient/MockFullQueueClient.java
@@ -9,6 +9,7 @@ import java.util.*;
 public class MockFullQueueClient extends AbstractMockQueueClient {
     private final List<String> testBeneficiaryIds = Arrays.asList("20140000008325", "20140000008326");
 
+    @Override
     public Optional<Pair<UUID, JobModel>> workJob() {
         final UUID uuid = UUID.randomUUID();
         return Optional.of(new Pair<>(

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/bbclient/BlueButtonClientTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/bbclient/BlueButtonClientTest.java
@@ -17,6 +17,7 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.Parameter;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -167,6 +168,6 @@ class BlueButtonClientTest {
             throw new MissingResourceException("Cannot find sample requests", BlueButtonClientTest.class.getName(), path);
         }
 
-        return new String(sampleData.readAllBytes());
+        return new String(sampleData.readAllBytes(), StandardCharsets.UTF_8);
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
@@ -32,6 +32,7 @@ public class DPCAPIConfiguration extends TypesafeConfiguration implements IDPCDa
     @NotNull
     private String attributionURL;
 
+    @Override
     public DataSourceFactory getDatabase() {
         return database;
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
@@ -30,7 +30,7 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
         // https://github.com/dropwizard/dropwizard/issues/1772
         JerseyGuiceUtils.reset();
         GuiceBundle<DPCAPIConfiguration> guiceBundle = GuiceBundle.defaultBuilder(DPCAPIConfiguration.class)
-                .modules(new DPCHibernateModule(), new DPCAPIModule(), new JobQueueModule(), new FHIRModule())
+                .modules(new DPCHibernateModule<>(), new DPCAPIModule(), new JobQueueModule<>(), new FHIRModule())
                 .build();
 
         bootstrap.addBundle(guiceBundle);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -52,7 +52,7 @@ public class GroupResource extends AbstractGroupResource {
         // Get a list of attributed beneficiaries
         final Optional<List<String>> attributedBeneficiaries = this.client.getAttributedPatientIDs(FHIRBuilders.buildPractitionerFromNPI(providerID));
 
-        if (!attributedBeneficiaries.isPresent()) {
+        if (attributedBeneficiaries.isEmpty()) {
             throw new WebApplicationException(String.format("Unable to get attributed patients for provider: %s", providerID), Response.Status.NOT_FOUND);
         }
 
@@ -98,7 +98,7 @@ public class GroupResource extends AbstractGroupResource {
         }
 
         final var resources = new ArrayList<ResourceType>();
-        for (String queryResource: resourcesListParam.split(LIST_DELIM)) {
+        for (String queryResource: resourcesListParam.split(LIST_DELIM, -1)) {
             final var foundResourceType = matchResourceType(queryResource);
             if (foundResourceType.isEmpty()) {
                 throw new WebApplicationException(String.format("Unsupported resource name in the '_type' query parameter: %s", queryResource), Response.Status.BAD_REQUEST);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -14,7 +14,10 @@ import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 
 public class GroupResource extends AbstractGroupResource {
@@ -38,9 +41,10 @@ public class GroupResource extends AbstractGroupResource {
     /**
      * Begin export process for the given provider
      * On success, returns a {@link org.eclipse.jetty.http.HttpStatus#NO_CONTENT_204} response along with a {@link org.hl7.fhir.dstu3.model.OperationOutcome} result.
-     * The `Content-Location` header contains the URI to call when
+     * The `Content-Location` header contains the URI to call when checking job status.
      *
-     * @param providerID {@link String} ID of provider to retrieve data for
+     * @param providerID    {@link String} ID of provider to retrieve data for
+     * @param resourceTypes - {@link String} of comma separated values corresponding to FHIR {@link ResourceType}
      * @return - {@link org.hl7.fhir.dstu3.model.OperationOutcome} specifying whether or not the request was successful.
      */
     @Override
@@ -72,6 +76,7 @@ public class GroupResource extends AbstractGroupResource {
      * Test method for verifying FHIR deserialization, it will eventually be removed.
      * TODO(nickrobison): Remove this
      *
+     * @param group - {@link Group} to use for testing
      * @return - {@link String} test string
      */
     @POST
@@ -86,9 +91,10 @@ public class GroupResource extends AbstractGroupResource {
     }
 
     /**
-     * Convert the '_types' query param to a list of resources to add to the job. Handle the empty case,
+     * Convert the '_types' {@link QueryParam} to a list of resources to add to the job. Handle the empty case,
      * by returning all valid resource types.
      *
+     * @param resourcesListParam - {@link String} of comma separated values corresponding to FHIR {@link ResourceType}s
      * @return - A list of {@link ResourceType} to return for this request.
      */
     private List<ResourceType> handleTypeQueryParam(String resourcesListParam) {
@@ -98,7 +104,7 @@ public class GroupResource extends AbstractGroupResource {
         }
 
         final var resources = new ArrayList<ResourceType>();
-        for (String queryResource: resourcesListParam.split(LIST_DELIM, -1)) {
+        for (String queryResource : resourcesListParam.split(LIST_DELIM, -1)) {
             final var foundResourceType = matchResourceType(queryResource);
             if (foundResourceType.isEmpty()) {
                 throw new WebApplicationException(String.format("Unsupported resource name in the '_type' query parameter: %s", queryResource), Response.Status.BAD_REQUEST);

--- a/dpc-api/src/test/java/gov/cms/dpc/api/EndToEndRequestTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/EndToEndRequestTest.java
@@ -14,6 +14,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -101,7 +102,7 @@ public class EndToEndRequestTest extends AbstractApplicationTest {
         // Read the file back in and parse the patients
         final IParser parser = ctx.newJsonParser();
 
-        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(tempFile))) {
+        try (BufferedReader bufferedReader = new BufferedReader(new FileReader(tempFile, StandardCharsets.UTF_8))) {
             final List<T> entries = bufferedReader.lines()
                     .map((line) -> clazz.cast(parser.parseResource(line)))
                     .collect(Collectors.toList());

--- a/dpc-api/src/test/java/gov/cms/dpc/api/FHIRSubmissionTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/FHIRSubmissionTest.java
@@ -57,11 +57,11 @@ public class FHIRSubmissionTest {
                 .thenReturn(Optional.of(testBeneficiaries));
 
         // Mock the submission call to verify the job type
-        doAnswer((answer -> {
+        doAnswer(answer -> {
             final JobModel data = answer.getArgument(1);
             assertEquals(testJobModel.getPatients().size(), data.getPatients().size(), "Should have 4 patients");
             return answer.callRealMethod();
-        })).when(queue).submitJob(Mockito.any(UUID.class), Mockito.any(JobModel.class));
+        }).when(queue).submitJob(Mockito.any(UUID.class), Mockito.any(JobModel.class));
     }
 
     @Test

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
@@ -11,7 +11,6 @@ import gov.cms.dpc.attribution.resources.v1.V1AttributionResource;
 import gov.cms.dpc.attribution.tasks.TruncateDatabase;
 import gov.cms.dpc.common.hibernate.DPCHibernateBundle;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
-import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import org.hibernate.SessionFactory;
@@ -19,17 +18,11 @@ import org.jooq.DSLContext;
 import org.jooq.conf.RenderNameStyle;
 import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.inject.Singleton;
 import java.sql.SQLException;
 import java.time.Duration;
 
 class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfiguration> {
-
-    private static final Logger logger = LoggerFactory.getLogger(AttributionAppModule.class);
-
 
     AttributionAppModule() {
     }
@@ -52,13 +45,13 @@ class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfigura
      * @return - {@link GroupResource} with injected database session
      */
     @Provides
-    GroupResource provideAttributionResource(DPCHibernateBundle hibernateModule, AttributionEngine engine) {
+    GroupResource provideAttributionResource(DPCHibernateBundle<DPCAttributionConfiguration> hibernateModule, AttributionEngine engine) {
         return new UnitOfWorkAwareProxyFactory(hibernateModule)
                 .create(GroupResource.class, AttributionEngine.class, engine);
     }
 
     @Provides
-    RelationshipDAO provideRelationshipDAO(DPCHibernateBundle hibernateModule, SessionFactory factory) {
+    RelationshipDAO provideRelationshipDAO(DPCHibernateBundle<DPCAttributionConfiguration> hibernateModule, SessionFactory factory) {
         return new UnitOfWorkAwareProxyFactory(hibernateModule)
                 .create(RelationshipDAO.class, SessionFactory.class, factory);
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
@@ -22,6 +22,7 @@ import org.jooq.impl.DSL;
 import java.sql.SQLException;
 import java.time.Duration;
 
+@SuppressWarnings("rawtypes") // Until we merge DPC-104
 class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfiguration> {
 
     AttributionAppModule() {
@@ -45,13 +46,13 @@ class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfigura
      * @return - {@link GroupResource} with injected database session
      */
     @Provides
-    GroupResource provideAttributionResource(DPCHibernateBundle<DPCAttributionConfiguration> hibernateModule, AttributionEngine engine) {
+    GroupResource provideAttributionResource(DPCHibernateBundle hibernateModule, AttributionEngine engine) {
         return new UnitOfWorkAwareProxyFactory(hibernateModule)
                 .create(GroupResource.class, AttributionEngine.class, engine);
     }
 
     @Provides
-    RelationshipDAO provideRelationshipDAO(DPCHibernateBundle<DPCAttributionConfiguration> hibernateModule, SessionFactory factory) {
+    RelationshipDAO provideRelationshipDAO(DPCHibernateBundle hibernateModule, SessionFactory factory) {
         return new UnitOfWorkAwareProxyFactory(hibernateModule)
                 .create(RelationshipDAO.class, SessionFactory.class, factory);
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionConfiguration.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionConfiguration.java
@@ -25,6 +25,7 @@ public class DPCAttributionConfiguration extends TypesafeConfiguration implement
     @JsonProperty("sundial")
     private SundialConfiguration sundial = new SundialConfiguration();
 
+    @Override
     public DataSourceFactory getDatabase() {
         return database;
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
@@ -36,7 +36,7 @@ public class DPCAttributionService extends Application<DPCAttributionConfigurati
         // https://github.com/dropwizard/dropwizard/issues/1772
         JerseyGuiceUtils.reset();
         GuiceBundle<DPCAttributionConfiguration> guiceBundle = GuiceBundle.defaultBuilder(DPCAttributionConfiguration.class)
-                .modules(new DPCHibernateModule(),
+                .modules(new DPCHibernateModule<>(),
                         new AttributionAppModule(),
                         new FHIRModule())
                 .build();

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.MissingResourceException;
 
 public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration> {
@@ -86,7 +87,7 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
     private static OffsetDateTime generateTimestamp(Namespace namespace) {
         final String timestamp = namespace.getString("timestamp");
         if (timestamp == null) {
-            return OffsetDateTime.now();
+            return OffsetDateTime.now(ZoneOffset.UTC);
         }
         return OffsetDateTime.parse(timestamp.trim());
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
@@ -41,7 +41,7 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> implements Attribut
         if (!providerExists(FHIRExtractors.getProviderNPI(provider))) {
             return Optional.empty();
         }
-        final Query query = namedQuery("findByProvider")
+        final Query<ProviderEntity> query = namedQuery("findByProvider")
                 .setParameter("id", FHIRExtractors.getProviderNPI(provider));
 
         final ProviderEntity providerEntity = uniqueResult(query);
@@ -73,9 +73,9 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> implements Attribut
                 .stream()
                 .filter(Bundle.BundleEntryComponent::hasResource)
                 .map(Bundle.BundleEntryComponent::getResource)
-                .filter((resource -> resource.getResourceType() == ResourceType.Patient))
+                .filter(resource -> resource.getResourceType() == ResourceType.Patient)
                 .map(patient -> PatientEntity.fromFHIR((Patient) patient))
-                .map((pEntity) -> new AttributionRelationship(provider, pEntity))
+                .map(pEntity -> new AttributionRelationship(provider, pEntity))
                 .forEach(this.rDAO::addAttributionRelationship);
     }
 
@@ -103,7 +103,7 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> implements Attribut
     }
 
     private boolean providerExists(String providerNPI) {
-        final Query query = namedQuery("getProvider");
+        final Query<ProviderEntity> query = namedQuery("getProvider");
         query.setParameter("provID", providerNPI);
         return uniqueResult(query) != null;
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
@@ -39,7 +39,7 @@ public class RelationshipDAO extends AbstractDAO<AttributionRelationship> {
         final String patientMPI = FHIRExtractors.getPatientMPI(patient);
         logger.debug("Looking up attribution between {} and {}", providerNPI, patientMPI);
 
-        final Query query = namedQuery("findRelationship");
+        final Query<AttributionRelationship> query = namedQuery("findRelationship");
         query.setParameter("provID", providerNPI);
         query.setParameter("patID", patientMPI);
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterEngine.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -46,7 +47,7 @@ public class RosterEngine implements AttributionEngine {
         final List<String> beneficiaryIDs = context.select()
                 .from(PROVIDERS)
                 .join(ATTRIBUTIONS).on(ATTRIBUTIONS.PROVIDER_ID.eq(PROVIDERS.ID))
-                .join(PATIENTS).on((ATTRIBUTIONS.PATIENT_ID).eq(PATIENTS.ID))
+                .join(PATIENTS).on(ATTRIBUTIONS.PATIENT_ID.eq(PATIENTS.ID))
                 .where(PROVIDERS.PROVIDER_ID.eq(providerNPI))
                 .fetch().getValues(PATIENTS.BENEFICIARY_ID);
 
@@ -71,7 +72,7 @@ public class RosterEngine implements AttributionEngine {
             final AttributionsRecord attr = new AttributionsRecord();
             attr.setProviderId(providerRecord.getId());
             attr.setPatientId(patientRecord.getId());
-            attr.setCreatedAt(OffsetDateTime.now());
+            attr.setCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
 
             final int updated = ctx.executeInsert(attr);
             if (updated != 1) {
@@ -85,7 +86,7 @@ public class RosterEngine implements AttributionEngine {
         context.transaction(config -> {
 
             final DSLContext ctx = DSL.using(config);
-            RosterUtils.submitAttributionBundle(attributionBundle, ctx, OffsetDateTime.now());
+            RosterUtils.submitAttributionBundle(attributionBundle, ctx, OffsetDateTime.now(ZoneOffset.UTC));
         });
     }
 
@@ -104,7 +105,7 @@ public class RosterEngine implements AttributionEngine {
             final String patientMPI = FHIRExtractors.getPatientMPI(patient);
             final Result<AttributionsRecord> attributionsRecords = ctx.selectFrom(ATTRIBUTIONS
                     .join(PROVIDERS).on(ATTRIBUTIONS.PROVIDER_ID.eq(PROVIDERS.ID))
-                    .join(PATIENTS).on((ATTRIBUTIONS.PATIENT_ID).eq(PATIENTS.ID)))
+                    .join(PATIENTS).on(ATTRIBUTIONS.PATIENT_ID.eq(PATIENTS.ID)))
                     .where(PROVIDERS.PROVIDER_ID.eq(providerNPI).and(PATIENTS.BENEFICIARY_ID.eq(patientMPI)))
                     .fetchInto(ATTRIBUTIONS);
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
@@ -55,7 +55,7 @@ public class RosterUtils {
                 .getEntry()
                 .stream()
                 .map(Bundle.BundleEntryComponent::getResource)
-                .filter((resource -> resource.getResourceType() == ResourceType.Patient))
+                .filter(resource -> resource.getResourceType() == ResourceType.Patient)
                 .map(patient -> PatientEntity.fromFHIR((Patient) patient))
                 .forEach(patientEntity -> RosterUtils.createUpdateAttributionRelationship(ctx, patientEntity, providerRecord, creationTimestamp));
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jobs/ExpireAttributions.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jobs/ExpireAttributions.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 /**
@@ -37,7 +38,7 @@ public class ExpireAttributions extends Job {
         attribute.injectMembers(this);
         logger.debug("Expiration threshold: {} days", expirationThreshold.toDays());
         // Calculate the expiration date (e.g. all relationships created BEFORE this time will be removed
-        this.expirationTemporal = OffsetDateTime.now().minus(this.expirationThreshold);
+        this.expirationTemporal = OffsetDateTime.now(ZoneOffset.UTC).minus(this.expirationThreshold);
     }
 
     @Override

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -28,6 +28,7 @@ public class GroupResource extends AbstractGroupResource {
 
     @POST
     @FHIR
+    @Override
     public Response submitRoster(Bundle providerBundle) {
         logger.debug("API request to submit roster");
         this.engine.addAttributionRelationships(providerBundle);

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/AttributionRelationship.java
@@ -36,13 +36,13 @@ public class AttributionRelationship {
     private OffsetDateTime created;
 
     public AttributionRelationship() {
-        this.created = OffsetDateTime.now();
+        this.created = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public AttributionRelationship(ProviderEntity provider, PatientEntity patient) {
         this.provider = provider;
         this.patient = patient;
-        this.created = OffsetDateTime.now();
+        this.created = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public AttributionRelationship(ProviderEntity provider, PatientEntity patient, OffsetDateTime created) {
@@ -92,7 +92,7 @@ public class AttributionRelationship {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof AttributionRelationship)) return false;
         AttributionRelationship that = (AttributionRelationship) o;
         return Objects.equals(attributionID, that.attributionID) &&
                 Objects.equals(provider, that.provider) &&

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
@@ -80,7 +80,7 @@ public class PatientEntity {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof PatientEntity)) return false;
         PatientEntity that = (PatientEntity) o;
         return patientID.equals(that.patientID) &&
                 beneficiaryID.equals(that.beneficiaryID) &&

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
@@ -90,7 +90,7 @@ public class ProviderEntity {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof ProviderEntity)) return false;
         ProviderEntity that = (ProviderEntity) o;
         return Objects.equals(providerID, that.providerID) &&
                 Objects.equals(providerNPI, that.providerNPI) &&

--- a/dpc-common/src/main/java/gov/cms/dpc/common/exceptions/UnknownRelationship.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/exceptions/UnknownRelationship.java
@@ -9,6 +9,8 @@ import org.hl7.fhir.dstu3.model.Practitioner;
  */
 public class UnknownRelationship extends RuntimeException {
 
+    public static final long serialVersionUID = 42L;
+
     private final String providerNPI;
     private final String patientMPI;
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
@@ -26,11 +26,11 @@ public class DPCHibernateModule<T extends Configuration & IDPCDatabase> extends 
 
     @Provides
     @Singleton
-    SessionFactory getSessionFactory(DPCHibernateBundle hibernate) {
+    @SuppressWarnings("CloseableProvides") // Until we merge DPC-233
+    SessionFactory getSessionFactory(DPCHibernateBundle<T> hibernate) {
         // This is necessary because the session factory doesn't load on its own.
         // I'm really not sure how to fix this, I think it's due to the interaction with the Proxy Factory
         try {
-            //noinspection unchecked
             hibernate.run(getConfiguration(), getEnvironment());
         } catch (Exception e) {
             throw new IllegalStateException(e);
@@ -46,6 +46,7 @@ public class DPCHibernateModule<T extends Configuration & IDPCDatabase> extends 
     }
 
     @Provides
+    @SuppressWarnings("CloseableProvides") // Until we merge DPC-233
     Session provideSession(SessionFactory factory) {
         return factory.openSession();
     }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
@@ -26,8 +26,8 @@ public class DPCHibernateModule<T extends Configuration & IDPCDatabase> extends 
 
     @Provides
     @Singleton
-    @SuppressWarnings("CloseableProvides") // Until we merge DPC-233
-    SessionFactory getSessionFactory(DPCHibernateBundle<T> hibernate) {
+    @SuppressWarnings({"CloseableProvides", "rawtypes", "unchecked"}) // Until we merge DPC-233 and DPC-104
+    SessionFactory getSessionFactory(DPCHibernateBundle hibernate) {
         // This is necessary because the session factory doesn't load on its own.
         // I'm really not sure how to fix this, I think it's due to the interaction with the Proxy Factory
         try {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/SeedProcessor.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/SeedProcessor.java
@@ -1,9 +1,13 @@
 package gov.cms.dpc.common.utils;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.hl7.fhir.dstu3.model.*;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.IdType;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Practitioner;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -33,9 +37,10 @@ public class SeedProcessor {
     public Map<String, List<Pair<String, String>>> extractProviderMap() throws IOException {
         List<Pair<String, String>> providerPairs = new ArrayList<>();
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(this.is))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(this.is, StandardCharsets.UTF_8))) {
             for (String line; (line = reader.readLine()) != null; ) {
-                final String[] splits = line.split(",");
+                // We can ignore this, because it's not worth pulling in Guava just for this.
+                final String[] splits = line.split(",", -1);
 
                 providerPairs.add(Pair.of(splits[1], splits[0]));
             }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/SeedProcessor.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/SeedProcessor.java
@@ -33,6 +33,7 @@ public class SeedProcessor {
      * Processes the provided attribution file and groups the patients by provider ID
      *
      * @return - {@link Map} of Provider IDs and a {@link List} of {@link Pair} of providerID and patientID
+     * @throws IOException - throws if unable to read the input file
      */
     public Map<String, List<Pair<String, String>>> extractProviderMap() throws IOException {
         List<Pair<String, String>> providerPairs = new ArrayList<>();

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRMediaTypes.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRMediaTypes.java
@@ -13,12 +13,13 @@ public class FHIRMediaTypes {
     /**
      * Validates whether or not the given content type is of type FHIR
      * String can be null or empty
+     *
      * @param mediaType - {@link String} value from {@link javax.ws.rs.core.HttpHeaders#CONTENT_TYPE} header.
      * @return - {@code true} content type is FHIR. {@code false} content type is not FHIR
      */
     public static boolean isFHIRContent(MediaType mediaType) {
 
-        return mediaType.isCompatible(MediaType.valueOf(FHIR_JSON)) ||
-                mediaType.isCompatible(MediaType.valueOf(FHIR_NDJSON));
+        return mediaType.isCompatible(FHIR_JSON_MT) ||
+                mediaType.isCompatible(FHIR_NDJSON_MT);
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/CustomIDSerializer.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/CustomIDSerializer.java
@@ -1,6 +1,5 @@
 package gov.cms.dpc.fhir.dropwizard;
 
-import ca.uhn.fhir.context.FhirContext;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
@@ -10,15 +9,14 @@ import java.io.IOException;
 
 public class CustomIDSerializer extends StdSerializer<IdType> {
 
-    private final FhirContext context;
+    public static final long serialVersionUID = 42L;
 
-    public CustomIDSerializer(FhirContext ctx) {
-        this(null, ctx);
+    public CustomIDSerializer() {
+        this(null);
     }
 
-    protected CustomIDSerializer(Class<IdType> t, FhirContext ctx) {
+    protected CustomIDSerializer(Class<IdType> t) {
         super(t);
-        this.context = ctx;
     }
 
 

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/CustomResourceSerializer.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/CustomResourceSerializer.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 
 public class CustomResourceSerializer extends StdSerializer<Resource> {
 
+    public static final long serialVersionUID = 42L;
+
     private final FhirContext context;
 
     public CustomResourceSerializer(FhirContext ctx) {

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/FHIRHandler.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/FHIRHandler.java
@@ -15,6 +15,7 @@ import javax.ws.rs.ext.Provider;
 import java.io.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 
 @Provider
 @FHIR
@@ -35,7 +36,7 @@ public class FHIRHandler implements MessageBodyReader<BaseResource>, MessageBody
     @Override
     public BaseResource readFrom(Class<BaseResource> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
         final IParser parser = ctx.newJsonParser();
-        return (BaseResource) parser.parseResource(new InputStreamReader(entityStream));
+        return (BaseResource) parser.parseResource(new InputStreamReader(entityStream, StandardCharsets.UTF_8));
     }
 
     @Override
@@ -52,6 +53,6 @@ public class FHIRHandler implements MessageBodyReader<BaseResource>, MessageBody
     @Override
     public void writeTo(BaseResource baseResource, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
         final IParser parser = ctx.newJsonParser();
-        parser.encodeResourceToWriter(baseResource, new OutputStreamWriter(entityStream));
+        parser.encodeResourceToWriter(baseResource, new OutputStreamWriter(entityStream, StandardCharsets.UTF_8));
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/MethodOutcomeHandler.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/MethodOutcomeHandler.java
@@ -1,11 +1,9 @@
 package gov.cms.dpc.fhir.dropwizard.handlers;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.dropwizard.CustomIDSerializer;
 import gov.cms.dpc.fhir.dropwizard.CustomResourceSerializer;
@@ -14,15 +12,11 @@ import org.hl7.fhir.dstu3.model.Resource;
 
 import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -31,14 +25,12 @@ import java.lang.reflect.Type;
 @FHIR
 public class MethodOutcomeHandler implements MessageBodyWriter<MethodOutcome> {
 
-    private final FhirContext ctx;
     private final ObjectMapper mapper;
 
     @Inject
     MethodOutcomeHandler(FhirContext context) {
-        this.ctx = context;
         final CustomResourceSerializer serializer = new CustomResourceSerializer(context);
-        final CustomIDSerializer customIDSerializer = new CustomIDSerializer(context);
+        final CustomIDSerializer customIDSerializer = new CustomIDSerializer();
         final SimpleModule module = new SimpleModule();
         module.addSerializer(Resource.class, serializer);
         module.addSerializer(IdType.class, customIDSerializer);

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.Queue;
@@ -35,8 +36,8 @@ public class DistributedQueue implements JobQueue {
 
     @Override
     public void submitJob(UUID jobID, JobModel data) {
-        assert (jobID == data.getJobID() && data.getStatus() == JobStatus.QUEUED);
-        final OffsetDateTime submitTime = OffsetDateTime.now();
+        assert (jobID.equals(data.getJobID()) && data.getStatus() == JobStatus.QUEUED);
+        final OffsetDateTime submitTime = OffsetDateTime.now(ZoneOffset.UTC);
         logger.debug("Adding jobID {} to the queue at {} with for provider {}.",
                 jobID, submitTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                 data.getProviderID());
@@ -88,7 +89,7 @@ public class DistributedQueue implements JobQueue {
         if (jobID == null) {
             return Optional.empty();
         }
-        final OffsetDateTime startTime = OffsetDateTime.now();
+        final OffsetDateTime startTime = OffsetDateTime.now(ZoneOffset.UTC);
         final JobModel updatedJob = updateModel(jobID, (JobModel job) -> {
             // Verify that the job is in progress, otherwise fail
             if (job.getStatus() != JobStatus.QUEUED) {
@@ -98,19 +99,20 @@ public class DistributedQueue implements JobQueue {
             job.setStatus(JobStatus.RUNNING);
             job.setStartTime(startTime);
         });
+        //noinspection OptionalGetWithoutIsPresent
         final var delay = Duration.between(updatedJob.getSubmitTime().get(), updatedJob.getStartTime().get());
         logger.debug("Started job {} at {}, waited in queue for {} seconds",
                 jobID,
                 startTime.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
                 delay.toSeconds());
 
-        return Optional.of(new Pair(jobID, updatedJob));
+        return Optional.of(new Pair<>(jobID, updatedJob));
     }
 
     @Override
     public void completeJob(UUID jobID, JobStatus status) {
         assert (status == JobStatus.COMPLETED || status == JobStatus.FAILED);
-        final OffsetDateTime completionTime = OffsetDateTime.now();
+        final OffsetDateTime completionTime = OffsetDateTime.now(ZoneOffset.UTC);
         final JobModel updatedJob = updateModel(jobID, (JobModel job) -> {
             // Verify that the job is running
             if (job.getStatus() != JobStatus.RUNNING) {

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
@@ -8,12 +8,8 @@ import io.dropwizard.Configuration;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JobQueueModule<T extends Configuration & DPCQueueConfig> extends DropwizardAwareModule<T> {
-
-    private static final Logger logger = LoggerFactory.getLogger(JobQueueModule.class);
 
     private final boolean inMemory;
     private Config config;

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/MemoryQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/MemoryQueue.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -29,8 +30,8 @@ public class MemoryQueue implements JobQueue {
 
     @Override
     public synchronized void submitJob(UUID jobID, JobModel job) {
-        assert(jobID == job.getJobID() && job.getStatus() == JobStatus.QUEUED);
-        job.setSubmitTime(OffsetDateTime.now());
+        assert(jobID.equals(job.getJobID()) && job.getStatus() == JobStatus.QUEUED);
+        job.setSubmitTime(OffsetDateTime.now(ZoneOffset.UTC));
         logger.debug("Submitting job: {}", jobID);
         this.queue.put(jobID, job);
     }
@@ -58,7 +59,7 @@ public class MemoryQueue implements JobQueue {
             assert(job.getSubmitTime().isPresent());
 
             job.setStatus(JobStatus.RUNNING);
-            job.setStartTime(OffsetDateTime.now());
+            job.setStartTime(OffsetDateTime.now(ZoneOffset.UTC));
             this.queue.replace(key, job);
 
             final var queueDuration = Duration.between(job.getSubmitTime().get(), job.getStartTime().get());
@@ -81,7 +82,7 @@ public class MemoryQueue implements JobQueue {
         assert(job.getStartTime().isPresent());
 
         job.setStatus(status);
-        job.setCompleteTime(OffsetDateTime.now());
+        job.setCompleteTime(OffsetDateTime.now(ZoneOffset.UTC));
         this.queue.replace(jobID, job);
 
         final var workDuration = Duration.between(job.getStartTime().get(), job.getCompleteTime().get());

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/converters/ResourceTypeListConverter.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/converters/ResourceTypeListConverter.java
@@ -30,7 +30,7 @@ public class ResourceTypeListConverter implements AttributeConverter<List<Resour
     @Override
     public List<ResourceType> convertToEntityAttribute(String dbData) {
         final var resourceList = new ArrayList<ResourceType>();
-        for (String typeString: dbData.split(LIST_DELIM)) {
+        for (String typeString: dbData.split(LIST_DELIM, -1)) {
             try {
                 final var type = ResourceType.valueOf(typeString);
                 resourceList.add(type);

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/exceptions/JobQueueFailure.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/exceptions/JobQueueFailure.java
@@ -4,6 +4,8 @@ import java.util.UUID;
 
 public class JobQueueFailure extends RuntimeException {
 
+    public static final long serialVersionUID = 42L;
+
     public JobQueueFailure(UUID jobID, String message) {
         super(String.format("Operation on Job: %s failed for reason: %s", jobID, message));
     }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
@@ -8,12 +8,13 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.hl7.fhir.dstu3.model.ResourceType;
 
 import javax.persistence.*;
+import java.io.Serializable;
 import java.security.interfaces.RSAPublicKey;
 import java.time.OffsetDateTime;
 import java.util.*;
 
 @Entity(name = "job_queue")
-public class JobModel {
+public class JobModel implements Serializable  {
     public static final long serialVersionUID = 42L;
 
     /**
@@ -211,7 +212,7 @@ public class JobModel {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof JobModel)) return false;
         JobModel other = (JobModel) o;
         return new EqualsBuilder()
                 .append(jobID, other.jobID)

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
@@ -25,7 +25,7 @@ public class JobModel implements Serializable  {
     /**
      * Test if the resource type is in the list of resources supported by the DCP
      *
-     * @param type
+     * @param type - {@code true} resource is supported by DPC. {@code false} resource is not supported by DPC.
      * @return True iff the passed in type is valid f
      */
     public static Boolean isValidResourceType(ResourceType type) {

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
@@ -7,10 +7,11 @@ import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.query.Query;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Practitioner;
 import org.hl7.fhir.dstu3.model.ResourceType;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 import org.redisson.Redisson;
 import org.redisson.api.RQueue;
 import org.redisson.api.RedissonClient;
@@ -18,7 +19,6 @@ import org.redisson.config.Config;
 
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class QueueTest {
 
-//    private JobQueue queue;
+    //    private JobQueue queue;
     private SessionFactory sessionFactory;
     private Session session;
     private List<String> queues = List.of("memory", "distributed");
@@ -77,7 +77,7 @@ public class QueueTest {
     public void shutdown() {
         final Transaction tx = session.beginTransaction();
         try {
-            final Query query = session.createQuery("delete from job_queue");
+            final Query<?> query = session.createQuery("delete from job_queue");
             query.executeUpdate();
         } finally {
             tx.commit();
@@ -169,32 +169,11 @@ public class QueueTest {
         return set.stream().findFirst().orElseThrow(() -> new IllegalStateException("Cannot get first from empty array"));
     }
 
-    private static class TestJob implements Statisable {
-
-        private final String data;
-        private JobStatus status;
-
-        TestJob(String data) {
-            this.data = data;
-            this.status = JobStatus.QUEUED;
-        }
-
-        @Override
-        public JobStatus getStatus() {
-            return this.status;
-        }
-
-        @Override
-        public void setStatus(JobStatus status) {
-            this.status = status;
-        }
-    }
-
     private static JobModel buildModel(UUID id) {
-        return buildModel(id, ResourceType.Patient );
+        return buildModel(id, ResourceType.Patient);
     }
 
-    private static JobModel buildModel(UUID id, ResourceType ... resources) {
+    private static JobModel buildModel(UUID id, ResourceType... resources) {
         return new JobModel(id, Arrays.asList(resources), "test-provider-1", List.of("test-patient-1", "test-patient-2"));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,33 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>error-prone</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <showWarnings>true</showWarnings>
+                            <compilerArgs>
+                                <arg>-XDcompilePolicy=simple</arg>
+                                <arg>-Xplugin:ErrorProne</arg>
+                                <arg>-Xlint:all</arg>
+                                <arg>-Werror</arg>
+                            </compilerArgs>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>com.google.errorprone</groupId>
+                                    <artifactId>error_prone_core</artifactId>
+                                    <version>2.3.3</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -198,6 +225,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.1.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.6.1</version>
+                    <configuration>
+                        <source>${java.version}</source>
+                        <target>${java.version}</target>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>com.google.cloud.tools</groupId>
@@ -230,7 +265,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.3</version>
                 <configuration>
                     <excludes>
                         <!--Exclude auto-generated JOOQ classes-->


### PR DESCRIPTION
**Why**
As we've been developing, there have been a number of warnings creeping into the build that we've been meaning to address. The goal should be to keep our build as clean as possible, excepting the annoying (and harmless) warnings that come from the maven shade plugin.

**What Changed**

Added an `error-prone` profile to the root pom. When enabled (as it is during CI compilation) it enables a bunch of additional checks provided by the [error-prone](https://errorprone.info) compiler plugin. In addition to enabling these checks also build with all warnings as errors to be even more pedantic.

This PR is mostly about addressing the warnings/errors reported by ErrorProne. While most of them are fairly cosmetic, a couple are worth pointing out.

1. Require an explicit timezone instead of implicitly relying on the system default: https://errorprone.info/bugpattern/JavaTimeDefaultTimeZone
1. Require an explicit charset when reading/writing byte buffers instead of relying on the system default: https://errorprone.info/bugpattern/DefaultCharset
1. Check parent class when overriding `equals()` method in order to avoid issues with subclasses: https://errorprone.info/bugpattern/EqualsGetClass
1. Pass an explicit (infinite) limit to `String.split()`: https://errorprone.info/bugpattern/StringSplitter

**Choices Made**
- Whenever a timezone was required by Errorprone, I used `ZoneOffset.UTC`
- Whenever a character encoding was required by Errorprone, I used `StandardCharsets.UTF-8`.
- Whenever Errorprone flagged a potentially dodgy string split, I used a default length of `-1`.
- A few of the warnings were suppressed until future work is done. We should make a habit out of ridding us of these suppressions.

**Tickets closed**
DPC-177: Addressed all the build warnings

Future work
DPC-233: Refactor how we provide DB handles within the Dropwizard services
DPC-104: Refactor the various resources we provide into Dropwizard bundles