### PR TITLE
create api documentation route

### DIFF
--- a/dpc-web/app/views/public/docs.html.erb
+++ b/dpc-web/app/views/public/docs.html.erb
@@ -1,0 +1,2 @@
+
+<h1>API Documentation</h1>

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   root to: 'public#home'
 
   match '/home', to: 'public#home', via: :get
+
+  match '/docs', to: 'public#docs', via: :get
 end


### PR DESCRIPTION
**Why**

Create a route for API documentation and page in `views/public`. http://localhost:3000/docs should now resolve.

**Choices Made**

Used `match` method since that's what we were using for the landing page. 

**Future Work**

- Breaking up some of the partials and layout files to better improve the design of this site.  
- Don't quite know what will be included in the documentation. Will it be a single page or include multiple sections? I think we are going to follow Bue Button 2.0 for now, which is a single page.
