### PR TITLE
DPC-318: Instrumentation

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
@@ -1,8 +1,7 @@
 package gov.cms.dpc.api;
 
 import ca.mestevens.java.configuration.bundle.TypesafeConfigurationBundle;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListener;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import gov.cms.dpc.api.cli.DemoCommand;
@@ -44,6 +43,7 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
     @Override
     public void run(final DPCAPIConfiguration configuration,
                     final Environment environment) {
-        // Not used yet
+        final var listener = new InstrumentedResourceMethodApplicationListener(environment.metrics());
+        environment.jersey().getResourceConfig().register(listener);
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.resources.AbstractDataResource;
 import gov.cms.dpc.common.annotations.ExportPath;
@@ -28,9 +29,10 @@ public class DataResource extends AbstractDataResource {
 
 
     @Override
-    @Timed
     @Path("/{fileID}/")
     @GET
+    @Timed
+    @ExceptionMetered
     public Response export(@PathParam("fileID") String fileID) {
         final StreamingOutput fileStream = outputStream -> {
             final java.nio.file.Path path = Paths.get(String.format("%s/%s.ndjson", fileLocation, fileID));

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
@@ -1,7 +1,8 @@
 package gov.cms.dpc.api.resources.v1;
 
-import gov.cms.dpc.common.annotations.ExportPath;
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.resources.AbstractDataResource;
+import gov.cms.dpc.common.annotations.ExportPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -9,11 +10,8 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -30,6 +28,7 @@ public class DataResource extends AbstractDataResource {
 
 
     @Override
+    @Timed
     @Path("/{fileID}/")
     @GET
     public Response export(@PathParam("fileID") String fileID) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -1,6 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
-import ca.uhn.fhir.context.FhirContext;
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.resources.AbstractGroupResource;
 import gov.cms.dpc.common.annotations.APIV1;
@@ -50,9 +50,10 @@ public class GroupResource extends AbstractGroupResource {
      * @return - {@link org.hl7.fhir.dstu3.model.OperationOutcome} specifying whether or not the request was successful.
      */
     @Override
-    @Timed
-    @Path("/{providerID}/$export")
     @GET // Need this here, since we're using a path param
+    @Path("/{providerID}/$export")
+    @Timed
+    @ExceptionMetered
     public Response export(@PathParam("providerID") String providerID, @QueryParam("_type") String resourceTypes) {
         logger.debug("Exporting data for provider: {}", providerID);
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -1,5 +1,7 @@
 package gov.cms.dpc.api.resources.v1;
 
+import ca.uhn.fhir.context.FhirContext;
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.resources.AbstractGroupResource;
 import gov.cms.dpc.common.annotations.APIV1;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
@@ -48,6 +50,7 @@ public class GroupResource extends AbstractGroupResource {
      * @return - {@link org.hl7.fhir.dstu3.model.OperationOutcome} specifying whether or not the request was successful.
      */
     @Override
+    @Timed
     @Path("/{providerID}/$export")
     @GET // Need this here, since we're using a path param
     public Response export(@PathParam("providerID") String providerID, @QueryParam("_type") String resourceTypes) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.queue.JobQueue;
 import gov.cms.dpc.queue.JobStatus;
 import gov.cms.dpc.common.annotations.APIV1;
@@ -39,9 +40,10 @@ public class JobResource extends AbstractJobResource {
         this.baseURL = baseURL;
     }
 
+    @Override
+    @Timed
     @Path("/{jobID}")
     @GET
-    @Override
     public Response checkJobStatus(@PathParam("jobID") String jobID) {
         final UUID jobUUID = UUID.fromString(jobID);
         final Optional<JobModel> maybeJob = this.queue.getJob(jobUUID);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
@@ -1,11 +1,12 @@
 package gov.cms.dpc.api.resources.v1;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
-import gov.cms.dpc.queue.JobQueue;
-import gov.cms.dpc.queue.JobStatus;
-import gov.cms.dpc.common.annotations.APIV1;
 import gov.cms.dpc.api.models.JobCompletionModel;
 import gov.cms.dpc.api.resources.AbstractJobResource;
+import gov.cms.dpc.common.annotations.APIV1;
+import gov.cms.dpc.queue.JobQueue;
+import gov.cms.dpc.queue.JobStatus;
 import gov.cms.dpc.queue.exceptions.JobQueueFailure;
 import gov.cms.dpc.queue.models.JobModel;
 import gov.cms.dpc.queue.models.JobResult;
@@ -41,9 +42,10 @@ public class JobResource extends AbstractJobResource {
     }
 
     @Override
-    @Timed
     @Path("/{jobID}")
     @GET
+    @Timed
+    @ExceptionMetered
     public Response checkJobStatus(@PathParam("jobID") String jobID) {
         final UUID jobUUID = UUID.fromString(jobID);
         final Optional<JobModel> maybeJob = this.queue.getJob(jobUUID);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources.v1;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.resources.AbstractPractionerResource;
 import org.hl7.fhir.dstu3.model.Bundle;
@@ -25,6 +26,7 @@ public class PractitionerResource extends AbstractPractionerResource {
 
     @Override
     @Timed
+    @ExceptionMetered
     public Bundle getPractitioners(String providerNPI) {
         return this.client
                 .search()
@@ -38,6 +40,7 @@ public class PractitionerResource extends AbstractPractionerResource {
 
     @Override
     @Timed
+    @ExceptionMetered
     public Practitioner submitProvider(Practitioner provider) {
         final MethodOutcome outcome = this.client
                 .create()
@@ -54,6 +57,7 @@ public class PractitionerResource extends AbstractPractionerResource {
 
     @Override
     @Timed
+    @ExceptionMetered
     public Practitioner getProvider(UUID providerID) {
         return this.client
                 .read()
@@ -65,6 +69,7 @@ public class PractitionerResource extends AbstractPractionerResource {
 
     @Override
     @Timed
+    @ExceptionMetered
     public Response deleteProvider(UUID providerID) {
         this.client
                 .delete()
@@ -77,6 +82,7 @@ public class PractitionerResource extends AbstractPractionerResource {
 
     @Override
     @Timed
+    @ExceptionMetered
     public Practitioner updateProvider(UUID providerID, Practitioner provider) {
         return null;
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources.v1;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.resources.AbstractPractionerResource;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.IdType;
@@ -23,6 +24,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     }
 
     @Override
+    @Timed
     public Bundle getPractitioners(String providerNPI) {
         return this.client
                 .search()
@@ -35,6 +37,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     }
 
     @Override
+    @Timed
     public Practitioner submitProvider(Practitioner provider) {
         final MethodOutcome outcome = this.client
                 .create()
@@ -50,6 +53,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     }
 
     @Override
+    @Timed
     public Practitioner getProvider(UUID providerID) {
         return this.client
                 .read()
@@ -60,6 +64,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     }
 
     @Override
+    @Timed
     public Response deleteProvider(UUID providerID) {
         this.client
                 .delete()
@@ -71,6 +76,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     }
 
     @Override
+    @Timed
     public Practitioner updateProvider(UUID providerID, Practitioner provider) {
         return null;
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/RosterResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/RosterResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
 import gov.cms.dpc.api.resources.AbstractRosterResource;
@@ -20,6 +21,7 @@ public class RosterResource extends AbstractRosterResource {
     // TODO(nickrobison): Perform FHIR input validation
     @Override
     @Timed
+    @ExceptionMetered
     public Bundle submitRoster(Bundle providerBundle) {
         attributionEngine.addAttributionRelationships(providerBundle);
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/RosterResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/RosterResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
 import gov.cms.dpc.api.resources.AbstractRosterResource;
 import org.hl7.fhir.dstu3.model.Bundle;
@@ -18,6 +19,7 @@ public class RosterResource extends AbstractRosterResource {
     // TODO(nickrobison): The FHIR spec says we're supposed to return a MethodOutcome response, but per DPC-128, that's not happening.
     // TODO(nickrobison): Perform FHIR input validation
     @Override
+    @Timed
     public Bundle submitRoster(Bundle providerBundle) {
         attributionEngine.addAttributionRelationships(providerBundle);
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.attribution;
 
 import ca.mestevens.java.configuration.bundle.TypesafeConfigurationBundle;
+import com.codahale.metrics.jersey2.InstrumentedResourceMethodApplicationListener;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import gov.cms.dpc.attribution.cli.SeedCommand;
@@ -79,6 +80,8 @@ public class DPCAttributionService extends Application<DPCAttributionConfigurati
     @Override
     public void run(DPCAttributionConfiguration configuration, Environment environment) throws DatabaseException, SQLException {
         migrateDatabase(configuration, environment);
+        final var listener = new InstrumentedResourceMethodApplicationListener(environment.metrics());
+        environment.jersey().getResourceConfig().register(listener);
     }
 
     private void migrateDatabase(DPCAttributionConfiguration configuration, Environment environment) throws SQLException {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.attribution.resources.AbstractEndpointResource;
 import org.hl7.fhir.dstu3.model.Endpoint;
@@ -16,6 +17,7 @@ public class EndpointResource extends AbstractEndpointResource {
 
     @Override
     @Timed
+    @ExceptionMetered
     public Response createEndpoint(Endpoint endpoint) {
         return Response.ok().build();
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.attribution.resources.AbstractEndpointResource;
 import org.hl7.fhir.dstu3.model.Endpoint;
 
@@ -14,6 +15,7 @@ public class EndpointResource extends AbstractEndpointResource {
     }
 
     @Override
+    @Timed
     public Response createEndpoint(Endpoint endpoint) {
         return Response.ok().build();
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.attribution.resources.AbstractGroupResource;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
 import gov.cms.dpc.fhir.FHIRBuilders;
@@ -29,6 +30,7 @@ public class GroupResource extends AbstractGroupResource {
     @POST
     @FHIR
     @Override
+    @Timed
     public Response submitRoster(Bundle providerBundle) {
         logger.debug("API request to submit roster");
         this.engine.addAttributionRelationships(providerBundle);
@@ -36,9 +38,11 @@ public class GroupResource extends AbstractGroupResource {
         return Response.ok().build();
     }
 
+
     @Path("/{groupID}")
     @GET
     @Override
+    @Timed
     public List<String> getAttributedPatients(@PathParam("groupID") String groupID) {
         logger.debug("API request to retrieve attributed patients for {}", groupID);
 
@@ -60,6 +64,7 @@ public class GroupResource extends AbstractGroupResource {
     @Path("/{groupID}/{patientID}")
     @GET
     @Override
+    @Timed
     public boolean isAttributed(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to determine attribution between {} and {}", groupID, patientID);
         final boolean attributed = engine.isAttributed(
@@ -74,6 +79,7 @@ public class GroupResource extends AbstractGroupResource {
     @Path("/{groupID}/{patientID}")
     @PUT
     @Override
+    @Timed
     public void attributePatient(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to add attribution between {} and {}", groupID, patientID);
         try {
@@ -89,6 +95,7 @@ public class GroupResource extends AbstractGroupResource {
     @Path("/{groupID}/{patientID}")
     @Override
     @DELETE
+    @Timed
     public void removeAttribution(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to remove attribution between {} and {}", groupID, patientID);
         try {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.attribution.resources.AbstractGroupResource;
 import gov.cms.dpc.common.interfaces.AttributionEngine;
@@ -31,6 +32,7 @@ public class GroupResource extends AbstractGroupResource {
     @FHIR
     @Override
     @Timed
+    @ExceptionMetered
     public Response submitRoster(Bundle providerBundle) {
         logger.debug("API request to submit roster");
         this.engine.addAttributionRelationships(providerBundle);
@@ -43,6 +45,7 @@ public class GroupResource extends AbstractGroupResource {
     @GET
     @Override
     @Timed
+    @ExceptionMetered
     public List<String> getAttributedPatients(@PathParam("groupID") String groupID) {
         logger.debug("API request to retrieve attributed patients for {}", groupID);
 
@@ -65,6 +68,7 @@ public class GroupResource extends AbstractGroupResource {
     @GET
     @Override
     @Timed
+    @ExceptionMetered
     public boolean isAttributed(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to determine attribution between {} and {}", groupID, patientID);
         final boolean attributed = engine.isAttributed(
@@ -80,6 +84,7 @@ public class GroupResource extends AbstractGroupResource {
     @PUT
     @Override
     @Timed
+    @ExceptionMetered
     public void attributePatient(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to add attribution between {} and {}", groupID, patientID);
         try {
@@ -96,6 +101,7 @@ public class GroupResource extends AbstractGroupResource {
     @Override
     @DELETE
     @Timed
+    @ExceptionMetered
     public void removeAttribution(@PathParam("groupID") String groupID, @PathParam("patientID") String patientID) {
         logger.debug("API request to remove attribution between {} and {}", groupID, patientID);
         try {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.Timed;
 import com.github.nitram509.jmacaroons.Macaroon;
 import gov.cms.dpc.attribution.jdbi.OrganizationDAO;
 import gov.cms.dpc.attribution.resources.AbstractOrganizationResource;
@@ -39,6 +40,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
 
     @Override
     @UnitOfWork
+    @Timed
     public Response createOrganization(Bundle transactionBundle) {
 
         final Optional<Organization> organization = transactionBundle
@@ -74,6 +76,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @Path("/{organizationID}/token")
     @UnitOfWork
     @Override
+    @Timed
     public List<String> getOrganizationTokens(@PathParam("organizationID") UUID organizationID) {
         final Optional<OrganizationEntity> entityOptional = this.dao.fetchOrganization(organizationID);
 
@@ -86,6 +89,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @Path("/{organizationID}/token")
     @UnitOfWork
     @Override
+    @Timed
     public String createOrganizationToken(@PathParam("organizationID") UUID organizationID) {
         final Optional<OrganizationEntity> entityOptional = this.dao.fetchOrganization(organizationID);
 
@@ -106,6 +110,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @Override
     @GET
     @Path("/{organizationID}/token/verify")
+    @Timed
     public boolean verifyOrganizationToken(@PathParam("organizationID") UUID organizationID, @QueryParam("token") String token) {
         final Macaroon macaroon = parseToken(token);
         try {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import com.github.nitram509.jmacaroons.Macaroon;
 import gov.cms.dpc.attribution.jdbi.OrganizationDAO;
@@ -41,6 +42,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @Override
     @UnitOfWork
     @Timed
+    @ExceptionMetered
     public Response createOrganization(Bundle transactionBundle) {
 
         final Optional<Organization> organization = transactionBundle
@@ -77,6 +79,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @UnitOfWork
     @Override
     @Timed
+    @ExceptionMetered
     public List<String> getOrganizationTokens(@PathParam("organizationID") UUID organizationID) {
         final Optional<OrganizationEntity> entityOptional = this.dao.fetchOrganization(organizationID);
 
@@ -90,6 +93,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @UnitOfWork
     @Override
     @Timed
+    @ExceptionMetered
     public String createOrganizationToken(@PathParam("organizationID") UUID organizationID) {
         final Optional<OrganizationEntity> entityOptional = this.dao.fetchOrganization(organizationID);
 
@@ -111,6 +115,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @GET
     @Path("/{organizationID}/token/verify")
     @Timed
+    @ExceptionMetered
     public boolean verifyOrganizationToken(@PathParam("organizationID") UUID organizationID, @QueryParam("token") String token) {
         final Macaroon macaroon = parseToken(token);
         try {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/PractitionerResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/PractitionerResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.attribution.jdbi.ProviderDAO;
 import gov.cms.dpc.attribution.resources.AbstractPractionerResource;
@@ -28,6 +29,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @UnitOfWork
     @Override
     @Timed
+    @ExceptionMetered
     // TODO: Migrate this signature to a List<Practitioner> in DPC-302
     public Bundle getPractitioners(@QueryParam("identifier") String providerNPI) {
         final Bundle bundle = new Bundle();
@@ -44,6 +46,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @UnitOfWork
     @Override
     @Timed
+    @ExceptionMetered
     public Practitioner submitProvider(Practitioner provider) {
 
         final ProviderEntity entity = ProviderEntity.fromFHIR(provider);
@@ -57,6 +60,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @UnitOfWork
     @Override
     @Timed
+    @ExceptionMetered
     public Practitioner getProvider(@PathParam("providerID") UUID providerID) {
         final ProviderEntity providerEntity = this.dao
                 .getProvider(providerID)
@@ -72,6 +76,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @UnitOfWork
     @Override
     @Timed
+    @ExceptionMetered
     public Response deleteProvider(@PathParam("providerID") UUID providerID) {
         try {
             this.dao.deleteProvider(providerID);
@@ -87,6 +92,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @UnitOfWork
     @Override
     @Timed
+    @ExceptionMetered
     public Practitioner updateProvider(@PathParam("providerID") UUID providerID, Practitioner provider) {
         final ProviderEntity providerEntity = this.dao.persistProvider(ProviderEntity.fromFHIR(provider, providerID));
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/PractitionerResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/PractitionerResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.resources.v1;
 
+import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.attribution.jdbi.ProviderDAO;
 import gov.cms.dpc.attribution.resources.AbstractPractionerResource;
 import gov.cms.dpc.common.entities.ProviderEntity;
@@ -26,6 +27,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @GET
     @UnitOfWork
     @Override
+    @Timed
     // TODO: Migrate this signature to a List<Practitioner> in DPC-302
     public Bundle getPractitioners(@QueryParam("identifier") String providerNPI) {
         final Bundle bundle = new Bundle();
@@ -41,6 +43,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @FHIR
     @UnitOfWork
     @Override
+    @Timed
     public Practitioner submitProvider(Practitioner provider) {
 
         final ProviderEntity entity = ProviderEntity.fromFHIR(provider);
@@ -53,6 +56,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @Path("/{providerID}")
     @UnitOfWork
     @Override
+    @Timed
     public Practitioner getProvider(@PathParam("providerID") UUID providerID) {
         final ProviderEntity providerEntity = this.dao
                 .getProvider(providerID)
@@ -67,6 +71,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @Path("/{providerID}")
     @UnitOfWork
     @Override
+    @Timed
     public Response deleteProvider(@PathParam("providerID") UUID providerID) {
         try {
             this.dao.deleteProvider(providerID);
@@ -81,6 +86,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @Path("/{providerID}")
     @UnitOfWork
     @Override
+    @Timed
     public Practitioner updateProvider(@PathParam("providerID") UUID providerID, Practitioner provider) {
         final ProviderEntity providerEntity = this.dao.persistProvider(ProviderEntity.fromFHIR(provider, providerID));
 

--- a/dpc-bluebutton/pom.xml
+++ b/dpc-bluebutton/pom.xml
@@ -59,6 +59,12 @@
             <artifactId>mockserver-client-java</artifactId>
             <version>${mockserverVersion}</version>
         </dependency>
+       <dependency>
+          <groupId>gov.cms.dpc</groupId>
+          <artifactId>dpc-common</artifactId>
+          <version>0.3.0-SNAPSHOT</version>
+          <scope>compile</scope>
+       </dependency>
     </dependencies>
 
     <build>

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/BlueButtonClientModule.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/BlueButtonClientModule.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.bluebutton;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
@@ -61,8 +62,8 @@ public class BlueButtonClientModule<T extends Configuration & BlueButtonBundleCo
     }
 
     @Provides
-    public BlueButtonClient provideBlueButtonClient(IGenericClient fhirRestClient) {
-        return new BlueButtonClientImpl(fhirRestClient, this.bbClientConfiguration);
+    public BlueButtonClient provideBlueButtonClient(IGenericClient fhirRestClient, MetricRegistry registry) {
+        return new BlueButtonClientImpl(fhirRestClient, this.bbClientConfiguration, registry);
     }
 
     @Provides

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClientImpl.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClientImpl.java
@@ -4,7 +4,11 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.ICriterion;
 import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import gov.cms.dpc.bluebutton.config.BBClientConfiguration;
+import gov.cms.dpc.common.utils.MetricMaker;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
@@ -14,22 +18,37 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
 
 public class BlueButtonClientImpl implements BlueButtonClient {
+
+    private static final String REQUEST_PATIENT_METRIC = "requestPatient";
+    private static final String REQUEST_EOB_METRIC = "requestEOB";
+    private static final String REQUEST_COVERAGE_METRIC = "requestCoverage";
+    private static final String REQUEST_NEXT_METRIC = "requestNextBundle";
+    private static final String REQUEST_CAPABILITIES_METRIC = "requestCapabilities";
+    private static final List<String> REQUEST_METRICS = List.of(REQUEST_PATIENT_METRIC, REQUEST_EOB_METRIC, REQUEST_COVERAGE_METRIC, REQUEST_NEXT_METRIC, REQUEST_CAPABILITIES_METRIC);
 
     private static final Logger logger = LoggerFactory.getLogger(BlueButtonClientImpl.class);
 
     private IGenericClient client;
-
     private BBClientConfiguration config;
+    private Map<String, Timer> timers;
+    private Map<String, Meter> exceptionMeters;
 
-    public static String formBeneficiaryID(String fromPatientID) {
+    private static String formBeneficiaryID(String fromPatientID) {
         return "Patient/" + fromPatientID;
     }
 
-    public BlueButtonClientImpl(IGenericClient client, BBClientConfiguration config) {
+    public BlueButtonClientImpl(IGenericClient client, BBClientConfiguration config, MetricRegistry metricRegistry) {
         this.client = client;
         this.config = config;
+        final var metricMaker = new MetricMaker(metricRegistry, BlueButtonClientImpl.class);
+        this.exceptionMeters = metricMaker.registerMeters(REQUEST_METRICS);
+        this.timers = metricMaker.registerTimers(REQUEST_METRICS);
     }
 
     /**
@@ -42,11 +61,11 @@ public class BlueButtonClientImpl implements BlueButtonClient {
     @Override
     public Patient requestPatientFromServer(String patientID) throws ResourceNotFoundException {
         logger.debug("Attempting to fetch patient ID {} from baseURL: {}", patientID, client.getServerBase());
-        return client
+        return instrumentCall(REQUEST_PATIENT_METRIC, () -> client
                 .read()
                 .resource(Patient.class)
                 .withId(patientID)
-                .execute();
+                .execute());
     }
 
     /**
@@ -68,9 +87,9 @@ public class BlueButtonClientImpl implements BlueButtonClient {
      */
     @Override
     public Bundle requestEOBFromServer(String patientID) {
-        // TODO: need to implement some kind of pagination? EOB bundles can be HUGE. DPC-234
         logger.debug("Attempting to fetch EOBs for patient ID {} from baseURL: {}", patientID, client.getServerBase());
-        return fetchBundle(ExplanationOfBenefit.class, ExplanationOfBenefit.PATIENT.hasId(patientID), patientID);
+        return instrumentCall(REQUEST_EOB_METRIC, () ->
+                fetchBundle(ExplanationOfBenefit.class, ExplanationOfBenefit.PATIENT.hasId(patientID), patientID));
     }
 
     /**
@@ -93,25 +112,28 @@ public class BlueButtonClientImpl implements BlueButtonClient {
     @Override
     public Bundle requestCoverageFromServer(String patientID) throws ResourceNotFoundException {
         logger.debug("Attempting to fetch Coverage for patient ID {} from baseURL: {}", patientID, client.getServerBase());
-        return fetchBundle(Coverage.class, Coverage.BENEFICIARY.hasId(formBeneficiaryID(patientID)), patientID);
+        return instrumentCall(REQUEST_COVERAGE_METRIC, () ->
+                fetchBundle(Coverage.class, Coverage.BENEFICIARY.hasId(formBeneficiaryID(patientID)), patientID));
     }
 
     @Override
     public Bundle requestNextBundleFromServer(Bundle bundle) throws ResourceNotFoundException {
-        var nextURL = bundle.getLink(Bundle.LINK_NEXT).getUrl();
-        logger.debug("Attempting to fetch next bundle from url: {}", nextURL);
-        return client
-                .loadPage()
-                .next(bundle)
-                .execute();
+        return instrumentCall(REQUEST_NEXT_METRIC, () -> {
+            var nextURL = bundle.getLink(Bundle.LINK_NEXT).getUrl();
+            logger.debug("Attempting to fetch next bundle from url: {}", nextURL);
+            return client
+                    .loadPage()
+                    .next(bundle)
+                    .execute();
+        });
     }
 
     @Override
     public CapabilityStatement requestCapabilityStatement() throws ResourceNotFoundException {
-        return client
-                .capabilities()
-                .ofType(CapabilityStatement.class)
-                .execute();
+        return instrumentCall(REQUEST_CAPABILITIES_METRIC, () -> client
+                        .capabilities()
+                        .ofType(CapabilityStatement.class)
+                        .execute());
     }
 
     /**
@@ -137,5 +159,26 @@ public class BlueButtonClientImpl implements BlueButtonClient {
             throw new ResourceNotFoundException("No patient found with ID: " + patientID);
         }
         return bundle;
+    }
+
+    /**
+     * Instrument a call to Blue Button.
+     *
+     * @param metricName - The name of the method
+     * @param supplier - the call as lambda to instrumented
+     * @param <T> - the type returned by the call
+     * @return the value returned by the supplier (i.e. call)
+     */
+    private <T> T instrumentCall(String metricName, Supplier<T> supplier) {
+        final var timerContext = timers.get(metricName).time();
+        try {
+            return supplier.get();
+        } catch(Exception ex) {
+            final var exceptionMeter = exceptionMeters.get(metricName);
+            exceptionMeter.mark();
+            throw ex;
+        } finally {
+            timerContext.stop();
+        }
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/MetricMaker.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/MetricMaker.java
@@ -2,6 +2,9 @@ package gov.cms.dpc.common.utils;
 
 import com.codahale.metrics.*;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -34,6 +37,20 @@ public class MetricMaker {
     }
 
     /**
+     * Register a list of timers.
+     *
+     * @param names is a list of timer names
+     * @return a map of timers associated with the passed in names
+     */
+    public Map<String, Timer> registerTimers(List<String> names) {
+        final var map = new HashMap<String, Timer>();
+        for (String name: names) {
+            map.put(name, registerTimer(name + "Timer"));
+        }
+        return map;
+    }
+
+    /**
      * Register a meter
      *
      * @param name is unique
@@ -44,18 +61,33 @@ public class MetricMaker {
     }
 
     /**
-     * Register a cached gauge. A cached guage uses cached values to limit the number of polls of the supplier.
+     * Register a list of meters.
+     *
+     * @param names is a list of meter names
+     * @return a map of meters associated with the passed in names
+     */
+    public Map<String, Meter> registerMeters(List<String> names) {
+        final var map = new HashMap<String, Meter>();
+        for (String name: names) {
+            map.put(name, registerMeter(name + "Meter"));
+        }
+        return map;
+    }
+
+
+    /**
+     * Register a cached gauge. A cached gauge uses cached values to limit the number of polls of the supplier.
      *
      * @param name is unit
      * @param loadSupplier the supplier of the value of the gauge
-     * @param <T> is the unit of the guage
+     * @param <T> is the unit of the gauge
      */
-    public <T> void registerCachedGuage(String name, Supplier<T> loadSupplier) {
+    public <T> void registerCachedGauge(String name, Supplier<T> loadSupplier) {
         registerMetric(name, () -> new CachedGaugeFromSupplier<>(1, TimeUnit.SECONDS, loadSupplier));
     }
 
     /**
-     * Register a metric or retreive a previously registered metric
+     * Register a metric or retrieve a previously registered metric
      *
      * @param name of the metric
      * @param supplier of the new metric if needed

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedQueue.java
@@ -66,7 +66,7 @@ public class DistributedQueue implements JobQueue {
         this.waitTimer = metricBuilder.registerTimer("waitTime");
         this.successTimer = metricBuilder.registerTimer("successTime");
         this.failureTimer = metricBuilder.registerTimer("failureTime");
-        metricBuilder.registerCachedGuage("queueLength", this::queueSize);
+        metricBuilder.registerCachedGauge("queueLength", this::queueSize);
     }
 
     @Override


### PR DESCRIPTION
**Why**

This pull requests adds more instrumentation to the API and Attribution servers. 

**What Changed**

For each end-point method a Timer and an Exception Meter metric was added. For each Blue Button client method a Timer and an Exception Meter was added as well. Combined with the previously added metrics, a good set of metrics is now pushed to the logs.  

**Choices Made**

- DropWizard provides a very complete set of JVM and Servlet metrics. Decided not to add more. 
- Looked at adding Hibernate metrics. Decided against it after researching the performance cost of these metrics. See: https://www.baeldung.com/hibernate-common-performance-problems-in-logs. 
- Using the Dropwizard InstrumentedHttpClient was tried, but it proved too awkward to use for our system.  

**Tickets closed**:

DPC-317: API 
DPC-318: Attribution
DPC-319: Aggregation

**Future Work**
