### PR TITLE
 DPC-145: Finish parallel execution

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
@@ -60,10 +60,13 @@ public class AggregationAppModule extends DropwizardAwareModule<DPCAggregationCo
     @Provides
     OperationsConfig provideOperationsConfig() {
         final var config = getConfiguration();
-        return new OperationsConfig(config.getRetryCount(),
-                config.getResourcesPerFileCount(),
-                config.isParallelRequestsEnabled(),
+
+        return new OperationsConfig(config.getResourcesPerFileCount(),
                 config.getExportPath(),
-                config.isEncryptionEnabled());
+                config.getRetryCount(),
+                config.isEncryptionEnabled(),
+                config.isParallelEnabled(),
+                config.getWriteThreadFactor(),
+                config.getFetchThreadFactor());
     }
 }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
@@ -11,6 +11,7 @@ import gov.cms.dpc.aggregation.engine.OperationsConfig;
 import gov.cms.dpc.common.annotations.AdditionalPaths;
 import gov.cms.dpc.common.annotations.ExportPath;
 import gov.cms.dpc.common.hibernate.DPCHibernateBundle;
+import gov.cms.dpc.fhir.hapi.ContextUtils;
 import gov.cms.dpc.queue.models.JobModel;
 
 import javax.inject.Singleton;
@@ -35,10 +36,7 @@ public class AggregationAppModule extends DropwizardAwareModule<DPCAggregationCo
         final var fhirContext = FhirContext.forDstu3();
 
         // Setup the context with model scans (avoids doing this on the fetch threads and perhaps multithreaded bug)
-        for(var resourceType: JobModel.validResourceTypes) {
-            fhirContext.getResourceDefinition(resourceType.name());
-        }
-        fhirContext.getResourceDefinition("Bundle");
+        ContextUtils.prefetchResourceModels(fhirContext, JobModel.validResourceTypes);
         return fhirContext;
     }
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
@@ -11,6 +11,7 @@ import gov.cms.dpc.aggregation.engine.OperationsConfig;
 import gov.cms.dpc.common.annotations.AdditionalPaths;
 import gov.cms.dpc.common.annotations.ExportPath;
 import gov.cms.dpc.common.hibernate.DPCHibernateBundle;
+import gov.cms.dpc.queue.models.JobModel;
 
 import javax.inject.Singleton;
 import java.util.List;
@@ -31,7 +32,14 @@ public class AggregationAppModule extends DropwizardAwareModule<DPCAggregationCo
     @Provides
     @Singleton
     public FhirContext provideSTU3Context() {
-        return FhirContext.forDstu3();
+        final var fhirContext = FhirContext.forDstu3();
+
+        // Setup the context with model scans (avoids doing this on the fetch threads and perhaps multithreaded bug)
+        for(var resourceType: JobModel.validResourceTypes) {
+            fhirContext.getResourceDefinition(resourceType.name());
+        }
+        fhirContext.getResourceDefinition("Bundle");
+        return fhirContext;
     }
 
     @Provides

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationConfiguration.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationConfiguration.java
@@ -3,7 +3,6 @@ package gov.cms.dpc.aggregation;
 import ca.mestevens.java.configuration.TypesafeConfiguration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.typesafe.config.ConfigRenderOptions;
-import gov.cms.dpc.aggregation.engine.OperationsConfig;
 import gov.cms.dpc.bluebutton.config.BBClientConfiguration;
 import gov.cms.dpc.bluebutton.config.BlueButtonBundleConfiguration;
 import gov.cms.dpc.common.hibernate.IDPCDatabase;
@@ -44,11 +43,17 @@ public class DPCAggregationConfiguration extends TypesafeConfiguration implement
     @Max(100000) // Keep files under a GB
     private int resourcesPerFileCount = 10000;
 
-    // Enable parallel BlueButton requests
-    private boolean parallelRequestsEnabled = false;
-
     // Enable file encryption per BCDA
     private boolean encryptionEnabled = false;
