### PR TITLE
Fixed Analytics Id (IG Analytics Fix)

### DIFF
--- a/ig/framework/_includes/analytics.html
+++ b/ig/framework/_includes/analytics.html
@@ -4,6 +4,6 @@
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', 'UA-77240170-3', 'auto');
+  ga('create', 'UA-144775756-1', 'auto');
   ga('send', 'pageview');
 </script>


### PR DESCRIPTION
**Why**

We weren't getting any analytics data for [https://dpc.cms.gov/ig/index.html](https://dpc.cms.gov/ig/index.html)

**What Changed**

I put the wrong analytics tracking code, total goof, so I put the proper tracking code

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [ ] Demo and Seed commands are working
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
