### PR TITLE
Corrected Identifier value in Provider example

### DIFF
--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -742,7 +742,7 @@ curl -v https://sandbox.dpc.cms.gov/api/v1/Practitioner
   "identifier": [
     {
       "system": "http://hl7.org/fhir/sid/us-npi",
-      "code": "3116145044854423862"
+      "value": "3116145044854423862"
     }
   ],
   "address": [


### PR DESCRIPTION
**Why**

The `Provider.identifier` block was incorrect, the actual NPI should be in the `value` field, rather than `code`.

**What Changed**

Simple documentation change, the underlying code is correct.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated