### PR TITLE
DPC-554: Fix CloudWatch Logs

### DIFF
--- a/dpc-aggregation/src/main/resources/prod-sbx.application.conf
+++ b/dpc-aggregation/src/main/resources/prod-sbx.application.conf
@@ -13,11 +13,4 @@ dpc.aggregation {
     }
   }
   exportPath = "/app/data"
-
-  logging {
-    appenders = [{
-      type = console
-      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
-    }]
-  }
 }

--- a/dpc-aggregation/src/main/resources/test.application.conf
+++ b/dpc-aggregation/src/main/resources/test.application.conf
@@ -13,11 +13,4 @@ dpc.aggregation {
     }
   }
   exportPath = "/app/data"
-
-  logging {
-    appenders = [{
-      type = console
-      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
-    }]
-  }
 }

--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -19,11 +19,4 @@ dpc.api {
 
   attributionURL = "http://backend.dpc-prod-sbx.local:8080/v1/"
   exportPath = "/app/data"
-
-  logging {
-    appenders = [{
-      type = console
-      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
-    }]
-  }
 }

--- a/dpc-api/src/main/resources/test.application.conf
+++ b/dpc-api/src/main/resources/test.application.conf
@@ -19,11 +19,4 @@ dpc.api {
 
   attributionURL = "http://backend.dpc-test.local:8080/v1/"
   exportPath = "/app/data"
-
-  logging {
-    appenders = [{
-      type = console
-      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
-    }]
-  }
 }

--- a/dpc-attribution/src/main/resources/prod-sbx.application.conf
+++ b/dpc-attribution/src/main/resources/prod-sbx.application.conf
@@ -12,11 +12,4 @@ dpc.attribution {
       port = 8080
     }]
   }
-
-  logging {
-    appenders = [{
-      type = console
-      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
-    }]
-  }
 }

--- a/dpc-attribution/src/main/resources/test.application.conf
+++ b/dpc-attribution/src/main/resources/test.application.conf
@@ -12,11 +12,4 @@ dpc.attribution {
       port = 8080
     }]
   }
-
-  logging {
-    appenders = [{
-      type = console
-      logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','&#xd;'}&#xd;%replace(%rEx){'\n','&#xd;'}"
-    }]
-  }
 }

--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -25,7 +25,7 @@ server {
 logging {
   appenders = [{
     type = console
-    logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %m%n%rEx"
+    logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m){'\n','\r'}\r%replace(%rEx){'\n','\r'}"
   }]
 }
 


### PR DESCRIPTION
**Why**

The previous PR #195 only partially fixed the issue. Logs were being grouped, but newlines were being lost. This resolves the issue in a way that keeps CloudWatch logs grouped.

**What Changed**

Replaces the `\n` character in logs with `\r`, which CloudWatch recognizes as a newline.

**Choices Made**

This fix now applies to all environments, as `\r` will be recognized locally. Therefore we can close DPC-555 as well, and not have to worry about this for future environments.

**Tickets closed**:

DPC-554
DPC-555

**Future Work**

None

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
