### PR TITLE
DPC-604: Updated documentation to be clearer about profiles

### DIFF
--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -730,7 +730,7 @@ curl -v https://sandbox.dpc.cms.gov/api/v1/Practitioner
 {
   "meta": {
     "profile": [
-      "https://dpc.cms.gov/fhir/v1/StructureDefinition/dpc-profile-practitioner"
+      "https://dpc.cms.gov/api/v1/StructureDefinition/dpc-profile-practitioner"
     ],
     "lastUpdated": "2019-04-09T12:25:36.450182+00:00",
     "versionId": "MTU1NDgxMjczNjQ1MDE4MjAwMA"
@@ -844,9 +844,11 @@ curl -v https://sandbox.dpc.cms.gov/api/v1/Patient
   "resourceType": "Patient",
   "id": "728b270d-d7de-4143-82fe-d3ccd92cebe4",
   "meta": {
-    "versionId": "MTU1NDgxMjczNTM5MjYwMDAwMA",
-    "lastUpdated": "2019-04-09T12:25:35.392600+00:00"
-  },
+      "profile": [
+        "https://dpc.cms.gov/api/v1/StructureDefinition/dpc-profile-patient"
+      ],
+      "lastUpdated": "2019-04-09T12:25:36.450182+00:00"
+    },
   "identifier": [
     {
       "system": "http://bluebutton.cms.hhs.gov/identifier#bene_id",


### PR DESCRIPTION
The profile information in the docs was either missing, or pointed to the wrong URL. This should fix that.

**Why**

One of our partners reported that they were unable to submit patient and practitioner records. The issue was due to missing profiles in the submitted resources, but the documentation was wrong on the website, which may have been adding to the confusion.

**What Changed**

Updated the documentation have the correct URL and be present on both the patient and practitioner examples.

**Choices Made**


**Tickets closed**:

DPC-604

**Future Work**

DPC-532: Profile validations are not apply correctly.

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
