### PR TITLE
Jared/documentation page design dpc 431

### DIFF
--- a/dpc-web/app/assets/stylesheets/application.scss
+++ b/dpc-web/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@
  @import "components/footer";
  @import "components/hero";
  @import "components/navbar";
+ @import "components/page-headers";
  @import "components/pills";
  @import "components/process-list";
  @import "components/site-blocks";

--- a/dpc-web/app/assets/stylesheets/components/_page-headers.scss
+++ b/dpc-web/app/assets/stylesheets/components/_page-headers.scss
@@ -1,0 +1,42 @@
+.page-header {
+  background-color: $color-gray-dark;
+  color: $color-white;
+  padding-top: $spacer-5;
+
+  .ds-c-tabs {
+    border-bottom: 0;
+    margin-top: 0 - $spacer-3;
+  }
+
+  .ds-c-tabs__item {
+    background-color: rgba($color-gray, .3);
+    color: $color-white;
+    border: 0;
+    margin: 0 4px 0 0;
+  }
+
+  .ds-c-tabs__item--active {
+    background-color: $color-white;
+    color: $color-gray-dark;
+
+    &:before {
+      background-color: $color-primary;
+      content: "";
+      height: 4px;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: -1px;
+    }
+  }
+
+}
+
+.page-header__heading {
+  display: block;
+  font-size: $h1-font-size;
+  font-weight: $font-bold;
+  margin: 0;
+  padding-bottom: $spacer-5;
+}
+

--- a/dpc-web/app/assets/stylesheets/sidenav.scss
+++ b/dpc-web/app/assets/stylesheets/sidenav.scss
@@ -3,6 +3,11 @@
   top: $spacer-5;
   list-style: none;
   padding: 0;
