### PR TITLE
IG publisher build for dpc-web Docker

### DIFF
--- a/dpc-web/Dockerfile
+++ b/dpc-web/Dockerfile
@@ -1,23 +1,44 @@
 FROM ruby:2.6.2-alpine
 
 # Install build dependencies
-RUN apk add --no-cache postgresql-dev alpine-sdk npm tzdata
+RUN apk add --no-cache postgresql-dev alpine-sdk npm tzdata fontconfig ttf-dejavu
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community openjdk11
+
+# Configure Alpine Java dependencies
+RUN ln -s /usr/lib/libfontconfig.so.1 /usr/lib/libfontconfig.so && \
+    ln -s /lib/libuuid.so.1 /usr/lib/libuuid.so.1 && \
+    ln -s /lib/libc.musl-x86_64.so.1 /usr/lib/libc.musl-x86_64.so.1
+ENV LD_LIBRARY_PATH /usr/lib
 
 # Set the working directory
-RUN mkdir /dpc-web
-WORKDIR /dpc-web
+RUN mkdir /dpc-app
+WORKDIR /dpc-app/dpc-web
 
 # Copy over the files needed to fetch dependencies
-COPY Gemfile /dpc-web/Gemfile
-COPY Gemfile.lock /dpc-web/Gemfile.lock
-COPY package.json /dpc-web/package.json
-COPY package-lock.json /dpc-web/package-lock.json
+COPY /dpc-web/Gemfile /dpc-app/dpc-web/Gemfile
+COPY /dpc-web/Gemfile.lock /dpc-app/dpc-web/Gemfile.lock
+COPY /dpc-web/package.json /dpc-app/dpc-web/package.json
+COPY /dpc-web/package-lock.json /dpc-app/dpc-web/package-lock.json
 
 # Install the website dependencies
 RUN gem install bundler --no-document && bundle install && npm install
+RUN gem install jekyll
 
-# Copy the website
-COPY . /dpc-web
+# Copy the website and dependencies needed to build supplimental website components
+RUN mkdir -p /dpc-app/dpc-common/src/main/resources/validations && mkdir -p /dpc-app/dpc-api/src/main/resources
+COPY /dpc-web /dpc-app/dpc-web
+COPY /Makefile /dpc-app/Makefile
+COPY /ig /dpc-app/ig
+COPY /dpc-common/src/main/resources/validations /dpc-app/dpc-common/src/main/resources/validations
+COPY /dpc-api/src/main/resources /dpc-app/dpc-api/src/main/resources
+
+# Build the IG component
+WORKDIR /dpc-app
+RUN make ig/publish
+
+# Clean up after building
+RUN mv /dpc-app/dpc-web /dpc-web && cd / && rm -rf dpc-app
+WORKDIR /dpc-web
 
 # Start the rails server
 CMD ["./docker/entrypoint.sh"]

--- a/dpc-web/docker-compose.yml
+++ b/dpc-web/docker-compose.yml
@@ -11,7 +11,9 @@ services:
       - "5432:5432"
 
   web:
-    build: .
+    build:
+      context: ..
+      dockerfile: dpc-web/Dockerfile
     image: dpc-web:latest
     environment:
       - DATABASE_URL=postgresql://db/dpc-website_development


### PR DESCRIPTION
**Why**

We should also ensure we have the latest documentation every time we build. This ensures the Dockerfile for the website also build the IG documentation.

**What Changed**

Adds IG build process to Dockerfile.

**Choices Made**


**Tickets closed**:


**Future Work**


**Checklist**

- [X] Demo and Seed commands are working
- [X] Swagger documentation has been updated
- [X] FHIR documentation has been updated
