### PR TITLE
DPC-654 - As an internal user I want to manage organizations.

### DIFF
--- a/dpc-web/app/controllers/internal/organizations_controller.rb
+++ b/dpc-web/app/controllers/internal/organizations_controller.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module Internal
+  class OrganizationsController < ApplicationController
+    before_action :authenticate_internal_user!
+
+    def index
+      scope = Organization.all
+
+      if params[:keyword].present?
+        keyword = "%#{params[:keyword].downcase}%"
+        scope = scope.where(
+          'LOWER(name) LIKE :keyword', keyword: keyword
+        )
+      end
+
+      @organizations = scope.page params[:page]
+    end
+
+    def new
+      @organization = Organization.new
+    end
+
+    def create
+      @organization = Organization.new organization_params
+      if @organization.save
+        flash[:notice] = 'Organization created.'
+      else
+        flash[:alert] = "Organization could not be created: #{@organization.errors.full_messages.join(', ')}"
+      end
+      redirect_to index
+    end
+
+    def show
+      @organization = Organization.find params[:id]
+    end
+
+    def edit
+      @organization = Organization.find params[:id]
+    end
+
+    def update
+      @organization = Organization.find params[:id]
+      if @organization.update organization_params
+        flash[:notice] = 'Organization updated.'
+        redirect_to internal_organization_path(@organization)
+      else
+        flash[:alert] = "Organization could not be updated: #{@organization.errors.full_messages.join(', ')}"
+        render :edit
+      end
+    end
+
+    def destroy
+      @organization = Organization.find params[:id]
+      if @organization.update organization_params
+        flash[:notice] = 'Organization deleted.'
+        redirect_to index
+      else
+        flash[:alert] = "Organization could not be deleted: #{@organization.errors.full_messages.join(', ')}"
+        redirect_to internal_organization_path(@organization)
+      end
+    end
+
+    private
+
+    def organization_params
+      params.fetch(:organization).permit(:name, :organization_type)
+    end
+  end
+end

--- a/dpc-web/app/controllers/internal/organizations_controller.rb
+++ b/dpc-web/app/controllers/internal/organizations_controller.rb
@@ -54,19 +54,22 @@ module Internal
 
     def destroy
       @organization = Organization.find params[:id]
-      if @organization.update organization_params
+      if @organization.destroy
         flash[:notice] = 'Organization deleted.'
-        redirect_to index
+        redirect_to internal_organizations_path
       else
         flash[:alert] = "Organization could not be deleted: #{@organization.errors.full_messages.join(', ')}"
-        redirect_to internal_organization_path(@organization)
+        redirect_to internal_organizations_path
       end
     end
 
     private
 
     def organization_params
-      params.fetch(:organization).permit(:name, :organization_type, address_attributes: [:id, :street, :street_2, :city, :state, :zip])
+      params.fetch(:organization).permit(
+        :name, :organization_type, :num_providers,
+        address_attributes: %i[id street street_2 city state zip]
+      )
     end
   end
 end

--- a/dpc-web/app/controllers/internal/organizations_controller.rb
+++ b/dpc-web/app/controllers/internal/organizations_controller.rb
@@ -19,6 +19,7 @@ module Internal
 
     def new
       @organization = Organization.new
+      @organization.build_address
     end
 
     def create
@@ -65,7 +66,7 @@ module Internal
     private
 
     def organization_params
-      params.fetch(:organization).permit(:name, :organization_type)
+      params.fetch(:organization).permit(:name, :organization_type, address_attributes: [:id, :street, :street_2, :city, :state, :zip])
     end
   end
 end

--- a/dpc-web/app/controllers/internal/organizations_controller.rb
+++ b/dpc-web/app/controllers/internal/organizations_controller.rb
@@ -59,7 +59,7 @@ module Internal
         redirect_to internal_organizations_path
       else
         flash[:alert] = "Organization could not be deleted: #{@organization.errors.full_messages.join(', ')}"
-        redirect_to internal_organizations_path
+        redirect_to internal_organization_path(@organization)
       end
     end
 

--- a/dpc-web/app/controllers/internal/organizations_controller.rb
+++ b/dpc-web/app/controllers/internal/organizations_controller.rb
@@ -25,10 +25,11 @@ module Internal
       @organization = Organization.new organization_params
       if @organization.save
         flash[:notice] = 'Organization created.'
+        redirect_to internal_organization_path(@organization)
       else
         flash[:alert] = "Organization could not be created: #{@organization.errors.full_messages.join(', ')}"
+        render :new
       end
-      redirect_to index
     end
 
     def show

--- a/dpc-web/app/helpers/address_helper.rb
+++ b/dpc-web/app/helpers/address_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module AddressHelper
+  def states_for_select
+    Address::STATES.map { |abbrv, name| [name, abbrv.to_s] }
+  end
+end

--- a/dpc-web/app/helpers/application_helper.rb
+++ b/dpc-web/app/helpers/application_helper.rb
@@ -21,6 +21,10 @@ module ApplicationHelper
     ''
   end
 
+  def current_sidenav_class?(nav_item, current)
+    'ds-c-vertical-nav__label--current' if nav_item == current
+  end
+
   def meta_tag(tag, text)
     content_for :"meta_#{tag}", text
   end
@@ -31,5 +35,9 @@ module ApplicationHelper
 
   def tabs_set(tabs_set)
     content_for(:tabs_set) { tabs_set }
+  end
+
+  def internal_page?
+    request.path[0..9] == '/internal/'
   end
 end

--- a/dpc-web/app/helpers/organizations_helper.rb
+++ b/dpc-web/app/helpers/organizations_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module OrganizationsHelper
+  def organization_types_for_select
+    Organization.organization_types.keys.map do |key|
+      [key.to_s.titleize, key]
+    end
+  end
+end

--- a/dpc-web/app/models/address.rb
+++ b/dpc-web/app/models/address.rb
@@ -1,4 +1,25 @@
 # frozen_string_literal: true
 
 class Address < ApplicationRecord
