### PR TITLE
create helper method to allow overrides to banner text

### DIFF
--- a/dpc-web/app/helpers/application_helper.rb
+++ b/dpc-web/app/helpers/application_helper.rb
@@ -5,6 +5,10 @@ module ApplicationHelper
     content_for(:title) { page_title }
   end
 
+  def banner_title(banner_title)
+    content_for(:banner_title) { banner_title }
+  end
+
   def syntax_highlight(text)
     # Initialized in config/initializers/rouge_highlighter.rb
     html = HighlightSource.render(text)

--- a/dpc-web/app/views/layouts/pages.html.erb
+++ b/dpc-web/app/views/layouts/pages.html.erb
@@ -9,7 +9,9 @@
 
     <header class="page-header">
       <div class="ds-l-container">
-        <h1 class="page-header__heading"><%= yield(:title) %></h1>
+        <h1 class="page-header__heading">
+          <%= content_for?(:banner_title) ? yield(:banner_title) : yield(:title) %>
+        </h1>
       </div>
     </header>
 

--- a/dpc-web/app/views/pages/guide.html.erb
+++ b/dpc-web/app/views/pages/guide.html.erb
@@ -1,4 +1,5 @@
 <% title "Guide" %>
+<% banner_title "Documentation" %>
 
 <div class="ds-l-row">
   <div class="ds-l-col--12 ds-l-md-col--4">

--- a/dpc-web/app/views/pages/reference.html.erb
+++ b/dpc-web/app/views/pages/reference.html.erb
@@ -1,4 +1,5 @@
 <% title "Reference" %>
+<% banner_title "Documentation" %>
 
 <div class="ds-l-row">
   <div class="ds-l-col--12 ds-l-md-col--4">


### PR DESCRIPTION
**Why**

When we moved the docs to the pages controller, we lost the ability to have "Docs" as the banner title. This fix will allow us to override using the `<title>` as the banner title