### PR TITLE
add viewport and charset meta tags

### DIFF
--- a/dpc-web/app/views/shared/_head.html.erb
+++ b/dpc-web/app/views/shared/_head.html.erb
@@ -2,6 +2,8 @@
   <title>
     <%= content_for?(:title) ? yield(:title) : 'CMS.gov' %> | Data at the Point of Care
   </title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
 


### PR DESCRIPTION
**Why**
This PR adds the `charset` meta tag, and, more importantly, the `viewport` meta tag which allows the site to scale down on mobile devices. 