+  STATES = {
+    AK: 'Alaska', AL: 'Alabama', AR: 'Arkansas', AZ: 'Arizona',
+    CA: 'California', CO: 'Colorado', CT: 'Connecticut',
+    DC: 'District of Columbia', DE: 'Delaware', FL: 'Florida',
+    GA: 'Georgia', HI: 'Hawaii', IA: 'Iowa', ID: 'Idaho',
+    IL: 'Illinois', IN: 'Indiana', KS: 'Kansas', KY: 'Kentucky',
+    LA: 'Louisiana', MA: 'Massachusetts', MD: 'Maryland', ME: 'Maine',
+    MI: 'Michigan', MN: 'Minnesota', MO: 'Missouri', MS: 'Mississippi',
+    MT: 'Montana', NC: 'North Carolina', ND: 'North Dakota',
+    NE: 'Nebraska', NH: 'New Hampshire', NJ: 'New Jersey',
+    NM: 'New Mexico', NV: 'Nevada', NY: 'New York', OH: 'Ohio',
+    OK: 'Oklahoma', OR: 'Oregon', PA: 'Pennsylvania', RI: 'Rhode Island',
+    SC: 'South Carolina', SD: 'South Dakota', TN: 'Tennessee', TX: 'Texas',
+    UT: 'Utah', VA: 'Virginia', VT: 'Vermont', WA: 'Washington',
+    WI: 'Wisconsin', WV: 'West Virginia', WY: 'Wyoming', AS: 'American Samoa',
+    GU: 'Guam', PR: 'Puerto Rico', VI: 'Virgin Islands'
+  }.freeze
+
+  validates_presence_of :street, :city, :state, :zip
+  validates :state, inclusion: { in: STATES.keys.map(&:to_s) }
+  validates :zip, format: { with: /\A\d{5}(?:\-\d{4})?\z/ }
 end

--- a/dpc-web/app/models/address.rb
+++ b/dpc-web/app/models/address.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-module RegistrationsHelper
+class Address < ApplicationRecord
 end

--- a/dpc-web/app/models/concerns/organization_typable.rb
+++ b/dpc-web/app/models/concerns/organization_typable.rb
@@ -1,0 +1,21 @@
+require "active_support/concern"
+
+module OrganizationTypable
+  extend ActiveSupport::Concern
+
+  included do
+    enum organization_type: {
+      'primary_care_clinic' => 0,
+      'speciality_clinic' => 1,
+      'multispecialty_clinic' => 2,
+      'inpatient_facility' => 3,
+      'emergency_room' => 4,
+      'urgent_care' => 5,
+      'academic_facility' => 6,
+      'health_it_vendor' => 7,
+      'other' => 8
+    }
+
+    validates :organization_type, inclusion: { in: organization_types.keys }
+  end
+end

--- a/dpc-web/app/models/concerns/organization_typable.rb
+++ b/dpc-web/app/models/concerns/organization_typable.rb
@@ -1,4 +1,6 @@
-require "active_support/concern"
+# frozen_string_literal: true
+
+require 'active_support/concern'
 
 module OrganizationTypable
   extend ActiveSupport::Concern

--- a/dpc-web/app/models/organization.rb
+++ b/dpc-web/app/models/organization.rb
@@ -3,7 +3,12 @@
 class Organization < ApplicationRecord
   include OrganizationTypable
 
+  has_one :address, as: :addressable
+
   validates :name, uniqueness: true, presence: true
+
+  delegate :street, :street_2, :city, :state, :zip, to: :address, allow_nil: true, prefix: true
+  accepts_nested_attributes_for :address
 
   def num_providers=(input)
     if input.blank?

--- a/dpc-web/app/models/organization.rb
+++ b/dpc-web/app/models/organization.rb
@@ -9,10 +9,4 @@ class Organization < ApplicationRecord
 
   delegate :street, :street_2, :city, :state, :zip, to: :address, allow_nil: true, prefix: true
   accepts_nested_attributes_for :address
-
-  def num_providers=(input)
-    if input.blank?
-      self[:num_providers] = 0
-    end
-  end
 end

--- a/dpc-web/app/models/organization.rb
+++ b/dpc-web/app/models/organization.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Organization < ApplicationRecord
+  include OrganizationTypable
+
+  validates :name, uniqueness: true, presence: true
+
+  def num_providers=(input)
+    if input.blank?
+      self[:num_providers] = 0
+    end
+  end
+end

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  include OrganizationTypable
   has_one :dpc_registration, inverse_of: :user
   has_many :taggings, as: :taggable
   has_many :tags, through: :taggings
@@ -32,17 +33,8 @@ class User < ApplicationRecord
          :validatable, :trackable, :registerable,
          :timeoutable, :recoverable
 
-  enum organization_type: {
-    primary_care_clinic: 0, speciality_clinic: 1,
-    multispecialty_clinic: 2, inpatient_facility: 3,
-    emergency_room: 4, urgent_care: 5,
-    academic_facility: 6, health_it_vendor: 7,
-    other: 8
-  }
-
   validates :last_name, :first_name, presence: true
   validates :organization, presence: true
-  validates :organization_type, inclusion: { in: organization_types.keys }
   validates :num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
   validates :address_1, presence: true
   validates :city, presence: true

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -8,24 +8,6 @@ class User < ApplicationRecord
 
   before_save :num_providers_to_zero_if_blank
 
-  STATES = {
-    AK: 'Alaska', AL: 'Alabama', AR: 'Arkansas', AZ: 'Arizona',
-    CA: 'California', CO: 'Colorado', CT: 'Connecticut',
-    DC: 'District of Columbia', DE: 'Delaware', FL: 'Florida',
-    GA: 'Georgia', HI: 'Hawaii', IA: 'Iowa', ID: 'Idaho',
-    IL: 'Illinois', IN: 'Indiana', KS: 'Kansas', KY: 'Kentucky',
-    LA: 'Louisiana', MA: 'Massachusetts', MD: 'Maryland', ME: 'Maine',
-    MI: 'Michigan', MN: 'Minnesota', MO: 'Missouri', MS: 'Mississippi',
-    MT: 'Montana', NC: 'North Carolina', ND: 'North Dakota',
-    NE: 'Nebraska', NH: 'New Hampshire', NJ: 'New Jersey',
-    NM: 'New Mexico', NV: 'Nevada', NY: 'New York', OH: 'Ohio',
-    OK: 'Oklahoma', OR: 'Oregon', PA: 'Pennsylvania', RI: 'Rhode Island',
-    SC: 'South Carolina', SD: 'South Dakota', TN: 'Tennessee', TX: 'Texas',
-    UT: 'Utah', VA: 'Virginia', VT: 'Vermont', WA: 'Washington',
-    WI: 'Wisconsin', WV: 'West Virginia', WY: 'Wyoming', AS: 'American Samoa',
-    GU: 'Guam', PR: 'Puerto Rico', VI: 'Virgin Islands'
-  }.freeze
-
   # Include default devise modules. Others available are:
   # :confirmable, :lockable,
   # :trackable, and :omniauthable, :recoverable,
