### PR TITLE
DPC-547: Fix authentication Group operations

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/MacaroonsAuthenticator.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/MacaroonsAuthenticator.java
@@ -1,10 +1,10 @@
 package gov.cms.dpc.api.auth;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import io.dropwizard.auth.AuthenticationException;
 import io.dropwizard.auth.Authenticator;
 import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.slf4j.Logger;
@@ -49,6 +49,12 @@ public class MacaroonsAuthenticator implements Authenticator<DPCAuthCredentials,
         Map<String, List<String>> searchParams = new HashMap<>();
         searchParams.put("_id", Collections.singletonList(credentials.getPathValue()));
         searchParams.put("organization", Collections.singletonList(credentials.getOrganization().getId()));
+
+        // Special handl ing of Group resources, which use tags instead of resource properties.
+        // TODO: Remove with DPC-552
+        if (credentials.getPathAuthorizer().type() == ResourceType.Group) {
+            searchParams.put("_tag", Collections.singletonList(String.format("%s|%s", DPCIdentifierSystem.DPC.getSystem(), credentials.getOrganization().getId())));
+        }
         final Bundle bundle = this.client
                 .search()
                 .forResource(credentials.getPathAuthorizer().type().toString())

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -135,7 +135,7 @@ public class GroupResource extends AbstractGroupResource {
 
     @PUT
     @Path("/{rosterID}")
-    @PathAuthorizer(type = ResourceType.Patient, pathParam = "rosterID")
+    @PathAuthorizer(type = ResourceType.Group, pathParam = "rosterID")
     @FHIR
     @Timed
     @ExceptionMetered
@@ -157,7 +157,7 @@ public class GroupResource extends AbstractGroupResource {
     @DELETE
     @FHIR
     @Path("/{rosterID}")
-    @PathAuthorizer(type = ResourceType.Patient, pathParam = "rosterID")
+    @PathAuthorizer(type = ResourceType.Group, pathParam = "rosterID")
     @Timed
     @ExceptionMetered
     @ApiOperation(value = "Delete Attribution Roster", notes = "Remove specific Attribution roster")
@@ -187,6 +187,7 @@ public class GroupResource extends AbstractGroupResource {
     @Override
     @GET // Need this here, since we're using a path param
     @Path("/{rosterID}/$export")
+    @PathAuthorizer(type = ResourceType.Group, pathParam = "rosterID")
     @Timed
     @ExceptionMetered
     @FHIRAsync

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -97,12 +97,18 @@ public class GroupResource extends AbstractGroupResource {
                                @ApiParam(value = "Patient ID")
                                @QueryParam(Group.SP_MEMBER) String patientID) {
 
-        final Pair<IdType, IdType> idPair = parseCompositeID(providerNPI);
+        final String providerIDPart;
+        if (providerNPI != null) {
+            providerIDPart = parseCompositeID(providerNPI).getRight().getIdPart();
+        } else {
+            providerIDPart = null;
+        }
+
         final Bundle bundle = new Bundle();
         bundle.setType(Bundle.BundleType.SEARCHSET);
 
         final UUID organizationID = RESTUtils.tokenTagToUUID(organizationToken);
-        this.rosterDAO.findEntities(organizationID, idPair.getRight().getIdPart(), patientID)
+        this.rosterDAO.findEntities(organizationID, providerIDPart, patientID)
                 .stream()
                 .map(RosterEntity::toFHIR)
                 .forEach(entity -> bundle.addEntry().setResource(entity));

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/RESTUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/RESTUtils.java
@@ -1,10 +1,7 @@
 package gov.cms.dpc.attribution.utils;
 
 import org.eclipse.jetty.http.HttpStatus;
-import org.hl7.fhir.dstu3.model.BaseResource;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Parameters;
-import org.hl7.fhir.dstu3.model.Resource;
+import org.hl7.fhir.dstu3.model.*;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -77,6 +74,10 @@ public class RESTUtils {
     }
 
     public static UUID tokenTagToUUID(String tokenTag) {
-        return parseTokenTag(UUID::fromString, tokenTag);
+        final Function<String, UUID> builder = (tag) -> {
+            final IdType idType = new IdType(tag);
+            return UUID.fromString(idType.getIdPart());
+        };
+        return parseTokenTag(builder, tokenTag);
     }
 }


### PR DESCRIPTION
**Why**

Group operations were failing due to the Macaroons authenticator not building the search query correctly. This surfaced a number of issues that need to be address, most pressingly, our lack of authenticated test suites.

**What Changed**

Made quick fix to have the authenticator specially handle Group resources, along with a ticket (DPC-552) to centralize how we're handling Organization tagging.

Also fixed an NPE that was happening in the Group search method when a providerNPI wasn't passed.

**Choices Made**

Just a quick fix for now, because when we make these changes we'll need to really work on improving our test suite.

**Tickets closed**:

DPC-547: Fix Group authorization bug

**Future Work**

DPC-552: Standardize on Organization tags for searching
DPC-553: Move Postman tests to fully authenticated setup

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
