### PR TITLE
DPC-554: Fix CloudWatch logging format for Java apps

### DIFF
--- a/dpc-aggregation/src/main/resources/prod-sbx.application.conf
+++ b/dpc-aggregation/src/main/resources/prod-sbx.application.conf
@@ -13,4 +13,11 @@ dpc.aggregation {
     }
   }
   exportPath = "/app/data"
+
+  logging {
+    appenders = [{
+      type = console
+      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
+    }]
+  }
 }

--- a/dpc-aggregation/src/main/resources/test.application.conf
+++ b/dpc-aggregation/src/main/resources/test.application.conf
@@ -13,4 +13,11 @@ dpc.aggregation {
     }
   }
   exportPath = "/app/data"
+
+  logging {
+    appenders = [{
+      type = console
+      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
+    }]
+  }
 }

--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -19,4 +19,11 @@ dpc.api {
 
   attributionURL = "http://backend.dpc-prod-sbx.local:8080/v1/"
   exportPath = "/app/data"
+
+  logging {
+    appenders = [{
+      type = console
+      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
+    }]
+  }
 }

--- a/dpc-api/src/main/resources/test.application.conf
+++ b/dpc-api/src/main/resources/test.application.conf
@@ -19,4 +19,11 @@ dpc.api {
 
   attributionURL = "http://backend.dpc-test.local:8080/v1/"
   exportPath = "/app/data"
+
+  logging {
+    appenders = [{
+      type = console
+      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
+    }]
+  }
 }

--- a/dpc-attribution/src/main/resources/prod-sbx.application.conf
+++ b/dpc-attribution/src/main/resources/prod-sbx.application.conf
@@ -12,4 +12,11 @@ dpc.attribution {
       port = 8080
     }]
   }
+
+  logging {
+    appenders = [{
+      type = console
+      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
+    }]
+  }
 }

--- a/dpc-attribution/src/main/resources/test.application.conf
+++ b/dpc-attribution/src/main/resources/test.application.conf
@@ -12,4 +12,11 @@ dpc.attribution {
       port = 8080
     }]
   }
+
+  logging {
+    appenders = [{
+      type = console
+      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
+    }]
+  }
 }


### PR DESCRIPTION
**Why**

We're having searching trouble for logs in CloudWatch. This is because CloudWatch does not recognize the `\n` character. See: https://stackoverflow.com/questions/53961216/new-line-problem-in-cloutwatch-output-when-logging-with-slf4j-and-io-symphonia/53961294#53961294

**What Changed**

Log format changes.

**Choices Made**

The log format change was only applied to AWS environments so the log format still looks okay locally.

**Tickets closed**:

DPC-554

**Future Work**

DPC-555: Apply logging changes to future AWS environments

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
