### PR TITLE
DPC-603: Remove the old queue tables

### DIFF
--- a/dpc-attribution/src/main/resources/queue_migrations.xml
+++ b/dpc-attribution/src/main/resources/queue_migrations.xml
@@ -42,4 +42,9 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="remove-old-queue-db" author="ronaldheft-usds">
+        <dropTable tableName="JOB_RESULT" />
+        <dropTable tableName="JOB_QUEUE" />
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
**THIS TICKET SHOULD NOT BE MERGED UNTIL DPC-499 (#218) IS DEPLOYED IN PROD-SBX AND TESTED**

**Why**

We've built an entirely new database to manage the queue. The old tables are no longer needed and should be removed.

**What Changed**

Includes the database changeset to remove the old queue tables.

**Choices Made**

- A separate PR was created to ensure the new queue is working before we delete the data from the old tables.
- If we need to ensure old jobs are still retrievable, we should not merge this. Since we're only in synthetic data, I believe a breaking change of this scale is acceptable.

**Tickets closed**:

DPC-603: This ticket.

**Future Work**

- This PR should be rebased after #218 is merged to get a clean changeset.

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
