### PR TITLE
Fix the sign up feature tests from recent UI change

### DIFF
--- a/dpc-web/app/views/shared/_navbar.html.erb
+++ b/dpc-web/app/views/shared/_navbar.html.erb
@@ -43,17 +43,18 @@ aria-controls="topnav-wrap" aria-label="Close menu">
         </li>
       <% else %>
         <li class="topnav__item usa-accordion">
-          <button class="topnav__link usa-accordion__button" type="button" aria-expanded="false" aria-controls="nav-1">My account</button>
+          <button class="topnav__link usa-accordion__button" type="button" aria-expanded="false"
+                  aria-controls="nav-1" data-test="my-account-menu">My account</button>
           <ul id="nav-1" class="topnav__dropdown usa-accordion__content" hidden>
             <li class="topnav__dropdown__item">
-              <%= link_to profile_path, id: :dpc_registrations_profile_link,
-                :class => "topnav__dropdown__link" do %>
+              <%= link_to profile_path, class: "topnav__dropdown__link",
+                  data: { test: 'dpc-registrations-profile-link' } do %>
                   Profile
                 <% end %>
             </li>
             <li class="topnav__dropdown__item">
-              <a class="topnav__dropdown__link"
-                 id="sign-out" href="<%= destroy_user_session_path %>" data-method="delete">
+              <a class="topnav__dropdown__link" href="<%= destroy_user_session_path %>"
+                 id="sign-out" data-method="delete">
                  Sign out
               </a>
             </li>

--- a/dpc-web/spec/features/new_user_signs_up_for_account_spec.rb
+++ b/dpc-web/spec/features/new_user_signs_up_for_account_spec.rb
@@ -35,11 +35,12 @@ RSpec.feature 'new user signs up for account' do
 
     scenario 'is brought to the registrations dashboard' do
       expect(page).to have_http_status(200)
-      expect(page).to have_content('Dashboard')
+      expect(page).to have_css('[data-test="my-account-menu"]')
     end
 
     scenario 'can see profile information' do
-      click_link('dpc_registrations_profile_link')
+      find('[data-test="my-account-menu"]').click
+      find('[data-test="dpc-registrations-profile-link"]', visible: false).click
       expect(page).to have_content(user.email)
     end
   end


### PR DESCRIPTION
**Why**

When we changed the UI to remove the tabs and use a My Account dropdown
menu, we inadvertently broke some tests. This PR fixes those and uses
data-test attributes rather than text strings or id/class selectors.

**What Changed**

Feature test

**Choices Made**

Note: I used `visible: false` to make one of the dropdown links
clickable, because otherwise we would need to enable javascript for this
scenario and that would a) decrease speed of tests and b) introduce new
issues with making the rest of the test compatible with the JS driver
(e.g. the checkbox for agreeing to terms is rendered as hidden, which
then throws an error that the "element is not interactable"). This was
the most straightforward and quickest way of getting the tests fixed.