@@ -38,7 +20,7 @@ class User < ApplicationRecord
   validates :num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
   validates :address_1, presence: true
   validates :city, presence: true
-  validates :state, inclusion: { in: STATES.keys.map(&:to_s) }
+  validates :state, inclusion: { in: Address::STATES.keys.map(&:to_s) }
   validates :zip, format: { with: /\A\d{5}(?:\-\d{4})?\z/ }
   validates :agree_to_terms, inclusion: {
     in: [true], message: 'you must agree to the terms of service to create an account'

--- a/dpc-web/app/views/devise/registrations/edit.html.erb
+++ b/dpc-web/app/views/devise/registrations/edit.html.erb
@@ -69,7 +69,7 @@
         <div class="field">
           <%= f.label :state, class: "ds-c-label" %>
           <%= f.select :state,
-                User::STATES.each_with_object([]) { |state, memo| memo << [state[1], state[0]] },
+                states_for_select,
                 { include_blank: 'Please select a state' },
                 class: "ds-c-field",
                 value: @user.state

--- a/dpc-web/app/views/devise/registrations/edit.html.erb
+++ b/dpc-web/app/views/devise/registrations/edit.html.erb
@@ -32,7 +32,7 @@
         <div class="field">
           <%= f.label :organization_type, 'Type of organization', class: "ds-c-label" %>
           <%= f.select :organization_type,
-            User::organization_types.keys.each_with_object([]) { |key, memo| memo << [key.titleize, key] },
+            organization_types_for_select,
             { include_blank: 'Please select a practice type' },
             class: "ds-c-field",
             :data => {:hide_follow_up => 'health_it_vendor'},

--- a/dpc-web/app/views/devise/registrations/new.html.erb
+++ b/dpc-web/app/views/devise/registrations/new.html.erb
@@ -79,7 +79,7 @@
         <div class="field">
           <%= f.label :state, class: "ds-c-label" %>
           <%= f.select :state,
-                User::STATES.each_with_object([]) { |state, memo| memo << [state[1], state[0]] },
+                states_for_select,
                 { include_blank: 'Please select a state' },
                 class: "ds-c-field",
                 value: @user.state

--- a/dpc-web/app/views/internal/organizations/_fields.html.erb
+++ b/dpc-web/app/views/internal/organizations/_fields.html.erb
@@ -21,7 +21,7 @@
     <%= ff.text_field :city, class: "ds-c-field" %>
 
     <%= ff.label :state, class: "ds-c-label" %>
-    <%= ff.text_field :state, class: "ds-c-field" %>
+    <%= ff.select :state, states_for_select, {}, class: "ds-c-field" %>
 
     <%= ff.label :zip, class: "ds-c-label" %>
     <%= ff.text_field :zip, class: "ds-c-field" %>

--- a/dpc-web/app/views/internal/organizations/_fields.html.erb
+++ b/dpc-web/app/views/internal/organizations/_fields.html.erb
@@ -8,6 +8,15 @@
   <%= f.select :organization_type, organization_types_for_select, {}, class: "ds-c-field" %>
 </div>
 
+<div class="field">
+  <%= f.label :num_providers, class: "ds-c-label" do %>
+  Number of Providers
+  <span class="ds-c-field__hint">You may use an approximate number.<br/>If organization is a vendor, leave blank.</span>
+  <% end %>
+  <%= f.number_field :num_providers,
+    min: 0, class: "ds-c-field ds-c-field--small" %>
+</div>
+
 <div>
   <%= f.fields_for :address do |ff| %>
     <%= ff.label :street, class: "ds-c-label" %>

--- a/dpc-web/app/views/internal/organizations/_fields.html.erb
+++ b/dpc-web/app/views/internal/organizations/_fields.html.erb
@@ -1,0 +1,34 @@
+<div class="field">
+  <%= f.label :name, class: "ds-c-label" %>
+  <%= f.text_field :name, class: "ds-c-field" %>
+</div>
+
+<div class="field">
+  <%= f.label :organization_type, class: "ds-c-label" %>
+  <%= f.select :organization_type, organization_types_for_select, {}, class: "ds-c-field" %>
+</div>
+
+<div>
+  <%= f.fields_for :address do |ff| %>
+    <%= ff.label :street, class: "ds-c-label" %>
+    <%= ff.text_field :street, class: "ds-c-field" %>
+
+
+    <%= ff.label :street_2, class: "ds-c-label" %>
+    <%= ff.text_field :street_2, class: "ds-c-field" %>
+
+    <%= ff.label :city, class: "ds-c-label" %>
+    <%= ff.text_field :city, class: "ds-c-field" %>
+
+    <%= ff.label :state, class: "ds-c-label" %>
+    <%= ff.text_field :state, class: "ds-c-field" %>
+
+    <%= ff.label :zip, class: "ds-c-label" %>
+    <%= ff.text_field :zip, class: "ds-c-field" %>
+  <% end %>
+</div>
+
+<div class="actions ds-u-margin-top--3">
+  <%= f.submit "Save", class: "ds-c-button ds-c-button--primary", data: { test: "form-submit" } %>
+  <%= link_to "Cancel", :back, class: "ds-c-button ds-c-button--transparent" %>
+</div>

--- a/dpc-web/app/views/internal/organizations/edit.html.erb
+++ b/dpc-web/app/views/internal/organizations/edit.html.erb
@@ -1,0 +1,9 @@
+<% title "Editing #{@organization.name}" %>
+
+<div class="ds-l-row">
+  <div class="ds-l-col--12 ds-l-md-col--6 ds-u-margin-bottom--1 ds-u-margin-x--auto ds-u-border--1 ds-u-padding-bottom--2 ds-u-radius">
+    <%= form_for @organization, url: internal_organization_path(@organization), html: { method: :put } do |f| %>
+      <%= render 'internal/organizations/fields', f: f %>
+    <% end %>
+  </div>
+</div>

--- a/dpc-web/app/views/internal/organizations/edit.html.erb
+++ b/dpc-web/app/views/internal/organizations/edit.html.erb
@@ -1,9 +1,15 @@
-<% title "Editing #{@organization.name}" %>
+<% title "Edit Organization" %>
 
 <div class="ds-l-row">
-  <div class="ds-l-col--12 ds-l-md-col--6 ds-u-margin-bottom--1 ds-u-margin-x--auto ds-u-border--1 ds-u-padding-bottom--2 ds-u-radius">
-    <%= form_for @organization, url: internal_organization_path(@organization), html: { method: :put } do |f| %>
-      <%= render 'internal/organizations/fields', f: f %>
-    <% end %>
-  </div>
+  <section class="ds-l-row--12 ds-l-md-col--9 ds-u-md-padding-left--2">
+
+    <%= link_to "Back to index", internal_organizations_path %>
+    <h1><%= @organization.name %></h1>
+
+    <div class="ds-u-border--1 ds-u-padding--2 ds-u-radius">
+      <%= form_for @organization, url: internal_organization_path(@organization), html: { method: :put } do |f| %>
+        <%= render 'internal/organizations/fields', f: f %>
+      <% end %>
+    </div>
+  <section>
 </div>

--- a/dpc-web/app/views/internal/organizations/index.html.erb
+++ b/dpc-web/app/views/internal/organizations/index.html.erb
@@ -1,0 +1,40 @@
+<% title "Organizations" %>
+
+<div class="ds-l-row">
+  <div class="ds-l-row--12 ds-l-md-col--3">
+    <%= render "shared/internal/sidenav", current: :organizations %>
+  </div>
+
+  <div class="ds-l-row--12 ds-l-md-col--9">
+    <div class="ds-l-row">
+      <h1 class="ds-h1">Viewing <b><%= @organizations.total_count %></b> provider organizations</h1>
+    </div>
+
+    <div class="ds-l-row">
+      <p class="ds-u-padding-x--1"><%= page_entries_info @organizations %></p>
+    </div>
+
+    <div class="ds-l-row">
+      <%= form_tag internal_organizations_path, method: "get" do %>
+        <%= text_field_tag :keyword, params[:keyword], placeholder: "name" %>
+        <%= submit_tag "Search", data: { test: 'organizations-keyword-search-submit' } %>
+      <% end %>
+    </div>
+
+    <% @organizations.each do |org| %>
+      <div class="ds-l-row">
+        <div class="ds-l-col ds-u-flex-wrap--wrap ds-u-display--flex-sm ds-u-padding--1">
+          <div class="ds-u-border--1 ds-u-radius height-sm--auto height-md--full">
+            <div class="ds-u-padding--1 ds-u-display--inline-block">
+              <div class="ds-u-font-size--lead">
+                <%= link_to org.name, internal_organization_path(org) %>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+    <%= paginate @organizations %>
+  </div>
+</div>
+

--- a/dpc-web/app/views/internal/organizations/index.html.erb
+++ b/dpc-web/app/views/internal/organizations/index.html.erb
@@ -5,36 +5,36 @@
     <%= render "shared/internal/sidenav", current: :organizations %>
   </div>
 
-  <div class="ds-l-row--12 ds-l-md-col--9">
-    <div class="ds-l-row">
-      <h1 class="ds-h1">Viewing <b><%= @organizations.total_count %></b> provider organizations</h1>
-    </div>
 
-    <div class="ds-l-row">
-      <p class="ds-u-padding-x--1"><%= page_entries_info @organizations %></p>
-    </div>
+  <section class="ds-l-row--12 ds-l-md-col--9 ds-u-md-padding-left--2">
+    <%= link_to "Create new organization", new_internal_organization_path %>
 
-    <div class="ds-l-row">
-      <%= form_tag internal_organizations_path, method: "get" do %>
-        <%= text_field_tag :keyword, params[:keyword], placeholder: "name" %>
-        <%= submit_tag "Search", data: { test: 'organizations-keyword-search-submit' } %>
-      <% end %>
+    <h1 class="ds-h1">Viewing <strong><%= @organizations.total_count %></strong> provider organizations</h1>
+    <p class=""><%= page_entries_info @organizations %></p>
+    <%= form_tag internal_organizations_path, method: "get", class: "ds-u-display--flex" do %>
+      <%= text_field_tag :keyword, params[:keyword], placeholder: "name", class: "ds-c-field ds-u-margin--0" %>
+      <%= submit_tag "Search", data: { test: 'organizations-keyword-search-submit' }, class: "ds-c-button ds-c-button--primary ds-u-margin-left--1" %>
+    <% end %>
+
+    <div class="ds-u-margin-top--5 ds-u-margin-bottom--2">
+
+    <button type="button" id="filter-modal-trigger" class="list-control-button" data-modal-show="filter-modal" data-test="filter-modal-trigger">
+      <svg class="icon ds-u-margin-right--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <use xlink:href="/assets/solid.svg#filter"></use>
+      </svg>
+      Filter
+    </button>
+
     </div>
 
     <% @organizations.each do |org| %>
-      <div class="ds-l-row">
-        <div class="ds-l-col ds-u-flex-wrap--wrap ds-u-display--flex-sm ds-u-padding--1">
-          <div class="ds-u-border--1 ds-u-radius height-sm--auto height-md--full">
-            <div class="ds-u-padding--1 ds-u-display--inline-block">
-              <div class="ds-u-font-size--lead">
-                <%= link_to org.name, internal_organization_path(org) %>
-              </div>
-            </div>
-          </div>
+      <div class="module-container">
+        <div class="module-container__primary">
+          <h3 class="module-container__heading"><%= link_to org.name, internal_organization_path(org) %></h3>
         </div>
       </div>
     <% end %>
     <%= paginate @organizations %>
-  </div>
+  </section>
 </div>
 

--- a/dpc-web/app/views/internal/organizations/new.html.erb
+++ b/dpc-web/app/views/internal/organizations/new.html.erb
@@ -1,0 +1,9 @@
+<% title "New Organization" %>
+
+<div class="ds-l-row">
+  <div class="ds-l-col--12 ds-l-md-col--6 ds-u-margin-bottom--1 ds-u-margin-x--auto ds-u-border--1 ds-u-padding-bottom--2 ds-u-radius">
+    <%= form_for @organization, url: internal_organizations_path do |f| %>
+      <%= render 'internal/organizations/fields', f: f %>
+    <% end %>
+  </div>
+</div>

--- a/dpc-web/app/views/internal/organizations/new.html.erb
+++ b/dpc-web/app/views/internal/organizations/new.html.erb
@@ -1,9 +1,15 @@
 <% title "New Organization" %>
 
 <div class="ds-l-row">
-  <div class="ds-l-col--12 ds-l-md-col--6 ds-u-margin-bottom--1 ds-u-margin-x--auto ds-u-border--1 ds-u-padding-bottom--2 ds-u-radius">
-    <%= form_for @organization, url: internal_organizations_path do |f| %>
-      <%= render 'internal/organizations/fields', f: f %>
-    <% end %>
-  </div>
+  <section class="ds-l-row--12 ds-l-md-col--9 ds-u-md-padding-left--2">
+
+    <%= link_to "Back to index", internal_organizations_path %>
+    <h1>Create a new provider organization</h1>
+
+    <div class="ds-u-border--1 ds-u-padding--2 ds-u-radius">
+      <%= form_for @organization, url: internal_organizations_path do |f| %>
+        <%= render 'internal/organizations/fields', f: f %>
+      <% end %>
+    </div>
+  <section>
 </div>

--- a/dpc-web/app/views/internal/organizations/show.html.erb
+++ b/dpc-web/app/views/internal/organizations/show.html.erb
@@ -3,7 +3,7 @@
 
 <section class="ds-u-margin--2">
   <div class="ds-l-row ds-u-justify-content--end">
-    <%= link_to "Edit details", edit_internal_organization_url(@organization), class: "ds-c-button  ds-c-button--big ds-c-button--primary" %>
+    <%= link_to "Edit details", edit_internal_organization_url(@organization), class: "ds-c-button  ds-c-button--big ds-c-button--primary", data: { test: "edit-link" } %>
   </div>
 </section>
 
@@ -24,7 +24,7 @@
         <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
           <use xlink:href="/assets/solid.svg#envelope"></use>
         </svg>
-        <%= @organization.organization_type %>
+        <%= @organization.organization_type.titleize %>
       </p>
     </div>
   </div>

--- a/dpc-web/app/views/internal/organizations/show.html.erb
+++ b/dpc-web/app/views/internal/organizations/show.html.erb
@@ -1,0 +1,31 @@
+
+<% title @organization.name %>
+
+<section class="ds-u-margin--2">
+  <div class="ds-l-row ds-u-justify-content--end">
+    <%= link_to "Edit details", edit_internal_organization_url(@organization), class: "ds-c-button  ds-c-button--big ds-c-button--primary" %>
+  </div>
+</section>
+
+<section class="ds-l-container ds-u-border--1 ds-u-radius">
+  <div class="ds-l-row">
+    <h2 class="ds-u-padding-x--2">Organization info</h2>
+  </div>
+
+  <div class="ds-l-row">
+    <div class="ds-l-row--12 ds-l-md-col--6">
+      <p>
+        <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <use xlink:href="/assets/solid.svg#user-alt"></use>
+        </svg>
+        <%= @organization.name %>
+      </p>
+      <p>
+        <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <use xlink:href="/assets/solid.svg#envelope"></use>
+        </svg>
+        <%= @organization.organization_type %>
+      </p>
+    </div>
+  </div>
+</section>

--- a/dpc-web/app/views/internal/organizations/show.html.erb
+++ b/dpc-web/app/views/internal/organizations/show.html.erb
@@ -29,6 +29,12 @@
         </svg>
         <%= @organization.organization_type.titleize %>
       </p>
+      <p>
+        <svg class="icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <use xlink:href="/assets/solid.svg#users"></use>
+        </svg>
+        <%= @organization.num_providers %>
+      </p>
     </div>
   </div>
 
@@ -50,5 +56,11 @@
         <%= @organization.address_zip %>
       </p>
     </div>
+  </div>
+</section>
+
+<section class="ds-u-margin--2">
+  <div class="ds-l-row ds-u-justify-content--center">
+    <%= link_to "Delete provider", internal_organization_url(@organization), method: :delete, class: "ds-u-color--error ds-u-text-align--center" %>
   </div>
 </section>

--- a/dpc-web/app/views/internal/organizations/show.html.erb
+++ b/dpc-web/app/views/internal/organizations/show.html.erb
@@ -2,6 +2,9 @@
 <% title @organization.name %>
 
 <section class="ds-u-margin--2">
+  <div class="ds-l-row">
+    <%= link_to "Back to index", internal_organizations_path %>
+  </div>
   <div class="ds-l-row ds-u-justify-content--end">
     <%= link_to "Edit details", edit_internal_organization_url(@organization), class: "ds-c-button  ds-c-button--big ds-c-button--primary", data: { test: "edit-link" } %>
   </div>

--- a/dpc-web/app/views/internal/organizations/show.html.erb
+++ b/dpc-web/app/views/internal/organizations/show.html.erb
@@ -28,4 +28,24 @@
       </p>
     </div>
   </div>
+
+  <div class="ds-l-row">
+    <div class="ds-l-row--12 ds-l-md-col--6">
+      <p>
+        <%= @organization.address_street %>
+      </p>
+      <p>
+        <%= @organization.address_street_2 %>
+      </p>
+      <p>
+        <%= @organization.address_city %>
+      </p>
+      <p>
+        <%= @organization.address_state %>
+      </p>
+      <p>
+        <%= @organization.address_zip %>
+      </p>
+    </div>
+  </div>
 </section>

--- a/dpc-web/app/views/internal/tags/index.html.erb
+++ b/dpc-web/app/views/internal/tags/index.html.erb
@@ -3,14 +3,7 @@
 
 <div class="ds-l-row">
   <div class="ds-l-row--12 ds-l-md-col--3">
-    <ul class="ds-c-vertical-nav">
-      <li class="ds-c-vertical-nav__item">
-        <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label" %>
-      </li>
-      <li class="ds-c-vertical-nav__item">
-        <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label ds-c-vertical-nav__label--current" %>
-      </li>
-    </ul>
+    <%= render "shared/internal/sidenav", current: :tags %>
   </div>
 
   <div class="ds-l-row--12 ds-l-md-col--9 ds-u-padding-bottom--2">

--- a/dpc-web/app/views/internal/users/index.html.erb
+++ b/dpc-web/app/views/internal/users/index.html.erb
@@ -2,14 +2,7 @@
 
 <div class="ds-l-row">
   <div class="ds-l-row--12 ds-l-md-col--3">
-    <ul class="ds-c-vertical-nav">
-      <li class="ds-c-vertical-nav__item">
-        <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label ds-c-vertical-nav__label--current" %>
-      </li>
-      <li class="ds-c-vertical-nav__item">
-        <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label" %>
-      </li>
-    </ul>
+    <%= render "shared/internal/sidenav", current: :users %>
   </div>
 
   <section class="ds-l-row--12 ds-l-md-col--9 ds-u-md-padding-left--2">

--- a/dpc-web/app/views/layouts/application.html.erb
+++ b/dpc-web/app/views/layouts/application.html.erb
@@ -3,11 +3,11 @@
 
   <%= render partial: 'shared/head' %>
 
-  <body class="ds-base <% if controller_name == "users" %>ds-u-fill--gray-ultra-light<% end %>">
+  <body class="ds-base <% if internal_page? %>ds-u-fill--gray-ultra-light<% end %>">
     <!-- nav -->
     <%= render partial: 'shared/navbar' %>
 
-    <% if controller_name == "users" %>
+    <% if internal_page? %>
     <div class="header-seperator"></div>
     <% else %>
     <header class="page-header">
@@ -25,7 +25,7 @@
     <%= render partial: 'shared/alerts', locals: { notice: flash[:notice], alert: flash[:alert] } %>
 
     <!-- content -->
-    <section class="ds-l-container ds-u-padding-top--7 ds-u-margin-bottom--7 <% if controller_name == "users" %>ds-u-max-width--none<% end %>" id="main">
+    <section class="ds-l-container ds-u-padding-top--7 ds-u-margin-bottom--7 <% if internal_page? %>ds-u-max-width--none<% end %>" id="main">
       <%= yield %>
     </section>
 

--- a/dpc-web/app/views/shared/internal/_sidenav.html.erb
+++ b/dpc-web/app/views/shared/internal/_sidenav.html.erb
@@ -1,11 +1,11 @@
 <ul class="ds-c-vertical-nav">
   <li class="ds-c-vertical-nav__item">
-    <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label ds-c-vertical-nav__label--current" %>
+    <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:users, current)}" %>
   </li>
   <li class="ds-c-vertical-nav__item">
