### PR TITLE
DPC-469: Pass auth token through Demo command

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
@@ -85,11 +85,11 @@ public class DemoCommand extends Command {
         // Disable validation against Attribution service
         ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
         final IGenericClient attributionClient = ctx.newRestfulGenericClient(attributionURL);
-        FHIRHelpers.registerOrganization(attributionClient, ctx.newJsonParser(), organizationID, attributionURL);
+        final String token = FHIRHelpers.registerOrganization(attributionClient, ctx.newJsonParser(), organizationID, attributionURL);
 
         // Make the initial export request
         // If it's a 404, that's fine, for anything else, fail
-        final IOperationUntypedWithInput<Parameters> exportOperation = createExportOperation(namespace, baseURL);
+        final IOperationUntypedWithInput<Parameters> exportOperation = createExportOperation(namespace, baseURL, token);
         try {
             exportOperation.execute();
         } catch (ResourceNotFoundException e) {
@@ -114,9 +114,9 @@ public class DemoCommand extends Command {
         System.exit(0);
     }
 
-    private IOperationUntypedWithInput<Parameters> createExportOperation(Namespace namespace, String baseURL) {
+    private IOperationUntypedWithInput<Parameters> createExportOperation(Namespace namespace, String baseURL, String token) {
         // Submit an export request for a provider which is not known to the system.
-        final IGenericClient exportClient = ClientUtils.createExportClient(ctx, baseURL);
+        final IGenericClient exportClient = ClientUtils.createExportClient(ctx, baseURL, token);
 
         final String providerID = namespace.getString("provider-id");
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/client/ClientUtils.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/client/ClientUtils.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gov.cms.dpc.api.models.JobCompletionModel;
 import gov.cms.dpc.common.utils.SeedProcessor;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -53,16 +54,18 @@ public class ClientUtils {
      *
      * @param context - FHIR context to use
      * @param serverBaseURL - the base URL for the FHIR endpoint
+     * @param token - Authorization token to use for requests
      * @return {@link IGenericClient} for FHIR requests
      * @see #createExportOperation(IGenericClient, String)
      */
-    public static IGenericClient createExportClient(FhirContext context, String serverBaseURL) {
+    public static IGenericClient createExportClient(FhirContext context, String serverBaseURL, String token) {
         final IGenericClient exportClient = context.newRestfulGenericClient(serverBaseURL);
         // Add a header the hard way
         final var addPreferInterceptor = new IClientInterceptor()  {
             @Override
             public void interceptRequest(IHttpRequest iHttpRequest) {
                 iHttpRequest.addHeader(PREFER_HEADER, PREFER_RESPOND_ASYNC);
+                iHttpRequest.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", token));
             }
 
             @Override
@@ -80,7 +83,7 @@ public class ClientUtils {
      * @param exportClient - {@link IGenericClient} client to use for the request.
      * @param providerID - {@link String} provider ID to request data for
      * @return - {@link IOperationUntypedWithInput} export request, ready to execute
-     * @see #createExportClient(FhirContext, String)
+     * @see #createExportClient(FhirContext, String, String)
      */
     public static IOperationUntypedWithInput<Parameters> createExportOperation(IGenericClient exportClient, String providerID) {
         return exportClient


### PR DESCRIPTION
**Why**

We need the newly generated auth token, and we need to pass it along through the demo command.

**What Changed**

Updated the `exportClient` commands to take the auth token as a parameter.

**Choices Made**

**Tickets closed**:
DPC-469

**Future Work**


**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
