### PR TITLE
DPC-320: Reduce default threadpool size

### DIFF
--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -5,6 +5,9 @@ database {
   url = "jdbc:postgresql://localhost:5432/dpc_attribution"
   user = postgres
   password = dpc-safe
+  initialSize = 5
+  minSize = 5
+  maxSize = 10
 }
 
 server {


### PR DESCRIPTION
**Why**

During integration testing, we're opening a ton of database connections (nearly 100) since the connection pool will automatically scale to 100. Since Postgres only allows 100 connections by default, this means we quickly run into errors.

**What Changed**

Reduced the default thread pool size, and the maximum value as well. We now start 5 DB connections and can flex up to 10. This prevents Postgres from throwing exceptions when too many clients are open. Such as when rapidly running integration tests where the connection pool doesn't get cleaned up in time.

This can (and will be) be overridden in higher environments.

**Choices Made**
Small for now, with the theory that we'll always override in production, plus our unit of scaling isn't making the individual services bigger, it's adding more services.

**Tickets closed**:
DPC-320

**Future Work**
None