### PR TITLE
fix empty links and text styling

### DIFF
--- a/dpc-web/app/views/public/home.html.erb
+++ b/dpc-web/app/views/public/home.html.erb
@@ -126,7 +126,7 @@
         <li class="site-process-list__item">
           <h3 class="site-process-list__heading">Request access to the pilot</h3>
           <div class="site-process-list__body">
-            <p>Do this on the <a href="#">Request Access Page</a>. Remember, this is a pilot and and the process may move slowly. You can prepare for connection by reviewing the <a href="#">API documentation</a>.</p>
+            <p>Do this on the <a href="#">Request Access Page</a>. Remember, this is a pilot and and the process may move slowly. You can prepare for connection by reviewing the <%= link_to "API documentation", docs_path %>.</p>
           </div>
         </li>
         <li class="site-process-list__item">
@@ -162,7 +162,8 @@
       <div class="site-block-header">
         <h2 class="site-block-header__heading">About the data</h2>
         <div class="site-block-header__description">
-          <p>The claims data is provided using the industry-standard <a href="#">HL7 Fast Healthcare Interoperability Resources (FHIR)</a> resources, specifically the <a href="#">Bulk FHIR specification</a>.</p>
+          <p>The claims data is provided using the industry-standard <a href="http://hl7.org/fhir/">HL7 Fast Healthcare Interoperability Resources (FHIR)</a> resources, specifically the <a href="The Nick [1:39 PM]
+http://hl7.org/fhir/us/bulkdata/2019May/index.html">Bulk FHIR specification</a>.</p>
         </div>
 
         <div class="usa-accordion usa-accordion--bordered ds-u-margin-top--7">
@@ -187,15 +188,15 @@
           <!-- Use the accurate heading level to maintain the document outline -->
           <h2 class="usa-accordion__heading">
             <button class="usa-accordion__button" aria-expanded="false" aria-controls="a2">
-               How is the Data at the Point of Care pilot different from Blue Button 2.0 and Beneficiary Claims Data API?
+               How is the Data at the Point of Care pilot different from Blue Button 2.0 and Beneficiary Claims Data API (BCDA)?
             </button>
           </h2>
           <div id="a2" class="usa-accordion__content">
-            <p>Blue Button 2.0 provides FHIR-formatted data for one individual Medicare beneficiary at a time, to registered applications with beneficiary authorization. See https://bluebutton.cms.gov/.</p>
+            <p><strong>Blue Button 2.0</strong> provides FHIR-formatted data for one individual Medicare beneficiary at a time, to registered applications with beneficiary authorization. See https://bluebutton.cms.gov/.</p>
 
-            <p>BCDA provides FHIR-formatted bulk data files to an ACO for all of the beneficiaries eligible to a given Shared Savings Program ACO. BCDA does not require individual beneficiary authorization but does allow a process for patients to opt out of data sharing.</p>
+            <p><strong>BCDA</strong> provides FHIR-formatted bulk data files to an ACO for all of the beneficiaries eligible to a given Shared Savings Program ACO. BCDA does not require individual beneficiary authorization but does allow a process for patients to opt out of data sharing.</p>
 
-            <p>Data at the Point of Care Pilot provides FHIR-formatted bulk data files to fee-for-service providers for their active patients as needed for treatment purposes under HIPAA. Data at the Point of Care does not require individual beneficiary authorization but does allow a process for patients to opt out of data sharing.</p>
+            <p><strong>Data at the Point of Care</strong> pilot provides FHIR-formatted bulk data files to fee-for-service providers for their active patients as needed for treatment purposes under HIPAA. Data at the Point of Care does not require individual beneficiary authorization but does allow a process for patients to opt out of data sharing.</p>
 
           </div>
         </div>


### PR DESCRIPTION
**Why**

- Broken links are bad.
- Bold text in accordions help improve readability. This was something that got flagged in a usability research call.

**Checklist**

- [x] API documentation link in Getting Started section is working
- [x] Both FHIR links in the about the data section are working
- [x] Text is bolded in the last accordion