+
+  @media (min-width: $width-md) {
+    position: sticky;
+    top: $spacer-5;
+  }
 }
 
 .sidenav__item {

--- a/dpc-web/app/controllers/public_controller.rb
+++ b/dpc-web/app/controllers/public_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class PublicController < ApplicationController
+  layout 'landing-page'
 end

--- a/dpc-web/app/helpers/application_helper.rb
+++ b/dpc-web/app/helpers/application_helper.rb
@@ -10,4 +10,9 @@ module ApplicationHelper
     html = HighlightSource.render(text)
     html.html_safe
   end
+
+  def current_class?(test_path)
+    return 'ds-c-tabs__item--active' if request.path == test_path
+    ''
+  end
 end

--- a/dpc-web/app/views/docs/guide.html.erb
+++ b/dpc-web/app/views/docs/guide.html.erb
@@ -1,9 +1,29 @@
 <% title "Guide" %>
 
-<p>Content for Guide</p>
+<div class="ds-l-row">
+  <div class="ds-l-col--12 ds-l-md-col--4">
+    <ul class="sidenav">
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+    </ul>
+  </div>
+  <main class="ds-l-col--12 ds-l-md-col--8" id="main">
 
-<%= link_to docs_path, :class => "ds-c-button" do %>
-reference
-<% end %>
+    <h1>Guide</h1>
 
-<%= raw(@html_content) %>
+    <%= raw(@html_content) %>
+  </main>
+</div>

--- a/dpc-web/app/views/docs/reference.html.erb
+++ b/dpc-web/app/views/docs/reference.html.erb
@@ -1,9 +1,30 @@
 <% title "Reference" %>
 
-<p>Content for Reference</p>
+<div class="ds-l-row">
+  <div class="ds-l-col--12 ds-l-md-col--4">
+    <ul class="sidenav">
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+      <li class="sidenav__item">
+        <a href="#" class="sidenav__link">Side nav link</a>
+      </li>
+    </ul>
+  </div>
+  <main class="ds-l-col--12 ds-l-md-col--8" id="main">
 
-<%= link_to docs_guide_path, :class => "ds-c-button" do %>
-guide
-<% end %>
+    <h1>Reference</h1>
 
-<%= raw(@html_content) %>
+    <%= raw(@html_content) %>
+  </main>
+</div>
+

--- a/dpc-web/app/views/layouts/application.html.erb
+++ b/dpc-web/app/views/layouts/application.html.erb
@@ -7,16 +7,24 @@
     <!-- nav -->
     <%= render partial: 'shared/navbar' %>
 
-    <div class="ds-l-container">
-      <div class="ds-l-row">
-        <div class="ds-l-col--12">
-          <h1><%= yield(:title) %></h1>
+    <header class="page-header">
+      <div class="ds-l-container">
+        <span class="page-header__heading">Docs</span>
+
+        <div class="ds-c-tabs">
+          <%= link_to docs_path, :class => "ds-c-tabs__item #{current_class?(docs_path)}" do %>
+            Reference
+          <% end %>
+          <%= link_to docs_guide_path, :class => "ds-c-tabs__item #{current_class?(docs_guide_path)}" do %>
+            Guide
+          <% end %>
         </div>
+
       </div>
-    </div>
+    </header>
 
     <!-- content -->
-    <section class="ds-l-container" id="main">
+    <section class="ds-l-container ds-u-padding-top--7">
       <%= yield %>
     </section>
 

--- a/dpc-web/app/views/layouts/application.html.erb
+++ b/dpc-web/app/views/layouts/application.html.erb
@@ -1,26 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>
-      <%= content_for?(:title) ? yield(:title) : 'CMS.gov' %> | Data at the Point of Care
-    </title>
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag    'application', media: 'all' %>
-  </head>
+  <%= render partial: 'shared/head' %>
 
   <body class="ds-base">
-
-    <a class="ds-c-skip-nav" href="#main">Skip to main content</a>
-
     <!-- nav -->
     <%= render partial: 'shared/navbar' %>
 
-    <!-- hero -->
-    <% if controller.controller_name == "public" %>
-      <%= render partial: 'public/hero' %>
-    <% else %>
     <div class="ds-l-container">
       <div class="ds-l-row">
         <div class="ds-l-col--12">
@@ -28,21 +14,14 @@
         </div>
       </div>
     </div>
-    <% end %>
 
     <!-- content -->
-    <% if controller.controller_name == "public" %>
-      <%= yield %>
-    <% else %>
     <section class="ds-l-container" id="main">
       <%= yield %>
     </section>
-    <% end %>
 
 
     <%= render partial: 'shared/footer' %>
-
-    <%= javascript_include_tag 'application' %>
 
   </body>
 </html>

--- a/dpc-web/app/views/layouts/landing-page.html.erb
+++ b/dpc-web/app/views/layouts/landing-page.html.erb
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+
+  <%= render partial: 'shared/head' %>
+
+  <body class="ds-base">
+
+    <!-- nav -->
+    <%= render partial: 'shared/navbar' %>
+
+    <!-- hero -->
+    <%= render partial: 'public/hero' %>
+
+    <!-- main content -->
+    <%= yield %>
+
+    <%= render partial: 'shared/footer' %>
+
+  </body>
+</html>

--- a/dpc-web/app/views/shared/_footer.html.erb
+++ b/dpc-web/app/views/shared/_footer.html.erb
@@ -32,3 +32,5 @@
     </div>
   </div>
 </footer>
+
+<%= javascript_include_tag 'application' %>

--- a/dpc-web/app/views/shared/_head.html.erb
+++ b/dpc-web/app/views/shared/_head.html.erb
@@ -1,0 +1,9 @@
+<head>
+  <title>
+    <%= content_for?(:title) ? yield(:title) : 'CMS.gov' %> | Data at the Point of Care
+  </title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+</head>

--- a/dpc-web/app/views/shared/_navbar.html.erb
+++ b/dpc-web/app/views/shared/_navbar.html.erb
@@ -1,3 +1,5 @@
+<a class="ds-c-skip-nav" href="#main">Skip to main content</a>
+
 <nav class="navbar" id="navbar">
   <a class="site-logo" href="/">
     <%= image_tag("top-nav-heart.svg", alt: "Heart logo") %> <span class="site-logo-text">Data at the Point of Care</span>


### PR DESCRIPTION
**Why**

Provides design layout for the documentation pages

<img width="1024" alt="Screen Shot 2019-07-22 at 4 44 50 PM" src="https://user-images.githubusercontent.com/25435289/61664166-3c6c8300-aca0-11e9-9b9c-6f2d679bf4bd.png">


**What Changed**

- Cleaned up layout files
- Added current_page helper


**Choices Made**

- Provided layout for documentation pages. 
- Sidenav is just stubbed because we dont' have content yet


**Tickets closed**:

https://jiraent.cms.gov/browse/DPC-431

**Checklist**

- [x] Routes in tabs work
