### PR TITLE
Fixed up devise helper

### DIFF
--- a/dpc-web/app/helpers/devise_helper.rb
+++ b/dpc-web/app/helpers/devise_helper.rb
@@ -2,29 +2,34 @@
 
 module DeviseHelper
   def devise_error_messages!
-    flash_alerts = []
-    error_key = 'errors.messages.not_saved'
+    return if flash.notice.blank? && flash.alert.blank? || flash.notice =~ /signed out/i
+    return notice_msg.html_safe if flash.notice
 
-    unless flash.empty?
-      flash_alerts.push(flash[:error]) if flash[:error]
-      flash_alerts.push(flash[:alert]) if flash[:alert]
-      flash_alerts.push(flash[:notice]) if flash[:notice]
-      error_key = 'devise.failure.invalid'
-    end
+    incorrect_email_or_password_msg.html_safe
+  end
 
-    return '' if resource.errors.empty? && flash_alerts.empty?
+  def notice_msg
+    <<-HTML
+      <div class="ds-c-alert ds-u-margin-bottom--5">
+        <div class="ds-c-alert__body">
+          <h3 class="ds-c-alert__heading">#{flash.notice}</h3>
+        </div>
+      </div>
+    HTML
+  end
 
-    errors = resource.errors.empty? ? flash_alerts : resource.errors.full_messages
-
-    html = <<-HTML
+  def incorrect_email_or_password_msg
+    <<-HTML
     <div class="ds-c-alert ds-c-alert--error">
       <div class="ds-c-alert__body">
         <h3 class="ds-c-alert__heading">Your email or password is incorrect.</h3>
-        <p class="ds-c-alert__text">If you forgot your password, please email <a href="mailto:dpcinfo@cms.hhs.gov?subject=Forgot password">dpcinfo@cms.hhs.gov</a> to request a reset.</p>
+        <p class="ds-c-alert__text">
+          If you forgot your password, please email
+          <a href="mailto:dpcinfo@cms.hhs.gov?subject=Forgot password">dpcinfo@cms.hhs.gov</a>
+          to request a reset.
+        </p>
       </div>
     </div>
     HTML
-
-    html.html_safe
   end
 end


### PR DESCRIPTION
**Why**

There was an annoying error message when signing out and then signing in. 

**What Changed**

Redid the devise helper to return nothing if there is not a login error, or if the flash contains a sign out message. Otherwise, displayed the custom email/pw error message.

**Choices Made**

Needed devise helper because we changed the default logout behavior.

