### PR TITLE
link to google group

### DIFF
--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -1,7 +1,7 @@
 <% title "Frequently asked questions" %>
 
   <div class="ds-text--lead ds-u-measure--wide">
-    <p>As we continue to gather feedback from users on the Data at the Point of Care (DPC) pilot, we will likekly add more FAQs to this page. If you have a question that is not listed below, please use the <a href="#">DPC Google Group</a>.</p>
+    <p>As we continue to gather feedback from users on the Data at the Point of Care (DPC) pilot, we will likekly add more FAQs to this page. If you have a question that is not listed below, please use the <a href="https://groups.google.com/d/forum/dpc-api">DPC Google Group</a>.</p>
   </div>
 
   <div class="usa-accordion usa-accordion--bordered ds-u-margin-top--7">
@@ -16,7 +16,7 @@
       <ul>
         <li>First, <a href="#">request access</a> to the pilot. This puts you on the list of providers who are interested, regardless of whether your vendors are ready to participate.</li>
         <li>Ask your software provider if they have implemented the Bulk FHIR specification.</li>
-        <li>Direct them to this website and encourage them to use the <a href="#">Google Group</a>.</li>
+        <li>Direct them to this website and encourage them to use the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a>.</li>
         <li>Ask them if they can commit to working with you on this project and if so, when will they be ready.</li>
       </ul>
     </div>
@@ -59,7 +59,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
     <div id="a4" class="usa-accordion__content">
       <ul>
         <li>Technical documentation is available in the <a href="#">API Documentation</a>.</li>
-        <li>A Google Group has been created to provide answers to questions and to support providers and developers who are implementing Data at the Point of Care. Sign up at https://dpc.cms.gov and join the <a href="#">Google Group</a>.</li>
+        <li>A Google Group has been created to provide answers to questions and to support providers and developers who are implementing Data at the Point of Care. Sign up at https://dpc.cms.gov and join the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a>.</li>
       </ul>
     </div>
 
@@ -135,7 +135,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
     <div id="a10" class="usa-accordion__content">
       <ul>
         <li>CMS will slowly roll out the tokens to providers based on order of request, their readiness, their experience with FHIR, claims data, Blue Button and BCDA, and our ability to respond.</li>
-        <li>Updates will be posted to the Google Group as we progress through the pilot process.</li>
+        <li>Updates will be posted to the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a> as we progress through the pilot process.</li>
       </ul>
     </div>
   </div>

--- a/dpc-web/app/views/pages/support.html.erb
+++ b/dpc-web/app/views/pages/support.html.erb
@@ -7,7 +7,7 @@
 <p>The Data at the Point of Care (DPC) Google Group is the best place to get your questions answered by the DPC team. In this community you can sign up for feedback session opportunities, get answers to your questions, share your feedback and ideas, and get updates on the project.</p>
 
 <div class="ds-u-margin-top--5">
-  <a href="#" class="ds-c-button ds-c-button--big">Join Google group</a>
+  <a href="https://groups.google.com/d/forum/dpc-api" class="ds-c-button ds-c-button--big">Join Google group</a>
 </div>
 
 <h2 class="ds-u-margin-top--7">Have other questions?</h2>

--- a/dpc-web/app/views/public/home.html.erb
+++ b/dpc-web/app/views/public/home.html.erb
@@ -214,7 +214,7 @@ http://hl7.org/fhir/us/bulkdata/2019May/index.html">Bulk FHIR specification</a>.
             <use xlink:href="/assets/solid.svg#key"></use>
           </svg>Request access
         <% end %>
-        <%= link_to support_path, :class => "ds-c-button ds-c-button--inverse ds-c-button--inverse--alt ds-c-button--big" do %>
+        <%= link_to "https://groups.google.com/d/forum/dpc-api", :class => "ds-c-button ds-c-button--inverse ds-c-button--inverse--alt ds-c-button--big" do %>
           Join Google Group
         <% end %>
         </div>


### PR DESCRIPTION
**Why**

Now that we have the google group set up, let's link to it!

**Tickets closed**:

https://jiraent.cms.gov/browse/DPC-445
