### PR TITLE
Temporarily disable parallel job processing

### DIFF
--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -42,7 +42,8 @@ class BatchAggregationEngineTest {
         fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
         final var config = ConfigFactory.load("dev-test.application.conf").getConfig("dpc.aggregation");
         exportPath = config.getString("exportPath");
-        operationsConfig = new OperationsConfig(10, exportPath);
+        // TODO: Re-enable parallelism with DPC-465
+        operationsConfig = new OperationsConfig(10, exportPath, 3, false, false, 0.5f, 2.5f);
         AggregationEngine.setGlobalErrorHandler();
         ContextUtils.prefetchResourceModels(fhirContext, JobModel.validResourceTypes);
     }


### PR DESCRIPTION
**Why**

Until we get DPC-465 merged in, this disables the parallel testing (which we're not using in production) in order to get CI back up and running.

**What Changed**

**Choices Made**

We need CI, so we'll disable testing for what we're not using.

**Tickets closed**:

**Future Work**

DPC-465

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