+
+    // Enable parallel operation
+    private boolean parallelEnabled = false;
+
+    // Number of threads to create for fetching = factor * number of cpu cores
+    private Number fetchThreadFactor = 2.5;
+
+    // Number of threads to create for writing = factor * number of cpu cores
+    private Number writeThreadFactor = 0.5;
 
     @Override
     public DataSourceFactory getDatabase() {
@@ -79,8 +84,16 @@ public class DPCAggregationConfiguration extends TypesafeConfiguration implement
         return resourcesPerFileCount;
     }
 
-    public boolean isParallelRequestsEnabled() {
-        return parallelRequestsEnabled;
+    public boolean isParallelEnabled() {
+        return parallelEnabled;
+    }
+
+    public float getWriteThreadFactor() {
+        return writeThreadFactor.floatValue();
+    }
+
+    public float getFetchThreadFactor() {
+        return fetchThreadFactor.floatValue();
     }
 
     @Override
@@ -96,9 +109,5 @@ public class DPCAggregationConfiguration extends TypesafeConfiguration implement
     @Override
     public BBClientConfiguration getBlueButtonConfiguration() {
         return this.clientConfiguration;
-    }
-
-    public OperationsConfig getOperationsConfig() {
-        return new OperationsConfig(retryCount, resourcesPerFileCount, parallelRequestsEnabled, exportPath, encryptionEnabled);
     }
 }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
