### PR TITLE
DPC-256: JMeter load test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ smoke/test: ${JMETER}
 	@echo "Running Smoke Tests against Test env"
 	@${JMETER} -p src/main/resources/test.properties -Jthreads=${SMOKE_THREADS} -n -t src/main/resources/SmokeTest.jmx -l out.jtl
 
-.PHONY: smoke/sbx
-smoke/sbx: ${JMETER}
+.PHONY: smoke/prod-sbx
+smoke/prod-sbx: ${JMETER}
 	@echo "Running Smoke Tests against Sandbox env"
 	@${JMETER} -p src/main/resources/sbx.properties -Jthreads=${SMOKE_THREADS} -n -t src/main/resources/SmokeTest.jmx -l out.jtl

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 IG_PUBLISHER = ./.bin/org.hl7.fhir.publisher.jar
-JMETER = ./.bin/jmeter/bin/jmeter
 REPORT_COVERAGE ?= false
+
+JMETER = ./.bin/jmeter/bin/jmeter
+SMOKE_THREADS ?= 10
 
 ${IG_PUBLISHER}:
 	-mkdir ./.bin
@@ -30,9 +32,9 @@ website:
 .PHONY: smoke/test
 smoke/test: ${JMETER}
 	@echo "Running Smoke Tests against Test env"
-	@${JMETER} -p src/main/resources/test.properties -n -t src/main/resources/SmokeTest.jmx -l out.jtl
+	@${JMETER} -p src/main/resources/test.properties -Jthreads=${SMOKE_THREADS} -n -t src/main/resources/SmokeTest.jmx -l out.jtl
 
 .PHONY: smoke/sbx
 smoke/sbx: ${JMETER}
 	@echo "Running Smoke Tests against Sandbox env"
-	@${JMETER} -p src/main/resources/sbx.properties -n -t src/main/resources/SmokeTest.jmx -l out.jtl
+	@${JMETER} -p src/main/resources/sbx.properties -Jthreads=${SMOKE_THREADS} -n -t src/main/resources/SmokeTest.jmx -l out.jtl

--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ smoke/test: ${JMETER}
 .PHONY: smoke/prod-sbx
 smoke/prod-sbx: ${JMETER}
 	@echo "Running Smoke Tests against Sandbox env"
-	@${JMETER} -p src/main/resources/sbx.properties -Jthreads=${SMOKE_THREADS} -n -t src/main/resources/SmokeTest.jmx -l out.jtl
+	@${JMETER} -p src/main/resources/prod-sbx.properties -Jthreads=${SMOKE_THREADS} -n -t src/main/resources/SmokeTest.jmx -l out.jtl

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-IG_PUBLISHER = ./.bin/org.hl7.fhir.publisher.jar 
+IG_PUBLISHER = ./.bin/org.hl7.fhir.publisher.jar
+JMETER = ./.bin/jmeter/bin/jmeter
 REPORT_COVERAGE ?= false
 
 ${IG_PUBLISHER}:
 	-mkdir ./.bin
 	curl https://fhir.github.io/latest-ig-publisher/org.hl7.fhir.publisher.jar -o ${IG_PUBLISHER}
+
+./.bin/jmeter.tgz:
+	-mkdir ./.bin
+	curl http://mirrors.ibiblio.org/apache/jmeter/binaries/apache-jmeter-5.1.1.tgz -o ./.bin/jmeter.tgz
+
+${JMETER}: ./.bin/jmeter.tgz
+	-mkdir ./.bin/jmeter
+	tar -xvf ./.bin/jmeter.tgz -C ./.bin/jmeter --strip-components 1
 
 .PHONY: ig/publish
 ig/publish: ${IG_PUBLISHER}
@@ -17,3 +26,13 @@ travis:
 .PHONY: website
 website:
 	@docker build -f dpc-web/Dockerfile .
+
+.PHONY: smoke/test
+smoke/test: ${JMETER}
+	@echo "Running Smoke Tests against Test env"
+	@${JMETER} -p src/main/resources/test.properties -n -t src/main/resources/SmokeTest.jmx -l out.jtl
+
+.PHONY: smoke/sbx
+smoke/sbx: ${JMETER}
+	@echo "Running Smoke Tests against Sandbox env"
+	@${JMETER} -p src/main/resources/sbx.properties -n -t src/main/resources/SmokeTest.jmx -l out.jtl

--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/DemoCommand.java
@@ -1,34 +1,19 @@
 package gov.cms.dpc.api.cli;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