-    <%= link_to "Organizations", internal_organizations_path, class: "ds-c-vertical-nav__label" %>
+    <%= link_to "Organizations", internal_organizations_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:organizations, current)}" %>
   </li>
   <li class="ds-c-vertical-nav__item">
-    <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label" %>
+    <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:tags, current)}" %>
   </li>
 </ul>

--- a/dpc-web/app/views/shared/internal/_sidenav.html.erb
+++ b/dpc-web/app/views/shared/internal/_sidenav.html.erb
@@ -1,0 +1,11 @@
+<ul class="ds-c-vertical-nav">
+  <li class="ds-c-vertical-nav__item">
+    <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label ds-c-vertical-nav__label--current" %>
+  </li>
+  <li class="ds-c-vertical-nav__item">
+    <%= link_to "Organizations", internal_organizations_path, class: "ds-c-vertical-nav__label" %>
+  </li>
+  <li class="ds-c-vertical-nav__item">
+    <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label" %>
+  </li>
+</ul>

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :show, :edit, :update]
     resources :taggings, only: [:create, :destroy]
     resources :tags, only: [:index, :create, :destroy]
+    resources :organizations
   end
 
   authenticated :user do

--- a/dpc-web/db/migrate/20190918195816_create_organizations.rb
+++ b/dpc-web/db/migrate/20190918195816_create_organizations.rb
@@ -1,0 +1,11 @@
+class CreateOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :organizations do |t|
+      t.string :name, null: false
+      t.integer :organization_type, null: false
+      t.integer :num_providers, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/dpc-web/db/migrate/20190918195851_create_addresses.rb
+++ b/dpc-web/db/migrate/20190918195851_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :addresses do |t|
+      t.string :street, null: false
+      t.string :street_2
+      t.string :city, null: false
+      t.string :state, null: false
+      t.string :zip, null: false
+      t.references :addressable, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/dpc-web/db/schema.rb
+++ b/dpc-web/db/schema.rb
@@ -10,10 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_190939) do
+ActiveRecord::Schema.define(version: 2019_09_18_195851) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "addresses", force: :cascade do |t|
+    t.string "street", null: false
+    t.string "street_2"
+    t.string "city", null: false
+    t.string "state", null: false
+    t.string "zip", null: false
+    t.string "addressable_type", null: false
+    t.bigint "addressable_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
+  end
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -55,6 +68,14 @@ ActiveRecord::Schema.define(version: 2019_09_16_190939) do
     t.string "name"
     t.string "github_nickname"
     t.index ["uid", "provider"], name: "index_internal_users_on_uid_and_provider", unique: true
