### PR TITLE
DPC-613: Improve handling of malformed tokens

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -7,34 +7,26 @@ import gov.cms.dpc.attribution.jdbi.OrganizationDAO;
 import gov.cms.dpc.attribution.resources.AbstractOrganizationResource;
 import gov.cms.dpc.common.entities.EndpointEntity;
 import gov.cms.dpc.common.entities.OrganizationEntity;
-import gov.cms.dpc.common.entities.TokenEntity;
-import gov.cms.dpc.common.models.TokenResponse;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.converters.EndpointConverter;
 import gov.cms.dpc.macaroons.MacaroonBakery;
-import gov.cms.dpc.macaroons.MacaroonCaveat;
 import gov.cms.dpc.macaroons.exceptions.BakeryException;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.*;
 import org.eclipse.jetty.http.HttpStatus;
-import org.hibernate.validator.constraints.NotEmpty;
 import org.hl7.fhir.dstu3.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static gov.cms.dpc.attribution.utils.RESTUtils.parseTokenTag;
-import static gov.cms.dpc.attribution.utils.RESTUtils.tokenTagToUUID;
 
 @Api(value = "Organization")
 public class OrganizationResource extends AbstractOrganizationResource {
@@ -59,8 +51,9 @@ public class OrganizationResource extends AbstractOrganizationResource {
                     "<p>The *_tag* parameter is used to convey the token, which is half-way between FHIR and REST.")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Organization matching (valid) token was found."),
+            @ApiResponse(code = 401, message = "Organization was found, but token was invalid", response = OperationOutcome.class),
             @ApiResponse(code = 404, message = "Organization was not found matching token", response = OperationOutcome.class),
-            @ApiResponse(code = 401, message = "Organization was found, but token was invalid", response = OperationOutcome.class)
+            @ApiResponse(code = 422, message = "Access token is malformed, or unprocessable", response = OperationOutcome.class)
     })
     public Bundle searchOrganizations(
             @ApiParam(value = "NPI of Organization")
@@ -163,7 +156,13 @@ public class OrganizationResource extends AbstractOrganizationResource {
     }
 
     private Bundle searchAndValidationByToken(String token) {
-        final Macaroon macaroon = parseTokenTag(this.bakery::deserializeMacaroon, token);
+        final Macaroon macaroon;
+        try {
+            macaroon = parseTokenTag(this.bakery::deserializeMacaroon, token);
+        } catch (BakeryException e) {
+            logger.error("Cannot parse Token tag", e);
+            throw new WebApplicationException("Token is malformed", HttpStatus.UNPROCESSABLE_ENTITY_422);
+        }
 
         final List<OrganizationEntity> organizationEntities = this.dao.searchByToken(macaroon.identifier);
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/RESTUtils.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/utils/RESTUtils.java
@@ -67,7 +67,7 @@ public class RESTUtils {
     public static <T> T parseTokenTag(Function<String, T> builder, String tokenTag) {
         final int idx = tokenTag.indexOf('|');
         if (idx < 0) {
-            throw new WebApplicationException("Malformed tokenTag", Response.Status.BAD_REQUEST);
+            throw new WebApplicationException("Malformed tokenTag", HttpStatus.UNPROCESSABLE_ENTITY_422);
         }
 
         return builder.apply(tokenTag.substring(idx + 1));

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationRegistrationTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationRegistrationTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -137,6 +139,18 @@ class OrganizationRegistrationTest extends AbstractAttributionTest {
 
             try (CloseableHttpResponse response = client.execute(httpGet)) {
                 assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatusLine().getStatusCode(), "Should not be able to verify empty token");
+            }
+        }
+    }
+
+    @Test
+    void testNonMacaroonHandling() throws IOException {
+        final String badToken = Base64.getUrlEncoder().encodeToString(new String("This is not a macaroon").getBytes(StandardCharsets.UTF_8));
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", ORGANIZATION_ID, badToken));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, response.getStatusLine().getStatusCode(), "Should not be able to verify empty token");
             }
         }
     }

--- a/dpc-macaroons/src/main/java/gov/cms/dpc/macaroons/MacaroonBakery.java
+++ b/dpc-macaroons/src/main/java/gov/cms/dpc/macaroons/MacaroonBakery.java
@@ -168,7 +168,11 @@ public class MacaroonBakery {
         } else {
             decodedString = serializedString.getBytes(CAVEAT_CHARSET);
         }
-        return MacaroonsBuilder.deserialize(new String(decodedString, StandardCharsets.UTF_8));
+        try {
+            return MacaroonsBuilder.deserialize(new String(decodedString, StandardCharsets.UTF_8));
+        } catch (NotDeSerializableException e) {
+            throw new BakeryException("Cannot deserialize Macaroon", e);
+        }
     }
 
     private void addCaveats(MacaroonsBuilder builder, List<MacaroonCaveat> caveats) {

--- a/dpc-macaroons/src/main/java/gov/cms/dpc/macaroons/exceptions/BakeryException.java
+++ b/dpc-macaroons/src/main/java/gov/cms/dpc/macaroons/exceptions/BakeryException.java
@@ -10,4 +10,8 @@ public class BakeryException extends RuntimeException {
     public BakeryException(String message) {
         super(message);
     }
+
+    public BakeryException(String message, Exception e) {
+        super(message, e);
+    }
 }


### PR DESCRIPTION
**Why**

We received a bug report where 500 errors were being returned for all endpoints, this was due to the client sending a malformed authorization token, which was causing Bakery to throw an exception. This was really confusing for both us and the client.

**What Changed**

Bakery now traps `DeSerializationExceptions` and re-throws them as a `BakeryException`. We then catch that in the token routines and return a `422`, rather than simply failing with a `500` status.

**Choices Made**

Only `422` errors are caught and handled (which covers missing tokens and malformed tokens), anything else is returned as a 500, which I think makes sense.

**Tickets closed**:

DPC-613:

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
