### PR TITLE
DPC-558: Jenkins Integration Tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -30,3 +30,10 @@ dpc-web/.rakeTasks
 out/
 
 node_modules/
+
+Dockerfile
+*/Dockerfile
+docker-compose.yml
+*/docker-compose.yml
+
+*-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,8 @@ cache:
 
 before_install:
   - sudo /etc/init.d/postgresql stop
-  - docker-compose up -d db redis
-  - wget https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 -O ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
 
 install:
-  - npm install newman
   - gem install jekyll
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ cache:
 before_install:
   - sudo /etc/init.d/postgresql stop
 
-install:
-  - gem install jekyll
-
 script:
-  - ./dpc-test.sh
-  - ./dpc-web-test.sh
+  - make ci-app
+  - make ci-web

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,12 @@ travis:
 
 .PHONY: website
 website:
-	@docker build -f dpc-web/Dockerfile .
+	@docker build -f dpc-web/Dockerfile . -t dpc-web
+
+.PHONY: ci-app
+ci-app:
+	@./dpc-test.sh
+
+.PHONY: ci-web
+ci-web:
+	@./dpc-web-test.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,10 +52,24 @@ services:
       - JACOCO=${REPORT_COVERAGE}
       - exportPath=/app/data
     depends_on:
-      - attribution
+      - start_dependencies
     volumes:
       - export-volume:/app/data
       - ./jacocoReport/dpc-api:/jacoco-report
+
+  start_dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - attribution
+      - aggregation
+    command: attribution:8080 aggregation:9900
+
+  start_api:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - api
+    command: api:3002
+
 volumes:
   export-volume:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - JACOCO=${REPORT_COVERAGE}
       - exportPath=/app/data
     depends_on:
-      - start_dependencies
+      - attribution
     volumes:
       - export-volume:/app/data
       - ./jacocoReport/dpc-api:/jacoco-report

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -40,15 +40,13 @@ if [ -n "$REPORT_COVERAGE" ]; then
 fi
 
 docker-compose down
-docker-compose up -d --scale api=0
-sleep 60
+docker-compose up start_dependencies
 
 # Run the integration tests
 mvn test -Pintegration-tests -pl dpc-api -am
 
 # Start the API server
-docker-compose up -d
-sleep 60
+docker-compose up start_api
 
 # Run the Postman tests
 npm install newman

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -19,11 +19,12 @@ fi
 
 mvn clean compile -Perror-prone -B -V
 mvn package -Pci
-# Format the test results and copy to a new directory
-mvn jacoco:report
-mkdir reports
 
+# Format the test results and copy to a new directory
 if [ -n "$REPORT_COVERAGE" ]; then
+    mvn jacoco:report
+    mkdir -p reports
+
     for module in dpc-aggregation dpc-api dpc-attribution dpc-queue dpc-macaroons
     do
       JACOCO_SOURCE_PATH=./$module/src/main/java ./cc-test-reporter format-coverage ./$module/target/site/jacoco/jacoco.xml --input-type jacoco -o reports/codeclimate.unit.$module.json
@@ -46,14 +47,16 @@ node_modules/.bin/newman run src/test/EndToEndRequestTest.postman_collection.jso
 
 # Wait for Jacoco to finish writing the output files
 docker-compose down -t 60
-# Collect the coverage reports for the Docker integration tests
-mvn jacoco:report-integration -Pci
 
+# Collect the coverage reports for the Docker integration tests
 if [ -n "$REPORT_COVERAGE" ]; then
+    mvn jacoco:report-integration -Pci
+
     for module in dpc-aggregation dpc-api dpc-attribution
     do
       JACOCO_SOURCE_PATH=./$module/src/main/java ./cc-test-reporter format-coverage ./$module/target/site/jacoco-it/jacoco.xml --input-type jacoco -o reports/codeclimate.integration.$module.json
     done
+
     ./cc-test-reporter sum-coverage reports/codeclimate.* -o coverage/codeclimate.json
     ./cc-test-reporter upload-coverage
 fi

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -e
 
 if [ -n "$REPORT_COVERAGE" ]; then
@@ -17,6 +16,15 @@ else
     echo "└──────────────────────────────────────────┘"
 fi
 
+# Install Code Climate
+if [ -n "$REPORT_COVERAGE" ]; then
+  wget https://codeclimate.com/downloads/test-reporter/test-reporter-0.6.3-linux-amd64 -O ./cc-test-reporter
+  chmod +x ./cc-test-reporter
+  ./cc-test-reporter before-build
+fi
+
+# Build the application
+docker-compose up -d db redis
 mvn clean compile -Perror-prone -B -V
 mvn package -Pci
 
@@ -43,6 +51,7 @@ docker-compose up -d
 sleep 60
 
 # Run the Postman tests
+npm install newman
 node_modules/.bin/newman run src/test/EndToEndRequestTest.postman_collection.json
 
 # Wait for Jacoco to finish writing the output files

