### PR TITLE
As a CMS user, I want to tag users.

### DIFF
--- a/dpc-web/app/controllers/internal/taggings_controller.rb
+++ b/dpc-web/app/controllers/internal/taggings_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Internal
+  class TaggingsController < ApplicationController
+    before_action :authenticate_internal_user!
+
+    def create
+      @tagging = Tagging.new tagging_params
+      if @tagging.save
+        flash[:notice] = 'Tag added.'
+      else
+        flash[:alert] = "Tag could not be added. Errors:#{@tagging.errors.full_messages.join(', ')}"
+      end
+      redirect_to taggable_path
+    end
+
+    private
+
+    # Right now only users are taggable
+    def taggable_path
+      internal_user_path(id: tagging_params[:taggable_id])
+    end
+
+    def tagging_params
+      params.fetch(:tagging).permit(:tag_id, :taggable_id, :taggable_type)
+    end
+  end
+end

--- a/dpc-web/app/controllers/internal/taggings_controller.rb
+++ b/dpc-web/app/controllers/internal/taggings_controller.rb
@@ -11,14 +11,24 @@ module Internal
       else
         flash[:alert] = "Tag could not be added. Errors:#{@tagging.errors.full_messages.join(', ')}"
       end
-      redirect_to taggable_path
+      redirect_back(fallback_location: taggable_path)
+    end
+
+    def destroy
+      @tagging = Tagging.find(params[:id])
+      if @tagging.destroy
+        flash[:notice] = 'Tag removed.'
+      else
+        flash[:alert] = "Tag could not be removed. Errors:#{@tagging.errors.full_messages.join(', ')}"
+      end
+      redirect_back(fallback_location: taggable_path)
     end
 
     private
 
     # Right now only users are taggable
     def taggable_path
-      internal_user_path(id: tagging_params[:taggable_id])
+      internal_user_path(id: @tagging.taggable_id)
     end
 
     def tagging_params

--- a/dpc-web/app/controllers/internal/tags_controller.rb
+++ b/dpc-web/app/controllers/internal/tags_controller.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Internal
+  class TagsController < ApplicationController
+    before_action :authenticate_internal_user!
+
+    def index
+      @tags = Tag.all
+    end
+
+    def create
+      @tag = Tag.new tag_params
+      if @tag.save
+        flash[:notice] = 'Tag created.'
+      else
+        flash[:alert] = "Tag could not be created. Errors: #{@tag.errors.full_messages.join(', ')}"
+      end
+      redirect_to internal_tags_path
+    end
+
+    def destroy
+      @tag = Tag.find(params[:id])
+      if @tag.destroy
+        flash[:notice] = 'Tag deleted.'
+      else
+        flash[:alert] = "Tag could not be deleted. Errors:#{@tag.errors.full_messages.join(', ')}"
+      end
+      redirect_to internal_tags_path
+    end
+
+    private
+
+    def tag_params
+      params.fetch(:tag).permit(:name)
+    end
+  end
+end

--- a/dpc-web/app/helpers/internal/tags_helper.rb
+++ b/dpc-web/app/helpers/internal/tags_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Internal
+  module TagsHelper
+    def confirm_text(tag)
+      "Are you sure? #{tag.taggings.count} records have this tag."
+    end
+  end
+end

--- a/dpc-web/app/helpers/internal/users_helper.rb
+++ b/dpc-web/app/helpers/internal/users_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Internal
+  module UsersHelper
+    def available_tags(user)
+      Tag.where.not(id: user.tag_ids)
+    end
+  end
+end

--- a/dpc-web/app/models/tag.rb
+++ b/dpc-web/app/models/tag.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Tag < ApplicationRecord
+  has_many :taggings
+
+  validates :name, uniqueness: true
+end

--- a/dpc-web/app/models/tag.rb
+++ b/dpc-web/app/models/tag.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Tag < ApplicationRecord
-  has_many :taggings
+  has_many :taggings, dependent: :destroy
 
-  validates :name, uniqueness: true
+  validates :name, uniqueness: true, presence: true
 end

