### PR TITLE
Create API documents controller

### DIFF
--- a/dpc-web/app/assets/javascripts/api_documents.coffee
+++ b/dpc-web/app/assets/javascripts/api_documents.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/dpc-web/app/assets/stylesheets/api_documents.scss
+++ b/dpc-web/app/assets/stylesheets/api_documents.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the ApiDocuments controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/dpc-web/app/controllers/api_documents_controller.rb
+++ b/dpc-web/app/controllers/api_documents_controller.rb
@@ -1,3 +1,4 @@
-class ApiDocumentsController < ApplicationController
+# frozen_string_literal: true
 
+class ApiDocumentsController < ApplicationController
 end

--- a/dpc-web/app/controllers/api_documents_controller.rb
+++ b/dpc-web/app/controllers/api_documents_controller.rb
@@ -1,2 +1,3 @@
 class ApiDocumentsController < ApplicationController
+
 end

--- a/dpc-web/app/controllers/api_documents_controller.rb
+++ b/dpc-web/app/controllers/api_documents_controller.rb
@@ -1,0 +1,2 @@
+class ApiDocumentsController < ApplicationController
+end

--- a/dpc-web/app/helpers/api_documents_helper.rb
+++ b/dpc-web/app/helpers/api_documents_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module ApiDocumentsHelper
 end

--- a/dpc-web/app/helpers/api_documents_helper.rb
+++ b/dpc-web/app/helpers/api_documents_helper.rb
@@ -1,0 +1,2 @@
+module ApiDocumentsHelper
+end

--- a/dpc-web/app/helpers/application_helper.rb
+++ b/dpc-web/app/helpers/application_helper.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
-
   def title(page_title)
     content_for(:title) { page_title }
   end
-  
 end

--- a/dpc-web/app/helpers/application_helper.rb
+++ b/dpc-web/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+
+  def title(page_title)
+    content_for(:title) { page_title }
+  end
+  
 end

--- a/dpc-web/app/views/api_documents/home.html.erb
+++ b/dpc-web/app/views/api_documents/home.html.erb
@@ -1,1 +1,4 @@
-<h1>API Documentation in the new controller</h1>
+<% title "API Documentation" %>
+
+
+<p>Content for API Documentation</p>

--- a/dpc-web/app/views/api_documents/home.html.erb
+++ b/dpc-web/app/views/api_documents/home.html.erb
@@ -1,0 +1,1 @@
+<h1>API Documentation in the new controller</h1>

--- a/dpc-web/app/views/layouts/application.html.erb
+++ b/dpc-web/app/views/layouts/application.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Data Point of Care</title>
+    <title>
+      <%= content_for?(:title) ? yield(:title) : 'CMS.gov' %> | Data at the Point of Care
+    </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -49,6 +51,7 @@
     <div class="ds-l-container">
       <div class="ds-l-row">
         <div class="ds-l-col--12">
+          <h1><%= yield(:title) %></h1>
         </div>
       </div>
     </div>

--- a/dpc-web/app/views/layouts/application.html.erb
+++ b/dpc-web/app/views/layouts/application.html.erb
@@ -16,6 +16,44 @@
     <!-- nav -->
     <%= render partial: 'shared/navbar' %>
 
+    <!-- hero -->
+    <% if controller.controller_name == "public" %>
+    <div class="hero">
+      <div class="ds-l-container">
+        <div class="ds-l-row">
+          <div class="ds-l-col--12">
+            <h1 class="ds-display">Data Point of Care API</h1>
+          </div>
+        </div>
+        <div class="ds-l-row ds-u-margin-top--3">
+          <div class="ds-l-col--8 ds-text--lead">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut scelerisque risus.
+            Sed mattis placerat ante sit amet auctor. Donec ut nibh lobortis, aliquet ligula quis,
+            consectetur nisl. Phasellus eget quam tempor, tempus ligula in, lobortis massa.
+            Nullam venenatis varius vestibulum.
+          </div>
+        </div>
+        <div class="ds-l-row ds-u-margin-top--7">
+          <div class="ds-l-col--4">
+            <a href="/">
+              <a class="ds-c-button ds-c-button--inverse ds-c-button--big">Sign up for the Beta →</a>
+            </a>
+          </div>
+          <div class="ds-l-col--4">
+            <%= link_to "API Docs", docs_path, :class => "ds-c-button ds-c-button--inverse ds-c-button--big", :id => "my-id" %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <% else %>
+    <div class="ds-l-container">
+      <div class="ds-l-row">
+        <div class="ds-l-col--12">
+        </div>
+      </div>
+    </div>
+    <% end %>
+
     <!-- content -->
     <section class="ds-l-container" id="main">
       <%= yield %>

