### PR TITLE
DPC-543: Fix authentication on Practitioner resource

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "9901:9900"
     environment:
       - ENV=dev
-      - JACOCO=true
+      - JACOCO=${REPORT_COVERAGE}
     depends_on:
       - db
       - redis
@@ -35,7 +35,7 @@ services:
       - db
     environment:
       - ENV=dev
-      - JACOCO=true
+      - JACOCO=${REPORT_COVERAGE}
     ports:
       - "3500:8080"
       - "9902:9900"
@@ -49,7 +49,7 @@ services:
     environment:
       - attributionURL=http://attribution:8080/v1/
       - ENV=dev
-      - JACOCO=true
+      - JACOCO=${REPORT_COVERAGE}
       - exportPath=/app/data
     depends_on:
       - attribution

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
@@ -11,7 +11,6 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractPractitionerResource;
 import gov.cms.dpc.fhir.annotations.FHIR;
-import gov.cms.dpc.fhir.annotations.Profiled;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -51,9 +50,9 @@ public class PractitionerResource extends AbstractPractitionerResource {
             "<p>If a provider NPI is given, the results are filtered accordingly. " +
             "Otherwise, the method returns all Practitioners associated to the given Organization")
     public Bundle practitionerSearch(@ApiParam(hidden = true)
-                                   @Auth OrganizationPrincipal organization,
+                                     @Auth OrganizationPrincipal organization,
                                      @ApiParam(value = "Provider NPI")
-                                   @QueryParam(value = Practitioner.SP_IDENTIFIER) String providerNPI) {
+                                     @QueryParam(value = Practitioner.SP_IDENTIFIER) String providerNPI) {
 
         // Create search params
         Map<String, List<String>> searchParams = new HashMap<>();
@@ -146,7 +145,7 @@ public class PractitionerResource extends AbstractPractitionerResource {
     @Override
     @DELETE
     @Path("/{providerID}")
-    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "providerID")
+    @PathAuthorizer(type = ResourceType.Practitioner, pathParam = "providerID")
     @FHIR
     @Timed
     @ExceptionMetered
@@ -167,7 +166,7 @@ public class PractitionerResource extends AbstractPractitionerResource {
     @Override
     @PUT
     @Path("/{providerID}")
-    @PathAuthorizer(type = ResourceType.PractitionerRole, pathParam = "providerID")
+    @PathAuthorizer(type = ResourceType.Practitioner, pathParam = "providerID")
     @FHIR
     @Timed
     @ExceptionMetered

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.attribution.resources;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Endpoint;
 
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import java.util.UUID;
@@ -15,7 +16,7 @@ public abstract class AbstractEndpointResource {
     }
 
     @GET
-    public abstract Bundle searchEndpoints(String organizationID);
+    public abstract Bundle searchEndpoints(@NotNull String organizationID);
 
     @GET
     @Path("/{endpointID}")

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -31,8 +31,14 @@ if [ -n "$REPORT_COVERAGE" ]; then
 fi
 
 docker-compose down
-docker-compose up -d
+docker-compose up -d --scale api=0
 sleep 120
+
+# Run the integration tests
+mvn test -Pintegration-tests -pl dpc-api -am
+
+# Start the API server
+docker-compose up -d
 
 # Run the Postman tests
 node_modules/.bin/newman run src/test/EndToEndRequestTest.postman_collection.json

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -32,13 +32,14 @@ fi
 
 docker-compose down
 docker-compose up -d --scale api=0
-sleep 120
+sleep 60
 
 # Run the integration tests
 mvn test -Pintegration-tests -pl dpc-api -am
 
 # Start the API server
 docker-compose up -d
+sleep 60
 
 # Run the Postman tests
 node_modules/.bin/newman run src/test/EndToEndRequestTest.postman_collection.json


### PR DESCRIPTION
**Why**
Authorization was failing for Practitioners because it was still using the old PractitionerRole resource.

**What Changed**

Updated the path parameters to use the correct resource. Added a new step in the integration tests to make sure the fix sticks.

Reenabled the API integration tests, which hadn't been running since adding the Postman tests. This makes CI longer, but should be ok.

Also fixed a bug in the docker compose file that was causing it to fail when not running under CI.

**Choices Made**

**Tickets closed**:

DPC-543: Practitioner role fixes

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
