### PR TITLE
Add bundler audit to CI

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -40,3 +40,7 @@ plugins:
     channel: rubocop-0-67
     config:
       file: "dpc-web/.rubocop.yml"
+  bundler-audit:
+    enabled: true
+    config:
+      path: "dpc-web/Gemfile.lock"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -40,7 +40,3 @@ plugins:
     channel: rubocop-0-67
     config:
       file: "dpc-web/.rubocop.yml"
-  bundler-audit:
-    enabled: true
-    config:
-      path: "dpc-web/Gemfile.lock"

--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -16,7 +16,7 @@ docker-compose -f dpc-web/docker-compose.yml run web rails db:create db:migrate 
 docker-compose -f dpc-web/docker-compose.yml run web rails spec
 
 # Run bundler audit
-docker-compose -f dpc-web/docker-compose.yml run web bundle audit update && bundle audit check --ignore CVE-2015-9284
+docker-compose -f dpc-web/docker-compose.yml run web cd dpc-web && bundle audit update && bundle audit check --ignore CVE-2015-9284
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"

--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -16,7 +16,7 @@ docker-compose -f dpc-web/docker-compose.yml run web rails db:create db:migrate 
 docker-compose -f dpc-web/docker-compose.yml run web rails spec
 
 # Run bundler audit
-docker-compose -f dpc-web/docker-compose.yml run web gem install bundler-audit && bundle audit update && bundle audit check --ignore CVE-2015-9284
+docker-compose -f dpc-web/docker-compose.yml run web bundle exec bundle audit update && bundle exec bundle audit check --ignore CVE-2015-9284
 docker-compose -f dpc-web/docker-compose.yml down
 
 echo "┌──────────────────────────────────────────┐"

--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -3,7 +3,7 @@ set -e
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"
-echo "│  Running Website Tests & Bundler Aduit   │"
+echo "│  Running Website Tests & Bundler Audit   │"
 echo "│                                          │"
 echo "└──────────────────────────────────────────┘"
 
@@ -15,8 +15,12 @@ docker-compose -f dpc-web/docker-compose.yml up start_core_dependencies
 docker-compose -f dpc-web/docker-compose.yml run web rails db:create db:migrate db:seed
 docker-compose -f dpc-web/docker-compose.yml run web rails spec
 
+# Run bundler audit
+docker-compose -f dpc-web/docker-compose.yml run web gem install bundler-audit && bundle audit update && bundle audit check --ignore CVE-2015-9284
+docker-compose -f dpc-web/docker-compose.yml down
+
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"
-echo "│     All Website Tests & AuditComplete    │"
+echo "│    All Website Tests & Audit Complete    │"
 echo "│                                          │"
 echo "└──────────────────────────────────────────┘"

--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -3,7 +3,7 @@ set -e
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"
-echo "│        Running Website Tests...          │"
+echo "│  Running Website Tests & Bundler Aduit   │"
 echo "│                                          │"
 echo "└──────────────────────────────────────────┘"
 
@@ -17,6 +17,6 @@ docker-compose -f dpc-web/docker-compose.yml run web rails spec
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"
-echo "│        All Website Tests Complete        │"
+echo "│     All Website Tests & AuditComplete    │"
 echo "│                                          │"
 echo "└──────────────────────────────────────────┘"

--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -16,8 +16,7 @@ docker-compose -f dpc-web/docker-compose.yml run web rails db:create db:migrate 
 docker-compose -f dpc-web/docker-compose.yml run web rails spec
 
 # Run bundler audit
-docker-compose -f dpc-web/docker-compose.yml run web bundle exec bundle audit update && bundle exec bundle audit check --ignore CVE-2015-9284
-docker-compose -f dpc-web/docker-compose.yml down
+docker-compose -f dpc-web/docker-compose.yml run web bundle audit update && bundle audit check --ignore CVE-2015-9284
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -34,6 +34,8 @@ group :development, :test do
   gem 'simplecov', require: false
   gem 'vcr'
   gem 'webmock'
+
+  gem 'bundler-audit'
 end
 
 group :test do

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
       sassc-rails (>= 2.0.0)
     brakeman (4.7.2)
     builder (3.2.3)
+    bundler-audit (0.6.1)
+      bundler (>= 1.2.0, < 3)
+      thor (~> 0.18)
     byebug (11.0.1)
     capybara (3.29.0)
       addressable
@@ -352,6 +355,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bootstrap
   brakeman
+  bundler-audit
   byebug
   capybara
   climate_control


### PR DESCRIPTION
**Why**

We want to get vulnerability warnings when a PR is opened.

**What Changed**

Add bundler-audit to codeclimate config. For more info:

https://docs.codeclimate.com/docs/bundler-audit
https://github.com/rubysec/bundler-audit

