### PR TITLE
DPC-242: Update capabilities statement

### DIFF
--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -96,6 +96,7 @@
             </resource>
             <resource>
                 <directory>src/main/resources</directory>
+                <filtering>true</filtering>
             </resource>
         </resources>
         <!--Pull in the attribution seeds so we can use them for the integration tests.-->

--- a/dpc-api/src/main/java/gov/cms/dpc/api/converters/OffsetDateTimeToStringConverter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/converters/OffsetDateTimeToStringConverter.java
@@ -1,19 +1,17 @@
 package gov.cms.dpc.api.converters;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
+import gov.cms.dpc.fhir.FHIRFormatters;
 
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Serialize in the format expected the FHIR spec. For details see https://hl7.org/fhir/2018May/datatypes.html#instant
  */
 public class OffsetDateTimeToStringConverter extends StdConverter<OffsetDateTime, String> {
 
-    private static final DateTimeFormatter fhirFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
-
     @Override
     public String convert(OffsetDateTime time) {
-        return fhirFormatter.format(time);
+        return FHIRFormatters.INSTANT_FORMATTER.format(time);
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
@@ -62,9 +62,25 @@ public class Capabilities {
         final CapabilityStatementRestOperationComponent metadataResource = new CapabilityStatementRestOperationComponent(new StringType("Metadata"), new Reference(String.format("%s/metadata", baseURI)));
         final CapabilityStatementRestOperationComponent versionResource = new CapabilityStatementRestOperationComponent(new StringType("Version"), new Reference(String.format("%s/_version", baseURI)));
 
-        // Add the Group export paths
-        final CapabilityStatementRestOperationComponent providerExport = new CapabilityStatement.CapabilityStatementRestOperationComponent(new StringType("Provider export"), new Reference(String.format("%s/Group/providerID/$export", baseURI)));
-        serverComponent.setOperation(Arrays.asList(providerExport, metadataResource, versionResource));
+        //  Group resources
+        final CapabilityStatementRestOperationComponent providerExport = new CapabilityStatementRestOperationComponent(new StringType("Provider export"), new Reference(String.format("%s/Group/providerID/$export", baseURI)));
+
+        // Job resources
+        final CapabilityStatementRestOperationComponent jobResource = new CapabilityStatementRestOperationComponent(new StringType("Job Status"), new Reference(String.format("%s/Job/jobID", baseURI)));
+
+        // Roster endpoints
+        final CapabilityStatementRestOperationComponent rosterResource = new CapabilityStatementRestOperationComponent(new StringType("Roster submission and updating"), new Reference(String.format("%s/Bundle", baseURI)));
+
+        // Data endpoints
+        final CapabilityStatementRestOperationComponent dataResource = new CapabilityStatementRestOperationComponent(new StringType("Export file retrieval"), new Reference(String.format("%s/Data/fileID", baseURI)));
+
+        serverComponent.setOperation(Arrays.asList(
+                providerExport,
+                metadataResource,
+                versionResource,
+                jobResource,
+                rosterResource,
+                dataResource));
 
         return Collections.singletonList(serverComponent);
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
@@ -2,9 +2,9 @@ package gov.cms.dpc.api.core;
 
 
 import gov.cms.dpc.common.utils.PropertiesProvider;
+import gov.cms.dpc.fhir.FHIRFormatters;
 import org.hl7.fhir.dstu3.model.*;
 
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -12,7 +12,6 @@ import java.util.List;
 import static org.hl7.fhir.dstu3.model.CapabilityStatement.*;
 
 public class Capabilities {
-    private static final DateTimeFormatter FHIR_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     private Capabilities() {
     }
@@ -20,7 +19,7 @@ public class Capabilities {
     public static CapabilityStatement buildCapabilities(String baseUri, String version) {
         final PropertiesProvider pp = new PropertiesProvider();
 
-        DateTimeType releaseDate = DateTimeType.parseV3(pp.getBuildTimestamp().format(FHIR_FORMATTER));
+        DateTimeType releaseDate = DateTimeType.parseV3(pp.getBuildTimestamp().format(FHIRFormatters.DATE_TIME_FORMATTER));
 
         CapabilityStatement capabilityStatement = new CapabilityStatement();
         capabilityStatement

--- a/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
@@ -1,8 +1,10 @@
 package gov.cms.dpc.api.core;
 
 
+import gov.cms.dpc.common.utils.PropertiesProvider;
 import org.hl7.fhir.dstu3.model.*;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -10,23 +12,24 @@ import java.util.List;
 import static org.hl7.fhir.dstu3.model.CapabilityStatement.*;
 
 public class Capabilities {
+    private static final DateTimeFormatter FHIR_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 
     private Capabilities() {
-//        Should not use
     }
 
     public static CapabilityStatement buildCapabilities(String baseUri, String version) {
-        DateTimeType releaseDate = DateTimeType.now();
+        final PropertiesProvider pp = new PropertiesProvider();
+
+        DateTimeType releaseDate = DateTimeType.parseV3(pp.getBuildTimestamp().format(FHIR_FORMATTER));
 
         CapabilityStatement capabilityStatement = new CapabilityStatement();
-
         capabilityStatement
                 .setStatus(Enumerations.PublicationStatus.ACTIVE)
                 .setDateElement(releaseDate)
                 .setPublisher("Centers for Medicare and Medicaid Services")
                 // This should track the FHIR version used by BlueButton
                 .setFhirVersion("3.0.1")
-                .setSoftware(generateSoftwareComponent(releaseDate))
+                .setSoftware(generateSoftwareComponent(releaseDate, pp.getBuildVersion()))
                 .setKind(CapabilityStatementKind.CAPABILITY)
                 .setRest(generateRestComponents(baseUri + version))
                 .setAcceptUnknown(UnknownContentCode.NO)
@@ -40,10 +43,10 @@ public class Capabilities {
         return capabilityStatement;
     }
 
-    private static CapabilityStatementSoftwareComponent generateSoftwareComponent(DateTimeType releaseDate) {
+    private static CapabilityStatementSoftwareComponent generateSoftwareComponent(DateTimeType releaseDate, String releaseVersion) {
         return new CapabilityStatementSoftwareComponent()
                 .setName("Data @ Point of Care API")
-                .setVersion("0.0.1")
+                .setVersion(releaseVersion)
                 .setReleaseDateElement(releaseDate);
     }
 

--- a/dpc-api/src/main/resources/app.properties
+++ b/dpc-api/src/main/resources/app.properties
@@ -1,2 +1,2 @@
 application.version = ${project.version}
-application.builddate = ${maven.build.timestamp}
+application.builddate = ${timestamp}

--- a/dpc-api/src/main/resources/app.properties
+++ b/dpc-api/src/main/resources/app.properties
@@ -1,0 +1,2 @@
+application.version = ${project.version}
+application.builddate = ${maven.build.timestamp}

--- a/dpc-api/src/test/java/gov/cms/dpc/api/core/CapabilitiesTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/core/CapabilitiesTest.java
@@ -14,32 +14,31 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CapabilitiesTest {
+class CapabilitiesTest {
 
     private FhirValidator validator;
 
     @BeforeEach
-    public void setupValidator() {
+    void setupValidator() {
         final FhirContext ctx = FhirContext.forDstu3();
 
         validator = ctx.newValidator();
 
         final SchemaBaseValidator val1 = new SchemaBaseValidator(ctx);
         final SchematronBaseValidator val2 = new SchematronBaseValidator(ctx);
-//        new FhirInstanceValidator();
         validator.registerValidatorModule(val1);
         validator.registerValidatorModule(val2);
     }
 
     @Test
-    public void capabilitiesIsValid() {
+    void capabilitiesIsValid() {
         final CapabilityStatement capabilities = Capabilities.buildCapabilities("http://localhost:3002", "/v1");
         final ValidationResult validationResult = validator.validateWithResult(capabilities);
         assertTrue(validationResult.isSuccessful(), validationResultsToString(validationResult));
 
         // Verify properties
         assertAll(() -> assertEquals(1, capabilities.getRest().size(), "Should have a single server operation"),
-                () -> assertEquals(3, capabilities.getRest().get(0).getOperation().size(), "Should have three routes"));
+                () -> assertEquals(6, capabilities.getRest().get(0).getOperation().size(), "Should have six routes"));
     }
 
     private static String validationResultsToString(ValidationResult result) {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 public class PropertiesProvider {
 
     private static final String PROPERTIES_FILE = "app.properties";
-    private static final DateTimeFormatter MAVEN_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmm");
+    private static final DateTimeFormatter MAVEN_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
 
     private final Properties properties;
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.common.utils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.MissingResourceException;
 import java.util.Properties;
@@ -26,8 +27,8 @@ public class PropertiesProvider {
         }
     }
 
-    public LocalDateTime getBuildTimestamp() {
-        return LocalDateTime.parse(this.properties.getProperty("application.builddate"), MAVEN_FORMATTER);
+    public OffsetDateTime getBuildTimestamp() {
+        return OffsetDateTime.parse(this.properties.getProperty("application.builddate"), MAVEN_FORMATTER);
     }
 
     public String getBuildVersion() {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
@@ -1,0 +1,36 @@
+package gov.cms.dpc.common.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.MissingResourceException;
+import java.util.Properties;
+
+public class PropertiesProvider {
+
+    private static final String PROPERTIES_FILE = "app.properties";
+    private static final DateTimeFormatter MAVEN_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmm");
+
+    private final Properties properties;
+
+    public PropertiesProvider() {
+        this.properties = new Properties();
+        try (final InputStream is = PropertiesProvider.class.getClassLoader().getResourceAsStream(PROPERTIES_FILE)) {
+            if (is == null) {
+                throw new MissingResourceException("Cannot find application properties file", PropertiesProvider.class.getName(), PROPERTIES_FILE);
+            }
+            this.properties.load(is);
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format("Cannot load properties file: %s", PROPERTIES_FILE), e);
+        }
+    }
+
+    public LocalDateTime getBuildTimestamp() {
+        return LocalDateTime.parse(this.properties.getProperty("application.builddate"), MAVEN_FORMATTER);
+    }
+
+    public String getBuildVersion() {
+        return this.properties.getProperty("application.version");
+    }
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRFormatters.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRFormatters.java
@@ -1,0 +1,22 @@
+package gov.cms.dpc.fhir;
+
+import java.time.format.DateTimeFormatter;
+
+public class FHIRFormatters {
+
+    /**
+     * {@link DateTimeFormatter} which outputs in a format parsable by {@link org.hl7.fhir.dstu3.model.InstantType}.
+     * See: https://www.hl7.org/fhir/datatypes.html#instant
+     */
+    public static final DateTimeFormatter INSTANT_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
+
+    /**
+     * {@link DateTimeFormatter} which outputs in a format parsable by {@link org.hl7.fhir.dstu3.model.DateTimeType}.
+     * See: https://www.hl7.org/fhir/datatypes.html#dateTime
+     */
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssxxx");
+
+    private FHIRFormatters() {
+        // Not used
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <java.version>11</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>
         <jib.ecr.root>430398651479.dkr.ecr.us-east-1.amazonaws.com</jib.ecr.root>
+        <timestamp>${maven.build.timestamp}</timestamp>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Why**
FHIR clients use the capabilities statement to determine which operations they can perform against our system. Previously, the statement was really bare bones and hadn't been updated with the new Roster, Job and Data endpoints. That's now been fixed.

**What Changed**
Updated the Capabilities Statement to include the new endpoints.
Added a generic ability to inject Maven variables (build time values) into the Java runtime, so we can now automatically use the build timestamp and version number in our capabilities statement.

**Choices Made**
I'm intentionally keeping things simple for now. The statements are really verbose which means the best option going forward is to find a way to autogenerate values using something like ByteBuddy.

**Tickets closed**
DPC-242

**Future Work**
DPC-125: Expand the amount of information available in the capabilities statement
DPC-66: We should automatically generate the capabilities statement from our annotated FHIR resources.