### PR TITLE
blockquote styling

### DIFF
--- a/dpc-web/app/assets/stylesheets/base/_base.scss
+++ b/dpc-web/app/assets/stylesheets/base/_base.scss
@@ -44,6 +44,13 @@ samp {
   font-family: $font-mono;
 }
 
+blockquote {
+  border-left: 5px solid $color-gray-light;
+  color: $color-gray;
+  margin-left: 0;
+  padding-left: $spacer-2;
+}
+
 .ds-c-choice + label a {
   margin-left: 1ch;
 }


### PR DESCRIPTION
**Why**

Blockquotes need styling

**What Changed**

Added styles to element selector.

**Choices Made**

<img width="713" alt="Screen Shot 2019-08-05 at 2 50 05 PM" src="https://user-images.githubusercontent.com/25435289/62487727-8c634380-b790-11e9-96f7-bc41a35ac85b.png">

**Tickets closed**:

https://jiraent.cms.gov/browse/DPC-472
