### PR TITLE
DPC-626: Refactor Validator injection to avoid multi-threading issues

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/dropwizard/FHIRValidationModule.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/dropwizard/FHIRValidationModule.java
@@ -1,16 +1,15 @@
 package gov.cms.dpc.fhir.validations.dropwizard;
 
 import ca.uhn.fhir.validation.FhirValidator;
-import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
-import com.google.inject.Scopes;
-import com.google.inject.TypeLiteral;
+import com.google.inject.*;
 import com.google.inject.multibindings.Multibinder;
 import gov.cms.dpc.fhir.configuration.DPCFHIRConfiguration.FHIRValidationConfiguration;
 import gov.cms.dpc.fhir.dropwizard.handlers.FHIRValidationExceptionHandler;
 import gov.cms.dpc.fhir.validations.DPCProfileSupport;
 import gov.cms.dpc.fhir.validations.ProfileValidator;
 import org.glassfish.jersey.server.internal.inject.ConfiguredValidator;
+import org.hl7.fhir.dstu3.hapi.ctx.DefaultProfileValidationSupport;
+import org.hl7.fhir.dstu3.hapi.validation.ValidationSupportChain;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorFactory;
@@ -32,7 +31,7 @@ public class FHIRValidationModule extends AbstractModule {
     @Override
     protected void configure() {
 
-        // Create a multibinder for automatically bundling and injecting a Set of ConstraintValidators
+        // Create a multi-binder for automatically bundling and injecting a Set of ConstraintValidators
         TypeLiteral<ConstraintValidator<?, ?>> constraintType = new TypeLiteral<>() {
         };
         Multibinder<ConstraintValidator<?, ?>> constraintBinder = Multibinder.newSetBinder(binder(), constraintType);
@@ -45,7 +44,7 @@ public class FHIRValidationModule extends AbstractModule {
         bind(FHIRValidationExceptionHandler.class);
 
         bind(DPCProfileSupport.class).asEagerSingleton();
-        bind(FhirValidator.class).toProvider(FHIRValidatorProvider.class).asEagerSingleton();
+        bind(FhirValidator.class).toProvider(FHIRValidatorProvider.class);
     }
 
     @Provides
@@ -56,5 +55,11 @@ public class FHIRValidationModule extends AbstractModule {
     @Provides
     Validator provideValidator(ValidatorFactory factory) {
         return factory.getValidator();
+    }
+
+    @Provides
+    @Singleton
+    ValidationSupportChain provideSupportChain(DPCProfileSupport dpcModule) {
+        return new ValidationSupportChain(new DefaultProfileValidationSupport(), dpcModule);
     }
 }


### PR DESCRIPTION
**Why**

During the FHIR Connectathon we ran into an issue where incorrect profiles were being applied to resources, for seemingly no reason.

Turns out, we can't inject the FHIRValidator as a singleton, because it's not thread-safe. That means we need a new `FhirInstanceValidator` per invocation.

**What Changed**

Removed the `Singleton` scope from the `FHIRValidatorProfile` class, which solves the threading issue. Unfortunately, that breaks our cache priming so the first couple of invocations are incredibly slow.

Added a hacky double lock-checking process in the provider constructor to prime the cache, but only once.

**Choices Made**

Justify changes made and any reasons for why a given path was taken, as opposed to an alternative option.

**Tickets closed**:

DPC-626

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
