### PR TITLE
Lock HAPI FHIR dependencies to specific commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <jitpack.groupID>com.github.nickrobison-usds</jitpack.groupID>
         <typesafe.config.groupID>${jitpack.groupID}</typesafe.config.groupID>
         <hapi.fhir.groupID>${jitpack.groupID}.hapi-fhir</hapi.fhir.groupID>
-        <hapi.fhir.version>jitpack-SNAPSHOT</hapi.fhir.version>
+        <hapi.fhir.version>f8e3716809dd02e90ecdac411abeee2f76f8d4dd</hapi.fhir.version>
         <pgsql.version>42.2.5</pgsql.version>
         <java.version>11</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>


### PR DESCRIPTION
**Why**

When rebasing our HAPI fork against the latest master, we introduced some breaking changes that caused all of our builds to fail. This was due to our current pom coordinates pointing to the tip of our branch, rather than a specific commit.

**What Changed**

Rather than pointing to our fork head, we're targeting a specific commit, which should be much more stable.

**Choices Made**

**Tickets closed**:

**Future Work**

Eventually, we'll need to mainline some of our changes.

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
