### PR TITLE
Remove viewbox to fix IE scaling

### DIFF
--- a/dpc-web/app/views/public/_hero.html.erb
+++ b/dpc-web/app/views/public/_hero.html.erb
@@ -12,13 +12,13 @@
     </div>
     <div class="ds-u-margin-top--7">
       <a class="ds-c-button ds-c-button--big ds-c-button--success ds-u-margin-right--2">
-        <svg class="ds-u-margin-right--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 24 24">
+        <svg class="ds-u-margin-right--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" >
         <use xlink:href="/assets/solid.svg#key"></use>
       </svg>
       Request acccess</a>
 
       <%= link_to docs_path, :class => "ds-c-button ds-c-button--inverse ds-c-button--big" do %>
-        <svg class="ds-u-margin-right--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" viewBox="0 0 24 24">
+        <svg class="ds-u-margin-right--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <use xlink:href="/assets/solid.svg#code"></use>
         </svg>API documentation
       <% end %>


### PR DESCRIPTION
**Why**

SVG scaling is messed up in IE11. Removing the` viewbox` from the `svg` tag resolves the issue, and the property is already in the sprite.