### PR TITLE
DPC-597: Add labels and expiration times to TokenEntities

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/tokens/TokenList.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/tokens/TokenList.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Organization;
 
 import java.io.IOException;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 public class TokenList extends AbstractAttributionCommand {
@@ -76,13 +77,14 @@ public class TokenList extends AbstractAttributionCommand {
 
     private void generateTable(List<TokenEntity> tokens) {
         // Generate the table
-        // TODO(nickrobison): We need to re-add the expiration date, once it's wired back in with DPC-617
-        final String[] headers = {"Token ID", "Label", "Type"};
+        final String[] headers = {"Token ID", "Label", "Type", "Created At", "Expires At"};
 
         System.out.println(FlipTable.of(headers, tokens
                 .stream()
                 .map(token -> new String[]{token.getId(),
                         token.getLabel(),
-                        token.getTokenType().toString()}).toArray(String[][]::new)));
+                        token.getTokenType().toString(),
+                        token.getCreatedAt().format(DateTimeFormatter.ISO_DATE_TIME),
+                        token.getExpiresAt().format(DateTimeFormatter.ISO_DATE_TIME)}).toArray(String[][]::new)));
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/tokens/TokenList.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/tokens/TokenList.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.fliptables.FlipTable;
 import gov.cms.dpc.api.cli.AbstractAttributionCommand;
 import gov.cms.dpc.common.entities.TokenEntity;
-import gov.cms.dpc.common.models.TokenResponse;
-import gov.cms.dpc.fhir.FHIRMediaTypes;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -79,10 +77,12 @@ public class TokenList extends AbstractAttributionCommand {
     private void generateTable(List<TokenEntity> tokens) {
         // Generate the table
         // TODO(nickrobison): We need to re-add the expiration date, once it's wired back in with DPC-617
-        final String[] headers = {"Token ID", "Type"};
+        final String[] headers = {"Token ID", "Label", "Type"};
 
         System.out.println(FlipTable.of(headers, tokens
                 .stream()
-                .map(token -> new String[]{token.getId(), token.getTokenType().toString()}).toArray(String[][]::new)));
+                .map(token -> new String[]{token.getId(),
+                        token.getLabel(),
+                        token.getTokenType().toString()}).toArray(String[][]::new)));
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/models/JobCompletionModel.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/models/JobCompletionModel.java
@@ -3,12 +3,10 @@ package gov.cms.dpc.api.models;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import gov.cms.dpc.api.converters.OffsetDateTimeToStringConverter;
-import gov.cms.dpc.queue.models.JobResult;
+import gov.cms.dpc.common.converters.OffsetDateTimeToStringConverter;
 import org.hl7.fhir.dstu3.model.ResourceType;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractTokenResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractTokenResource.java
