### PR TITLE
Hotfix to address IG header

### DIFF
--- a/ig/framework/_includes/header.html
+++ b/ig/framework/_includes/header.html
@@ -10,17 +10,6 @@
 <meta name="author" content="{{site.data.fhir.ig.publisher}}"/>
   <link href="fhir.css" rel="stylesheet"/>
 
-   <!-- Analytics -->
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-144775756-1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'UA-144775756-1');
-  </script>
-
   <!-- Bootstrap core CSS -->
 
    <!-- Latest compiled and minified CSS -->


### PR DESCRIPTION
This time, it should actually stick.

Addressing what should have been fixed with #162. The IG doesn't seem to parse analytics tags correctly, so I just pulled them out.