### PR TITLE
DPC-504 Set up Sidekiq as the backend for ActiveJob

### DIFF
--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -1,3 +1,4 @@
+
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
@@ -48,3 +49,4 @@ group :development do
 end
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'sidekiq'

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -153,6 +154,8 @@ GEM
     public_suffix (3.1.1)
     puma (3.12.1)
     rack (2.0.7)
+    rack-protection (2.0.7)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)
@@ -184,6 +187,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.2)
     regexp_parser (1.5.1)
     responders (3.0.0)
       actionpack (>= 5.0)
@@ -235,6 +239,11 @@ GEM
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simplecov (0.17.0)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -319,6 +328,7 @@ DEPENDENCIES
   rubocop-performance
   sassc-rails (>= 2.1.2)
   selenium-webdriver
+  sidekiq
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/dpc-web/README.md
+++ b/dpc-web/README.md
@@ -88,6 +88,16 @@ export DB_PASS=password
 export DATABASE_URL=postgresql://localhost/dpc-website_development
 ```
 
+#### Background Jobs
+The web app uses Sidekiq for background job processing, which relies on Redis. If your Redis server is not running at `localhost:6379` (the default for development environments), be sure to specify the `REDIS_URL` ENV variable:
+
+```
+export REDIS_URL=redis://redis.example.com:7372/0
+```
+
+For more information, see Sidekiq's wiki on [Using Redis](https://github.com/mperham/sidekiq/wiki/Using-Redis).
+
+*Note:* You must have Sidekiq (and Redis) running in order to process asynchronous jobs, including sending email.
 
 # Running via Docker
 

--- a/dpc-web/config/application.rb
+++ b/dpc-web/config/application.rb
@@ -44,5 +44,7 @@ module DpcWebsite
 
     # Add middleware to fix issue with /ig links breaking
     config.middleware.insert_before ActionDispatch::Static, DpcMiddleware::IgFix
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/dpc-web/docker-compose.yml
+++ b/dpc-web/docker-compose.yml
@@ -10,7 +10,13 @@ services:
     ports:
       - "15432:5432"
 
+  redis:
+    image: redis
+
   web:
+    depends_on:
+      - db
+      - redis
     build:
       context: ..
       dockerfile: dpc-web/Dockerfile
@@ -20,7 +26,20 @@ services:
       - DB_USER=postgres
       - DB_PASS=dpc-safe
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
+      - REDIS_URL=redis://redis:6379
     ports:
       - "3000:3000"
+
+  sidekiq:
     depends_on:
       - db
+      - redis
+    build:
+      context: ..
+      dockerfile: dpc-web/docker/sidekiq/Dockerfile
+    environment:
+      - DATABASE_URL=postgresql://db/dpc-website_development
+      - DB_USER=postgres
+      - DB_PASS=dpc-safe
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
+      - REDIS_URL=redis://redis:6379

--- a/dpc-web/docker/sidekiq/Dockerfile
+++ b/dpc-web/docker/sidekiq/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.6.2-alpine
+
+# Set the working directory
+RUN mkdir /dpc-web
+WORKDIR /dpc-web
+
+# Install build dependencies
+RUN apk add --no-cache postgresql-dev && \
+    apk add --no-cache --virtual build-deps alpine-sdk npm tzdata
+
+# Copy the code
+COPY /dpc-web /dpc-web
+
+# Install the website dependencies
+RUN gem install bundler --no-document && bundle install
+
+# Clean up from the build
+RUN rm -rf /usr/local/bundle/cache/*.gem && \
+    find /usr/local/bundle/gems/ -name "*.c" -delete && \
+    find /usr/local/bundle/gems/ -name "*.o" -delete
+
+# Start the Sidekiq process
+CMD ["bundle", "exec", "sidekiq"]


### PR DESCRIPTION
Sidekiq is a well-supported backend job processing library. This commit
adds it to the standard config as well as sets it up with Docker. We're
running the Sidekiq as a separate container due to the Docker best
practice of running one process per container. This container is pretty
much the same as the web app container but without the IG and Node
stuff (since background jobs don't typically deal with the front end).

**Why**

We need background job processing for emails in production. This is a prerequisite to #203 

**What Changed**

Adds Sidekiq to the app as the background job processor for the web app. Updates the docker setup to run Sidekiq in its own container.

**Choices Made**

Sidekiq rocks and is a well supported library. We already have Redis so using Redis to support Sidekiq should be no issue. 

**Checklist**

- [ ] Demo and Seed commands are working
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