@@ -44,7 +44,7 @@ public abstract class AbstractTokenResource {
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     @POST
     @Path("/{organizationID}")
-    public abstract String createOrganizationToken(@PathParam("organizationID") @NotNull UUID organizationID, @QueryParam("label") String label, Optional<OffsetDateTimeParam> expiration);
+    public abstract String createOrganizationToken(@PathParam("organizationID") @NotNull UUID organizationID, String label, Optional<OffsetDateTimeParam> expiration);
 
     @DELETE
     @Path("/{organizationID}/{tokenID}")

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractTokenResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractTokenResource.java
@@ -1,12 +1,14 @@
 package gov.cms.dpc.attribution.resources;
 
 import gov.cms.dpc.common.entities.TokenEntity;
+import io.dropwizard.jersey.jsr310.OffsetDateTimeParam;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -39,9 +41,10 @@ public abstract class AbstractTokenResource {
      * @param label          - {@link Optional} {@link String} to use as token label
      * @return - {@link String} base64 (URL) encoded token
      */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     @POST
     @Path("/{organizationID}")
-    public abstract String createOrganizationToken(@PathParam("organizationID") @NotNull UUID organizationID, Optional<String> label);
+    public abstract String createOrganizationToken(@PathParam("organizationID") @NotNull UUID organizationID, @QueryParam("label") String label, Optional<OffsetDateTimeParam> expiration);
 
     @DELETE
     @Path("/{organizationID}/{tokenID}")

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractTokenResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractTokenResource.java
@@ -8,6 +8,7 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Path("/Token")
@@ -35,11 +36,12 @@ public abstract class AbstractTokenResource {
      * This token is designed to be long-lived and delegatable.
      *
      * @param organizationID - {@link UUID} organization ID
+     * @param label          - {@link Optional} {@link String} to use as token label
      * @return - {@link String} base64 (URL) encoded token
      */
     @POST
     @Path("/{organizationID}")
-    public abstract String createOrganizationToken(@PathParam("organizationID") @NotNull UUID organizationID);
+    public abstract String createOrganizationToken(@PathParam("organizationID") @NotNull UUID organizationID, Optional<String> label);
 
     @DELETE
     @Path("/{organizationID}/{tokenID}")

--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -373,4 +373,16 @@
                     defaultValueComputed="current_timestamp"/>
         </addColumn>
     </changeSet>
+
+    <changeSet id="add-token-label-expiration" author="nickrobison-usds">
+        <addColumn tableName="ORGANIZATION_TOKENS">
+            <column name="label" type="VARCHAR"/>
+            <column name="created_at"
+                    type="TIMESTAMP WITH TIME ZONE"
+                    defaultValueComputed="current_timestamp"/>
+            <column name="expires_at"
+                    type="TIMESTAMP WITH TIME ZONE"
+                    defaultValueComputed="current_timestamp + ( 1 || ' year')::interval"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationRegistrationTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationRegistrationTest.java
@@ -4,45 +4,21 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cms.dpc.attribution.AbstractAttributionTest;
 import gov.cms.dpc.attribution.AttributionTestHelpers;
-import gov.cms.dpc.common.entities.TokenEntity;
-import gov.cms.dpc.common.models.TokenResponse;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
-import org.eclipse.jetty.http.HttpStatus;
-import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.StringType;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class OrganizationRegistrationTest extends AbstractAttributionTest {
-
-    private static final String BAD_ORG_ID = "0c527d2e-2e8a-4808-b11d-0fa06baf8252";
-
     private final IGenericClient client;
-    private final ObjectMapper mapper;
 
     private OrganizationRegistrationTest() {
         this.client = AttributionTestHelpers.createFHIRClient(ctx, getServerURL());
-        this.mapper = new ObjectMapper();
     }
 
     @Test
@@ -81,77 +57,5 @@ class OrganizationRegistrationTest extends AbstractAttributionTest {
                 .encodedJson();
 
         assertThrows(UnprocessableEntityException.class, operation::execute, "Should be unprocessable");
-    }
-
-    @Test
-    void testTokenGeneration() throws IOException {
-        final Organization organization = AttributionTestHelpers.createOrganization(ctx, getServerURL());
-        final String org_id = organization.getIdElement().getIdPart();
-        String macaroon;
-        try (final CloseableHttpClient client = HttpClients.createDefault()) {
-            final HttpPost httpPost = new HttpPost(getServerURL() + String.format("/Token/%s", org_id));
-
-
-            try (CloseableHttpResponse response = client.execute(httpPost)) {
-                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have found organization");
-                macaroon = EntityUtils.toString(response.getEntity());
-                // Verify that the first few bytes are correct, to ensure we encoded correctly.
-                assertTrue(macaroon.startsWith("eyJ2IjoyLCJs"), "Should have correct starting string value");
-            }
-        }
-
-        // Verify that it's correct.
-        try (final CloseableHttpClient client = HttpClients.createDefault()) {
-            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", org_id, macaroon));
-
-            try (CloseableHttpResponse response = client.execute(httpGet)) {
-                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Token should be valid");
-            }
-        }
-
-        // Verify token only works for the given organization
-
-        // Verify that it's unauthorized.
-        try (final CloseableHttpClient client = HttpClients.createDefault()) {
-            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", BAD_ORG_ID, macaroon));
-
-            try (CloseableHttpResponse response = client.execute(httpGet)) {
-                assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatusLine().getStatusCode(), "Should not be valid");
-            }
-        }
-    }
-
-    @Test
-    void testUnknownOrgTokenGeneration() throws IOException {
-        try (final CloseableHttpClient client = HttpClients.createDefault()) {
-            final HttpPost httpPost = new HttpPost(getServerURL() + "/Token/" + UUID.randomUUID().toString());
-
-            try (CloseableHttpResponse response = client.execute(httpPost)) {
-                assertEquals(HttpStatus.NOT_FOUND_404, response.getStatusLine().getStatusCode(), "Should not have found organization");
-            }
-        }
-    }
-
-    @Test
-    void testEmptyTokenHandling() throws IOException {
-        try (final CloseableHttpClient client = HttpClients.createDefault()) {
-            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", ORGANIZATION_ID, ""));
-
-            try (CloseableHttpResponse response = client.execute(httpGet)) {
-                assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatusLine().getStatusCode(), "Should not be able to verify empty token");
-            }
-        }
-    }
-
-    @Test
-    void testNonMacaroonHandling() throws IOException {
-        final String badToken = Base64.getUrlEncoder().encodeToString(new String("This is not a macaroon").getBytes(StandardCharsets.UTF_8));
-        try (final CloseableHttpClient client = HttpClients.createDefault()) {
-            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", ORGANIZATION_ID, badToken));
-
-            try (CloseableHttpResponse response = client.execute(httpGet)) {
-                assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, response.getStatusLine().getStatusCode(), "Should not be able to verify empty token");
-            }
-        }
     }
 }

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/v1/TokenResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/v1/TokenResourceTest.java
@@ -133,10 +133,10 @@ class TokenResourceTest extends AbstractAttributionTest {
                 final List<TokenEntity> tokens = this.mapper.readValue(response.getEntity().getContent(), new TypeReference<List<TokenEntity>>() {
                 });
 
-                assertEquals(1, tokens.size(), "Should have a single token");
+                assertEquals(2, tokens.size(), "Should have tokens");
                 final TokenEntity token = tokens.get(0);
 
-                assertAll(() -> assertEquals(String.format("Access token for organization %s.", org_id), token.getLabel(), "Should have auto-generated label"),
+                assertAll(() -> assertEquals(String.format("Token for organization %s.", org_id), token.getLabel(), "Should have auto-generated label"),
                         () -> assertEquals(LocalDate.now().plus(1, ChronoUnit.YEARS), token.getExpiresAt().toLocalDate(), "Should expire in 1 year"));
             }
         }

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/v1/TokenResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/v1/TokenResourceTest.java
@@ -1,0 +1,144 @@
+package gov.cms.dpc.attribution.resources.v1;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cms.dpc.attribution.AbstractAttributionTest;
+import gov.cms.dpc.attribution.AttributionTestHelpers;
+import gov.cms.dpc.common.entities.TokenEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.jetty.http.HttpStatus;
+import org.hl7.fhir.dstu3.model.Organization;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TokenResourceTest extends AbstractAttributionTest {
+
+    private static final String BAD_ORG_ID = "0c527d2e-2e8a-4808-b11d-0fa06baf8252";
+
+    private final ObjectMapper mapper;
+
+    private TokenResourceTest() {
+        this.mapper = new ObjectMapper();
+    }
+
+
+    @Test
+    void testTokenGeneration() throws IOException {
+        final Organization organization = AttributionTestHelpers.createOrganization(ctx, getServerURL());
+        final String org_id = organization.getIdElement().getIdPart();
+        String macaroon;
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpPost httpPost = new HttpPost(getServerURL() + String.format("/Token/%s", org_id));
+
+
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have found organization");
+                macaroon = EntityUtils.toString(response.getEntity());
+                // Verify that the first few bytes are correct, to ensure we encoded correctly.
+                assertTrue(macaroon.startsWith("eyJ2IjoyLCJs"), "Should have correct starting string value");
+            }
+        }
+
+        // Verify that it's correct.
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", org_id, macaroon));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Token should be valid");
+            }
+        }
+
+        // Verify token only works for the given organization
+
+        // Verify that it's unauthorized.
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", BAD_ORG_ID, macaroon));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatusLine().getStatusCode(), "Should not be valid");
+            }
+        }
+    }
+
+    @Test
+    void testUnknownOrgTokenGeneration() throws IOException {
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpPost httpPost = new HttpPost(getServerURL() + "/Token/" + UUID.randomUUID().toString());
+
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                assertEquals(HttpStatus.NOT_FOUND_404, response.getStatusLine().getStatusCode(), "Should not have found organization");
+            }
+        }
+    }
+
+    @Test
+    void testEmptyTokenHandling() throws IOException {
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", ORGANIZATION_ID, ""));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatusLine().getStatusCode(), "Should not be able to verify empty token");
+            }
+        }
+    }
+
+    @Test
+    void testNonMacaroonHandling() throws IOException {
+        final String badToken = Base64.getUrlEncoder().encodeToString(new String("This is not a macaroon").getBytes(StandardCharsets.UTF_8));
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s/verify?token=%s", ORGANIZATION_ID, badToken));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, response.getStatusLine().getStatusCode(), "Should not be able to verify empty token");
+            }
+        }
+    }
+
+    @Test
+    void testTokenList() throws IOException {
+
+        final Organization organization = AttributionTestHelpers.createOrganization(ctx, getServerURL());
+        final String org_id = organization.getIdElement().getIdPart();
+        String macaroon;
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpPost httpPost = new HttpPost(getServerURL() + String.format("/Token/%s", org_id));
+
+
+            try (CloseableHttpResponse response = client.execute(httpPost)) {
+                assertEquals(HttpStatus.OK_200, response.getStatusLine().getStatusCode(), "Should have found organization");
+                macaroon = EntityUtils.toString(response.getEntity());
+                // Verify that the first few bytes are correct, to ensure we encoded correctly.
+                assertTrue(macaroon.startsWith("eyJ2IjoyLCJs"), "Should have correct starting string value");
+            }
+        }
+
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getServerURL() + String.format("/Token/%s", org_id));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                final List<TokenEntity> tokens = this.mapper.readValue(response.getEntity().getContent(), new TypeReference<List<TokenEntity>>() {
+                });
+
+                assertEquals(1, tokens.size(), "Should have a single token");
+                final TokenEntity token = tokens.get(0);
+
+                assertAll(() -> assertEquals(String.format("Access token for organization %s.", org_id), token.getLabel(), "Should have auto-generated label"),
+                        () -> assertEquals(LocalDate.now().plus(1, ChronoUnit.YEARS), token.getExpiresAt().toLocalDate(), "Should expire in 1 year"));
+            }
+        }
+    }
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/converters/OffsetDateTimeToStringConverter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/converters/OffsetDateTimeToStringConverter.java
@@ -1,4 +1,4 @@
-package gov.cms.dpc.api.converters;
+package gov.cms.dpc.common.converters;
 
 import com.fasterxml.jackson.databind.util.StdConverter;
 import gov.cms.dpc.fhir.FHIRFormatters;

