### PR TITLE
DPC-312: Fix token expiration logic

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/macaroons/ExpirationCaveatVerifier.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/macaroons/ExpirationCaveatVerifier.java
@@ -15,11 +15,8 @@ import java.util.Optional;
 public class ExpirationCaveatVerifier implements CaveatVerifier {
 
     static final String CAVEAT_INVALID = "Caveat is expired";
-    private final TokenPolicy.ExpirationPolicy expirationPolicy;
 
-    ExpirationCaveatVerifier(TokenPolicy policy) {
-        this.expirationPolicy = policy.getExpirationPolicy();
-    }
+    ExpirationCaveatVerifier(TokenPolicy policy) { }
 
     @Override
     public Optional<String> check(MacaroonCaveat caveat) {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/macaroons/ExpirationCaveatVerifier.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/macaroons/ExpirationCaveatVerifier.java
@@ -27,9 +27,9 @@ public class ExpirationCaveatVerifier implements CaveatVerifier {
         if (caveat.getKey().equals(ExpirationCaveatSupplier.EXPIRATION_KEY)) {
 
             final OffsetDateTime caveatExpiration = OffsetDateTime.parse(caveat.getValue());
-            final OffsetDateTime expirationTime = OffsetDateTime.now(ZoneOffset.UTC).plus(expirationPolicy.getExpirationOffset(), expirationPolicy.getExpirationUnit());
-            final boolean isBefore = caveatExpiration.isBefore(expirationTime);
-            if (!isBefore) {
+            final OffsetDateTime currentTime = OffsetDateTime.now(ZoneOffset.UTC);
+            final boolean isBefore = caveatExpiration.isBefore(currentTime);
+            if (isBefore) {
                 return Optional.of(CAVEAT_INVALID);
             }
             return Optional.empty();

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/macaroons/ExpirationVerifierTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/macaroons/ExpirationVerifierTest.java
@@ -1,37 +1,36 @@
-//package gov.cms.dpc.attribution.macaroons;
-//
-//import gov.cms.dpc.macaroons.MacaroonCaveat;
-//import org.junit.jupiter.api.Disabled;
-//
-//import java.time.LocalDate;
-//import java.time.OffsetDateTime;
-//import java.time.ZoneOffset;
-//import java.time.temporal.ChronoUnit;
-//
-//@Disabled // TODO: Disabled until DPC-312 is merged
-//class ExpirationVerifierTest extends AbstractVerifierTest<ExpirationCaveatVerifier> {
-//
-//    ExpirationVerifierTest() {
-//        super(new ExpirationCaveatVerifier(getTokenPolicy()));
-//    }
-//
-//    @Override
-//    MacaroonCaveat getNonMatchingCaveat() {
-//        return new MacaroonCaveat("nothing", MacaroonCaveat.Operator.EQ, "nothing");
-//    }
-//
-//    @Override
-//    MacaroonCaveat getWrongCaveat() {
-//        return new MacaroonCaveat("expires", MacaroonCaveat.Operator.EQ, LocalDate.of(1990, 1, 1).atStartOfDay().atOffset(ZoneOffset.UTC).toString());
-//    }
-//
-//    @Override
-//    MacaroonCaveat getCorrectCaveat() {
-//        return new MacaroonCaveat("expires", MacaroonCaveat.Operator.EQ, OffsetDateTime.now().plus(2, ChronoUnit.YEARS).toString());
-//    }
-//
-//    @Override
-//    String provideFailureMessage() {
-//        return ExpirationCaveatVerifier.CAVEAT_INVALID;
-//    }
-//}
+package gov.cms.dpc.attribution.macaroons;
+
+import gov.cms.dpc.macaroons.MacaroonCaveat;
+import org.junit.jupiter.api.Disabled;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+
+class ExpirationVerifierTest extends AbstractVerifierTest<ExpirationCaveatVerifier> {
+
+    ExpirationVerifierTest() {
+        super(new ExpirationCaveatVerifier(getTokenPolicy()));
+    }
+
+    @Override
+    MacaroonCaveat getNonMatchingCaveat() {
+        return new MacaroonCaveat("nothing", MacaroonCaveat.Operator.EQ, "nothing");
+    }
+
+    @Override
+    MacaroonCaveat getWrongCaveat() {
+        return new MacaroonCaveat("expires", MacaroonCaveat.Operator.EQ, LocalDate.of(1990, 1, 1).atStartOfDay().atOffset(ZoneOffset.UTC).toString());
+    }
+
+    @Override
+    MacaroonCaveat getCorrectCaveat() {
+        return new MacaroonCaveat("expires", MacaroonCaveat.Operator.EQ, OffsetDateTime.now().plus(2, ChronoUnit.YEARS).toString());
+    }
+
+    @Override
+    String provideFailureMessage() {
+        return ExpirationCaveatVerifier.CAVEAT_INVALID;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
             <email>ronak.shah@hhs.gov</email>
             <organization>US Department of Health and Human Services</organization>
         </developer>
+        <developer>
+            <id>ron</id>
+            <name>Ron Heft</name>
+            <email>ronald.k.heft@omb.eop.gov</email>
+            <organization>United States Digital Service</organization>
+        </developer>
     </developers>
 
     <dependencyManagement>


### PR DESCRIPTION
**Why**

The token expiration logic is currently messed up.

**What Changed**

* Re-enabled ExpirationVerifierTest
* Fixed ExpirationCaveatVerifier: The token contains the expiration time. The ExpirationCaveatVerifier was assuming the token contained a generated time and not an expiration time. Due to this, it was applying the token expiration policy to the current time when all that needed to occur was verify that expiration time was after the current time.

**Choices Made**

N/A

**Tickets closed**:

DPC-312

**Future Work**

None.

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated