### PR TITLE
style collapsible left nav, static html for later use

### DIFF
--- a/dpc-web/app/assets/stylesheets/application.scss
+++ b/dpc-web/app/assets/stylesheets/application.scss
@@ -35,6 +35,7 @@
  @import "components/footer";
  @import "components/hero";
  @import "components/icons";
+ @import "components/left-nav";
  @import "components/modals";
  @import "components/module-containers";
  @import "components/navbar";

--- a/dpc-web/app/assets/stylesheets/components/_left-nav.scss
+++ b/dpc-web/app/assets/stylesheets/components/_left-nav.scss
@@ -1,0 +1,41 @@
+.usa-accordion .ds-c-vertical-nav__item {
+  list-style: none;
+}
+
+.ds-c-vertical-nav__item.usa-accordion + .usa-accordion {
+  margin-top: 0;
+}
+
+.usa-accordion__button.ds-c-vertical-nav__label {
+  background-color: transparent;
+  border-left: $spacer-1/2 solid transparent;
+  background-position: right $spacer-1 center;
+  font-weight: $font-normal;
+  padding: $spacer-1 $spacer-2;
+
+  &.ds-c-vertical-nav__label--parent {
+    background-image: url("../images/arrow-down.svg");
+
+    &[aria-expanded="true"] {
+      background-image: url("../images/arrow-up.svg");
+    }
+  }
+  &.ds-c-vertical-nav__label--current {
+    border-left-color: $color-primary;
+    color: $color-primary;
+    font-weight: $font-bold;
+  }
+
+  &:hover {
+    background-color: $color-gray-lightest;
+    color: $color-primary;
+  }
+}
+
+.usa-accordion .ds-c-vertical-nav__subnav .ds-c-vertical-nav__item {
+  border-top: none;
+}
+
+.usa-accordion .ds-c-vertical-nav__subnav .ds-c-vertical-nav__label--current {
+    border-color: transparent;
+}

--- a/dpc-web/app/views/shared/internal/_sidenav.html.erb
+++ b/dpc-web/app/views/shared/internal/_sidenav.html.erb
@@ -11,12 +11,12 @@
 
 <ul class="ds-c-vertical-nav">
   <li class="ds-c-vertical-nav__item usa-accordion">
-    <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--current ds-c-vertical-nav__label--parent" aria-controls="nav-providers-main" aria-expanded="true">
+    <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--parent <%= current_sidenav_class?(:users, current) %>" aria-controls="nav-providers-main" aria-expanded="true">
     Providers
     </button>
     <ul id="nav-providers-main" class="ds-c-vertical-nav__subnav">
       <li class="ds-c-vertical-nav__item usa-accordion">
-        <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--current ds-c-vertical-nav__label--parent" aria-controls="provider-users" aria-expanded="true">
+        <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--parent <%= current_sidenav_class?(:users, current) %>" aria-controls="provider-users" aria-expanded="true">
         Users
         </button>
         <ul id="provider-users" class="ds-c-vertical-nav__subnav" aria-hidden="false">

--- a/dpc-web/app/views/shared/internal/_sidenav.html.erb
+++ b/dpc-web/app/views/shared/internal/_sidenav.html.erb
@@ -1,9 +1,70 @@
 <ul class="ds-c-vertical-nav">
   <li class="ds-c-vertical-nav__item">
-    <%= link_to "Users", internal_users_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:users, current)}" %>
+
   </li>
   <li class="ds-c-vertical-nav__item">
-    <%= link_to "Organizations", internal_organizations_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:organizations, current)}" %>
+
+  </li>
+
+</ul>
+
+
+<ul class="ds-c-vertical-nav">
+  <li class="ds-c-vertical-nav__item usa-accordion">
+    <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--current ds-c-vertical-nav__label--parent" aria-controls="nav-providers-main" aria-expanded="true">
+    Providers
+    </button>
+    <ul id="nav-providers-main" class="ds-c-vertical-nav__subnav">
+      <li class="ds-c-vertical-nav__item usa-accordion">
+        <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--current ds-c-vertical-nav__label--parent" aria-controls="provider-users" aria-expanded="true">
+        Users
+        </button>
+        <ul id="provider-users" class="ds-c-vertical-nav__subnav" aria-hidden="false">
+          <li class="ds-c-vertical-nav__item">
+            <%= link_to "All users", internal_users_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:users, current)}" %>
+          </li>
+          <li class="ds-c-vertical-nav__item">
+            <a href="#" class="ds-c-vertical-nav__label">
+              <span>
+                Unassigned users
+              </span>
+            </a>
+          </li>
+          <li class="ds-c-vertical-nav__item">
+            <a href="#" class="ds-c-vertical-nav__label">
+              <span>
+                Assigned users
+              </span>
+            </a>
+          </li>
+        </ul>
+      </li>
+      <li class="ds-c-vertical-nav__item">
+        <%= link_to "Organizations", internal_organizations_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:organizations, current)}" %>
+      </li>
+    </ul>
+  </li>
+
+  <li class="ds-c-vertical-nav__item  usa-accordion">
+    <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--parent" aria-controls="nav-vendors" aria-expanded="false">
+    Vendors
+    </button>
+    <ul id="nav-vendors" class="ds-c-vertical-nav__subnav" aria-hidden="true">
+      <li class="ds-c-vertical-nav__item">
+        <a href="#" class="ds-c-vertical-nav__label">
+          <span>
+            Users
+          </span>
+        </a>
+      </li>
+      <li class="ds-c-vertical-nav__item">
+        <a href="#" class="ds-c-vertical-nav__label">
+          <span>
+            Organizations
+          </span>
+        </a>
+      </li>
+    </ul>
   </li>
   <li class="ds-c-vertical-nav__item">
     <%= link_to "Tags", internal_tags_path, class: "ds-c-vertical-nav__label #{current_sidenav_class?(:tags, current)}" %>


### PR DESCRIPTION

![Screen Recording 2019-10-02 at 11 17 AM](https://user-images.githubusercontent.com/25435289/66057459-bd4cc400-e506-11e9-8a6b-4996243426a0.gif)


**Why**

Creating separate pages for all users, unassigned users, and assigned users will improve the usability and interaction design of all the filter menus. This means we had to create a collapsible left nav menu to support the additional levels.

**What Changed**

Added CSS for the left navigation and provide sample HTML to use as we build out the internal user experience.

**Choices Made**

Use the accordions javascript for the interactions so we don't have to write new javascript. This is consistent with the way the US Web Design system handles the mobile navigation menus. 

**Future Work**

Hook up to actual views
