### PR TITLE
DPC-562: Update docker entrypoint to download S3 config files

### DIFF
--- a/dpc-aggregation/docker/entrypoint.sh
+++ b/dpc-aggregation/docker/entrypoint.sh
@@ -21,7 +21,7 @@ else
 fi
 
 if [ -n "$BOOTSTRAP" ]; then
-  echo "hello"
+  echo "Bootstrapping image from S3"
   bootstrap_config
 fi
 

--- a/dpc-aggregation/docker/entrypoint.sh
+++ b/dpc-aggregation/docker/entrypoint.sh
@@ -2,10 +2,27 @@
 
 set -e
 
+bootstrap_config() {
+  # Install the AWS CLI
+  apt-get update
+  apt-get -y install awscli
+
+  # Create the config directory
+  mkdir -p /config
+
+  # Sync the aws bucket
+  aws s3 sync s3://dpc-${ENV}-app-config/ config/
+}
+
 if [ -n "$JACOCO" ]; then
   JACOCO="-javaagent:/org.jacoco.agent-runtime.jar=destfile=/jacoco-report/jacoco-it.exec"
 else
   JACOCO=""
+fi
+
+if [ -n "$BOOTSTRAP" ]; then
+  echo "hello"
+  bootstrap_config
 fi
 
 CMDLINE="java ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.aggregation.DPCAggregationService"


### PR DESCRIPTION
**Why**

Now that we have private keys and certs that need to be setup for connecting to the BB backends, we need the containers to be able to grab the files from S3 on startup.

**What Changed**

Updated the Docker entrypoint to install the AWSCLI and sync the S3 config bucket on startup. This is behind the BOOTSTRAP environment variable, so it should only run when running in AWS.

**Choices Made**

Rather than rebasing our Docker image onto something with the cli already installed, we just grab it on startup each time. It should only had a half a minute or so to the startup time, and we can always optimize later.

**Tickets closed**:

**Future Work**

Ongoing work as part of DPC-560

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
