### PR TITLE
DPC-558: Fix testing race condition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,24 +57,25 @@ services:
       - export-volume:/app/data
       - ./jacocoReport/dpc-api:/jacoco-report
 
-  start_dependencies:
+  start_core_dependencies:
     image: dadarek/wait-for-dependencies
     depends_on:
       - redis
       - db
+    command: redis:6379 db:5432
+
+  start_api_dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
       - attribution
       - aggregation
-    command: redis:6379 db:5432 attribution:8080 aggregation:9900
+    command: attribution:8080 aggregation:9900
 
   start_api:
     image: dadarek/wait-for-dependencies
     depends_on:
-      - redis
-      - db
-      - attribution
-      - aggregation
       - api
-    command: redis:6379 db:5432 attribution:8080 aggregation:9900 api:3002
+    command: api:3002
 
 volumes:
   export-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,15 +60,21 @@ services:
   start_dependencies:
     image: dadarek/wait-for-dependencies
     depends_on:
+      - redis
+      - db
       - attribution
       - aggregation
-    command: attribution:8080 aggregation:9900
+    command: redis:6379 db:5432 attribution:8080 aggregation:9900
 
   start_api:
     image: dadarek/wait-for-dependencies
     depends_on:
+      - redis
+      - db
+      - attribution
+      - aggregation
       - api
-    command: api:3002
+    command: redis:6379 db:5432 attribution:8080 aggregation:9900 api:3002
 
 volumes:
   export-volume:

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -24,7 +24,7 @@ if [ -n "$REPORT_COVERAGE" ]; then
 fi
 
 # Build the application
-docker-compose up -d db redis
+docker-compose up start_core_dependencies
 mvn clean compile -Perror-prone -B -V
 mvn package -Pci
 
@@ -40,7 +40,7 @@ if [ -n "$REPORT_COVERAGE" ]; then
 fi
 
 docker-compose down
-docker-compose up start_dependencies
+docker-compose up start_api_dependencies
 
 # Run the integration tests
 mvn test -Pintegration-tests -pl dpc-api -am

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -40,6 +40,7 @@ if [ -n "$REPORT_COVERAGE" ]; then
 fi
 
 docker-compose down
+docker-compose up start_core_dependencies
 docker-compose up start_api_dependencies
 
 # Run the integration tests


### PR DESCRIPTION
**Why**

We have a race condition during testing where the db sometimes will not be started when the attribution / aggregation sever starts. The docker container would exit and the attribution / aggregation server would not be started, causing the API tests to fail.

**What Changed**

This PR includes the DB and Redis server in our `start_dependencies` and `start_api` targets to ensure the ports are ready for traffic before starting any server that depends on them. This pattern was introduced in #199 but did not include the DB and Redis servers in the dependencies.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**