@@ -72,11 +72,16 @@ public class AggregationEngine implements Runnable {
         this.operationsConfig = operationsConfig;
 
         // Thread pools
-        final var cpuCount = Runtime.getRuntime().availableProcessors();
-        final int fetchCount = Math.max((int)(cpuCount * operationsConfig.getFetchThreadFactor()),1);
-        fetchScheduler = Schedulers.from(Executors.newFixedThreadPool(fetchCount));
-        final int writeCount = Math.max((int)(cpuCount * operationsConfig.getWriteThreadFactor()),1);
-        writeScheduler = Schedulers.from(Executors.newFixedThreadPool(writeCount));
+        if (operationsConfig.isParallelEnabled()) {
+            final var cpuCount = Runtime.getRuntime().availableProcessors();
+            final int fetchCount = Math.max((int) (cpuCount * operationsConfig.getFetchThreadFactor()), 1);
+            fetchScheduler = Schedulers.from(Executors.newFixedThreadPool(fetchCount));
+            final int writeCount = Math.max((int) (cpuCount * operationsConfig.getWriteThreadFactor()), 1);
+            writeScheduler = Schedulers.from(Executors.newFixedThreadPool(writeCount));
+        } else {
+            fetchScheduler = null;
+            writeScheduler = null;
+        }
 
         // Metrics
         final var metricFactory = new MetricMaker(metricRegistry, AggregationEngine.class);

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/OperationsConfig.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/OperationsConfig.java
@@ -5,21 +5,39 @@ package gov.cms.dpc.aggregation.engine;
  */
 public class OperationsConfig {
     private int retryCount;
-
     private int resourcesPerFileCount;
-
-    private boolean parallelRequestsEnabled;
-
     private String exportPath;
-
     private boolean encryptionEnabled;
+    private boolean parallelEnabled;
+    private float writeThreadFactor;
+    private float fetchThreadFactor;
 
-    public OperationsConfig(int retryCount, int resourcesPerFileCount, boolean parallelRequestsEnabled, String exportPath, boolean encryptionEnabled) {
+
+    public OperationsConfig(int resourcesPerFileCount,
+                            String exportPath,
+                            int retryCount,
+                            boolean encryptionEnabled,
+                            boolean parallelEnabled,
+                            float writeThreadFactor,
+                            float fetchThreadFactor) {
         this.retryCount = retryCount;
         this.resourcesPerFileCount = resourcesPerFileCount;
-        this.parallelRequestsEnabled = parallelRequestsEnabled;
+        this.parallelEnabled = parallelEnabled;
         this.exportPath = exportPath;
         this.encryptionEnabled = encryptionEnabled;
+        this.writeThreadFactor = writeThreadFactor;
+        this.fetchThreadFactor = fetchThreadFactor;
+    }
+
+    public OperationsConfig(int resourcesPerFileCount,
+                            String exportPath) {
+        this.retryCount = 3;
+        this.resourcesPerFileCount = resourcesPerFileCount;
+        this.parallelEnabled = true;
+        this.exportPath = exportPath;
+        this.encryptionEnabled = false;
+        this.writeThreadFactor = 0.5f;
+        this.fetchThreadFactor = 2.5f;
     }
 
     public int getRetryCount() {
@@ -30,15 +48,23 @@ public class OperationsConfig {
         return resourcesPerFileCount;
     }
 
-    public boolean isParallelRequestsEnabled() {
-        return parallelRequestsEnabled;
-    }
-
     public String getExportPath() {
         return exportPath;
     }
 
     public boolean isEncryptionEnabled() {
         return encryptionEnabled;
+    }
+
+    public boolean isParallelEnabled() {
+        return parallelEnabled;
+    }
+
+    public float getWriteThreadFactor() {
+        return writeThreadFactor;
+    }
+
+    public float getFetchThreadFactor() {
+        return fetchThreadFactor;
     }
 }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
@@ -59,7 +59,7 @@ class ResourceFetcher {
         return Flowable.fromCallable(() -> {
             logger.debug("Fetching first {} from BlueButton for {}", resourceType.toString(), patientID);
             final Resource firstFetched = fetchFirst(patientID);
-            if (firstFetched instanceof Bundle) {
+            if (ResourceType.Coverage.equals(resourceType) || ResourceType.ExplanationOfBenefit.equals(resourceType)) {
                 return fetchAllBundles(patientID, (Bundle)firstFetched);
             } else {
                 logger.debug("Done fetching {} for {}", resourceType.toString(), patientID);

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -44,15 +44,17 @@ class AggregationEngineTest {
     static void setupAll() {
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
+        AggregationEngine.setGlobalErrorHandler();
+        fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
     }
 
     @BeforeEach
     void setupEach() {
-        fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
         queue = new MemoryQueue();
         bbclient = Mockito.spy(new MockBlueButtonClient(fhirContext));
-        var operationalConfig = new OperationsConfig(3, 1000, false, exportPath, false);
+        var operationalConfig = new OperationsConfig(3, 1000, true, exportPath, false);
         engine = new AggregationEngine(bbclient, queue, fhirContext, metricRegistry, operationalConfig);
+        AggregationEngine.setGlobalErrorHandler();
     }
 
     /**

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -52,7 +52,7 @@ class AggregationEngineTest {
     void setupEach() {
         queue = new MemoryQueue();
         bbclient = Mockito.spy(new MockBlueButtonClient(fhirContext));
-        var operationalConfig = new OperationsConfig(3, 1000, true, exportPath, false);
+        var operationalConfig = new OperationsConfig(1000, exportPath);
         engine = new AggregationEngine(bbclient, queue, fhirContext, metricRegistry, operationalConfig);
         AggregationEngine.setGlobalErrorHandler();
     }

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.bluebutton.client.MockBlueButtonClient;
+import gov.cms.dpc.fhir.hapi.ContextUtils;
 import gov.cms.dpc.queue.JobQueue;
 import gov.cms.dpc.queue.JobStatus;
 import gov.cms.dpc.queue.MemoryQueue;
@@ -44,11 +45,7 @@ class AggregationEngineTest {
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
         AggregationEngine.setGlobalErrorHandler();
-        
-        // Force HAPI scanning early
-        fhirContext.getResourceDefinition("Patient");
-        fhirContext.getResourceDefinition("Bundle");
-        fhirContext.getResourceDefinition("ExplanationOfBenefit");
+        ContextUtils.prefetchResourceModels(fhirContext, JobModel.validResourceTypes);
     }
 
     @BeforeEach

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -1,7 +1,6 @@
 package gov.cms.dpc.aggregation.engine;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.PerformanceOptionsEnum;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
@@ -45,7 +44,11 @@ class AggregationEngineTest {
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
         AggregationEngine.setGlobalErrorHandler();
-        fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
+        
+        // Force HAPI scanning early
+        fhirContext.getResourceDefinition("Patient");
+        fhirContext.getResourceDefinition("Bundle");
+        fhirContext.getResourceDefinition("ExplanationOfBenefit");
     }
 
     @BeforeEach

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -43,7 +43,11 @@ class BatchAggregationEngineTest {
         exportPath = config.getString("exportPath");
         operationsConfig = new OperationsConfig(10, exportPath);
         AggregationEngine.setGlobalErrorHandler();
-        fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
+
+        // Force HAPI scanning early
+        fhirContext.getResourceDefinition("Patient");
+        fhirContext.getResourceDefinition("Bundle");
+        fhirContext.getResourceDefinition("ExplanationOfBenefit");
     }
 
     @BeforeEach

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -37,7 +37,9 @@ class BatchAggregationEngineTest {
         fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
-        operationsConfig = new OperationsConfig(3, 10, false, exportPath, false);
+        operationsConfig = new OperationsConfig(3, 10, true, exportPath, false);
+        AggregationEngine.setGlobalErrorHandler();
+        fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
     }
 
     @BeforeEach

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.context.PerformanceOptionsEnum;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.bluebutton.client.MockBlueButtonClient;
+import gov.cms.dpc.fhir.hapi.ContextUtils;
 import gov.cms.dpc.queue.JobQueue;
 import gov.cms.dpc.queue.JobStatus;
 import gov.cms.dpc.queue.MemoryQueue;
@@ -43,11 +44,7 @@ class BatchAggregationEngineTest {
         exportPath = config.getString("exportPath");
         operationsConfig = new OperationsConfig(10, exportPath);
         AggregationEngine.setGlobalErrorHandler();
-
-        // Force HAPI scanning early
-        fhirContext.getResourceDefinition("Patient");
-        fhirContext.getResourceDefinition("Bundle");
-        fhirContext.getResourceDefinition("ExplanationOfBenefit");
+        ContextUtils.prefetchResourceModels(fhirContext, JobModel.validResourceTypes);
     }
 
     @BeforeEach

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -131,7 +131,7 @@ class BatchAggregationEngineTest {
         final var completeJob = queue.getJob(jobId).orElseThrow();
         assertEquals(JobStatus.COMPLETED, completeJob.getStatus());
         assertAll(
-                () -> assertEquals(5, completeJob.getJobResults().size()),
+                () -> assertEquals(5, completeJob.getJobResults().size(), String.format("Unexpected JobModel: %s", completeJob.toString())),
                 () -> assertTrue(completeJob.getJobResult(ResourceType.ExplanationOfBenefit).isPresent(), "Expect a EOB"),
                 () -> assertTrue(completeJob.getJobResult(ResourceType.OperationOutcome).isPresent(), "Expect an error"));
 

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
@@ -1,7 +1,6 @@
 package gov.cms.dpc.aggregation.engine;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.PerformanceOptionsEnum;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,10 +19,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.crypto.*;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,8 +60,11 @@ class EncryptingAggregationEngineTest {
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
         operationsConfig = new OperationsConfig(1000, exportPath, 3, true, true, 0.5f, 2.5f);
-        AggregationEngine.setGlobalErrorHandler();
-        fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
+
+        // Force HAPI scanning early
+        fhirContext.getResourceDefinition("Patient");
+        fhirContext.getResourceDefinition("Bundle");
+        fhirContext.getResourceDefinition("ExplanationOfBenefit");
     }
 
     @BeforeEach

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
@@ -57,7 +57,7 @@ class EncryptingAggregationEngineTest {
         // Use the test.conf as the base for config. encrypt.conf will only enable encryption.
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
-        operationsConfig = new OperationsConfig(3, 1000, true, exportPath, true);
+        operationsConfig = new OperationsConfig(1000, exportPath, 3, true, true, 0.5f, 2.5f);
         AggregationEngine.setGlobalErrorHandler();
         fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
     }

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.aggregation.engine;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.PerformanceOptionsEnum;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -56,14 +57,16 @@ class EncryptingAggregationEngineTest {
         // Use the test.conf as the base for config. encrypt.conf will only enable encryption.
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
-        operationsConfig = new OperationsConfig(3, 1000, false, exportPath, true);
+        operationsConfig = new OperationsConfig(3, 1000, true, exportPath, true);
+        AggregationEngine.setGlobalErrorHandler();
+        fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
     }
 
     @BeforeEach
     void setupEach() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
         queue = new MemoryQueue();
         BlueButtonClient bbclient = new MockBlueButtonClient(fhirContext);
-        engine = new AggregationEngine(bbclient, queue, FhirContext.forDstu3(), metricRegistry, operationsConfig);
+        engine = new AggregationEngine(bbclient, queue, fhirContext, metricRegistry, operationsConfig);
 
         final InputStream testPrivateKeyResource = this.getClass().getClassLoader().getResourceAsStream(RSA_PRIVATE_KEY_PATH);
         final InputStream testPublicKeyResource = this.getClass().getClassLoader().getResourceAsStream(RSA_PUBLIC_KEY_PATH);

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/EncryptingAggregationEngineTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.bluebutton.client.MockBlueButtonClient;
+import gov.cms.dpc.fhir.hapi.ContextUtils;
 import gov.cms.dpc.queue.JobQueue;
 import gov.cms.dpc.queue.JobStatus;
 import gov.cms.dpc.queue.MemoryQueue;
@@ -60,11 +61,7 @@ class EncryptingAggregationEngineTest {
         final var config = ConfigFactory.load("test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
         operationsConfig = new OperationsConfig(1000, exportPath, 3, true, true, 0.5f, 2.5f);
-
-        // Force HAPI scanning early
-        fhirContext.getResourceDefinition("Patient");
-        fhirContext.getResourceDefinition("Bundle");
-        fhirContext.getResourceDefinition("ExplanationOfBenefit");
+        ContextUtils.prefetchResourceModels(fhirContext, JobModel.validResourceTypes);
     }
 
     @BeforeEach

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
@@ -24,7 +24,7 @@ public class MockBlueButtonClient implements BlueButtonClient {
     private static final String SAMPLE_COVERAGE_PATH_PREFIX = "bb-test-data/coverage/";
     private static final String SAMPLE_METADATA_PATH_PREFIX = "bb-test-data/";
     public static final List<String> TEST_PATIENT_IDS = List.of("20140000008325", "20140000009893");
-    public static final List<String> TEST_PATIENT_WITH_BAD_IDS = List.of("20140000008325", "20140000009893", "-1");
+    public static final List<String> TEST_PATIENT_WITH_BAD_IDS = List.of("-1", "-2", "20140000008325",  "20140000009893", "-3");
 
     private final IParser parser;
 

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/hapi/ContextUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/hapi/ContextUtils.java
@@ -1,0 +1,29 @@
+package gov.cms.dpc.fhir.hapi;
+
+import ca.uhn.fhir.context.FhirContext;
+import org.hl7.fhir.dstu3.model.ResourceType;
+
+import java.util.List;
+
+public class ContextUtils {
+    private ContextUtils() {
+        // this is a static class
+    }
+
+    /**
+     * This optimization primes the passed in context with the resource models it needs. Priming a HAPI FhirContext is
+     * an expensive operation that only needs to be done once, preferable at service start time. Although the HAPI
+     * library is multi-threaded, it locks while a resource model is downloaded. If a context is not primed before use
+     * it may lock up its thread and other threads as well.
+     *
+     * @param context to prime
+     * @param resourcesTypes that are used
+     */
+    public static void prefetchResourceModels(FhirContext context, List<ResourceType> resourcesTypes) {
+        context.getResourceDefinition("OperationOutcome");
+        context.getResourceDefinition("Bundle");
+        for(var resourceType: resourcesTypes) {
+            context.getResourceDefinition(resourceType.name());
+        }
+    }
+}


### PR DESCRIPTION
**Why**

Finish the parallel execution work on the aggregation engine to improve throughput.  

**What Changed**
- Turn on parallel execution by default
- Made fixed sized thread pools to avoid thread exhaustion error cases. 
- Added a new thread pool for parallel writes of files
- Added configuration fields for number of thread for fetches and writes

**Choices Made**
- Separate thread pools for fetches and writes to accommodate the different throughput requirements of each operation. 
- Initially, made the fetch pool 5x the size of the write because BB fetch latency dominates. 
- Made the global error handler setup in multiple places including tests. Made the handler a static method. 
- Made the thread pool size based on the CPU count, so configs do not need to be adjust as much between environments. 

**Tickets closed**:
DPC-145: Thread pool

**Future Work**
DPC-402: Tune thread pool sizes for production.