--- a/dpc-web/app/views/public/docs.html.erb
+++ b/dpc-web/app/views/public/docs.html.erb
@@ -1,2 +1,0 @@
-
-<h1>API Documentation</h1>

--- a/dpc-web/app/views/shared/_navbar.html.erb
+++ b/dpc-web/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <div class="ds-l-container">
   <nav class="navbar navbar-light ">
-    <a class="navbar-brand" href="#">
+    <a class="navbar-brand" href="/">
       <img src="/assets/site-logo.png" alt="CMS Logo">
     </a>
 

--- a/dpc-web/app/views/shared/_navbar.html.erb
+++ b/dpc-web/app/views/shared/_navbar.html.erb
@@ -29,33 +29,3 @@
     </div>
   </nav>
 </div>
-
-<div class="hero">
-  <div class="ds-l-container">
-    <div class="ds-l-row">
-      <div class="ds-l-col--12">
-        <h1 class="ds-display">Data Point of Care API</h1>
-      </div>
-    </div>
-    <div class="ds-l-row ds-u-margin-top--3">
-      <div class="ds-l-col--8 ds-text--lead">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut ut scelerisque risus.
-        Sed mattis placerat ante sit amet auctor. Donec ut nibh lobortis, aliquet ligula quis,
-        consectetur nisl. Phasellus eget quam tempor, tempus ligula in, lobortis massa.
-        Nullam venenatis varius vestibulum.
-      </div>
-    </div>
-    <div class="ds-l-row ds-u-margin-top--7">
-      <div class="ds-l-col--4">
-        <a href="/">
-          <button type="button" class="ds-c-button ds-c-button--inverse ds-c-button--big">Read The User Guide →</button>
-        </a>
-      </div>
-      <div class="ds-l-col--4">
-        <a href="/">
-          <button type="button" class="ds-c-button ds-c-button--inverse ds-c-button--big">Sign up for the Beta →</button>
-        </a>
-      </div>
-    </div>
-  </div>
-</div>

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
 
   match '/home', to: 'public#home', via: :get
 
-  match '/docs', to: 'public#docs', via: :get
+  match '/docs', to: 'api_documents#home', via: :get
 end

--- a/dpc-web/spec/controllers/api_documents_controller_spec.rb
+++ b/dpc-web/spec/controllers/api_documents_controller_spec.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe ApiDocumentsController, type: :controller do
-
 end

--- a/dpc-web/spec/controllers/api_documents_controller_spec.rb
+++ b/dpc-web/spec/controllers/api_documents_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ApiDocumentsController, type: :controller do
+
+end

--- a/dpc-web/spec/helpers/api_documents_helper_spec.rb
+++ b/dpc-web/spec/helpers/api_documents_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 # Specs in this file have access to a helper object that includes

--- a/dpc-web/spec/helpers/api_documents_helper_spec.rb
+++ b/dpc-web/spec/helpers/api_documents_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ApiDocumentsHelper. For example:
+#
+# describe ApiDocumentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ApiDocumentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
**Why**

Need to set up controller for API documentation

**What Changed**

- Created a new controller the API Documentation
- Organized layout files to support appropriate content
- Set up a better way of handling page titles.

**Choices Made**

- New controller for API documentation would the section up better for future needs
- Need page help to organize page titles outside of main content, also in the `<title>` tag.

**Tickets closed**:

https://jiraent.cms.gov/browse/DPC-299