### PR TITLE
DPC-328: Docker container for website

### DIFF
--- a/dpc-web/.dockerignore
+++ b/dpc-web/.dockerignore
@@ -1,0 +1,24 @@
+# Ignore bundler config.
+/.bundle
+
+# Ignore all logfiles and tempfiles.
+/log/*
+/tmp/*
+!/log/.keep
+!/tmp/.keep
+
+# Ignore uploaded files in development
+/storage/*
+!/storage/.keep
+
+/node_modules
+/yarn-error.log
+
+/public/assets
+.byebug_history
+
+# Ignore master key for decrypting credentials and more.
+/config/master.key
+
+Dockerfile
+docker-compose.yml

--- a/dpc-web/Dockerfile
+++ b/dpc-web/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.6.2-alpine
+
+# Install build dependencies
+RUN apk add --no-cache postgresql-dev alpine-sdk npm tzdata
+
+# Set the working directory
+RUN mkdir /dpc-web
+WORKDIR /dpc-web
+
+# Copy over the files needed to fetch dependencies
+COPY Gemfile /dpc-web/Gemfile
+COPY Gemfile.lock /dpc-web/Gemfile.lock
+COPY package.json /dpc-web/package.json
+COPY package-lock.json /dpc-web/package-lock.json
+
+# Install the website dependencies
+RUN gem install bundler --no-document && bundle install && npm install
+
+# Copy the website
+COPY . /dpc-web
+
+# Start the rails server
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/dpc-web/README.md
+++ b/dpc-web/README.md
@@ -70,7 +70,6 @@ rbenv gemset create {latest-ruby-version: eg 2.6.2} dpc-website
 5. Run `npm install`
 
 ### Credentials
-TODO: Instructions for dealing with encrypted databases, you can ignore this step for now
 
 The database is password encrypted. Additionally, sensitive information exists that mist also be encrypted in the credentials file. In order to build the database and run the application, you'll need a copy of the `master.key` file. TBD: contact information for this file.
 
@@ -81,16 +80,39 @@ rails db:create db:migrate db:seed
 rails server
 ```
 
+Note: If you need to change the database configuration, it can be overridden using the `DB_USER`, `DB_PASS`, and `DB_HOST` environment variables.
+
+
 # Running via Docker
+
+The DPC website can also be run via docker. Follow the below steps to build and run the website into a Docker container.
+
+## Build the Docker Container
+
+First, ensure the contents of the `master.key` from the above settings is added to an environment variable `RAILS_MASTER_KEY`. Then, to build the container, simply run the following command:
 
 ```Bash
 docker-compose build
 ```
 
+After the container is built, initialize the database:
+
 ```Bash
 docker-compose run web rails db:migrate db:seed
 ```
 
+## Start the Docker Container
+
+The following command will start both the database server and rails server:
+
 ```Bash
 docker-compose up
+```
+
+## Stop / Destroy the Docker Container
+
+When you're done, shut down the server with the following command:
+
+```Bash
+docker-compose down
 ```

--- a/dpc-web/README.md
+++ b/dpc-web/README.md
@@ -47,23 +47,22 @@ Follow the prompts following the installation to start running postgres as a ser
 Assuming you have access to the github repository housing this application (since you are reading this), clone the project using SSH or HTTPS. Change into the directory where you want the website to reside and using the command line. For SSH:
 
 ```SSH
-git clone git@github.cms.gov:dpc/dpc-website.git
+git clone git@github.com:CMSgov/dpc-app.git
 ```
 
 For HTTPS:
 
 ```HTTP
-https://github.cms.gov/dpc/dpc-website.git
+https://github.com/CMSgov/dpc-app.git
 ```
 
 You'll need to
 
-1. Change into the installation directory `dpc-website`
+1. Change into the installation directory `dpc-app/dpc-web`
 2. If you are using rbenv-gemset issue the following
 
 ```Bash
 rbenv gemset create {latest-ruby-version: eg 2.6.2} dpc-website
-echo dpc-website > .rbenv-gemsets
 ```
 
 3. `gem install bundler --no-document`
@@ -71,8 +70,27 @@ echo dpc-website > .rbenv-gemsets
 5. Run `npm install`
 
 ### Credentials
+TODO: Instructions for dealing with encrypted databases, you can ignore this step for now
+
 The database is password encrypted. Additionally, sensitive information exists that mist also be encrypted in the credentials file. In order to build the database and run the application, you'll need a copy of the `master.key` file. TBD: contact information for this file.
 
+
+### Running the server
 ```Bash
 rails db:create db:migrate db:seed
+rails server
+```
+
+# Running via Docker
+
+```Bash
+docker-compose build
+```
+
+```Bash
+docker-compose run web rails db:migrate db:seed
+```
+
+```Bash
+docker-compose up
 ```

--- a/dpc-web/config/database.yml
+++ b/dpc-web/config/database.yml
@@ -21,7 +21,8 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
-development:
+
+development: &development
   <<: *default
   database: dpc-website_development
 
@@ -29,12 +30,12 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  username: postgres
+  username: <%= ENV.fetch("DB_USER", nil) %>
 
   # The password associated with the postgres role (username).
-  password: dpc-safe
+  password: <%= ENV.fetch("DB_PASS", Rails.application.credentials.db[:development][:password]) %>
 
-  host: db
+  host: <%= ENV.fetch("DB_HOST", "localhost") %>
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
@@ -49,12 +50,14 @@ development:
   # Defaults to warning.
   #min_messages: notice
 
+
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
   database: dpc-website_test
+
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -79,4 +82,4 @@ production:
   <<: *default
   database: dpc-website_production
   username: dpc-website
-  password:
+  password: <%= Rails.application.credentials.db[:production][:password] %>

--- a/dpc-web/config/database.yml
+++ b/dpc-web/config/database.yml
@@ -29,15 +29,12 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: dpc-website
+  username: postgres
 
   # The password associated with the postgres role (username).
-  password: <%= Rails.application.credentials.db[:development][:password] %>
+  password: dpc-safe
 
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
+  host: db
 
   # The TCP port the server listens on. Defaults to 5432.
   # If your server runs on a different port number, change accordingly.
@@ -82,4 +79,4 @@ production:
   <<: *default
   database: dpc-website_production
   username: dpc-website
-  password: <%= Rails.application.credentials.db[:production][:password] %>
+  password:

--- a/dpc-web/docker-compose.yml
+++ b/dpc-web/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+
+  db:
+    image: postgres
+    environment:
+      - POSTGRES_DB=dpc-website_development
+      - POSTGRES_PASSWORD=dpc-safe
+    ports:
+      - "5432:5432"
+
+  web:
+    build: .
+    image: dpc-web:latest
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db

--- a/dpc-web/docker-compose.yml
+++ b/dpc-web/docker-compose.yml
@@ -13,6 +13,11 @@ services:
   web:
     build: .
     image: dpc-web:latest
+    environment:
+      - DB_HOST=db
+      - DB_USER=postgres
+      - DB_PASS=dpc-safe
+      - RAILS_MASTER_KEY
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
**Why**

The DPC hosting infrastructure will involve hosting the website in a Docker container on ECS. To prepare going live with the website, the static website should be dockerized for development testing in preparation for standing up staging and production environments.

**What Changed**

- A Docker file and docker-compose.yml file has been added to dpc-web to facilitate building the docker container.
- The dpc-web readme documentation has been updated with instructions for building the docker container.
- The dpc-web Ruby configuration has been tweaked to allow for environment variable overrides needed by the Docker container.

**Choices Made**

The base Ruby docker image was based off `ruby:2.6.2-alpine`. This is an official Docker image provided by Ruby. The Alpine Linux variant was chosen as it's smaller and simpler. Due to this, some additional dependencies had to be installed in the image to allow for building of the ruby gems.

Instead of creating a separate environment configuration for Docker, the existing Ruby development environment was made more configurable by allowing overriding of database variables using environment variables.

**Tickets closed**:

DPC-328

**Future Work**

Additional environment configuration will be needed to use this docker image in staging and production, but none of it is docker specific. The Ruby credentials file will be updated with database credentials and host information, and then Docker container will be started with `RUBY_ENV` and `RAILS_MASTER_KEY` environment variables to use the correct environment and decrypt the credentials file.