### PR TITLE
Fix google analytics tag and update bad link in FHIR IG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ ig/publish: ${IG_PUBLISHER}
 .PHONY: travis
 travis:
 	@./dpc-test.sh
+
+.PHONY: website
+website:
+	@docker build -f dpc-web/Dockerfile .

--- a/dpc-common/src/main/resources/validations/DPCPatient.json
+++ b/dpc-common/src/main/resources/validations/DPCPatient.json
@@ -82,7 +82,7 @@
         "type": [
           {
             "code": "Reference",
-            "targetProfile": "https://dpc.cms.gov/fhir/v1/StructureDefinition/dpc-profile-orgaization"
+            "targetProfile": "https://dpc.cms.gov/fhir/v1/StructureDefinition/dpc-profile-organization"
           }
         ]
       }

--- a/dpc-web/app/views/shared/_head.html.erb
+++ b/dpc-web/app/views/shared/_head.html.erb
@@ -1,4 +1,5 @@
 <head>
+  <%= render partial: 'shared/google-analytics' %>
   <title>
     <%= content_for?(:title) ? yield(:title) : 'CMS.gov' %> | Data at the Point of Care
   </title>
@@ -19,6 +20,4 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag    'application', media: 'all' %>
-
-  <%= render partial: 'shared/google-analytics' %>
 </head>


### PR DESCRIPTION
The Google Analytics tag needs to be the first element in the head block, otherwise the reporting doesn't work correctly.

Also fixed a typo in one of our FHIR profiles and added a `website` target to the make file.

