### PR TITLE
Run db migrations when starting dpc-web Docker container

### DIFF
--- a/dpc-web/Dockerfile
+++ b/dpc-web/Dockerfile
@@ -20,4 +20,4 @@ RUN gem install bundler --no-document && bundle install && npm install
 COPY . /dpc-web
 
 # Start the rails server
-CMD ["rails", "server", "-b", "0.0.0.0"]
+CMD ["./docker/entrypoint.sh"]

--- a/dpc-web/README.md
+++ b/dpc-web/README.md
@@ -101,12 +101,6 @@ To build the container, simply run the following command:
 docker-compose build
 ```
 
-After the container is built, initialize the database:
-
-```Bash
-docker-compose run web rails db:migrate db:seed
-```
-
 ## Start the Docker Container
 
 The following command will start both the database server and rails server:
@@ -117,7 +111,7 @@ docker-compose up
 
 ## Stop / Destroy the Docker Container
 
-When you're done, shut down the server with the following command:
+When you're done, shut down the server with the following command (this also destroys the database):
 
 ```Bash
 docker-compose down

--- a/dpc-web/config/application.rb
+++ b/dpc-web/config/application.rb
@@ -1,5 +1,8 @@
 require_relative 'boot'
 
+# Enable stout syncing for Docker
+$stdout.sync = true
+
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"

--- a/dpc-web/docker/entrypoint.sh
+++ b/dpc-web/docker/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+set -e
+
+# Clean the existing pid if the server was previously started (using docker-compose for example)
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+# Run the database migrations
+echo "Migrating the database..."
+rails db:migrate
+
+# Seed the database
+# This step is not needed, as there is no database seed data yet
+
+# Start the database service (and make accessible outside the Docker container)
+echo "Starting Rails server..."
+rails server -b 0.0.0.0


### PR DESCRIPTION
**Why**

Database migrations are not currently run anywhere in our manual deployment process.

**What Changed**

- Executes the rails `db:migrate` task on Docker container boot.
- Fixes Rails logs not making it to Docker.

**Choices Made**

The Rails `db:migrate` task is safe to run concurrently on multiple nodes according to: https://github.com/rails/rails/issues/22092

**Tickets closed**:

None.

**Future Work**

None.

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
