### PR TITLE
DPC-422: Fixed a bad profile renaming

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/TestResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/TestResource.java
@@ -26,7 +26,7 @@ public class TestResource {
     }
 
     @POST
-    public Response testValidations(@Valid @Profiled(profile = "https://dpc.cms.gov/fhir/StructureDefinition/dpc-patient") Patient patient) {
+    public Response testValidations(@Valid @Profiled(profile = "https://dpc.cms.gov/fhir/StructureDefinition/dpc-profile-patient") Patient patient) {
         return Response.ok().build();
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/DefinitionResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/DefinitionResourceTest.java
@@ -42,7 +42,7 @@ class DefinitionResourceTest {
     @Test
     void testFetchSpecificResource() {
         // Fetch the patient resource
-        final Response response = RESOURCES.target("/StructureDefinition/dpc-patient")
+        final Response response = RESOURCES.target("/StructureDefinition/dpc-profile-patient")
                 .request(FHIRMediaTypes.FHIR_JSON)
                 .get();
 

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/profiles/PatientProfile.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/profiles/PatientProfile.java
@@ -5,7 +5,7 @@ package gov.cms.dpc.fhir.validations.profiles;
  */
 public class PatientProfile implements IProfileLoader {
 
-    public static String PROFILE_URI = "https://dpc.cms.gov/fhir/StructureDefinition/dpc-patient";
+    public static String PROFILE_URI = "https://dpc.cms.gov/fhir/StructureDefinition/dpc-profile-patient";
 
     @Override
     public String getPath() {

--- a/dpc-common/src/main/resources/validations/DPCPatient.json
+++ b/dpc-common/src/main/resources/validations/DPCPatient.json
@@ -1,7 +1,7 @@
 {
   "resourceType": "StructureDefinition",
   "id": "dpc-profile-patient",
-  "url": "https://dpc.cms.gov/StructureDefinition/dpc-profile-patient",
+  "url": "https://dpc.cms.gov/fhir/StructureDefinition/dpc-profile-patient",
   "name": "DPC Patient Definition",
   "status": "draft",
   "kind": "resource",


### PR DESCRIPTION
**Why**

When updating our FHIR profiles, I neglected to update all the other references, which was causing some of the tests to fail.

**What Changed**

Updated the URL changes across the application

**Choices Made**

**Tickets closed**:

DPC-422

**Future Work**