+  end
+
+  create_table "organizations", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "organization_type", null: false
+    t.integer "num_providers", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/dpc-web/spec/controllers/internal/organizations_controller_spec.rb
+++ b/dpc-web/spec/controllers/internal/organizations_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+require './spec/shared_examples/internal_user_authenticable_controller'
+
+RSpec.describe Internal::OrganizationsController, type: :controller do
+  describe '#index' do
+    let!(:internal_user) { create(:internal_user) }
+
+    it_behaves_like 'an internal user authenticable controller action', :get, :index
+
+    context 'authenticated internal user' do
+      before(:each) do
+        sign_in internal_user, scope: :internal_user
+      end
+
+      it 'assigns @organizations to all organizations' do
+        organizations = create_list(:organization, 2)
+        get :index
+        expect(assigns(:organizations)).to eq(organizations)
+      end
+    end
+  end
+
+  describe '#show' do
+    it_behaves_like 'an internal user authenticable controller action', :get, :show, :organization
+  end
+
+  describe '#edit' do
+    it_behaves_like 'an internal user authenticable controller action', :get, :edit, :organization
+  end
+
+  describe '#update' do
+    it_behaves_like 'an internal user authenticable controller action',
+                    :put, :update, :organization, params: { organization: { name: 'Good Health' } }
+  end
+end

