### PR TITLE
Make log level an ENV var for debugging purposes

### DIFF
--- a/dpc-web/config/environments/production.rb
+++ b/dpc-web/config/environments/production.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :warn
+  config.log_level = ENV["LOG_LEVEL"] || :warn
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
**Why**

We want to see more detailed logs sometimes. 

**What Changed**

Make Log level an ENV var so we can change it at will. Default to the standard prod level, :warn.


