### PR TITLE
Fix a bug in SeedCommand

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -20,10 +20,7 @@ import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.sql.Timestamp;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.MissingResourceException;


### PR DESCRIPTION
**Why**

There is a condition where running  `dpc_attribution seed` throws an IO exception.   

**What Changed**

Made the resource stream open and used in the run function, instead of open at module create time. 

**Choices Made**

NA

**Tickets closed**:

DPC-290 Exception in seed command when dpc_attribution is run as a JAR

**Future Work**

NA
