### PR TITLE
Marc/ig fix

### DIFF
--- a/dpc-web/.gitignore
+++ b/dpc-web/.gitignore
@@ -25,3 +25,4 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/public/ig/**/*

--- a/dpc-web/app/controllers/pages_controller.rb
+++ b/dpc-web/app/controllers/pages_controller.rb
@@ -2,15 +2,16 @@
 
 class PagesController < ApplicationController
   before_action :load_markdown
-  
+
   protected
 
   def load_markdown
     # Assume markdown is named the same as the action.
     file_path = lookup_context.find_template("#{controller_path}/#{action_name}").identifier.sub('.html.erb', '.md')
-    if File.exist?(file_path)
-      md_content = File.read(file_path)
-      @html_content = Kramdown::Document.new(md_content).to_html
-    end
+
+    return unless File.exist?(file_path)
+
+    md_content = File.read(file_path)
+    @html_content = Kramdown::Document.new(md_content).to_html
   end
 end

--- a/dpc-web/app/helpers/application_helper.rb
+++ b/dpc-web/app/helpers/application_helper.rb
@@ -25,8 +25,7 @@ module ApplicationHelper
     content_for :"meta_#{tag}", text
   end
 
-  def yield_meta_tag(tag, default_text='')
+  def yield_meta_tag(tag, default_text = '')
     content_for?(:"meta_#{tag}") ? content_for(:"meta_#{tag}") : default_text
   end
-
 end

--- a/dpc-web/config/application.rb
+++ b/dpc-web/config/application.rb
@@ -15,6 +15,7 @@ require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
+require "./lib/dpc_middleware/ig_fix"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -40,5 +41,8 @@ module DpcWebsite
     config.action_view.field_error_proc = Proc.new { |html_tag, instance|
       html_tag
     }
+
+    # Add middleware to fix issue with /ig links breaking
+    config.middleware.insert_before ActionDispatch::Static, DpcMiddleware::IgFix
   end
 end

--- a/dpc-web/lib/dpc_middleware/ig_fix.rb
+++ b/dpc-web/lib/dpc_middleware/ig_fix.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module DpcMiddleware
+  class IgFix
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request = Rack::Request.new(env)
+      return @app.call(env) unless %r{^\/ig$}i.match?(request.path_info)
+
+      url_parts = request.url.split('?')
+      url_parts[0] += '/'
+
+      [301, { 'Location' => url_parts.join('?') }, []]
+    end
+  end
+end

--- a/dpc-web/spec/lib/dpc_middleware/ig_fix_spec.rb
+++ b/dpc-web/spec/lib/dpc_middleware/ig_fix_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+require './lib/dpc_middleware/ig_fix'
+
+describe DpcMiddleware::IgFix do
+  let(:host) { 'http://example.org' }
+  let(:path) { '/ig' }
+  let(:app) { proc { [200, {}, ['Hello']] } }
+  let(:middleware) { DpcMiddleware::IgFix.new(app) }
+  let(:request) { Rack::MockRequest.new(middleware) }
+
+  context 'without a query_string' do
+    it 'appends / if a trailing / is not present and redirects' do
+      response = request.get(path)
+      expect(response.status).to eq(301)
+      expect(response.header['Location']).to eq(host + path + '/')
+      expect(response.body).to be_empty
+    end
+
+    it 'does not redirect' do
+      response = request.get(path + '/')
+      expect(response.status).to eq(200)
+      expect(response.body).to eq('Hello')
+    end
+  end
+
+  context 'with a query_string' do
+    it 'appends / if a trailing / is not present and redirects' do
+      response = request.get(path + '?a=b')
+      expect(response.status).to eq(301)
+      expect(response.header['Location']).to eq(host + path + '/?a=b')
+      expect(response.body).to be_empty
+    end
+
+    it 'does not redirect' do
+      response = request.get(path + '/?a=b')
+      expect(response.status).to eq(200)
+      expect(response.body).to eq('Hello')
+    end
+  end
+
+  context 'with a different path' do
+    it 'does not redirect' do
+      response = request.get('/docs/guide')
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/dpc-web/spec/lib/dpc_middleware/ig_fix_spec.rb
+++ b/dpc-web/spec/lib/dpc_middleware/ig_fix_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 require './lib/dpc_middleware/ig_fix'
 


### PR DESCRIPTION
**Why**
Fixes an issue with the FHIR generated documentation, and broken links when not terminating path with /. Also fixes some minor Rubocop issues.

**What Changed**
Added a Rack middleware that checks path. If the path is '/ig', the middleware issues a redirect to '/ig/'.

**Choices Made**
Had to add to middleware just prior to Rack::Static, because Rack::Static responds to pages in the Public folder - and the router is bypassed.

**Tickets closed**:
DPC-494