--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -1,26 +1,22 @@
 #!/bin/bash
+set -e
 
-if [ -n "$TRAVIS_SECURE_ENV_VARS" ] && [ "$TRAVIS_SECURE_ENV_VARS" = "true" ]; then
-   echo "┌──────────────────────────────────────────┐"
-   echo "│                                          │"
-   echo "│        Running Website Tests...          │"
-   echo "│                                          │"
-   echo "└──────────────────────────────────────────┘"
+echo "┌──────────────────────────────────────────┐"
+echo "│                                          │"
+echo "│        Running Website Tests...          │"
+echo "│                                          │"
+echo "└──────────────────────────────────────────┘"
 
-   docker-compose down
-   docker-compose -f dpc-web/docker-compose.yml build
-   docker-compose -f dpc-web/docker-compose.yml run web rails db:migrate db:seed
+# Build the container
+make website
 
-   echo "┌──────────────────────────────────────────┐"
-   echo "│                                          │"
-   echo "│        All Website Tests Complete        │"
-   echo "│                                          │"
-   echo "└──────────────────────────────────────────┘"
-else
-    echo "┌──────────────────────────────────────────┐"
-    echo "│                                          │"
-    echo "│          Skipping Website Tests          │"
-    echo "│          (No Secure Environment)         │"
-    echo "│                                          │"
-    echo "└──────────────────────────────────────────┘"
-fi
+# Run the tests
+docker-compose -f dpc-web/docker-compose.yml run web rails db:create db:migrate db:seed
+docker-compose -f dpc-web/docker-compose.yml run web rails spec
+docker-compose -f dpc-web/docker-compose.yml down
+
+echo "┌──────────────────────────────────────────┐"
+echo "│                                          │"
+echo "│        All Website Tests Complete        │"
+echo "│                                          │"
+echo "└──────────────────────────────────────────┘"

--- a/dpc-web/Dockerfile
+++ b/dpc-web/Dockerfile
@@ -23,20 +23,19 @@ WORKDIR /dpc-web
 # Copy over the files needed to fetch dependencies
 COPY /dpc-web/Gemfile /dpc-web/Gemfile.lock /dpc-web/
 COPY /dpc-web/package.json /dpc-web/package-lock.json /dpc-web/
-COPY --from=java_builder /dpc-app/dpc-web/public/ig /dpc-web/public/ig
 
 # Install the website dependencies
 RUN gem install bundler --no-document && bundle install && npm install
 
-# Copy and build the assets pipeline
+# Copy the code, test the app, and build the assets pipeline
 COPY /dpc-web /dpc-web
+COPY --from=java_builder /dpc-app/dpc-web/public/ig /dpc-web/public/ig
 RUN RAILS_ENV=production SECRET_KEY_BASE=dummy bundle exec rake assets:precompile
 
 # Clean up from the build
 RUN rm -rf /usr/local/bundle/cache/*.gem && \
     find /usr/local/bundle/gems/ -name "*.c" -delete && \
-    find /usr/local/bundle/gems/ -name "*.o" -delete && \
-    rm -rf tmp/cache spec
+    find /usr/local/bundle/gems/ -name "*.o" -delete
 
 
 FROM ruby:2.6.2-alpine

--- a/dpc-web/docker-compose.yml
+++ b/dpc-web/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_DB=dpc-website_development
       - POSTGRES_PASSWORD=dpc-safe
     ports:
-      - "5432:5432"
+      - "15432:5432"
 
   web:
     build:
@@ -19,6 +19,7 @@ services:
       - DATABASE_URL=postgresql://db/dpc-website_development
       - DB_USER=postgres
       - DB_PASS=dpc-safe
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
**Why**

We'd like to run our integration tests as part of the build process on Jenkins (in addition to Travis CI). This PR makes it easier to share the logic between Jenkins and TravisCI, as well as adds integration tests for dpc-web.

**What Changed**

- Two new make commands `ci-app` and `ci-web` to build and run all integration tests.
- dpc-web will now run the existing integration test suite in Travis via rspec. (These were not being run before.)
- Speeds up the dpc-web Docker build by better reusing layers.
- Fixes issues with the `dpc-test.sh` script running code coverage steps without the `REPORT_COVERAGE` environment variable.

**Choices Made**

- Refactored the `dpc-test.sh` script to install dependencies instead of doing it via `travis.yml`. This allows Jenkins to share installation logic with Travis.
- Changed the docker-compose DB port for dpc-web to avoid a port conflict with dpc-app during Jenkins builds.
- Removes fragile sleep logic in `dpc-test.sh` in favor of using a blocking script that waits for dependencies to start.
  - Uses https://8thlight.com/blog/dariusz-pasciak/2016/10/17/docker-compose-wait-for-dependencies.html to handle the blocking wait logic in docker-compose.

**Tickets closed**:

On-going work in DPC-558.

**Future Work**

Jenkins will use these improved scripts when merged.

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