--- a/dpc-web/spec/controllers/internal/organizations_controller_spec.rb
+++ b/dpc-web/spec/controllers/internal/organizations_controller_spec.rb
@@ -35,4 +35,21 @@ RSpec.describe Internal::OrganizationsController, type: :controller do
     it_behaves_like 'an internal user authenticable controller action',
                     :put, :update, :organization, params: { organization: { name: 'Good Health' } }
   end
+
+  describe '#destroy' do
+    let!(:internal_user) { create(:internal_user) }
+
+    it_behaves_like 'an internal user authenticable controller action', :delete, :destroy, :tag
+
+    context 'authenticated internal user' do
+      before(:each) do
+        sign_in internal_user, scope: :internal_user
+      end
+
+      it 'destroys the organization' do
+        org = create(:organization)
+        expect { delete :destroy, params: { id: org.id } }.to change(Organization, :count).by(-1)
+      end
+    end
+  end
 end

--- a/dpc-web/spec/factories/addresses.rb
+++ b/dpc-web/spec/factories/addresses.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :address do
+    street { "15 Main St" }
+    street_2 { "Suite 1" }
+    city { "Fort Mill" }
+    state { "SC" }
+    zip { "29001" }
+
+    addressable { organization }
+  end
+end

--- a/dpc-web/spec/factories/organizations.rb
+++ b/dpc-web/spec/factories/organizations.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :organization do
+    sequence(:name) { |n| "The Health Factory #{n}" }
+    organization_type { 0 }
+    num_providers { 5 }
+  end
+end

