### PR TITLE
Resolve CVE-2015-9284 vulnerability

### DIFF
--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -57,4 +57,5 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'delayed_job_active_record'
 gem 'daemons'
 gem 'omniauth-github'
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
 gem 'octokit'

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -177,6 +177,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     parallel (1.17.0)
     parser (2.6.3.0)
@@ -358,6 +361,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   octokit
   omniauth-github
+  omniauth-rails_csrf_protection (~> 0.1)
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 3.11)

--- a/dpc-web/app/views/internal/auth/sessions/new.html.erb
+++ b/dpc-web/app/views/internal/auth/sessions/new.html.erb
@@ -5,7 +5,7 @@
     <div class="card card--border-top card--shadow">
       <h1 class="ds-u-margin-top--0">Log in</h1>
 
-      <%= link_to "Sign in with Github", internal_user_github_omniauth_authorize_path, data: { test: 'internal-user-sign-in-form' } %>
+      <%= link_to "Sign in with Github", internal_user_github_omniauth_authorize_path, method: :post, data: { test: 'internal-user-sign-in-form' } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Why**

We need to make sure that we're mitigating the Cross Site Scripting
Forgery vulnerability by using a POST method to initiate the Omniauth
flow. For more info:

https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
https://github.com/omniauth/omniauth/pull/809

**What Changed**

* Add a gem that enforces using `post` only with oauth initiation requests
* Change out github link to use the `post` method

