### PR TITLE
Add auth annotation tests

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/TestResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/TestResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources;
 
+import gov.cms.dpc.api.auth.annotations.Public;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.annotations.Profiled;
 import io.swagger.annotations.Api;
@@ -24,12 +25,14 @@ public class TestResource {
     }
 
     @GET
+    @Public
     @ApiOperation(value = "test resource")
     public Response base() {
         return Response.status(Response.Status.OK).entity("Hello there!").build();
     }
 
     @POST
+    @Public
     @ApiOperation(value = "validation test resource")
     public Response testValidations(@Valid @Profiled(profile = "https://dpc.cms.gov/fhir/StructureDefinition/dpc-profile-patient") Patient patient) {
         return Response.ok().build();

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
@@ -48,6 +48,7 @@ public class BaseResource extends AbstractBaseResource {
     }
 
     @Override
+    @Public
     @ApiOperation(value = "Get FHIR Metadata", notes = "Returns the FHIR Capabilities statement for the application", response = CapabilityStatement.class)
     public CapabilityStatement metadata() {
         return Capabilities.buildCapabilities();

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
+import gov.cms.dpc.api.auth.annotations.Public;
 import gov.cms.dpc.api.core.Capabilities;
 import gov.cms.dpc.api.resources.*;
 import io.swagger.annotations.Api;
@@ -40,6 +41,7 @@ public class BaseResource extends AbstractBaseResource {
     }
 
     @Override
+    @Public
     @ApiOperation(value = "Return the software version", hidden = true)
     public String version() {
         return "Version 1";

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiOperation;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
 
 import javax.inject.Inject;
+import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
 
@@ -48,6 +49,7 @@ public class BaseResource extends AbstractBaseResource {
     }
 
     @Override
+    @GET
     @Public
     @ApiOperation(value = "Get FHIR Metadata", notes = "Returns the FHIR Capabilities statement for the application", response = CapabilityStatement.class)
     public CapabilityStatement metadata() {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources.v1;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractDataResource;
 import gov.cms.dpc.common.annotations.ExportPath;
 import io.swagger.annotations.Api;
@@ -9,6 +10,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
+import org.hl7.fhir.dstu3.model.ResourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +38,7 @@ public class DataResource extends AbstractDataResource {
 
     @Override
     @Path("/{fileID}/")
+    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "fileID")
     @GET
     @Timed
     @ExceptionMetered

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DefinitionResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DefinitionResource.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.api.resources.v1;
 
 import ca.uhn.fhir.context.FhirContext;
+import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractDefinitionResource;
 import gov.cms.dpc.common.annotations.ServiceBaseURL;
 import gov.cms.dpc.fhir.annotations.FHIR;
@@ -8,6 +9,7 @@ import gov.cms.dpc.fhir.validations.DPCProfileSupport;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.ResourceType;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
 
 import javax.inject.Inject;
@@ -45,6 +47,7 @@ public class DefinitionResource extends AbstractDefinitionResource {
     @Override
     @GET
     @Path("/{definitionID}")
+    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "definitionId")
     @FHIR
     @ApiOperation(value = "Fetch specific structure definition", notes = "FHIR endpoint to fetch a specific structure definition from the server.", response = StructureDefinition.class)
     public StructureDefinition getStructureDefinition(@PathParam("definitionID") String definitionID) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DefinitionResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DefinitionResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources.v1;
 
 import ca.uhn.fhir.context.FhirContext;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
+import gov.cms.dpc.api.auth.annotations.Public;
 import gov.cms.dpc.api.resources.AbstractDefinitionResource;
 import gov.cms.dpc.common.annotations.ServiceBaseURL;
 import gov.cms.dpc.fhir.annotations.FHIR;
@@ -35,6 +36,7 @@ public class DefinitionResource extends AbstractDefinitionResource {
 
     @Override
     @ApiOperation(value = "Fetch all structure definitions", notes = "FHIR endpoint which fetches all structure definitions from the server", response = Bundle.class)
+    @Public
     @FHIR
     public Bundle getStructureDefinitions() {
         final Bundle bundle = new Bundle();
@@ -47,7 +49,7 @@ public class DefinitionResource extends AbstractDefinitionResource {
     @Override
     @GET
     @Path("/{definitionID}")
-    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "definitionId")
+    @Public
     @FHIR
     @ApiOperation(value = "Fetch specific structure definition", notes = "FHIR endpoint to fetch a specific structure definition from the server.", response = StructureDefinition.class)
     public StructureDefinition getStructureDefinition(@PathParam("definitionID") String definitionID) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
+import gov.cms.dpc.api.auth.annotations.*;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.resources.AbstractGroupResource;
@@ -60,6 +61,7 @@ public class GroupResource extends AbstractGroupResource {
     @Override
     @GET // Need this here, since we're using a path param
     @Path("/{providerID}/$export")
+    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "providerID/export")
     @Timed
     @ExceptionMetered
     @FHIRAsync
@@ -108,6 +110,7 @@ public class GroupResource extends AbstractGroupResource {
      * @return - {@link String} test string
      */
     @POST
+    @Public
     @ApiOperation(value = "FHIR marshall test", hidden = true)
     public Patient marshalTest(Group group) {
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources.v1;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.models.JobCompletionModel;
 import gov.cms.dpc.api.resources.AbstractJobResource;
 import gov.cms.dpc.common.annotations.APIV1;
@@ -48,6 +49,7 @@ public class JobResource extends AbstractJobResource {
 
     @Override
     @Path("/{jobID}")
+    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "jobID")
     @GET
     @Timed
     @ExceptionMetered

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
@@ -118,6 +118,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @Override
     @DELETE
     @Path("/{providerID}")
+    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "providerID")
     @FHIR
     @Timed
     @ExceptionMetered
@@ -138,6 +139,7 @@ public class PractitionerResource extends AbstractPractionerResource {
     @Override
     @PUT
     @Path("/{providerID}")
+    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "providerID")
     @FHIR
     @Timed
     @ExceptionMetered

--- a/dpc-api/src/test/java/gov/cms/dpc/api/APIResourceAnnotationTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/APIResourceAnnotationTest.java
@@ -45,7 +45,6 @@ class APIResourceAnnotationTest {
                 .addAll(reflections.getMethodsAnnotatedWith(HEAD.class))
                 .addAll(reflections.getMethodsAnnotatedWith(DELETE.class))
                 .addAll(reflections.getMethodsAnnotatedWith(PATCH.class))
-                .addAll(reflections.getMethodsAnnotatedWith(ApiOperation.class))
                 .build();
 
         methods = methods.stream()


### PR DESCRIPTION
**Why**

A large amount of the `dpc-api` methods did not have the appropriate annotations specifying the level of authentication provided.

**What Changed**
- Added `allResourcesHaveSecurityAnnotations()` test to `APIResourceAnnotationTest`
- Attempted to fix all the `v1` endpoints to make the test pass -- this needs review, I'm not sure if I added the correct annotations for everything, specifically the `PathAuthorizer` tests

**Choices Made**
**Tickets closed**
**Future Work**
**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
