### PR TITLE
Fix base url generation

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
@@ -8,7 +8,6 @@ import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import com.typesafe.config.Config;
-import gov.cms.dpc.api.health.AttributionHealthCheck;
 import gov.cms.dpc.api.resources.TestResource;
 import gov.cms.dpc.api.resources.v1.*;
 import gov.cms.dpc.common.annotations.APIV1;
@@ -75,7 +74,7 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
     @Provides
     @ServiceBaseURL
     public String provideBaseURL(@Context HttpServletRequest request) {
-        return String.format("%s://%s:%s", request.getScheme(), request.getServerName(), request.getServerPort());
+        return String.format("%s://%s:%d/%s", request.getScheme(), request.getServerName(), request.getServerPort(), request.getContextPath());
     }
 
     @Provides

--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
@@ -52,8 +52,8 @@ public class DemoCommand extends Command {
                 .addArgument("--host")
                 .dest("hostname")
                 .type(String.class)
-                .setDefault("localhost:3002")
-                .help("Set the hostname (including port number) for running the Demo against");
+                .setDefault("http://localhost:3002/v1")
+                .help("Set the hostname (including scheme, port number and path) for running the Demo against");
 
         subparser
                 .addArgument("-a", "--attribution")
@@ -132,7 +132,7 @@ public class DemoCommand extends Command {
     }
 
     private static String buildBaseURL(Namespace namespace) {
-        return "http://" + namespace.getString("hostname") + "/v1/";
+        return namespace.getString("hostname");
     }
 
     private <T extends BaseResource> Bundle bundleSubmitter(Class<T> clazz, String filename, IParser parser, IGenericClient client) throws IOException {


### PR DESCRIPTION
Our siteURL provider now pulls the context from the config and builds that into the path.

The Demo command now takes a full url, rather than doing the funky appends, which should help make it more portable between environments.
