### PR TITLE
Setup docker-compose file to wait for Database before running specs

### DIFF
--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -11,6 +11,7 @@ echo "└───────────────────────�
 make website
 
 # Run the tests
+docker-compose -f dpc-web/docker-compose.yml up start_core_dependencies
 docker-compose -f dpc-web/docker-compose.yml run web rails db:create db:migrate db:seed
 docker-compose -f dpc-web/docker-compose.yml run web rails spec
 docker-compose -f dpc-web/docker-compose.yml down

--- a/dpc-web/docker-compose.yml
+++ b/dpc-web/docker-compose.yml
@@ -10,6 +10,12 @@ services:
     ports:
       - "15432:5432"
 
+  start_core_dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      - db
+    command: db:5432
+
   web:
     build:
       context: ..
@@ -23,4 +29,4 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - db
+      - start_core_dependencies

--- a/dpc-web/docker-compose.yml
+++ b/dpc-web/docker-compose.yml
@@ -29,4 +29,4 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      - start_core_dependencies
+      - db


### PR DESCRIPTION
**Why**

My most recent Docker builds have been failing in Jenkins, the error thrown is that the database isn't ready when the tests start.

**What Changed**

Added the `wait-for-dependencies` docker image to block until the DB is truly ready.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
