### PR TITLE
DPC-424: Fix missing attribution constraint

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterUtils.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.jdbi;
 
+import gov.cms.dpc.attribution.dao.tables.Attributions;
 import gov.cms.dpc.attribution.dao.tables.records.AttributionsRecord;
 import gov.cms.dpc.attribution.dao.tables.records.PatientsRecord;
 import gov.cms.dpc.attribution.dao.tables.records.ProvidersRecord;
@@ -68,13 +69,26 @@ public class RosterUtils {
         final PatientRecordUpserter patientRecordUpserter = new PatientRecordUpserter(ctx, ctx.newRecord(PATIENTS, patientEntity));
         final PatientsRecord patient = patientRecordUpserter.upsert();
 
-        logger.debug("Attributing patient {} to provider {}.", patientEntity.getBeneficiaryID(), providerRecord.getProviderId());
+        // If the attribution relationship already exists, ignore it.
 
-        // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
-        final AttributionsRecord attr = new AttributionsRecord();
-        attr.setProviderId(providerRecord.getId());
-        attr.setPatientId(patient.getId());
-        attr.setCreatedAt(creationTimestamp);
-        ctx.executeInsert(attr);
+        final boolean attributionExist = ctx.fetchExists(Attributions.ATTRIBUTIONS,
+                Attributions.ATTRIBUTIONS.PROVIDER_ID
+                        .eq(providerRecord.getId())
+                        .and(Attributions.ATTRIBUTIONS.PATIENT_ID.eq(patient.getId())));
+
+        final String beneficiaryID = patientEntity.getBeneficiaryID();
+        final String providerNPI = providerRecord.getProviderId();
+
+        if (!attributionExist) {
+            logger.debug("Attributing patient {} to provider {}.", beneficiaryID, providerNPI);
+            // Manually create the attribution relationship because JOOQ doesn't understand JPA ManyToOne relationships
+            final AttributionsRecord attr = new AttributionsRecord();
+            attr.setProviderId(providerRecord.getId());
+            attr.setPatientId(patient.getId());
+            attr.setCreatedAt(creationTimestamp);
+            ctx.executeInsert(attr);
+        } else {
+            logger.debug("Attribution relationship already exists between patient {} and provider {}", beneficiaryID, providerRecord.getProviderId());
+        }
     }
 }

--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -244,5 +244,9 @@
 
         <dropColumn tableName="ORGANIZATIONS" columnName="token_ids"/>
     </changeSet>
+    
+    <changeSet id="add-roster-constraints" author="nickrobison-usds">
+        <addUniqueConstraint tableName="ATTRIBUTIONS" columnNames="provider_id, patient_id"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
@@ -88,7 +88,7 @@ public class AttributionFHIRTest {
 
         try (final CloseableHttpClient client = HttpClients.createDefault()) {
 
-            final HttpPost httpPost = new HttpPost("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group");
+            HttpPost httpPost = new HttpPost("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group");
             httpPost.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
             httpPost.setEntity(new StringEntity(ctx.newJsonParser().encodeResourceToString(bundle)));
 
@@ -99,7 +99,7 @@ public class AttributionFHIRTest {
             // Get the patients
 
             // Check how many are attributed
-            final HttpGet getPatients = new HttpGet("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group/" + providerID);
+            HttpGet getPatients = new HttpGet("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group/" + providerID);
             getPatients.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
 
             try (CloseableHttpResponse response = client.execute(getPatients)) {
@@ -115,6 +115,26 @@ public class AttributionFHIRTest {
 
             try (CloseableHttpResponse response = client.execute(isAttributed)) {
                 assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
+            }
+
+            // Submit again and make sure the size doesn't change
+            httpPost = new HttpPost("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group");
+            httpPost.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
+            httpPost.setEntity(new StringEntity(ctx.newJsonParser().encodeResourceToString(bundle)));
+
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have succeeded");
+            }
+
+            // Check how many are attributed
+            getPatients = new HttpGet("http://localhost:" + APPLICATION.getLocalPort() + "/v1/Group/" + providerID);
+            getPatients.setHeader("Accept", FHIRMediaTypes.FHIR_JSON);
+
+            try (CloseableHttpResponse response = client.execute(getPatients)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should be attributed");
+                List<String> beneies = mapper.readValue(EntityUtils.toString(response.getEntity()), new TypeReference<List<String>>() {
+                });
+                assertEquals(bundle.getEntry().size() - 1, beneies.size(), "Should have the same number of beneies");
             }
         }
     }


### PR DESCRIPTION
**Why**
The attribution list was growing uncontrollably, because we were missing a constraint that avoids patient being double attributed.

**What Changed**

Simple change to add the constraint and update the Roster logic to check before trying to write again.

**Choices Made**

Simple, quick solution.

**Tickets closed**:

DPC-424

**Future Work**

Nothing