### PR TITLE
DPC-315: Automatically apply database migrations

### DIFF
--- a/dpc-aggregation/src/main/resources/sbx.application.conf
+++ b/dpc-aggregation/src/main/resources/sbx.application.conf
@@ -5,9 +5,6 @@ dpc.aggregation {
     url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_attribution"
     user = postgres
     password = postgres
-    properties = {
-      "hibernate.hbm2ddl.auto" = update
-    }
   }
   bbclient.keyStore.location = "/bb.keystore"
   queue {

--- a/dpc-api/src/main/resources/sbx.application.conf
+++ b/dpc-api/src/main/resources/sbx.application.conf
@@ -5,9 +5,6 @@ dpc.api {
     url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_attribution"
     user = postgres
     password = postgres
-    properties = {
-      "hibernate.hbm2ddl.auto" = update
-    }
   }
   bbclient.keyStore.location = "/bb.keystore"
   queue {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionConfiguration.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionConfiguration.java
@@ -17,6 +17,8 @@ public class DPCAttributionConfiguration extends TypesafeConfiguration implement
     @Valid
     private Duration expirationThreshold;
 
+    private Boolean migrationEnabled;
+
     @Valid
     @NotNull
     @JsonProperty("database")
@@ -66,5 +68,13 @@ public class DPCAttributionConfiguration extends TypesafeConfiguration implement
 
     public void setTokenPolicy(TokenPolicy tokenPolicy) {
         this.tokenPolicy = tokenPolicy;
+    }
+
+    public Boolean getMigrationEnabled() {
+        return migrationEnabled;
+    }
+
+    public void setMigrationEnabled(Boolean migrationEnabled) {
+        this.migrationEnabled = migrationEnabled;
     }
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/cli/SeedCommand.java
@@ -1,10 +1,8 @@
 package gov.cms.dpc.attribution.cli;
 
 import gov.cms.dpc.attribution.DPCAttributionConfiguration;
-import gov.cms.dpc.attribution.dao.tables.Organizations;
-import gov.cms.dpc.attribution.dao.tables.Patients;
-import gov.cms.dpc.attribution.dao.tables.Providers;
 import gov.cms.dpc.attribution.jdbi.RosterUtils;
+import gov.cms.dpc.attribution.utils.DBUtils;
 import gov.cms.dpc.common.utils.SeedProcessor;
 import io.dropwizard.Application;
 import io.dropwizard.cli.EnvironmentCommand;
@@ -59,17 +57,16 @@ public class SeedCommand extends EnvironmentCommand<DPCAttributionConfiguration>
         // Read in the seeds file and write things
         logger.info("Seeding attributions at time {}", creationTimestamp.toLocalDateTime());
 
-
         try (final Connection connection = dataSource.getConnection();
              DSLContext context = DSL.using(connection, this.settings)) {
 
             // Truncate everything
-            context.truncate(Patients.PATIENTS).cascade().execute();
-            context.truncate(Providers.PROVIDERS).cascade().execute();
-            context.truncate(Organizations.ORGANIZATIONS).cascade().execute();
-            context.truncate("root_keys").cascade();
+            DBUtils.truncateAllTables(context, "public");
+        }
 
 
+        try (final Connection connection = dataSource.getConnection();
+             DSLContext context = DSL.using(connection, this.settings)) {
             // Get the test seeds
             try (InputStream resource = SeedCommand.class.getClassLoader().getResourceAsStream(CSV)) {
                 if (resource == null) {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/tasks/TruncateDatabase.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/tasks/TruncateDatabase.java
@@ -2,9 +2,8 @@ package gov.cms.dpc.attribution.tasks;
 
 import com.google.common.collect.ImmutableMultimap;
 import gov.cms.dpc.attribution.DPCAttributionConfiguration;
-import gov.cms.dpc.attribution.dao.tables.Attributions;
-import gov.cms.dpc.attribution.dao.tables.Patients;
-import gov.cms.dpc.attribution.dao.tables.Providers;
+import gov.cms.dpc.attribution.dao.Public;
+import gov.cms.dpc.attribution.utils.DBUtils;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.servlets.tasks.Task;
@@ -44,10 +43,8 @@ public class TruncateDatabase extends Task {
         try (final Connection connection = dataSource.getConnection();
              DSLContext context = DSL.using(connection, new Settings().withRenderNameStyle(RenderNameStyle.AS_IS))) {
 
-            // Truncate everything
-            context.truncate(Patients.PATIENTS).cascade().execute();
-            context.truncate(Providers.PROVIDERS).cascade().execute();
-            context.truncate(Attributions.ATTRIBUTIONS).cascade().execute();
+            DBUtils.truncateAllTables(context, "public");
         }
     }
+
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/DBUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/DBUtils.java
@@ -11,6 +11,10 @@ public class DBUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(DBUtils.class);
 
+    private DBUtils() {
+        // Not used
+    }
+
     /**
      * Truncate all data in a specific {@link Schema}
      *

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/DBUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/DBUtils.java
@@ -1,0 +1,40 @@
+package gov.cms.dpc.attribution.utils;
+
+import org.jooq.DSLContext;
+import org.jooq.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class DBUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(DBUtils.class);
+
+    /**
+     * Truncate all data in a specific {@link Schema}
+     *
+     * @param context - {@link DSLContext} to use
+     * @param schema  - {@link String} name of schema to truncate
+     */
+    public static void truncateAllTables(DSLContext context, String schema) {
+        logger.debug("Truncating schema: {}", schema);
+        final List<Schema> schemas = context.meta()
+                .getSchemas(schema);
+
+        if (schemas.isEmpty()) {
+            throw new IllegalArgumentException(String.format("Cannot find schema '%s'", schema));
+        }
+
+        // Truncate all the tables (except for the liquibase metadata)
+        schemas
+                .get(0)
+                .getTables()
+                .stream()
+                .filter(table -> !table.getName().startsWith("databasechangelog"))
+                .forEach(table -> {
+                    logger.trace("Truncating table: {}", table.getName());
+                    context.truncate(table).cascade().execute();
+                });
+    }
+}

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -3,6 +3,7 @@ dpc.attribution {
   include "server.conf"
 
   expirationThreshold = 90 // In days
+  migrationEnabled = true
   sundial {
     annotated-jobs-package-name = gov.cms.dpc.attribution.jobs
   }

--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -221,5 +221,7 @@
 
     <!--    Create the root table for the macaroons-->
     <include file="macaroon_migrations.xml"/>
+    <!--    Setup required tables for Job Queue-->
+    <include file="queue_migrations.xml"/>
 
 </databaseChangeLog>

--- a/dpc-attribution/src/main/resources/queue_migrations.xml
+++ b/dpc-attribution/src/main/resources/queue_migrations.xml
@@ -6,7 +6,7 @@
     
     <changeSet id="create-job-queue-table" author="nickrobison-usds">
         <createTable tableName="JOB_QUEUE">
-            <column name="id" type="UUID">
+            <column name="jobID" type="UUID">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
             <column name="provider_id" type="VARCHAR(50)"/>

--- a/dpc-attribution/src/main/resources/queue_migrations.xml
+++ b/dpc-attribution/src/main/resources/queue_migrations.xml
@@ -33,7 +33,7 @@
 
         <addForeignKeyConstraint baseTableName="JOB_RESULT" baseColumnNames="jobID" constraintName="fk_job_id_results"
                                  referencedTableName="JOB_QUEUE"
-                                 referencedColumnNames="id"/>
+                                 referencedColumnNames="jobID"/>
     </changeSet>
     
 </databaseChangeLog>

--- a/dpc-attribution/src/main/resources/queue_migrations.xml
+++ b/dpc-attribution/src/main/resources/queue_migrations.xml
@@ -3,10 +3,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-    
+
     <changeSet id="create-job-queue-table" author="nickrobison-usds">
         <createTable tableName="JOB_QUEUE">
-            <column name="jobID" type="UUID">
+            <column name="jobid" type="UUID">
                 <constraints primaryKey="true" nullable="false"/>
             </column>
             <column name="provider_id" type="VARCHAR(50)"/>
@@ -20,20 +20,20 @@
         </createTable>
 
         <createTable tableName="JOB_RESULT">
-            <column name="jobID" type="UUID">
+            <column name="jobid" type="UUID">
                 <constraints nullable="false"/>
             </column>
             <column name="resource_type" type="INTEGER"/>
             <column name="sequence" type="INTEGER"/>
             <column name="count" type="INTEGER"/>
         </createTable>
-        
-        <addPrimaryKey tableName="JOB_RESULT"
-                       columnNames="jobID, resource_type, sequence"/>
 
-        <addForeignKeyConstraint baseTableName="JOB_RESULT" baseColumnNames="jobID" constraintName="fk_job_id_results"
+        <addPrimaryKey tableName="JOB_RESULT"
+                       columnNames="jobid, resource_type, sequence"/>
+
+        <addForeignKeyConstraint baseTableName="JOB_RESULT" baseColumnNames="jobid" constraintName="fk_job_id_results"
                                  referencedTableName="JOB_QUEUE"
-                                 referencedColumnNames="jobID"/>
+                                 referencedColumnNames="jobid"/>
     </changeSet>
-    
+
 </databaseChangeLog>

--- a/dpc-attribution/src/main/resources/queue_migrations.xml
+++ b/dpc-attribution/src/main/resources/queue_migrations.xml
@@ -1,0 +1,39 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
+    
+    <changeSet id="create-job-queue-table" author="nickrobison-usds">
+        <createTable tableName="JOB_QUEUE">
+            <column name="id" type="UUID">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="provider_id" type="VARCHAR(50)"/>
+            <column name="patients" type="TEXT"/>
+            <column name="resource_types" type="VARCHAR"/>
+            <column name="status" type="TINYINT"/>
+            <column name="rsa_public_key" type="BYTEA"/>
+            <column name="submit_time" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="start_time" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="complete_time" type="TIMESTAMP WITH TIME ZONE"/>
+        </createTable>
+
+        <createTable tableName="JOB_RESULT">
+            <column name="jobID" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="resource_type" type="INTEGER"/>
+            <column name="sequence" type="INTEGER"/>
+            <column name="count" type="INTEGER"/>
+        </createTable>
+        
+        <addPrimaryKey tableName="JOB_RESULT"
+                       columnNames="jobID, resource_type, sequence"/>
+
+        <addForeignKeyConstraint baseTableName="JOB_RESULT" baseColumnNames="jobID" constraintName="fk_job_id_results"
+                                 referencedTableName="JOB_QUEUE"
+                                 referencedColumnNames="id"/>
+    </changeSet>
+    
+</databaseChangeLog>

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AbstractAttributionTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AbstractAttributionTest.java
@@ -16,7 +16,6 @@ public abstract class AbstractAttributionTest {
     @BeforeAll
     public static void initDB() throws Exception {
         APPLICATION.before();
-        APPLICATION.getApplication().run("db", "migrate");
         APPLICATION.getApplication().run("seed");
     }
 

--- a/dpc-macaroons/src/test/resources/hibernate.cfg.xml
+++ b/dpc-macaroons/src/test/resources/hibernate.cfg.xml
@@ -19,7 +19,7 @@
         <property name="show_sql">true</property>
 
         <!-- Update database on startup -->
-        <property name="hibernate.hbm2ddl.auto">update</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
         <property name="hibernate.connection.autocommit">true</property>
 
         <!-- Annotated entity classes -->

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobModel.java
@@ -44,6 +44,7 @@ public class JobModel implements Serializable {
      * The unique job identifier
      */
     @Id
+    @Column(name = "jobid")
     private UUID jobID;
 
     /**
@@ -52,7 +53,7 @@ public class JobModel implements Serializable {
      * We need to use {@link FetchType#EAGER}, otherwise the session will close before we actually read the job results and the call will fail.
      */
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name="jobID")
+    @JoinColumn(name="jobid")
     private List<JobResult> jobResults;
 
     /**

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobResult.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobResult.java
@@ -22,6 +22,7 @@ public class JobResult implements Serializable {
     public static class JobResultID implements Serializable {
         public static final long serialVersionUID = 3L;
 
+        @Column(name = "jobid")
         private UUID jobID;
 
         @Column(name = "resource_type")

--- a/dpc-queue/src/main/resources/queue.conf
+++ b/dpc-queue/src/main/resources/queue.conf
@@ -4,10 +4,3 @@ queue {
     address = "redis://localhost:6379"
   }
 }
-
-database {
-  properties = {
-    # Use Hibernate to setup the Job table in Postgres, this will eventually need to be removed
-    "hibernate.hbm2ddl.auto" = update
-  }
-}

--- a/dpc-queue/src/test/resources/hibernate.cfg.xml
+++ b/dpc-queue/src/test/resources/hibernate.cfg.xml
@@ -19,7 +19,7 @@
         <property name="show_sql">true</property>
 
         <!-- Update database on startup -->
-        <property name="hibernate.hbm2ddl.auto">update</property>
+        <property name="hibernate.hbm2ddl.auto">create-drop</property>
         <property name="hibernate.connection.autocommit">true</property>
 
         <!-- Annotated entity classes -->


### PR DESCRIPTION
**Why**
While working on DPC-30 some of the integration tests were failing due to the `root_key` table being missing. It turns out the Liquibase DB migrations were not being applied automatically on application startup. Most of the tests were passing because a config option in the `dpc-queue` module meant Hibernate was automatically creating some of the tables, but only ones that it knew about. This was not only incomplete, but also really brittle.

**What Changed**
Added support for automatically migrating the database schema when the `attribution` service starts. We can disable this by setting `schemaMigrationEnabled = false` in the configuration settings.

Moved the queue table creation into the main migration script and removed the errant Hibernate config option.

**Choices Made**
The attribution service is responsible for migrating the database, even for things that its doesn't know about, like the queue. This should help reduce complexity and error going forward.

**Tickets closed**:
DPC-315

**Future Work**
Nothing.... yet.