-import ca.uhn.fhir.rest.client.exceptions.NonFhirResponseException;
-import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import gov.cms.dpc.api.client.ClientUtils;
-import gov.cms.dpc.api.models.JobCompletionModel;
-import gov.cms.dpc.fhir.DPCIdentifierSystem;
-import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import io.dropwizard.cli.Command;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
-import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static gov.cms.dpc.api.client.ClientUtils.createExportOperation;
 
 public class DemoCommand extends Command {
     private final FhirContext ctx;
@@ -80,51 +65,18 @@ public class DemoCommand extends Command {
         final IGenericClient exportClient = ClientUtils.createExportClient(ctx, baseURL, token);
 
         // Upload a batch of patients and a batch of providers
-        final List<String> providerNPIs = this.submitPractitioners(exportClient);
-        final Map<String, Reference> patientReferences = this.submitPatients(exportClient);
+        final List<String> providerNPIs = ClientUtils.submitPractitioners(this.getClass(), ctx, exportClient);
+        final Map<String, Reference> patientReferences = ClientUtils.submitPatients(this.getClass(), ctx, exportClient);
 
         // Upload the roster bundle
-        this.createAndUploadRosters(namespace, exportClient, UUID.fromString(organizationID), patientReferences);
+        final String seedsFile = getSeedsFile(namespace);
+        ClientUtils.createAndUploadRosters(seedsFile, exportClient, UUID.fromString(organizationID), patientReferences);
 
         // Run the job
-        this.handleExportJob(exportClient, providerNPIs, token);
+        ClientUtils.handleExportJob(exportClient, providerNPIs, token);
 
         System.out.println("Export jobs completed");
         System.exit(0);
-    }
-
-    private void createAndUploadRosters(Namespace namespace, IGenericClient client, UUID organizationID, Map<String, Reference> patientReferences) throws IOException {
-        // Read the provider bundle from the given file
-        final String seedsFile = getSeedsFile(namespace);
-        try (InputStream resource = new FileInputStream(new File(seedsFile))) {
-            // Now, submit the bundle
-            System.out.println("Uploading Patient roster");
-            ClientUtils.createRosterSubmission(client, resource, organizationID, patientReferences);
-        }
-    }
-
-    private JobCompletionModel monitorExportRequest(IOperationUntypedWithInput<Parameters> exportOperation, String token) throws IOException, InterruptedException {
-        System.out.println("Retrying export request");
-        String exportURL = "";
-
-        try {
-            exportOperation.execute();
-        } catch (NonFhirResponseException e) {
-            if (e.getStatusCode() != HttpStatus.NO_CONTENT_204) {
-                e.printStackTrace();
-                System.exit(1);
-            }
-
-            // Get the correct header
-            final Map<String, List<String>> headers = e.getResponseHeaders();
-
-            // Get the headers and check the status
-            exportURL = headers.get("content-location").get(0);
-            System.out.printf("Export job started. Progress URL: %s%n", exportURL);
-        }
-
-        // Poll the job until it's done
-        return ClientUtils.awaitExportResponse(exportURL, "Checking job status", token);
     }
 
     private static String getSeedsFile(Namespace namespace) {
@@ -135,97 +87,4 @@ public class DemoCommand extends Command {
         return namespace.getString("hostname");
     }
 
-    private <T extends BaseResource> Bundle bundleSubmitter(Class<T> clazz, String filename, IParser parser, IGenericClient client) throws IOException {
-
-        try (InputStream resource = this.getClass().getClassLoader().getResourceAsStream(filename)) {
-            final Bundle bundle = parser.parseResource(Bundle.class, resource);
-
-            final Parameters parameters = new Parameters();
-            parameters.addParameter().setResource(bundle);
-
-            return client
-                    .operation()
-                    .onType(clazz)
-                    .named("submit")
-                    .withParameters(parameters)
-                    .returnResourceType(Bundle.class)
-                    .encodedJson()
-                    .execute();
-        }
-    }
-
-    private void handleExportJob(IGenericClient exportClient, List<String> providerNPIs, String token) {
-        providerNPIs
-                .stream()
-                .map(npi -> exportClient
-                        .search()
-                        .forResource(Group.class)
-                        .where(Group.CHARACTERISTIC_VALUE
-                                .withLeft(Group.CHARACTERISTIC.exactly().systemAndCode("", "attributed-to"))
-                                .withRight(Group.VALUE.exactly().systemAndCode(DPCIdentifierSystem.NPPES.getSystem(), npi)))
-                        .returnBundle(Bundle.class)
-                        .encodedJson()
-                        .execute())
-                .map(search -> (Group) search.getEntryFirstRep().getResource())
-                .map(group -> {
-                    final IOperationUntypedWithInput<Parameters> exportOperation = createExportOperation(exportClient, group.getId());
-                    try {
-                        return monitorExportRequest(exportOperation, token);
-                    } catch (IOException | InterruptedException e) {
-                        throw new RuntimeException("Error monitoring export", e);
-                    }
-                })
-                .forEach(jobResponse -> jobResponse.getOutput().forEach(entry -> {
-                    System.out.println(entry.getUrl());
-                    try {
-                        final File file = ClientUtils.fetchExportedFiles(entry.getUrl(), token);
-                        System.out.println(String.format("Downloaded file to: %s", file.getPath()));
-                    } catch (IOException e) {
-                        throw new RuntimeException("Cannot output file", e);
-                    }
-                }));
-    }
-
-    private Map<String, Reference> submitPatients(IGenericClient exportClient) {
-        final Bundle patientBundle;
-
-        try {
-            System.out.println("Submitting patients");
-            patientBundle = bundleSubmitter(Patient.class, "patient_bundle.json", ctx.newJsonParser(), exportClient);
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot submit patients.", e);
-        }
-
-        final Map<String, Reference> patientReferences = new HashMap<>();
-        patientBundle
-                .getEntry()
-                .stream()
-                .map(Bundle.BundleEntryComponent::getResource)
-                .map(resource -> (Patient) resource)
-                .forEach(patient -> {
-                    patientReferences.put(patient.getIdentifierFirstRep().getValue(), new Reference(patient.getId()));
-                });
-
-        return patientReferences;
-    }
-
-    private List<String> submitPractitioners(IGenericClient exportClient) {
-        final Bundle providerBundle;
-
-        try {
-            System.out.println("Submitting practitioners");
-            providerBundle = bundleSubmitter(Practitioner.class, "provider_bundle.json", ctx.newJsonParser(), exportClient);
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot submit providers.", e);
-        }
-
-        // Get the provider NPIs
-        return providerBundle
-                .getEntry()
-                .stream()
-                .map(Bundle.BundleEntryComponent::getResource)
-                .map(resource -> (Practitioner) resource)
-                .map(FHIRExtractors::getProviderNPI)
-                .collect(Collectors.toList());
-    }
 }

--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dpc-app</artifactId>
+        <groupId>gov.cms.dpc</groupId>
+        <version>0.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>dpc-smoketest</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>gov.cms.dpc</groupId>
+            <artifactId>dpc-api</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jmeter</groupId>
+            <artifactId>ApacheJMeter_core</artifactId>
+            <version>5.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.jmeter</groupId>
+            <artifactId>ApacheJMeter_java</artifactId>
+            <version>5.1.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+<!--                            <mainClass>${mainClass}</mainClass>-->
+                        </transformer>
+                    </transformers>
+                    <!-- exclude signed Manifests -->
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <finalName>${project.artifactId}</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -100,7 +100,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         try {
             ClientUtils.createAndUploadRosters(javaSamplerContext.getParameter("seed-file"), exportClient, UUID.fromString(organizationID), patientReferences);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException("Cannot upload roster", e);
         }
 
         // Run the job

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -1,0 +1,259 @@
+package gov.cms.dpc.testing.smoketests;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.client.exceptions.NonFhirResponseException;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
+import gov.cms.dpc.api.client.ClientUtils;
+import gov.cms.dpc.api.models.JobCompletionModel;
+import gov.cms.dpc.fhir.DPCIdentifierSystem;
+import gov.cms.dpc.fhir.FHIRExtractors;
+import gov.cms.dpc.fhir.helpers.FHIRHelpers;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
+import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
+import org.apache.jmeter.samplers.SampleResult;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hl7.fhir.dstu3.model.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static gov.cms.dpc.api.client.ClientUtils.createExportOperation;
+
+public class SmokeTest extends AbstractJavaSamplerClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(SmokeTest.class);
+
+    private FhirContext ctx;
+
+    @Override
+    public Arguments getDefaultParameters() {
+        final Arguments arguments = new Arguments();
+        arguments.addArgument("host", "http://localhost:3002/v1");
+        arguments.addArgument("attribution-url", "http://localhost:3500/v1");
+        arguments.addArgument("seed-file", "src/main/resources/test_associations.csv");
+
+        return arguments;
+    }
+
+    @Override
+    public void setupTest(JavaSamplerContext context) {
+        super.setupTest(context);
+    }
+
+    @Override
+    public SampleResult runTest(JavaSamplerContext javaSamplerContext) {
+        // Create things
+        final String organizationID = UUID.randomUUID().toString();
+        logger.debug("Creating organization {}", organizationID);
+        // Disable validation against Attribution service
+        this.ctx = FhirContext.forDstu3();
+        ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+        ctx.getRestfulClientFactory().setConnectTimeout(1800);
+        final String attributionURL = javaSamplerContext.getParameter("attribution-url");
+        final IGenericClient attributionClient = ctx.newRestfulGenericClient(attributionURL);
+
+        final SampleResult smokeTestResult = new SampleResult();
+        smokeTestResult.sampleStart();
+
+        final SampleResult orgRegistrationResult = new SampleResult();
+        smokeTestResult.addSubResult(orgRegistrationResult);
+
+
+        String token = null;
+        orgRegistrationResult.sampleStart();
+        try {
+            token = FHIRHelpers.registerOrganization(attributionClient, ctx.newJsonParser(), organizationID, attributionURL);
+            orgRegistrationResult.setSuccessful(true);
+        } catch (IOException e) {
+            orgRegistrationResult.setSuccessful(false);
+        } finally {
+            orgRegistrationResult.sampleEnd();
+        }
+
+        // Create an authenticated and async client (the async part is ignored by other endpoints)
+        final IGenericClient exportClient = ClientUtils.createExportClient(ctx, javaSamplerContext.getParameter("host"), token);
+
+        // Upload a batch of patients and a batch of providers
+        logger.debug("Submitting practitioners");
+        final SampleResult practitionerSample = new SampleResult();
+        practitionerSample.sampleStart();
+        final List<String> providerNPIs = this.submitPractitioners(exportClient);
+        practitionerSample.sampleEnd();
+        practitionerSample.setSuccessful(true);
+        smokeTestResult.addSubResult(practitionerSample);
+
+        logger.debug("Submitting patients");
+        final SampleResult patientSample = new SampleResult();
+
+        patientSample.sampleStart();
+        final Map<String, Reference> patientReferences = this.submitPatients(exportClient);
+        patientSample.setSuccessful(true);
+        patientSample.sampleEnd();
+        smokeTestResult.addSubResult(patientSample);
+
+        // Upload the roster bundle
+        logger.debug("Uploading roster");
+        try {
+            this.createAndUploadRosters(javaSamplerContext.getParameter("seed-file"), exportClient, UUID.fromString(organizationID), patientReferences);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        // Run the job
+        this.handleExportJob(exportClient, providerNPIs, token);
+        smokeTestResult.setSuccessful(true);
+
+        logger.info("Test completed");
+        return smokeTestResult;
+    }
+
+    private void createAndUploadRosters(String seedFile, IGenericClient client, UUID organizationID, Map<String, Reference> patientReferences) throws IOException {
+        // Read the provider bundle from the given file
+        try (InputStream resource = new FileInputStream(new File(seedFile))) {
+            // Now, submit the bundle
+            System.out.println("Uploading Patient roster");
+            ClientUtils.createRosterSubmission(client, resource, organizationID, patientReferences);
+        } catch (Exception e) {
+            logger.error("Cannot open seeds file.", e);
+            System.exit(1);
+        }
+    }
+
+    private JobCompletionModel monitorExportRequest(IOperationUntypedWithInput<Parameters> exportOperation, String token) throws IOException, InterruptedException {
+        System.out.println("Retrying export request");
+        String exportURL = "";
+
+        try {
+            exportOperation.execute();
+        } catch (NonFhirResponseException e) {
+            if (e.getStatusCode() != HttpStatus.NO_CONTENT_204) {
+                e.printStackTrace();
+                System.exit(1);
+            }
+
+            // Get the correct header
+            final Map<String, List<String>> headers = e.getResponseHeaders();
+
+            // Get the headers and check the status
+            exportURL = headers.get("content-location").get(0);
+            System.out.printf("Export job started. Progress URL: %s%n", exportURL);
+        }
+
+        // Poll the job until it's done
+        return ClientUtils.awaitExportResponse(exportURL, "Checking job status", token);
+    }
+
+    private <T extends BaseResource> Bundle bundleSubmitter(Class<T> clazz, String filename, IParser parser, IGenericClient client) throws IOException {
+
+        try (InputStream resource = this.getClass().getClassLoader().getResourceAsStream(filename)) {
+            final Bundle bundle = parser.parseResource(Bundle.class, resource);
+
+            final Parameters parameters = new Parameters();
+            parameters.addParameter().setResource(bundle);
+
+            return client
+                    .operation()
+                    .onType(clazz)
+                    .named("submit")
+                    .withParameters(parameters)
+                    .returnResourceType(Bundle.class)
+                    .encodedJson()
+                    .execute();
+        }
+    }
+
+    private void handleExportJob(IGenericClient exportClient, List<String> providerNPIs, String token) {
+        providerNPIs
+                .stream()
+                .map(npi -> {
+                    logger.warn("Finding with NPI: {}", npi);
+                    return exportClient
+                            .search()
+                            .forResource(Group.class)
+                            .where(Group.CHARACTERISTIC_VALUE
+                                    .withLeft(Group.CHARACTERISTIC.exactly().systemAndCode("", "attributed-to"))
+                                    .withRight(Group.VALUE.exactly().systemAndCode(DPCIdentifierSystem.NPPES.getSystem(), npi)))
+                            .returnBundle(Bundle.class)
+                            .encodedJson()
+                            .execute();
+                })
+                .map(search -> {
+                    logger.warn("Total number of groups: {}", search.getTotal());
+                    return (Group) search.getEntryFirstRep().getResource();
+                })
+                .map(group -> {
+                    logger.debug("Exporting with Group {}", group.getId());
+                    final IOperationUntypedWithInput<Parameters> exportOperation = createExportOperation(exportClient, group.getId());
+                    try {
+                        return monitorExportRequest(exportOperation, token);
+                    } catch (IOException | InterruptedException e) {
+                        throw new RuntimeException("Error monitoring export", e);
+                    }
+                })
+                .forEach(jobResponse -> jobResponse.getOutput().forEach(entry -> {
+                    System.out.println(entry.getUrl());
+                    try {
+                        final File file = ClientUtils.fetchExportedFiles(entry.getUrl(), token);
+                        System.out.println(String.format("Downloaded file to: %s", file.getPath()));
+                    } catch (IOException e) {
+                        throw new RuntimeException("Cannot output file", e);
+                    }
+                }));
+    }
+
+    private Map<String, Reference> submitPatients(IGenericClient exportClient) {
+        final Bundle patientBundle;
+
+        try {
+            System.out.println("Submitting patients");
+            patientBundle = bundleSubmitter(Patient.class, "patient_bundle.json", ctx.newJsonParser(), exportClient);
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot submit patients.", e);
+        }
+
+        final Map<String, Reference> patientReferences = new HashMap<>();
+        patientBundle
+                .getEntry()
+                .stream()
+                .map(Bundle.BundleEntryComponent::getResource)
+                .map(resource -> (Patient) resource)
+                .forEach(patient -> {
+                    patientReferences.put(patient.getIdentifierFirstRep().getValue(), new Reference(patient.getId()));
+                });
+
+        return patientReferences;
+    }
+
+    private List<String> submitPractitioners(IGenericClient exportClient) {
+        final Bundle providerBundle;
+
+        try {
+            System.out.println("Submitting practitioners");
+            providerBundle = bundleSubmitter(Practitioner.class, "provider_bundle.json", ctx.newJsonParser(), exportClient);
+        } catch (Exception e) {
+            throw new RuntimeException("Cannot submit providers.", e);
+        }
+
+        // Get the provider NPIs
+        return providerBundle
+                .getEntry()
+                .stream()
+                .map(Bundle.BundleEntryComponent::getResource)
+                .map(resource -> (Practitioner) resource)
+                .map(FHIRExtractors::getProviderNPI)
+                .collect(Collectors.toList());
+    }
+}

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -1,36 +1,23 @@
 package gov.cms.dpc.testing.smoketests;
 
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
-import ca.uhn.fhir.rest.client.exceptions.NonFhirResponseException;
-import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import gov.cms.dpc.api.client.ClientUtils;
-import gov.cms.dpc.api.models.JobCompletionModel;
-import gov.cms.dpc.fhir.DPCIdentifierSystem;
-import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import org.apache.jmeter.config.Arguments;
 import org.apache.jmeter.protocol.java.sampler.AbstractJavaSamplerClient;
 import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.SampleResult;
-import org.eclipse.jetty.http.HttpStatus;
-import org.hl7.fhir.dstu3.model.*;
+import org.apache.jmeter.threads.JMeterContextService;
+import org.hl7.fhir.dstu3.model.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
-
-import static gov.cms.dpc.api.client.ClientUtils.createExportOperation;
 
 public class SmokeTest extends AbstractJavaSamplerClient {
 
@@ -57,6 +44,10 @@ public class SmokeTest extends AbstractJavaSamplerClient {
     public SampleResult runTest(JavaSamplerContext javaSamplerContext) {
         // Create things
         final String organizationID = UUID.randomUUID().toString();
+        final String hostParam = javaSamplerContext.getParameter("host");
+        logger.info("Running against {}", hostParam);
+        logger.info("Running with {} threads", JMeterContextService.getNumberOfThreads());
+
         logger.debug("Creating organization {}", organizationID);
         // Disable validation against Attribution service
         this.ctx = FhirContext.forDstu3();
@@ -84,13 +75,13 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         }
 
         // Create an authenticated and async client (the async part is ignored by other endpoints)
-        final IGenericClient exportClient = ClientUtils.createExportClient(ctx, javaSamplerContext.getParameter("host"), token);
+        final IGenericClient exportClient = ClientUtils.createExportClient(ctx, hostParam, token);
 
         // Upload a batch of patients and a batch of providers
         logger.debug("Submitting practitioners");
         final SampleResult practitionerSample = new SampleResult();
         practitionerSample.sampleStart();
-        final List<String> providerNPIs = this.submitPractitioners(exportClient);
+        final List<String> providerNPIs = ClientUtils.submitPractitioners(this.getClass(), ctx, exportClient);
         practitionerSample.sampleEnd();
         practitionerSample.setSuccessful(true);
         smokeTestResult.addSubResult(practitionerSample);
@@ -99,7 +90,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         final SampleResult patientSample = new SampleResult();
 
         patientSample.sampleStart();
-        final Map<String, Reference> patientReferences = this.submitPatients(exportClient);
+        final Map<String, Reference> patientReferences = ClientUtils.submitPatients(this.getClass(), ctx, exportClient);
         patientSample.setSuccessful(true);
         patientSample.sampleEnd();
         smokeTestResult.addSubResult(patientSample);
@@ -107,153 +98,16 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         // Upload the roster bundle
         logger.debug("Uploading roster");
         try {
-            this.createAndUploadRosters(javaSamplerContext.getParameter("seed-file"), exportClient, UUID.fromString(organizationID), patientReferences);
+            ClientUtils.createAndUploadRosters(javaSamplerContext.getParameter("seed-file"), exportClient, UUID.fromString(organizationID), patientReferences);
         } catch (IOException e) {
             e.printStackTrace();
         }
 
         // Run the job
-        this.handleExportJob(exportClient, providerNPIs, token);
+        ClientUtils.handleExportJob(exportClient, providerNPIs, token);
         smokeTestResult.setSuccessful(true);
 
         logger.info("Test completed");
         return smokeTestResult;
-    }
-
-    private void createAndUploadRosters(String seedFile, IGenericClient client, UUID organizationID, Map<String, Reference> patientReferences) throws IOException {
-        // Read the provider bundle from the given file
-        try (InputStream resource = new FileInputStream(new File(seedFile))) {
-            // Now, submit the bundle
-            System.out.println("Uploading Patient roster");
-            ClientUtils.createRosterSubmission(client, resource, organizationID, patientReferences);
-        } catch (Exception e) {
-            logger.error("Cannot open seeds file.", e);
-            System.exit(1);
-        }
-    }
-
-    private JobCompletionModel monitorExportRequest(IOperationUntypedWithInput<Parameters> exportOperation, String token) throws IOException, InterruptedException {
-        System.out.println("Retrying export request");
-        String exportURL = "";
-
-        try {
-            exportOperation.execute();
-        } catch (NonFhirResponseException e) {
-            if (e.getStatusCode() != HttpStatus.NO_CONTENT_204) {
-                e.printStackTrace();
-                System.exit(1);
-            }
-
-            // Get the correct header
-            final Map<String, List<String>> headers = e.getResponseHeaders();
-
-            // Get the headers and check the status
-            exportURL = headers.get("content-location").get(0);
-            System.out.printf("Export job started. Progress URL: %s%n", exportURL);
-        }
-
-        // Poll the job until it's done
-        return ClientUtils.awaitExportResponse(exportURL, "Checking job status", token);
-    }
-
-    private <T extends BaseResource> Bundle bundleSubmitter(Class<T> clazz, String filename, IParser parser, IGenericClient client) throws IOException {
-
-        try (InputStream resource = this.getClass().getClassLoader().getResourceAsStream(filename)) {
-            final Bundle bundle = parser.parseResource(Bundle.class, resource);
-
-            final Parameters parameters = new Parameters();
-            parameters.addParameter().setResource(bundle);
-
-            return client
-                    .operation()
-                    .onType(clazz)
-                    .named("submit")
-                    .withParameters(parameters)
-                    .returnResourceType(Bundle.class)
-                    .encodedJson()
-                    .execute();
-        }
-    }
-
-    private void handleExportJob(IGenericClient exportClient, List<String> providerNPIs, String token) {
-        providerNPIs
-                .stream()
-                .map(npi -> {
-                    logger.warn("Finding with NPI: {}", npi);
-                    return exportClient
-                            .search()
-                            .forResource(Group.class)
-                            .where(Group.CHARACTERISTIC_VALUE
-                                    .withLeft(Group.CHARACTERISTIC.exactly().systemAndCode("", "attributed-to"))
-                                    .withRight(Group.VALUE.exactly().systemAndCode(DPCIdentifierSystem.NPPES.getSystem(), npi)))
-                            .returnBundle(Bundle.class)
-                            .encodedJson()
-                            .execute();
-                })
-                .map(search -> {
-                    logger.warn("Total number of groups: {}", search.getTotal());
-                    return (Group) search.getEntryFirstRep().getResource();
-                })
-                .map(group -> {
-                    logger.debug("Exporting with Group {}", group.getId());
-                    final IOperationUntypedWithInput<Parameters> exportOperation = createExportOperation(exportClient, group.getId());
-                    try {
-                        return monitorExportRequest(exportOperation, token);
-                    } catch (IOException | InterruptedException e) {
-                        throw new RuntimeException("Error monitoring export", e);
-                    }
-                })
-                .forEach(jobResponse -> jobResponse.getOutput().forEach(entry -> {
-                    System.out.println(entry.getUrl());
-                    try {
-                        final File file = ClientUtils.fetchExportedFiles(entry.getUrl(), token);
-                        System.out.println(String.format("Downloaded file to: %s", file.getPath()));
-                    } catch (IOException e) {
-                        throw new RuntimeException("Cannot output file", e);
-                    }
-                }));
-    }
-
-    private Map<String, Reference> submitPatients(IGenericClient exportClient) {
-        final Bundle patientBundle;
-
-        try {
-            System.out.println("Submitting patients");
-            patientBundle = bundleSubmitter(Patient.class, "patient_bundle.json", ctx.newJsonParser(), exportClient);
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot submit patients.", e);
-        }
-
-        final Map<String, Reference> patientReferences = new HashMap<>();
-        patientBundle
-                .getEntry()
-                .stream()
-                .map(Bundle.BundleEntryComponent::getResource)
-                .map(resource -> (Patient) resource)
-                .forEach(patient -> {
-                    patientReferences.put(patient.getIdentifierFirstRep().getValue(), new Reference(patient.getId()));
-                });
-
-        return patientReferences;
-    }
-
-    private List<String> submitPractitioners(IGenericClient exportClient) {
-        final Bundle providerBundle;
-
-        try {
-            System.out.println("Submitting practitioners");
-            providerBundle = bundleSubmitter(Practitioner.class, "provider_bundle.json", ctx.newJsonParser(), exportClient);
-        } catch (Exception e) {
-            throw new RuntimeException("Cannot submit providers.", e);
-        }
-
-        // Get the provider NPIs
-        return providerBundle
-                .getEntry()
-                .stream()
-                .map(Bundle.BundleEntryComponent::getResource)
-                .map(resource -> (Practitioner) resource)
-                .map(FHIRExtractors::getProviderNPI)
-                .collect(Collectors.toList());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -492,7 +492,7 @@
                         <!-- Exclude HL7 parsers, because they're too big-->
                         <exclude>org/hl7/fhir/r4/formats/*</exclude>
                         <!-- We can exclude testing files, because they're for testing-->
-                        <exclude>gov.cms.dpc.testing.*</exclude>
+                        <exclude>gov/cms/dpc/testing/**/*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>dpc-common</module>
         <module>dpc-bluebutton</module>
         <module>dpc-macaroons</module>
+        <module>dpc-smoketest</module>
     </modules>
 
     <groupId>gov.cms.dpc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,9 @@
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <configuration combine.self="append">
                             <dataFile>${project.basedir}/../jacocoReport/${project.artifactId}/jacoco-it.exec</dataFile>
+                            <excludes>
+                                <exclude>gov.cms.dpc.testing.*</exclude>
+                            </excludes>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -283,9 +283,6 @@
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <configuration combine.self="append">
                             <dataFile>${project.basedir}/../jacocoReport/${project.artifactId}/jacoco-it.exec</dataFile>
-                            <excludes>
-                                <exclude>gov.cms.dpc.testing.*</exclude>
-                            </excludes>
                         </configuration>
                         <executions>
                             <execution>
@@ -494,6 +491,8 @@
                         <exclude>gov/cms/dpc/**/cli/**/*</exclude>
                         <!-- Exclude HL7 parsers, because they're too big-->
                         <exclude>org/hl7/fhir/r4/formats/*</exclude>
+                        <!-- We can exclude testing files, because they're for testing-->
+                        <exclude>gov.cms.dpc.testing.*</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/src/main/resources/SmokeTest.jmx
+++ b/src/main/resources/SmokeTest.jmx
@@ -18,7 +18,7 @@
           <boolProp name="LoopController.continue_forever">false</boolProp>
           <stringProp name="LoopController.loops">1</stringProp>
         </elementProp>
-        <stringProp name="ThreadGroup.num_threads">10</stringProp>
+        <stringProp name="ThreadGroup.num_threads">${__P(threads,5)}</stringProp>
         <stringProp name="ThreadGroup.ramp_time">30</stringProp>
         <boolProp name="ThreadGroup.scheduler">false</boolProp>
         <stringProp name="ThreadGroup.duration"></stringProp>

--- a/src/main/resources/SmokeTest.jmx
+++ b/src/main/resources/SmokeTest.jmx
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jmeterTestPlan version="1.2" properties="5.0" jmeter="5.1.1 r1855137">
+  <hashTree>
+    <TestPlan guiclass="TestPlanGui" testclass="TestPlan" testname="Test Plan" enabled="true">
+      <stringProp name="TestPlan.comments"></stringProp>
+      <boolProp name="TestPlan.functional_mode">false</boolProp>
+      <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
+        <collectionProp name="Arguments.arguments"/>
+      </elementProp>
+      <stringProp name="TestPlan.user_define_classpath">dpc-smoketest/target</stringProp>
+    </TestPlan>
+    <hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Thread Group" enabled="true">
+        <stringProp name="ThreadGroup.on_sample_error">stopthread</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">10</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">30</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+      </ThreadGroup>
+      <hashTree>
+        <JavaSampler guiclass="JavaTestSamplerGui" testclass="JavaSampler" testname="Java Request" enabled="true">
+          <elementProp name="arguments" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" enabled="true">
+            <collectionProp name="Arguments.arguments">
+              <elementProp name="seed-file" elementType="Argument">
+                <stringProp name="Argument.name">seed-file</stringProp>
+                <stringProp name="Argument.value">src/main/resources/test_associations.csv</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="host" elementType="Argument">
+                <stringProp name="Argument.name">host</stringProp>
+                <stringProp name="Argument.value">${__P(host,)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="attribution-url" elementType="Argument">
+                <stringProp name="Argument.name">attribution-url</stringProp>
+                <stringProp name="Argument.value">${__P(attribution-url,)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+            </collectionProp>
+          </elementProp>
+          <stringProp name="classname">gov.cms.dpc.testing.smoketests.SmokeTest</stringProp>
+        </JavaSampler>
+        <hashTree/>
+        <ResultCollector guiclass="SummaryReport" testclass="ResultCollector" testname="Summary Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename"></stringProp>
+        </ResultCollector>
+        <hashTree/>
+        <ResultCollector guiclass="StatVisualizer" testclass="ResultCollector" testname="Aggregate Report" enabled="true">
+          <boolProp name="ResultCollector.error_logging">false</boolProp>
+          <objProp>
+            <name>saveConfig</name>
+            <value class="SampleSaveConfiguration">
+              <time>true</time>
+              <latency>true</latency>
+              <timestamp>true</timestamp>
+              <success>true</success>
+              <label>true</label>
+              <code>true</code>
+              <message>true</message>
+              <threadName>true</threadName>
+              <dataType>true</dataType>
+              <encoding>false</encoding>
+              <assertions>true</assertions>
+              <subresults>true</subresults>
+              <responseData>false</responseData>
+              <samplerData>false</samplerData>
+              <xml>false</xml>
+              <fieldNames>true</fieldNames>
+              <responseHeaders>false</responseHeaders>
+              <requestHeaders>false</requestHeaders>
+              <responseDataOnError>false</responseDataOnError>
+              <saveAssertionResultsFailureMessage>true</saveAssertionResultsFailureMessage>
+              <assertionsResultsToSave>0</assertionsResultsToSave>
+              <bytes>true</bytes>
+              <sentBytes>true</sentBytes>
+              <url>true</url>
+              <threadCounts>true</threadCounts>
+              <idleTime>true</idleTime>
+              <connectTime>true</connectTime>
+            </value>
+          </objProp>
+          <stringProp name="filename">smoke.out</stringProp>
+        </ResultCollector>
+        <hashTree/>
+      </hashTree>
+    </hashTree>
+  </hashTree>
+</jmeterTestPlan>

--- a/src/main/resources/prod-sbx.properties
+++ b/src/main/resources/prod-sbx.properties
@@ -1,0 +1,2 @@
+host=https://dpc.cms.gov/api/v1
+attribution-url=http://internal-dpc-prod-sbx-backend-555206083.us-east-1.elb.amazonaws.com:8080/v1

--- a/src/main/resources/test.properties
+++ b/src/main/resources/test.properties
@@ -1,0 +1,2 @@
+host=https://test.dpc.cms.gov/api/v1
+attribution-url=http://internal-dpc-test-backend-1231988696.us-east-1.elb.amazonaws.com:8080/v1


### PR DESCRIPTION
**Why**

We need a way to run load and smoke tests against our AWS environments. This PR adds a really basic JMeter script which should accomplish this.

**What Changed**

Added a `dpc-smoketest` module, which contains the necessary classes for building a custom `JavaRequestSampler` which is how we can wrap our custom Java logic into something that JMeter can understand.

Also added `smoke/test` and `smoke/sbx` targets to the Makefile, which should make it nice and easy to run tests after deploys.

**Choices Made**

Everything is in a single class right now, which was easy to get working, but doesn't really give us deep insights into which parts of the application are slow, or how long individual requests take. We may want to improve that in the future, but JMeter makes it really hard to have nested Samples, so we we'll have to break things into individual classes and juggle the state.

JMeter tests are a little brittle, paths are relative to the application root and we can't easily override specific values (like iteration count) due to the way variables are passed. It's possible, but clunky.

We're currently running a single test iteration of _n_ number of threads. We default to 5, or it can be configured based on the `SMOKE_THREADS` param in the Makefile.

**Tickets closed**:

DPC-256

**Future Work**


**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