--- a/dpc-web/app/models/tagging.rb
+++ b/dpc-web/app/models/tagging.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Tagging < ApplicationRecord
+  belongs_to :tag
+  belongs_to :taggable, polymorphic: true
+
+  validates :tag, presence: true
+  validates :taggable, presence: true
+end

--- a/dpc-web/app/models/tagging.rb
+++ b/dpc-web/app/models/tagging.rb
@@ -6,4 +6,6 @@ class Tagging < ApplicationRecord
 
   validates :tag, presence: true
   validates :taggable, presence: true
+
+  delegate :name, to: :tag, prefix: true
 end

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -2,6 +2,9 @@
 
 class User < ApplicationRecord
   has_one :dpc_registration, inverse_of: :user
+  has_many :taggings, as: :taggable
+  has_many :tags, through: :taggings
+
   before_save :num_providers_to_zero_if_blank
 
   STATES = {

--- a/dpc-web/app/views/internal/tags/index.html.erb
+++ b/dpc-web/app/views/internal/tags/index.html.erb
@@ -1,0 +1,68 @@
+<% title "Manage Tags" %>
+
+
+<div class="ds-l-row">
+  <div class="ds-l-row--12 ds-l-md-col--3">
+    <ul class="ds-c-vertical-nav">
+      <li class="ds-c-vertical-nav__item">
+        <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label" %>
+      </li>
+      <li class="ds-c-vertical-nav__item">
+        <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label ds-c-vertical-nav__label--current" %>
+      </li>
+    </ul>
+  </div>
+
+  <div class="ds-l-row--12 ds-l-md-col--9 ds-u-padding-bottom--2">
+
+    <div class="ds-l-row">
+      <h2 class="ds-u-padding-x--2">Existing Tags</h2>
+      <p>
+        Gray tags indicate currently unused tags.
+        Blue tags are being used, and the number with the tag indicates the number of records with that tag.
+      </p>
+    </div>
+
+    <div class="ds-l-row">
+      <ul class="ds-c-list ds-c-list--bare">
+        <% @tags.each do |tag| %>
+          <li>
+            <% if tag.taggings.count == 0 %>
+
+              <span class="ds-c-badge">
+                <%= tag.name %>
+                <%= link_to(internal_tag_url(tag), method: :delete, data: {test: "delete-tag-#{tag.id}"}) do %>
+                  <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <use xlink:href="/assets/solid.svg#times"></use>
+                  </svg>
+                <% end %>
+              </span>
+
+            <% else %>
+
+              <span class="ds-c-badge ds-u-fill--primary-alt">
+                <%= tag.name %> - <%= tag.taggings.count %>
+
+                <%= link_to(internal_tag_url(tag), method: :delete, data: { confirm: confirm_text(tag), test: "delete-tag-#{tag.id}" }) do %>
+                  <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <use xlink:href="/assets/solid.svg#times"></use>
+                  </svg>
+                <% end %>
+              </span>
+
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <div class="ds-l-row ds-u-margin-y--3 ds-u-border--1 ds-u-radius">
+      <%= form_for Tag.new, url: internal_tags_path, html: { method: :post } do |f| %>
+        <%= f.label :name, "New tag", class: "ds-c-label ds-u-margin-top--0" %>
+        <%= f.text_field :name, class: "ds-c-field" %>
+        <%= f.submit "Create", data: { test: "add-tag-submit" } %>
+      <% end %>
+    </div>
+  </div>
+</div>
+

--- a/dpc-web/app/views/internal/users/index.html.erb
+++ b/dpc-web/app/views/internal/users/index.html.erb
@@ -51,6 +51,14 @@
                 <%= link_to user.name, internal_user_path(user) %>
               </div>
 
+              <div class="ds-u-padding-y--1">
+                <% user.taggings.each do |tagging| %>
+                  <span class="ds-c-badge ds-u-fill--primary-alt">
+                    <%= tagging.tag_name %>
+                  </span>
+                <% end %>
+              </div>
+
               <div class="ds-u-align-items--end ds-u-font-style--italic">
                 Signed up: <%= user.created_at %>
               </div>

--- a/dpc-web/app/views/internal/users/index.html.erb
+++ b/dpc-web/app/views/internal/users/index.html.erb
@@ -2,6 +2,14 @@
 
 <div class="ds-l-row">
   <div class="ds-l-row--12 ds-l-md-col--3">
+    <ul class="ds-c-vertical-nav">
+      <li class="ds-c-vertical-nav__item">
+        <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label ds-c-vertical-nav__label--current" %>
+      </li>
+      <li class="ds-c-vertical-nav__item">
+        <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label" %>
+      </li>
+    </ul>
   </div>
 
   <div class="ds-l-row--12 ds-l-md-col--9">

--- a/dpc-web/app/views/internal/users/show.html.erb
+++ b/dpc-web/app/views/internal/users/show.html.erb
@@ -13,11 +13,19 @@
   </div>
 
   <div class="ds-l-row--12" data-test="user-tags">
-    <% if @user.tags.count == 0 %>
+    <% if @user.taggings.count == 0 %>
       <p>No tags</p>
     <% else %>
-      <% @user.tags.each do |tag| %>
-        <span class="ds-c-badge"><%= tag.name %></span>
+      <% @user.taggings.each do |tagging| %>
+        <span class="ds-c-badge ds-u-fill--primary-alt">
+          <%= tagging.tag_name %>
+
+          <%= link_to(internal_tagging_url(tagging), method: :delete, data: {test: "delete-tag-#{tagging.id}"}) do %>
+            <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <use xlink:href="/assets/solid.svg#times"></use>
+            </svg>
+          <% end %>
+        </span>
       <% end %>
     <% end %>
   </div>

--- a/dpc-web/app/views/internal/users/show.html.erb
+++ b/dpc-web/app/views/internal/users/show.html.erb
@@ -9,6 +9,32 @@
 
 <section class="ds-l-container ds-u-border--1 ds-u-radius">
   <div class="ds-l-row">
+    <h2 class="ds-u-padding-x--2">Tags</h2>
+  </div>
+
+  <div class="ds-l-row--12" data-test="user-tags">
+    <% if @user.tags.count == 0 %>
+      <p>No tags</p>
+    <% else %>
+      <% @user.tags.each do |tag| %>
+        <span class="ds-c-badge"><%= tag.name %></span>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div class="ds-l-row--12">
+    <%= form_for Tagging.new, url: internal_taggings_path, html: { method: :post } do |f| %>
+      <%= f.label :tag_id, "New tag", class: "ds-c-label ds-u-margin-top--0" %>
+      <%= f.collection_select :tag_id, available_tags(@user), :id, :name, { include_blank: true }, class: "ds-c-field" %>
+      <%= f.hidden_field :taggable_id, value: @user.id %>
+      <%= f.hidden_field :taggable_type, value: 'User' %>
+      <%= f.submit "Add tag", data: { test: "add-tag-submit" } %>
+    <% end %>
+  </div>
+</section>
+
+<section class="ds-l-container ds-u-border--1 ds-u-radius">
+  <div class="ds-l-row">
     <h2 class="ds-u-padding-x--2">Signup info</h2>
   </div>
 

--- a/dpc-web/app/views/shared/_alerts.html.erb
+++ b/dpc-web/app/views/shared/_alerts.html.erb
@@ -1,5 +1,5 @@
 <% if notice %>
-  <div class="ds-c-alert ds-u-margin-bottom--5"">
+  <div class="ds-c-alert"">
     <div class="ds-c-alert__body">
       <h3 class="ds-c-alert__heading"><%= notice %></h3>
     </div>
@@ -7,7 +7,7 @@
 <% end %>
 
 <% if alert %>
-  <div class="ds-c-alert ds-c-alert--error ds-u-margin-bottom--5"">
+  <div class="ds-c-alert ds-c-alert--error"">
     <div class="ds-c-alert__body">
       <h3 class="ds-c-alert__heading"><%= alert %></h3>
     </div>

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   namespace 'internal' do
     resources :users, only: [:index, :show, :edit, :update]
     resources :taggings, only: [:create, :destroy]
+    resources :tags, only: [:index, :create, :destroy]
   end
 
   authenticated :user do

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
 
   namespace 'internal' do
     resources :users, only: [:index, :show, :edit, :update]
-    resources :taggings, only: [:create]
+    resources :taggings, only: [:create, :destroy]
   end
 
   authenticated :user do

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   namespace 'internal' do
     resources :users, only: [:index, :show, :edit, :update]
+    resources :taggings, only: [:create]
   end
 
   authenticated :user do

--- a/dpc-web/db/migrate/20190916190939_create_tags.rb
+++ b/dpc-web/db/migrate/20190916190939_create_tags.rb
@@ -1,0 +1,15 @@
+class CreateTags < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tags do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    create_table :taggings do |t|
+      t.integer :tag_id
+      t.references :taggable, polymorphic: true
+      t.timestamps
+    end
+  end
+end

--- a/dpc-web/db/schema.rb
+++ b/dpc-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_11_175348) do
+ActiveRecord::Schema.define(version: 2019_09_16_190939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,21 @@ ActiveRecord::Schema.define(version: 2019_09_11_175348) do
     t.string "name"
     t.string "github_nickname"
     t.index ["uid", "provider"], name: "index_internal_users_on_uid_and_provider", unique: true
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.bigint "taggable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/dpc-web/spec/controllers/internal/taggings_controller_spec.rb
+++ b/dpc-web/spec/controllers/internal/taggings_controller_spec.rb
@@ -59,4 +59,19 @@ RSpec.describe Internal::TaggingsController, type: :controller do
       end
     end
   end
+
+  describe '#destroy' do
+    let!(:internal_user) { create(:internal_user) }
+
+    context 'authenticated internal user' do
+      before(:each) do
+        sign_in internal_user, scope: :internal_user
+      end
+
+      it 'destroys the tagging' do
+        tagging = create(:tagging)
+        expect { delete :destroy, params: { id: tagging.id } }.to change(Tagging, :count).by(-1)
+      end
+    end
+  end
 end

--- a/dpc-web/spec/controllers/internal/taggings_controller_spec.rb
+++ b/dpc-web/spec/controllers/internal/taggings_controller_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe Internal::TaggingsController, type: :controller do
   describe '#destroy' do
     let!(:internal_user) { create(:internal_user) }
 
+    it_behaves_like 'an internal user authenticable controller action', :delete, :destroy, :tagging
+
     context 'authenticated internal user' do
       before(:each) do
         sign_in internal_user, scope: :internal_user

--- a/dpc-web/spec/controllers/internal/taggings_controller_spec.rb
+++ b/dpc-web/spec/controllers/internal/taggings_controller_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require './spec/shared_examples/internal_user_authenticable_controller'
+
+RSpec.describe Internal::TaggingsController, type: :controller do
+  describe '#create' do
+    let!(:internal_user) { create(:internal_user) }
+    let(:tag) { create(:tag) }
+    let(:user) { create(:user) }
+
+    context 'authenticated internal user' do
+      before(:each) do
+        sign_in internal_user, scope: :internal_user
+      end
+
+      context 'valid params' do
+        it 'creates a Tagging' do
+          expect do
+            post :create, params: { tagging: { tag_id: tag.id, taggable_id: user.id, taggable_type: 'User' } }
+          end.to change(Tagging, :count).by(1)
+        end
+
+        it 'redirects to user path' do
+          post :create, params: { tagging: { tag_id: tag.id, taggable_id: user.id, taggable_type: 'User' } }
+          expect(response.location).to include(internal_user_path(id: user.id))
+        end
+      end
+
+      context 'invalid params' do
+        it 'does not create a Tagging' do
+          expect do
+            post :create, params: { tagging: { tag_id: nil, taggable_id: user.id, taggable_type: 'User' } }
+          end.to change(Tagging, :count).by(0)
+        end
+
+        it 'redirects to user path' do
+          post :create, params: { tagging: { tag_id: nil, taggable_id: user.id, taggable_type: 'User' } }
+          expect(response.location).to include(internal_user_path(id: user.id))
+        end
+      end
+    end
+
+    context 'unauthenticated internal user' do
+      before(:each) do
+        logout(:internal_user)
+      end
+
+      it 'does not create a Tagging' do
+        expect do
+          post :create, params: { tagging: { tag_id: tag.id, taggable_id: user.id, taggable_type: 'User' } }
+        end.to change(Tagging, :count).by(0)
+      end
+
+      it 'redirects to new session path' do
+        post :create, params: { tagging: { tag_id: tag.id, taggable_id: user.id, taggable_type: 'User' } }
+        expect(response.location).to include(new_internal_user_session_path)
+      end
+    end
+  end
+end

--- a/dpc-web/spec/controllers/internal/tags_controller_spec.rb
+++ b/dpc-web/spec/controllers/internal/tags_controller_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require './spec/shared_examples/internal_user_authenticable_controller'
+
+RSpec.describe Internal::TagsController, type: :controller do
+  describe '#index' do
+    it_behaves_like 'an internal user authenticable controller action', :get, :index
+  end
+
+  describe '#create' do
+    let!(:internal_user) { create(:internal_user) }
+
+    context 'authenticated internal user' do
+      before(:each) do
+        sign_in internal_user, scope: :internal_user
+      end
+
+      context 'valid params' do
+        it 'creates a Tag' do
+          expect do
+            post :create, params: { tag: { name: 'Live' } }
+          end.to change(Tag, :count).by(1)
+        end
+
+        it 'redirects to tags path' do
+          post :create, params: { tag: { name: 'Live' } }
+          expect(response.location).to include(internal_tags_path)
+        end
+      end
+
+      context 'invalid params' do
+        it 'does not create a Tag' do
+          expect do
+            post :create, params: { tag: { name: '' } }
+          end.to change(Tagging, :count).by(0)
+        end
+
+        it 'redirects to tags path' do
+          post :create, params: { tag: { name: '' } }
+          expect(response.location).to include(internal_tags_path)
+        end
+      end
+    end
+
+    context 'unauthenticated internal user' do
+      before(:each) do
+        logout(:internal_user)
+      end
+
+      it 'does not create a Tag' do
+        expect do
+          post :create, params: { tag: { name: 'Live' } }
+        end.to change(Tagging, :count).by(0)
+      end
+
+      it 'redirects to new session path' do
+        post :create, params: { tag: { name: 'Live' } }
+        expect(response.location).to include(new_internal_user_session_path)
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let!(:internal_user) { create(:internal_user) }
+
+    it_behaves_like 'an internal user authenticable controller action', :delete, :destroy, :tag
+
+    context 'authenticated internal user' do
+      before(:each) do
+        sign_in internal_user, scope: :internal_user
+      end
+
+      it 'destroys the tag' do
+        tag = create(:tag)
+        expect { delete :destroy, params: { id: tag.id } }.to change(Tag, :count).by(-1)
+      end
+    end
+  end
+end

--- a/dpc-web/spec/factories/taggings.rb
+++ b/dpc-web/spec/factories/taggings.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tagging do
+    tag { create(:tag) }
+    taggable { create(:user) }
+  end
+end

--- a/dpc-web/spec/factories/tags.rb
+++ b/dpc-web/spec/factories/tags.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :tag do
+    sequence(:name) { |n| "MyTag-#{n}" }
+  end
+end

--- a/dpc-web/spec/features/authentication/internal_user_sign_in_spec.rb
+++ b/dpc-web/spec/features/authentication/internal_user_sign_in_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.feature 'internal user signs in' do
   around do |example|
     OmniAuth.config.test_mode = true

--- a/dpc-web/spec/features/authentication/user_resets_password_spec.rb
+++ b/dpc-web/spec/features/authentication/user_resets_password_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.feature 'user resets password' do
   let(:user) { create :user }
 

--- a/dpc-web/spec/features/authentication/user_sign_in_spec.rb
+++ b/dpc-web/spec/features/authentication/user_sign_in_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.feature 'user signs in' do
   let!(:user) { create :user, password: '123456', password_confirmation: '123456' }
   let!(:dpc_registration) { create :dpc_registration, user: user }

--- a/dpc-web/spec/features/internal/user_management/searching_and_filtering_users_spec.rb
+++ b/dpc-web/spec/features/internal/user_management/searching_and_filtering_users_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.feature 'searching and filtering users' do
   let!(:internal_user) { create :internal_user }
 

--- a/dpc-web/spec/features/internal/user_management/updating_users_spec.rb
+++ b/dpc-web/spec/features/internal/user_management/updating_users_spec.rb
@@ -42,10 +42,10 @@ RSpec.feature 'updating users' do
     expect(page).to have_css('[data-test="user-form-submit"]')
   end
 
-  scenario 'adding tags to a user' do
+  scenario 'adding and removing tags from a user' do
     crabby = create(:user, first_name: 'Crab', last_name: 'Olsen', email: 'co@beach.com')
 
-    create(:tag, name: 'Red')
+    red_tag = create(:tag, name: 'Red')
     create(:tag, name: 'Yellow')
 
     visit internal_user_path(crabby)
@@ -66,6 +66,12 @@ RSpec.feature 'updating users' do
 
     within('[data-test="user-tags"]') do
       expect(page).to have_content('Red')
+      expect(page).to have_content('Yellow')
+    end
+
+    find("[data-test=\"delete-tag-#{red_tag.id}\"]").click
+
+    within('[data-test="user-tags"]') do
       expect(page).to have_content('Yellow')
     end
   end

--- a/dpc-web/spec/features/internal/user_management/updating_users_spec.rb
+++ b/dpc-web/spec/features/internal/user_management/updating_users_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature 'searching and filtering users' do
+RSpec.feature 'updating users' do
   let!(:internal_user) { create :internal_user }
 
   before(:each) do
@@ -40,5 +40,33 @@ RSpec.feature 'searching and filtering users' do
 
     # Still on edit page
     expect(page).to have_css('[data-test="user-form-submit"]')
+  end
+
+  scenario 'adding tags to a user' do
+    crabby = create(:user, first_name: 'Crab', last_name: 'Olsen', email: 'co@beach.com')
+
+    create(:tag, name: 'Red')
+    create(:tag, name: 'Yellow')
+
+    visit internal_user_path(crabby)
+
+    within('[data-test="user-tags"]') do
+      expect(page).to have_content('No tags')
+    end
+
+    select 'Red', from: 'tagging_tag_id'
+    find('[data-test="add-tag-submit"]').click
+
+    within('[data-test="user-tags"]') do
+      expect(page).to have_content('Red')
+    end
+
+    select 'Yellow', from: 'tagging_tag_id'
+    find('[data-test="add-tag-submit"]').click
+
+    within('[data-test="user-tags"]') do
+      expect(page).to have_content('Red')
+      expect(page).to have_content('Yellow')
+    end
   end
 end

--- a/dpc-web/spec/features/internal/user_management/updating_users_spec.rb
+++ b/dpc-web/spec/features/internal/user_management/updating_users_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.feature 'updating users' do
   let!(:internal_user) { create :internal_user }
 
@@ -69,7 +71,8 @@ RSpec.feature 'updating users' do
       expect(page).to have_content('Yellow')
     end
 
-    find("[data-test=\"delete-tag-#{red_tag.id}\"]").click
+    tagging = crabby.taggings.find_by(tag_id: red_tag.id)
+    find("[data-test=\"delete-tag-#{tagging.id}\"]").click
 
     within('[data-test="user-tags"]') do
       expect(page).to have_content('Yellow')

--- a/dpc-web/spec/features/registration/new_user_signs_up_for_account_spec.rb
+++ b/dpc-web/spec/features/registration/new_user_signs_up_for_account_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+
 RSpec.feature 'new user signs up for account' do
   let(:user) { build :user }
 

--- a/dpc-web/spec/helpers/internal/tags_helper_spec.rb
+++ b/dpc-web/spec/helpers/internal/tags_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Internal::TagsHelper. For example:
+#
+# describe Internal::TagsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Internal::TagsHelper, type: :helper do
+  describe '#confirm_text' do
+    it 'uses tagging number with confirm text' do
+      tag = create(:tag)
+      create_list(:tagging, 2, tag: tag)
+      expect(helper.confirm_text(tag)).to eq('Are you sure? 2 records have this tag.')
+    end
+  end
+end

--- a/dpc-web/spec/helpers/internal/users_helper_spec.rb
+++ b/dpc-web/spec/helpers/internal/users_helper_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PagesHelper. For example:
+#
+# describe PagesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+
+RSpec.describe Internal::UsersHelper, type: :helper do
+  describe '#available_tags' do
+    it 'only shows tags that the user does not have' do
+      user = create(:user)
+      tag = create(:tag)
+      user.tags << tag
+
+      available_tag = create(:tag)
+
+      expect(helper.available_tags(user)).to match_array([available_tag])
+    end
+  end
+end

--- a/dpc-web/spec/models/tag_spec.rb
+++ b/dpc-web/spec/models/tag_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  subject { create :tag }
+
+  describe 'factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'validations' do
+    it 'requires a unique name' do
+      create(:tag, name: 'Same')
+      tag = build(:tag, name: 'Same')
+      expect(tag).not_to be_valid
+    end
+  end
+end

--- a/dpc-web/spec/models/tag_spec.rb
+++ b/dpc-web/spec/models/tag_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Tag, type: :model do
   end
 
   describe 'validations' do
+    it 'requires a name' do
+      subject.name = nil
+      expect(subject).not_to be_valid
+    end
+
     it 'requires a unique name' do
       create(:tag, name: 'Same')
       tag = build(:tag, name: 'Same')

--- a/dpc-web/spec/models/tagging_spec.rb
+++ b/dpc-web/spec/models/tagging_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Tagging, type: :model do
+  subject { create :tagging }
+
+  describe 'factory' do
+    it { is_expected.to be_valid }
+  end
+
+  describe 'validations' do
+    it 'requires a tag' do
+      subject.tag = nil
+      expect(subject).not_to be_valid
+    end
+
+    it 'requires a taggable' do
+      subject.taggable = nil
+      expect(subject).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
**Why**

We want to use tags to help internal users manage users.

**What Changed**

Add tags to the user page so that an internal user can see and add tags to the user. Also add UI for creating tags themselves so that the internal user adds a tag before they can tag the user with that tag (eventually we probably want to change this UI but this was the fastest for now).

Managing tags:
<img width="1118" alt="Screen Shot 2019-09-17 at 12 24 11 PM" src="https://user-images.githubusercontent.com/54290681/65061479-010cce80-d948-11e9-8156-a05055703857.png">

When you try to delete a tag that is being used:
<img width="1109" alt="Screen Shot 2019-09-17 at 12 25 51 PM" src="https://user-images.githubusercontent.com/54290681/65061480-010cce80-d948-11e9-8b4f-8e9565e6adf0.png">

Adding tags to a user:
<img width="1115" alt="Screen Shot 2019-09-17 at 11 37 49 AM" src="https://user-images.githubusercontent.com/54290681/65061543-28639b80-d948-11e9-8693-a82f5c0b5d11.png">

Tags visible from the index page:
<img width="1095" alt="Screen Shot 2019-09-17 at 1 26 20 PM" src="https://user-images.githubusercontent.com/54290681/65064640-de31e880-d94e-11e9-8c02-4aa0e0f002b7.png">


**Choices Made**

I made this a polymorphic association with a `has_many: :through` association, so that we can use tags for organizations, vendors, etc, eventually rather than creating separate tables for those taggings. This architecture is more extensible and DRYer. 

**Tickets closed**:

Part of DPC-510

**Future Work**

- Improve UI
- Add filtering on users#index by tag