### PR TITLE
DPC-222: Update Docker Image tags

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "5432:5432"
 
   aggregation:
-    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc}:dpc-aggregation
+    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc-aggregation}:latest
     ports:
       - "8088:8081"
     environment:
@@ -28,7 +28,7 @@ services:
       - export-volume:/app/data
 
   attribution:
-    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc}:dpc-attribution
+    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc-attribution}:latest
     depends_on:
       - db
     environment:
@@ -38,7 +38,7 @@ services:
       - "9901:9900"
 
   api:
-    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc}:dpc-api
+    image: ${ECR_HOST:-430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc-api}:latest
     ports:
       - "3002:3002"
     environment:

--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -174,9 +174,10 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <to>
-                        <image>${jib.ecr.root}</image>
+                        <image>${jib.ecr.root}/dpc-aggregation</image>
                         <tags>
-                            <tag>dpc-aggregation</tag>
+                            <tag>latest</tag>
+                            <tag>${project.version}</tag>
                         </tags>
                     </to>
                     <extraDirectory>

--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -173,13 +173,6 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
-                    <to>
-                        <image>${jib.ecr.root}/dpc-aggregation</image>
-                        <tags>
-                            <tag>latest</tag>
-                            <tag>${project.version}</tag>
-                        </tags>
-                    </to>
                     <extraDirectory>
                         <path>${project.basedir}/../bbcerts</path>
                     </extraDirectory>

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -153,13 +153,6 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
-                    <to>
-                        <image>${jib.ecr.root}/dpc-api</image>
-                        <tags>
-                            <tag>latest</tag>
-                            <tag>${project.version}</tag>
-                        </tags>
-                    </to>
                     <container>
                         <args>
                             <arg>server</arg>

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -154,9 +154,10 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <to>
-                        <image>${jib.ecr.root}</image>
+                        <image>${jib.ecr.root}/dpc-api</image>
                         <tags>
-                            <tag>dpc-api</tag>
+                            <tag>latest</tag>
+                            <tag>${project.version}</tag>
                         </tags>
                     </to>
                     <container>

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -145,9 +145,10 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
                     <to>
-                        <image>${jib.ecr.root}</image>
+                        <image>${jib.ecr.root}/dpc-attribution</image>
                         <tags>
-                            <tag>dpc-attribution</tag>
+                            <tag>latest</tag>
+                            <tag>${project.version}</tag>
                         </tags>
                     </to>
                     <container>

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -144,13 +144,6 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
-                    <to>
-                        <image>${jib.ecr.root}/dpc-attribution</image>
-                        <tags>
-                            <tag>latest</tag>
-                            <tag>${project.version}</tag>
-                        </tags>
-                    </to>
                     <container>
                         <args>
                             <arg>server</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <pgsql.version>42.2.5</pgsql.version>
         <java.version>11</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>
-        <jib.ecr.root>430398651479.dkr.ecr.us-east-1.amazonaws.com/dpc</jib.ecr.root>
+        <jib.ecr.root>430398651479.dkr.ecr.us-east-1.amazonaws.com</jib.ecr.root>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,24 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.google.cloud.tools</groupId>
+                        <artifactId>jib-maven-plugin</artifactId>
+                        <configuration>
+                            <to>
+                                <tags combine.children="override">
+                                    <tag>${project.version}</tag>
+                                </tags>
+                            </to>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
@@ -234,11 +252,18 @@
                         <target>${java.version}</target>
                     </configuration>
                 </plugin>
+                <!-- Base configuration for Docker images -->
                 <plugin>
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>1.0.0</version>
                     <configuration>
+                        <to>
+                            <image>${jib.ecr.root}/${project.artifactId}</image>
+                            <tags>
+                                <tag>latest</tag>
+                            </tags>
+                        </to>
                         <from>
                             <image>openjdk:11-jdk-slim</image>
                         </from>


### PR DESCRIPTION
**Why**
The Docker images are currently setup to use the artifactName as the image tag. That's not a good way to handle it, we need to use the versions as the tags, that way we can separate out release and development versions.

**What Changed**
Refactored how we handle the Docker configuration and image naming. Most of the configuration now happens in the `dpc-app` pom where we setup the images names using the AWS ECR address and the maven module name. This means each service only needs to specify the variables that it cares about or needs changed. By default, we tag each service with the `latest` tag, which means ECS will automatically update the image on each service reload/restart.

Also added a `release` profile in maven which tags the image with the artifact version, instead of the `latest` tag. This is useful for cutting a new release which will get promoted into the higher environments.

**Choices Made**
By default, every image gets tagged with `latest` and we have to manually specify when we want to cut a release. We might want to consider more robust tagging in the future. Also, we don't push by default, we rely on the user pushing when they want. That will change once we have our CI/CD pipeline merged.

Tickets closed
DPC-224: Tag docker images correctly.