--- a/dpc-web/spec/factories/users.rb
+++ b/dpc-web/spec/factories/users.rb
@@ -7,11 +7,12 @@ FactoryBot.define do
     sequence(:first_name) { |n| "first_name_#{n}" }
 
     organization { 'Amalgamated Lint' }
+    organization_type { 'primary_care_clinic' }
+
     address_1 { '1234 Shut the Door Ave.' }
     city { 'Pecoima' }
     state { 'AZ' }
     zip { '12345' }
-    organization_type { 0 }
     agree_to_terms { true }
 
     password { '123456' }

--- a/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
+++ b/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'creating and updating organizations' do
+  let!(:internal_user) { create :internal_user }
+
+  before(:each) do
+    sign_in internal_user, scope: :internal_user
+  end
+
+  scenario 'successfully creating and updating an organization\'s attributes ' do
+    visit new_internal_organization_path
+
+    fill_in 'organization_name', with: 'Good Health'
+    fill_in 'organization_type', with: 'Primary Care Provider'
+
+    find('[data-test="form-submit"]').click
+
+    # No longer on edit page
+    expect(page).not_to have_css('[data-test="form-submit"]')
+    expect(page.body).to have_content('Good Health')
+    expect(page.body).to have_content('Primary Care Provider')
+
+    # Click edit link
+    # TODO: finish
+  end
+
+  scenario 'trying to update a organization with invalid attributes ' do
+    org = create(:organization, name: 'Good Health')
+
+    visit edit_internal_organization_path(org)
+
+    expect(page.body).to have_content('Good Health')
+
+    fill_in 'organization_name', with: ''
+
+    find('[data-test="form-submit"]').click
+
+    # Still on edit page
+    expect(page).to have_css('[data-test="form-submit"]')
+  end
+end

--- a/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
+++ b/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
@@ -14,22 +14,30 @@ RSpec.feature 'creating and updating organizations' do
 
     fill_in 'organization_name', with: 'Good Health'
     select 'Primary Care Clinic', from: 'organization_organization_type'
+    fill_in 'organization_address_attributes_street', with: '1 North Main'
+    fill_in 'organization_address_attributes_street_2', with: 'Ste 2000'
+    fill_in 'organization_address_attributes_city', with: 'Greenville'
+    select 'South Carolina', from: 'organization_address_attributes_state'
+    fill_in 'organization_address_attributes_zip', with: '29601'
 
     find('[data-test="form-submit"]').click
 
     expect(page).not_to have_css('[data-test="form-submit"]')
     expect(page.body).to have_content('Good Health')
     expect(page.body).to have_content('Primary Care Clinic')
+    expect(page.body).to have_content('1 North Main')
 
     find('[data-test="edit-link"]').click
 
     fill_in 'organization_name', with: 'Health Revisited'
     select 'Multispecialty Clinic', from: 'organization_organization_type'
+    fill_in 'organization_address_attributes_street', with: '50 River St'
     find('[data-test="form-submit"]').click
 
     expect(page).not_to have_css('[data-test="form-submit"]')
     expect(page.body).to have_content('Health Revisited')
     expect(page.body).to have_content('Multispecialty Clinic')
+    expect(page.body).to have_content('50 River St')
   end
 
   scenario 'trying to update a organization with invalid attributes ' do

--- a/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
+++ b/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'creating and updating organizations' do
 
     fill_in 'organization_name', with: 'Good Health'
     select 'Primary Care Clinic', from: 'organization_organization_type'
+    fill_in 'organization_num_providers', with: '2200'
     fill_in 'organization_address_attributes_street', with: '1 North Main'
     fill_in 'organization_address_attributes_street_2', with: 'Ste 2000'
     fill_in 'organization_address_attributes_city', with: 'Greenville'
@@ -24,6 +25,7 @@ RSpec.feature 'creating and updating organizations' do
 
     expect(page).not_to have_css('[data-test="form-submit"]')
     expect(page.body).to have_content('Good Health')
+    expect(page.body).to have_content('2200')
     expect(page.body).to have_content('Primary Care Clinic')
     expect(page.body).to have_content('1 North Main')
 

--- a/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
+++ b/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
@@ -13,17 +13,23 @@ RSpec.feature 'creating and updating organizations' do
     visit new_internal_organization_path
 
     fill_in 'organization_name', with: 'Good Health'
-    fill_in 'organization_type', with: 'Primary Care Provider'
+    select 'Primary Care Clinic', from: 'organization_organization_type'
 
     find('[data-test="form-submit"]').click
 
-    # No longer on edit page
     expect(page).not_to have_css('[data-test="form-submit"]')
     expect(page.body).to have_content('Good Health')
-    expect(page.body).to have_content('Primary Care Provider')
+    expect(page.body).to have_content('Primary Care Clinic')
 
-    # Click edit link
-    # TODO: finish
+    find('[data-test="edit-link"]').click
+
+    fill_in 'organization_name', with: 'Health Revisited'
+    select 'Multispecialty Clinic', from: 'organization_organization_type'
+    find('[data-test="form-submit"]').click
+
+    expect(page).not_to have_css('[data-test="form-submit"]')
+    expect(page.body).to have_content('Health Revisited')
+    expect(page.body).to have_content('Multispecialty Clinic')
   end
 
   scenario 'trying to update a organization with invalid attributes ' do

--- a/dpc-web/spec/features/internal/organization_management/searching_and_filtering_organizations_spec.rb
+++ b/dpc-web/spec/features/internal/organization_management/searching_and_filtering_organizations_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'searching and filtering organizations' do
+  let!(:internal_user) { create :internal_user }
+
+  before(:each) do
+    sign_in internal_user, scope: :internal_user
+  end
+
+  scenario 'searching by name with the text box' do
+    create(:organization, name: 'Crabby Health')
+    create(:organization, name: 'Fishy Health')
+    create(:organization, name: 'Unrelated Specialty Doc')
+
+    visit internal_organizations_path
+
+    expect(page.body).to have_content('Crabby Health')
+    expect(page.body).to have_content('Fishy Health')
+    expect(page.body).to have_content('Unrelated Specialty Doc')
+
+    fill_in 'keyword', with: 'crab'
+    find('[data-test="organizations-keyword-search-submit"]').click
+
+
+    expect(page.body).to have_content('Crabby Health')
+    expect(page.body).not_to have_content('Fishy Health')
+    expect(page.body).not_to have_content('Unrelated Specialty Doc')
+
+    fill_in 'keyword', with: 'healt'
+    find('[data-test="organizations-keyword-search-submit"]').click
+
+    expect(page.body).to have_content('Crabby Health')
+    expect(page.body).to have_content('Fishy Health')
+    expect(page.body).not_to have_content('Unrelated Specialty Doc')
+
+    fill_in 'keyword', with: ''
+    find('[data-test="organizations-keyword-search-submit"]').click
+
+    expect(page.body).to have_content('Crabby Health')
+    expect(page.body).to have_content('Fishy Health')
+    expect(page.body).to have_content('Unrelated Specialty Doc')
+  end
+end

