### PR TITLE
Updated authorization pattern in Data resource

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
@@ -74,7 +74,7 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
     @Provides
     @ServiceBaseURL
     public String provideBaseURL(@Context HttpServletRequest request) {
-        return String.format("%s://%s:%d/%s", request.getScheme(), request.getServerName(), request.getServerPort(), request.getContextPath());
+        return String.format("%s://%s:%d%s", request.getScheme(), request.getServerName(), request.getServerPort(), request.getContextPath());
     }
 
     @Provides
@@ -92,7 +92,7 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
     @Provides
     @Singleton
     public IGenericClient provideFHIRClient(FhirContext ctx) {
-        logger.debug("Connecting to attribution server at {}.", getConfiguration().getAttributionURL());
+        logger.info("Connecting to attribution server at {}.", getConfiguration().getAttributionURL());
         ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
         return ctx.newRestfulGenericClient(getConfiguration().getAttributionURL());
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
@@ -154,7 +154,7 @@ public class DemoCommand extends Command {
         }
     }
 
-    private void handleExportJob(IGenericClient exportClient, List<String> providerNPIs, String  token) {
+    private void handleExportJob(IGenericClient exportClient, List<String> providerNPIs, String token) {
         providerNPIs
                 .stream()
                 .map(npi -> exportClient
@@ -178,7 +178,8 @@ public class DemoCommand extends Command {
                 .forEach(jobResponse -> jobResponse.getOutput().forEach(entry -> {
                     System.out.println(entry.getUrl());
                     try {
-                        ClientUtils.fetchExportedFiles(entry.getUrl());
+                        final File file = ClientUtils.fetchExportedFiles(entry.getUrl(), token);
+                        System.out.println(String.format("Downloaded file to: %s", file.getPath()));
                     } catch (IOException e) {
                         throw new RuntimeException("Cannot output file", e);
                     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/client/ClientUtils.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/client/ClientUtils.java
@@ -158,12 +158,13 @@ public class ClientUtils {
      * @return - {@link File} file handle where the data is stored
      * @throws IOException - throws if the HTTP request or file writing fails
      */
-    public static File fetchExportedFiles(String fileID) throws IOException {
+    public static File fetchExportedFiles(String fileID, String token) throws IOException {
         try (CloseableHttpClient client = HttpClients.createDefault()) {
 
             final File tempFile = File.createTempFile("dpc", ".ndjson");
 
             final HttpGet fileGet = new HttpGet(fileID);
+            fileGet.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token);
             try (CloseableHttpResponse fileResponse = client.execute(fileGet)) {
 
                 fileResponse.getEntity().writeTo(new FileOutputStream(tempFile));

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractDataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractDataResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources;
 
+import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.fhir.FHIRMediaTypes;
 
 import javax.ws.rs.GET;
@@ -13,5 +14,5 @@ public abstract class AbstractDataResource {
 
     @Path("/{fileID}/")
     @GET
-    public abstract Response export(String fileID);
+    public abstract Response export(OrganizationPrincipal organizationPrincipal, String fileID);
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
@@ -2,13 +2,12 @@ package gov.cms.dpc.api.resources.v1;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractDataResource;
 import gov.cms.dpc.common.annotations.ExportPath;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.dropwizard.auth.Auth;
+import io.swagger.annotations.*;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.slf4j.Logger;
@@ -38,7 +37,6 @@ public class DataResource extends AbstractDataResource {
 
     @Override
     @Path("/{fileID}/")
-    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "fileID")
     @GET
     @Timed
     @ExceptionMetered
@@ -47,7 +45,7 @@ public class DataResource extends AbstractDataResource {
             @ApiResponse(code = 200, message = "File of newline-delimited JSON FHIR objects"),
             @ApiResponse(code = 500, message = "An error occurred", response = OperationOutcome.class)
     })
-    public Response export(@PathParam("fileID") String fileID) {
+    public Response export(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, @PathParam("fileID") String fileID) {
         final StreamingOutput fileStream = outputStream -> {
             final java.nio.file.Path path = Paths.get(String.format("%s/%s.ndjson", fileLocation, fileID));
             logger.debug("Streaming file {}", path.toString());


### PR DESCRIPTION
We now just require that the user have a valid auth token, we don't do any specific checking of permissions before returning the file. This will probably have to be revisited at a later date.

Also fixed a small bug in the base URL and updated the Demo Command to fully download the outputted files.