### PR TITLE
DPC-551: Fix resource creation failing on duplicates

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
@@ -20,7 +20,7 @@ public abstract class AbstractPatientResource {
     public abstract Bundle patientSearch(OrganizationPrincipal organization, String patientMBI);
 
     @POST
-    public abstract Patient submitPatient(OrganizationPrincipal organization, Patient patient);
+    public abstract Response submitPatient(OrganizationPrincipal organization, Patient patient);
     @POST
     @Path("/$submit")
     public abstract Bundle bulkSubmitPatients(@Auth OrganizationPrincipal organization, Parameters params);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 
 import static gov.cms.dpc.api.APIHelpers.addOrganizationTag;
 import static gov.cms.dpc.fhir.FHIRMediaTypes.FHIR_NDJSON;
+import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
 
 
 @Api(value = "Group")
@@ -71,10 +72,7 @@ public class GroupResource extends AbstractGroupResource {
                 .encodedJson()
                 .execute();
 
-        final Group createdGroup = (Group) outcome.getResource();
-        final Response.Status status = outcome.getCreated() != null ? Response.Status.CREATED : Response.Status.OK;
-
-        return Response.status(status).entity(createdGroup).build();
+        return handleMethodOutcome(outcome);
     }
 
     @SuppressWarnings("unchecked")

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -13,7 +13,6 @@ import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractPatientResource;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.annotations.FHIR;
-import gov.cms.dpc.fhir.annotations.Profiled;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.*;
 import org.hl7.fhir.dstu3.model.*;
@@ -26,6 +25,7 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import static gov.cms.dpc.api.APIHelpers.bulkResourceClient;
+import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
 
 @Api(value = "Patient")
 public class PatientResource extends AbstractPatientResource {
@@ -87,7 +87,7 @@ public class PatientResource extends AbstractPatientResource {
     @ExceptionMetered
     @ApiOperation(value = "Create Patient", notes = "Create a Patient record associated to the Organization.")
     @Override
-    public Patient submitPatient(@ApiParam(hidden = true) @Auth OrganizationPrincipal organization, Patient patient) {
+    public Response submitPatient(@ApiParam(hidden = true) @Auth OrganizationPrincipal organization, Patient patient) {
 
         // Set the Managing Organization on the Patient
         final Reference orgReference = new Reference(new IdType("Organization", organization.getOrganization().getId()));
@@ -98,11 +98,7 @@ public class PatientResource extends AbstractPatientResource {
                 .encodedJson()
                 .execute();
 
-        if (!outcome.getCreated()) {
-            throw new WebApplicationException("Unable to create Patient", Response.Status.INTERNAL_SERVER_ERROR);
-        }
-
-        return (Patient) outcome.getResource();
+        return handleMethodOutcome(outcome);
     }
 
     @FHIR

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
@@ -1,6 +1,5 @@
 package gov.cms.dpc.api.resources.v1;
 
-import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.validation.FhirValidator;
 import ca.uhn.fhir.validation.ValidationResult;
@@ -27,6 +26,7 @@ import java.util.*;
 import java.util.function.Consumer;
 
 import static gov.cms.dpc.api.APIHelpers.bulkResourceClient;
+import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
 
 public class PractitionerResource extends AbstractPractitionerResource {
 
@@ -108,19 +108,12 @@ public class PractitionerResource extends AbstractPractitionerResource {
     public Response submitProvider(@Auth OrganizationPrincipal organization, Practitioner provider) {
 
         APIHelpers.addOrganizationTag(provider, organization.getOrganization().getIdElement().getIdPart());
-        final var test = this.client
+        final var providerCreate = this.client
                 .create()
                 .resource(provider)
                 .encodedJson();
 
-        final MethodOutcome outcome = test.execute();
-
-        if (!outcome.getCreated() || (outcome.getResource() == null)) {
-            throw new WebApplicationException("Unable to submit provider", Response.Status.INTERNAL_SERVER_ERROR);
-        }
-
-        final Practitioner resource = (Practitioner) outcome.getResource();
-        return Response.status(Response.Status.CREATED).entity(resource).build();
+        return handleMethodOutcome(providerCreate.execute());
     }
 
     @POST


### PR DESCRIPTION
**Why**

There was some bad handling of outcome values, which could be null and throw an NPE. This meant that if you tried to double-create a resource it would throw a 500 even though the request returned from the attribution service correctly.

**What Changed**

This centralizes our MethodOutcome handling into a helper method, so we don't make the same mistake again, it now just checks to see if a resource is returned, if not, it throws a 500, otherwise it parses the created flag to determine if it should return a 200 or 201.

**Choices Made**


**Tickets closed**:

DPC-551: Fix group double creation.

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