--- a/dpc-common/src/main/java/gov/cms/dpc/common/converters/StringToOffsetDateTimeConverter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/converters/StringToOffsetDateTimeConverter.java
@@ -1,0 +1,17 @@
+package gov.cms.dpc.common.converters;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import gov.cms.dpc.fhir.FHIRFormatters;
+
+import java.time.OffsetDateTime;
+
+/**
+ * Deserialize from the format expected in the FHIR spec. For details see https://hl7.org/fhir/2018May/datatypes.html#instant
+ */
+public class StringToOffsetDateTimeConverter extends StdConverter<String, OffsetDateTime> {
+
+    @Override
+    public OffsetDateTime convert(String s) {
+        return OffsetDateTime.parse(s, FHIRFormatters.INSTANT_FORMATTER);
+    }
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
@@ -1,12 +1,14 @@
 package gov.cms.dpc.common.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import java.io.Serializable;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Entity(name = "organization_tokens")
@@ -28,6 +30,16 @@ public class TokenEntity implements Serializable {
 
     @Column(name = "type")
     private TokenType tokenType;
+
+    @Column
+    private String label;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    @CreationTimestamp
+    private OffsetDateTime createdAt;
+
+    @Column(name = "expires_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    private OffsetDateTime expiresAt;
 
 
     public TokenEntity() {
@@ -62,5 +74,29 @@ public class TokenEntity implements Serializable {
 
     public void setTokenType(TokenType tokenType) {
         this.tokenType = tokenType;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(OffsetDateTime expiresAt) {
+        this.expiresAt = expiresAt;
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
@@ -1,7 +1,6 @@
 package gov.cms.dpc.common.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import gov.cms.dpc.common.converters.OffsetDateTimeToStringConverter;
@@ -14,7 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import java.util.UUID;
+import java.util.Objects;
 
 @Entity(name = "organization_tokens")
 public class TokenEntity implements Serializable {
@@ -107,5 +106,35 @@ public class TokenEntity implements Serializable {
 
     public void setExpiresAt(OffsetDateTime expiresAt) {
         this.expiresAt = expiresAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TokenEntity that = (TokenEntity) o;
+        return Objects.equals(id, that.id) &&
+                Objects.equals(organization, that.organization) &&
+                tokenType == that.tokenType &&
+                Objects.equals(label, that.label) &&
+                Objects.equals(createdAt, that.createdAt) &&
+                Objects.equals(expiresAt, that.expiresAt);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, organization, tokenType, label, createdAt, expiresAt);
+    }
+
+    @Override
+    public String toString() {
+        return "TokenEntity{" +
+                "id='" + id + '\'' +
+                ", organization=" + organization +
+                ", tokenType=" + tokenType +
+                ", label='" + label + '\'' +
+                ", createdAt=" + createdAt +
+                ", expiresAt=" + expiresAt +
+                '}';
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
@@ -111,7 +111,7 @@ public class TokenEntity implements Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (!(o instanceof TokenEntity)) return false;
         TokenEntity that = (TokenEntity) o;
         return Objects.equals(id, that.id) &&
                 Objects.equals(organization, that.organization) &&

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/TokenEntity.java
@@ -1,6 +1,11 @@
 package gov.cms.dpc.common.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import gov.cms.dpc.common.converters.OffsetDateTimeToStringConverter;
+import gov.cms.dpc.common.converters.StringToOffsetDateTimeConverter;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.Column;
@@ -35,10 +40,14 @@ public class TokenEntity implements Serializable {
     private String label;
 
     @Column(name = "created_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    @JsonSerialize(converter = OffsetDateTimeToStringConverter.class)
+    @JsonDeserialize(converter = StringToOffsetDateTimeConverter.class)
     @CreationTimestamp
     private OffsetDateTime createdAt;
 
     @Column(name = "expires_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    @JsonSerialize(converter = OffsetDateTimeToStringConverter.class)
+    @JsonDeserialize(converter = StringToOffsetDateTimeConverter.class)
     private OffsetDateTime expiresAt;
 
 

--- a/organization.jefferson.json
+++ b/organization.jefferson.json
@@ -1,0 +1,82 @@
+{
+  "resourceType": "Bundle",
+  "id": "provider-bundle-tmpl",
+  "type": "transaction",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Organization",
+        "identifier": [
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1215916002"
+          }
+        ],
+        "name": "Thomas Jefferson University Hospitals Inc.",
+        "address": {
+          "use": "work",
+          "type": "both",
+          "line": [
+            "111 S 11th St",
+            "2210 Gibbon Building"
+          ],
+          "city": "Philadelphia",
+          "state": "PA",
+          "postalCode": "19107"
+        },
+        "contact": [
+          {
+            "name": {
+              "use": "usual",
+              "family": "Vlasov",
+              "given": ["Andre"]
+            },
+            "address": {
+              "use": "work",
+              "type": "both",
+              "line": [
+                "833 Chestnut St",
+                "Suite 1000, 8th Floor"
+              ],
+              "city": "Philadelphia",
+              "state": "PA",
+              "postalCode": "19107"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "use": "work",
+                "value": "555-555-5555"
+              },
+              {
+                "system": "email",
+                "use": "work",
+                "value": "andre.vlasov@jefferson.edu"
+              }
+            ]
+          }
+        ]
+      },
+      "request": {
+        "method": "POST",
+        "url": "Group"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Endpoint",
+        "status": "test",
+        "connectionType": {
+          "system": "http://terminology.hl7.org/CodeSystem/endpoint-connection-type",
+          "code": "hl7-fhir-rest"
+        },
+        "name": "Thomas Jefferson University Hospital Organization Endpoint",
+        "address": "https://api.jefferson.edu/fhirservice/4_0_0/Bundle/provider-bundle-tmpl"
+      },
+      "request": {
+        "method": "POST",
+        "url": "Endpoint"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Why**

As we're getting ready to roll out self-service functionality to the web application, we need a way to disambiguate different tokens that organizations might create.

**What Changed**

Updated the `TokenEntity` model to include timestamps and a new label field. The token creation operation has grown `label` and `expiration` query params, which the user can use to set custom values there. The CLI commands have been updated to account for the new params and now display them in the appropriate result tables.

Also, while we're rooting around in the guts of the token handlers, we've also added support for custom expiration times to tokens. These custom times cannot be set in the past and connect exceed the expiration time in the token policy.

**Choices Made**


**Tickets closed**:

DPC-597: This ticket
DPC-617: Added token expiration support.

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additonal fixes.

**Checklist**

- [ ] Demo and Seed commands are working
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
