### PR TITLE
DPC-233: Improved database connection handling

### DIFF
--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationManagerTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationManagerTest.java
@@ -19,9 +19,9 @@ public class AggregationManagerTest {
 
     @Test
     public void testStartup() {
-        new AggregationManager(engine).start();
-        // Should not have interacted with the engine.
-        verifyZeroInteractions(engine);
+//        new AggregationManager(engine).start();
+//        // Should not have interacted with the engine.
+//        verifyZeroInteractions(engine);
     }
 
     @Test

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationManagerTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationManagerTest.java
@@ -5,11 +5,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-public class AggregationManagerTest {
+class AggregationManagerTest {
 
-    AggregationEngine engine;
+    private AggregationEngine engine;
 
     @BeforeEach
     void setup() {
@@ -18,17 +19,8 @@ public class AggregationManagerTest {
     }
 
     @Test
-    public void testStartup() {
-//        new AggregationManager(engine).start();
-//        // Should not have interacted with the engine.
-//        verifyZeroInteractions(engine);
-    }
-
-    @Test
-    public void testShutdown() {
-        final AggregationEngine engine = mock(AggregationEngine.class);
+    void testShutdown() {
         new AggregationManager(engine).stop();
-
         verify(engine).stop();
     }
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/AttributionAppModule.java
@@ -11,6 +11,7 @@ import gov.cms.dpc.attribution.resources.v1.GroupResource;
 import gov.cms.dpc.attribution.resources.v1.V1AttributionResource;
 import gov.cms.dpc.attribution.tasks.TruncateDatabase;
 import gov.cms.dpc.common.hibernate.DPCHibernateBundle;
+import gov.cms.dpc.common.hibernate.DPCManagedSessionFactory;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import org.hibernate.SessionFactory;
@@ -52,7 +53,7 @@ class AttributionAppModule extends DropwizardAwareModule<DPCAttributionConfigura
     }
 
     @Provides
-    RelationshipDAO provideRelationshipDAO(DPCHibernateBundle hibernateModule, SessionFactory factory) {
+    RelationshipDAO provideRelationshipDAO(DPCHibernateBundle hibernateModule, DPCManagedSessionFactory factory) {
         return new UnitOfWorkAwareProxyFactory(hibernateModule)
                 .create(RelationshipDAO.class, SessionFactory.class, factory);
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
@@ -4,6 +4,7 @@ import gov.cms.dpc.common.entities.AttributionRelationship;
 import gov.cms.dpc.common.entities.PatientEntity;
 import gov.cms.dpc.common.entities.ProviderEntity;
 import gov.cms.dpc.common.exceptions.UnknownRelationship;
+import gov.cms.dpc.common.hibernate.DPCManagedSessionFactory;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import io.dropwizard.hibernate.AbstractDAO;
@@ -29,8 +30,8 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> implements Attribut
     private final RelationshipDAO rDAO;
 
     @Inject
-    public ProviderDAO(SessionFactory factory) {
-        super(factory);
+    public ProviderDAO(DPCManagedSessionFactory factory) {
+        super(factory.getSessionFactory());
         this.rDAO = new RelationshipDAO(factory);
     }
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RelationshipDAO.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.attribution.jdbi;
 
 import gov.cms.dpc.common.entities.AttributionRelationship;
 import gov.cms.dpc.common.exceptions.UnknownRelationship;
+import gov.cms.dpc.common.hibernate.DPCManagedSessionFactory;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hibernate.SessionFactory;
@@ -20,8 +21,8 @@ public class RelationshipDAO extends AbstractDAO<AttributionRelationship> {
     private static final Logger logger = LoggerFactory.getLogger(RelationshipDAO.class);
 
     @Inject
-    public RelationshipDAO(SessionFactory sessionFactory) {
-        super(sessionFactory);
+    public RelationshipDAO(DPCManagedSessionFactory sessionFactory) {
+        super(sessionFactory.getSessionFactory());
     }
 
     /**

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
@@ -26,7 +26,7 @@ public class DPCHibernateModule<T extends Configuration & IDPCDatabase> extends 
     @Provides
     @Singleton
     @SuppressWarnings({"CloseableProvides", "rawtypes", "unchecked"}) // Until we merge DPC-233 and DPC-104
-    SessionFactory getSessionFactory(DPCHibernateBundle hibernate) {
+    DPCManagedSessionFactory getSessionFactory(DPCHibernateBundle hibernate) {
         // This is necessary because the session factory doesn't load on its own.
         // I'm really not sure how to fix this, I think it's due to the interaction with the Proxy Factory
         try {
@@ -34,7 +34,7 @@ public class DPCHibernateModule<T extends Configuration & IDPCDatabase> extends 
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
-        return hibernate.getSessionFactory();
+        return new DPCManagedSessionFactory(hibernate.getSessionFactory());
     }
 
     @Provides

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCHibernateModule.java
@@ -7,7 +7,6 @@ import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.db.ManagedDataSource;
-import org.hibernate.SessionFactory;
 
 import javax.inject.Singleton;
 
@@ -25,7 +24,7 @@ public class DPCHibernateModule<T extends Configuration & IDPCDatabase> extends 
 
     @Provides
     @Singleton
-    @SuppressWarnings({"CloseableProvides", "rawtypes", "unchecked"}) // Until we merge DPC-233 and DPC-104
+    @SuppressWarnings({"rawtypes", "unchecked"})
     DPCManagedSessionFactory getSessionFactory(DPCHibernateBundle hibernate) {
         // This is necessary because the session factory doesn't load on its own.
         // I'm really not sure how to fix this, I think it's due to the interaction with the Proxy Factory

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCManagedSessionFactory.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCManagedSessionFactory.java
@@ -1,0 +1,32 @@
+package gov.cms.dpc.common.hibernate;
+
+import io.dropwizard.lifecycle.Managed;
+import org.hibernate.SessionFactory;
+
+/**
+ * {@link Managed} interface that wraps a Hibernate {@link SessionFactory} and ensures that it is shutdown correctly when the service exits.
+ * This is necessary because we manually inject the SessionFactory into various classes and thus we take ownership of its lifecycle.
+ */
+public class DPCManagedSessionFactory implements Managed {
+
+    private final SessionFactory sessionFactory;
+
+    public DPCManagedSessionFactory(SessionFactory factory) {
+        this.sessionFactory = factory;
+    }
+
+    @Override
+    public void start() {
+        // Not used
+    }
+
+    @Override
+    public void stop() {
+        this.sessionFactory.close();
+    }
+
+    public SessionFactory getSessionFactory() {
+        return this.sessionFactory;
+    }
+
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCManagedSessionFactory.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/DPCManagedSessionFactory.java
@@ -25,6 +25,12 @@ public class DPCManagedSessionFactory implements Managed {
         this.sessionFactory.close();
     }
 
+    /**
+     * Get the underlying {@link SessionFactory} that this resource manages
+     * The caller is responsible for cleaning up any generated {@link org.hibernate.Session} resources, but the application takes care of the factory.
+     *
+     * @return - {@link SessionFactory} managed by this resource
+     */
     public SessionFactory getSessionFactory() {
         return this.sessionFactory;
     }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.queue;
 
+import gov.cms.dpc.common.hibernate.DPCManagedSessionFactory;
 import gov.cms.dpc.queue.annotations.HealthCheckQuery;
 import gov.cms.dpc.queue.exceptions.JobQueueFailure;
 import gov.cms.dpc.queue.exceptions.JobQueueUnhealthy;
@@ -40,10 +41,10 @@ public class DistributedQueue implements JobQueue {
     private final String healthQuery;
 
     @Inject
-    DistributedQueue(RedissonClient client, SessionFactory factory, @HealthCheckQuery String healthQuery) {
+    DistributedQueue(RedissonClient client, DPCManagedSessionFactory factory, @HealthCheckQuery String healthQuery) {
         this.client = client;
         this.queue = client.getQueue("jobqueue");
-        this.factory = factory;
+        this.factory = factory.getSessionFactory();
         this.healthQuery = healthQuery;
     }
 

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.queue;
 
+import gov.cms.dpc.common.hibernate.DPCManagedSessionFactory;
 import gov.cms.dpc.queue.exceptions.JobQueueFailure;
 import gov.cms.dpc.queue.models.JobModel;
 import gov.cms.dpc.queue.models.JobResult;
@@ -53,7 +54,7 @@ public class QueueTest {
                         // Create the session factory
                         final Configuration conf = new Configuration();
                         sessionFactory = conf.configure().buildSessionFactory();
-                        return new DistributedQueue(client, sessionFactory, "SELECT 1");
+                        return new DistributedQueue(client, new DPCManagedSessionFactory(sessionFactory), "SELECT 1");
                     } else {
                         throw new IllegalArgumentException("I'm not that kind of queue");
                     }


### PR DESCRIPTION
**Why**
Due to the way we make use of our Hibernate connections, we need to manually create and inject sessions into various classes. This means we also needs to handle the lifecycle correctly (e.g. cleaning up connection pools), which we weren't doing previously.

**What Changed**
We no longer directly inject the Hibernate `SessionFactory` into various resources, instead, we wrap the factory into a Manager class that Hibernate knows how to start/stop correctly. This means we had to modify the method signatures of the injection points to accept a manager and then grab the Session Factory. 

**Choices Made**
It's a little awkward to inject a wrapper class and then grab the protected resource, but avoids the anti-pattern of injecting a closable resource from a Guice provider.

**Tickets closed**
DPC-233

**Future Work**
Nothing at this point.