### PR TITLE
Correct access token requirement on export response

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/models/JobCompletionModel.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/models/JobCompletionModel.java
@@ -67,7 +67,7 @@ public class JobCompletionModel {
      * The full request of the original request URL
      */
     private String request;
-    private final boolean requiresAccessToken = false;
+    private final boolean requiresAccessToken = true;
     private List<OutputEntry> output;
     private List<OutputEntry> error;
 


### PR DESCRIPTION
**Why**

We actually need an access token to retrieve the exported resources, so let's say so.

**What Changed**

Fixed the hard coded `false` value to be true.

**Choices Made**

It's still hard coded, because that's easy and will be mostly correct.

**Tickets closed**:

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
