### PR TITLE
DPC-624: Add environment variables for devise configuration

### DIFF
--- a/dpc-web/config/environments/production.rb
+++ b/dpc-web/config/environments/production.rb
@@ -65,7 +65,8 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "dpc-website_#{Rails.env}"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.asset_host = "https://dpc.cms.gov"
+  config.action_mailer.default_url_options = { host: ENV['HOST_NAME'], port: ENV['PORT'] }
+  config.action_mailer.asset_host = "https://#{ENV['HOST_NAME']}:#{ENV['PORT']}"
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
@@ -103,8 +104,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  # Devise requires mailer
-  config.action_mailer.default_url_options = { host: ENV['HOST_NAME'], port: ENV['PORT'] }
-  config.action_mailer.asset_host = "http://#{ENV['HOST_NAME']}:#{ENV['PORT']}"
 end


### PR DESCRIPTION
**Why**

In order to send password reset emails from our AWS environment, we need to configure the application HOST and PORT settings correctly. This PR adds those values as configurable via environment variables.

**What Changed**

Setup production level config for devise mailing in production (or test, dev, etc). Copied the params from the dev configuration, but made them overridable through environment variables.

**Choices Made**

Justify changes made and any reasons for why a given path was taken, as opposed to an alternative option.

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additonal fixes.

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
