### PR TITLE
DPC-627: Address NPE in malformed group resource

### DIFF
--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -742,7 +742,7 @@ curl -v https://sandbox.dpc.cms.gov/api/v1/Practitioner
   "identifier": [
     {
       "system": "http://hl7.org/fhir/sid/us-npi",
-      "value": "3116145044854423862"
+      "code": "3116145044854423862"
     }
   ],
   "address": [


### PR DESCRIPTION
**Why**

During the connectathon we ran into some issues with opaque error messages when trying to great a Group with an incorrect codeable concept.

Turns out, the documentation was incorrect which caused the confusion, but we needed to propagate the errors up from the attribution service.

**What Changed**

Split up the code parsing in the Group resource, so we can be a bit more detailed as to what's going on.

Improved our FHIRException handler to check to see if the thrown exception is a HAPI error, if so, we can pull the status and operation outcome from the object and send that along. This should really help improve our error handling and verbosity.

**Choices Made**

**Tickets closed**:

DPC-627

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