--- a/dpc-web/spec/helpers/address_helper_spec.rb
+++ b/dpc-web/spec/helpers/address_helper_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AddressHelper, type: :helper do
+  describe '#states_for_select' do
+    it 'formats states into an array of full names' do
+      expect(helper.states_for_select).to eq(
+        [
+          ['Alaska', 'AK'],
+          ['Alabama', 'AL'],
+          ['Arkansas', 'AR'],
+          ['Arizona', 'AZ'],
+          ['California', 'CA'],
+          ['Colorado', 'CO'],
+          ['Connecticut', 'CT'],
+          ['District of Columbia', 'DC'],
+          ['Delaware', 'DE'],
+          ['Florida', 'FL'],
+          ['Georgia', 'GA'],
+          ['Hawaii', 'HI'],
+          ['Iowa', 'IA'],
+          ['Idaho', 'ID'],
+          ['Illinois', 'IL'],
+          ['Indiana', 'IN'],
+          ['Kansas', 'KS'],
+          ['Kentucky', 'KY'],
+          ['Louisiana', 'LA'],
+          ['Massachusetts', 'MA'],
+          ['Maryland', 'MD'],
+          ['Maine', 'ME'],
+          ['Michigan', 'MI'],
+          ['Minnesota', 'MN'],
+          ['Missouri', 'MO'],
+          ['Mississippi', 'MS'],
+          ['Montana', 'MT'],
+          ['North Carolina', 'NC'],
+          ['North Dakota', 'ND'],
+          ['Nebraska', 'NE'],
+          ['New Hampshire', 'NH'],
+          ['New Jersey', 'NJ'],
+          ['New Mexico', 'NM'],
+          ['Nevada', 'NV'],
+          ['New York', 'NY'],
+          ['Ohio', 'OH'],
+          ['Oklahoma', 'OK'],
+          ['Oregon', 'OR'],
+          ['Pennsylvania', 'PA'],
+          ['Rhode Island', 'RI'],
+          ['South Carolina', 'SC'],
+          ['South Dakota', 'SD'],
+          ['Tennessee', 'TN'],
+          ['Texas', 'TX'],
+          ['Utah', 'UT'],
+          ['Virginia', 'VA'],
+          ['Vermont', 'VT'],
+          ['Washington', 'WA'],
+          ['Wisconsin', 'WI'],
+          ['West Virginia', 'WV'],
+          ['Wyoming', 'WY'],
+          ['American Samoa', 'AS'],
+          ['Guam', 'GU'],
+          ['Puerto Rico', 'PR'],
+          ['Virgin Islands', 'VI']
+        ]
+      )
+    end
+  end
+end

--- a/dpc-web/spec/helpers/application_helper_spec.rb
+++ b/dpc-web/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#internal_page?' do
+    it 'returns false if not an internal path' do
+      stubbed_request = instance_double('ActionDispatch::Request')
+      allow(stubbed_request).to receive(:path).and_return('/users/profile')
+      allow(helper).to receive(:request).and_return(stubbed_request)
+
+      expect(helper.internal_page?).to eq false
+    end
+
+    it 'returns true if an internal path' do
+      stubbed_request = instance_double('ActionDispatch::Request')
+      allow(stubbed_request).to receive(:path).and_return('/internal/users')
+      allow(helper).to receive(:request).and_return(stubbed_request)
+
+      expect(helper.internal_page?).to eq true
+    end
+  end
+end

--- a/dpc-web/spec/helpers/organizations_helper_spec.rb
+++ b/dpc-web/spec/helpers/organizations_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OrganizationsHelper, type: :helper do
+  describe '#organization_types_for_select' do
+    it 'formats types into an array with titleization' do
+      expect(helper.organization_types_for_select).to eq(
+        [
+          ['Primary Care Clinic', 'primary_care_clinic'],
+          ['Speciality Clinic', 'speciality_clinic'],
+          ['Multispecialty Clinic', 'multispecialty_clinic'],
+          ['Inpatient Facility', 'inpatient_facility'],
+          ['Emergency Room', 'emergency_room'],
+          ['Urgent Care', 'urgent_care'],
+          ['Academic Facility', 'academic_facility'],
+          ['Health IT Vendor', 'health_it_vendor'],
+          ['Other', 'other']
+        ]
+      )
+    end
+  end
+end

--- a/dpc-web/spec/models/address_spec.rb
+++ b/dpc-web/spec/models/address_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/dpc-web/spec/models/organization_spec.rb
+++ b/dpc-web/spec/models/organization_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Organization, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
**Why**

We want internal users to be able to create and manage organizations.

**What Changed**

* CRUD organizations for internal users
* Add Address model to encapsulate address logic (with accompanying table)

Index:
<img width="1236" alt="Screen Shot 2019-10-01 at 2 28 59 PM" src="https://user-images.githubusercontent.com/54290681/65989606-0560dd80-e458-11e9-94ca-606be84d26ce.png">

Show:
<img width="1211" alt="Screen Shot 2019-10-01 at 2 19 34 PM" src="https://user-images.githubusercontent.com/54290681/65989625-101b7280-e458-11e9-8800-7076b6e3dd7c.png">

Edit:
<img width="1227" alt="Screen Shot 2019-10-01 at 2 28 44 PM" src="https://user-images.githubusercontent.com/54290681/65989639-14e02680-e458-11e9-9f00-7e5ab75c9e00.png">

Create:
<img width="818" alt="Screen Shot 2019-10-01 at 2 14 00 PM" src="https://user-images.githubusercontent.com/54290681/65989663-1b6e9e00-e458-11e9-95b2-9e7cc139c5e7.png">


**Choices Made**

Extracted out an Address model for DRYness and extensibility, rather than duplication address fields and related logic in every model/table that needs one. 

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

- Refactor user address to use new address model and table: DPC-662 
- Add feature for internal users to assign provider users to provider organizations

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
