### PR TITLE
Export endpoint now correctly returns 202 status

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -173,7 +173,7 @@ public class GroupResource extends AbstractGroupResource {
 
     /**
      * Begin export process for the given provider
-     * On success, returns a {@link org.eclipse.jetty.http.HttpStatus#NO_CONTENT_204} response with no content in the result.
+     * On success, returns a {@link org.eclipse.jetty.http.HttpStatus#ACCEPTED_202} response with no content in the result.
      * The `Content-Location` header contains the URI to call when checking job status. On failure, return an {@link OperationOutcome}.
      *
      * @param rosterID      {@link String} ID of provider to retrieve data for
@@ -194,7 +194,7 @@ public class GroupResource extends AbstractGroupResource {
     @ApiImplicitParams(
             @ApiImplicitParam(name = "Prefer", required = true, paramType = "header", value = "respond-async"))
     @ApiResponses(
-            @ApiResponse(code = 204, message = "Export request has started", responseHeaders = @ResponseHeader(name = "Content-Location", description = "URL to query job status", response = UUID.class))
+            @ApiResponse(code = 202, message = "Export request has started", responseHeaders = @ResponseHeader(name = "Content-Location", description = "URL to query job status", response = UUID.class))
     )
     public Response export(@ApiParam(hidden = true)
                            @Auth OrganizationPrincipal organizationPrincipal,
@@ -222,7 +222,7 @@ public class GroupResource extends AbstractGroupResource {
         final var resources = handleTypeQueryParam(resourceTypes);
         this.queue.submitJob(jobID, new JobModel(jobID, orgID, resources, rosterID, attributedPatients));
 
-        return Response.status(Response.Status.NO_CONTENT)
+        return Response.status(Response.Status.ACCEPTED)
                 .contentLocation(URI.create(this.baseURL + "/Jobs/" + jobID)).build();
     }
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
@@ -56,7 +56,7 @@ public class JobResource extends AbstractJobResource {
     @ExceptionMetered
     @ApiOperation(value = "Check export job status",
             notes = "This endpoint is used to query the status of a given Export operation. " +
-                    "When the job is in progress, the API returns a 204 status." +
+                    "When the job is in progress, the API returns a 202 status." +
                     "When completed, an output response is returned, which contains the necessary metadata for retrieving any output files.")
     @ApiResponses({
             @ApiResponse(code = 202, message = "Export job is in progress"),

--- a/dpc-api/src/test/java/gov/cms/dpc/api/FHIRSubmissionTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/FHIRSubmissionTest.java
@@ -89,7 +89,7 @@ class FHIRSubmissionTest {
         final Response response = target.request()
                 .accept(FHIR_JSON).header(PREFER_HEADER, PREFER_RESPOND_ASYNC)
                 .get();
-        assertAll(() -> assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus(), "Should have 204 status"),
+        assertAll(() -> assertEquals(HttpStatus.ACCEPTED_202, response.getStatus(), "Should have 202 status"),
                 () -> assertNotEquals("", response.getHeaderString("Content-Location"), "Should have content location"));
 
         // Check that the job is in progress
@@ -120,7 +120,7 @@ class FHIRSubmissionTest {
         final Response response = target.request()
                 .accept(FHIR_JSON).header(PREFER_HEADER, PREFER_RESPOND_ASYNC)
                 .get();
-        assertAll(() -> assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus(), "Should have 204 status"),
+        assertAll(() -> assertEquals(HttpStatus.ACCEPTED_202, response.getStatus(), "Should have 202 status"),
                 () -> assertNotEquals("", response.getHeaderString("Content-Location"), "Should have content location"));
 
         // Should yield a job with Patient and EOB resources
@@ -143,7 +143,7 @@ class FHIRSubmissionTest {
         final Response response = target.request()
                 .accept(FHIR_JSON).header(PREFER_HEADER, PREFER_RESPOND_ASYNC)
                 .get();
-        assertAll(() -> assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus(), "Should have 204 status"),
+        assertAll(() -> assertEquals(HttpStatus.ACCEPTED_202, response.getStatus(), "Should have 202 status"),
                 () -> assertNotEquals("", response.getHeaderString("Content-Location"), "Should have content location"));
 
         // Should yield a job with Patient and EOB resources
@@ -164,7 +164,7 @@ class FHIRSubmissionTest {
         final Response response = target.request()
                 .accept(FHIR_JSON).header(PREFER_HEADER, PREFER_RESPOND_ASYNC)
                 .get();
-        assertAll(() -> assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus(), "Should have 204 status"),
+        assertAll(() -> assertEquals(HttpStatus.ACCEPTED_202, response.getStatus(), "Should have 202 status"),
                 () -> assertNotEquals("", response.getHeaderString("Content-Location"), "Should have content location"));
 
         // Should yield a job with Patient and EOB resources
@@ -203,7 +203,7 @@ class FHIRSubmissionTest {
         final Response response = target.request()
                 .accept(FHIR_JSON).header(PREFER_HEADER, PREFER_RESPOND_ASYNC)
                 .get();
-        assertAll(() -> assertEquals(HttpStatus.NO_CONTENT_204, response.getStatus(), "Should have 204 status"),
+        assertAll(() -> assertEquals(HttpStatus.ACCEPTED_202, response.getStatus(), "Should have 202 status"),
                 () -> assertNotEquals("", response.getHeaderString("Content-Location"), "Should have content location"));
 
         // Should yield a job with all resource types

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "6e2079b2-1878-4fac-95da-fa78bcb4c00e",
+		"_postman_id": "d553e433-459a-485a-8055-62e7f93df565",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -548,8 +548,8 @@
 						"id": "5497fa12-aefd-44c2-9254-2beb51c52e31",
 						"exec": [
 							"// Status should be 204",
-							"pm.test(\"Status is 204\", function () {",
-							"    pm.response.to.have.status(204);",
+							"pm.test(\"Status is 202\", function () {",
+							"    pm.response.to.have.status(202);",
 							"});",
 							"",
 							"// Url for job response should be in content-location header.",


### PR DESCRIPTION
**Why**

When starting an export job, we were sending a 204 response, but it's actually supposed to be 202. 

**What Changed**

Small tweak to the response and tests. Also updated the test suite to pass and the docs as well.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
