### PR TITLE
README Documentation Update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ Give a list of tickets closed in this PR.
 
 **Future Work**
 
-List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additonal fixes.
+List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additional fixes.
 
 **Checklist**
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ travis:
 website:
 	@docker build -f dpc-web/Dockerfile . -t dpc-web
 
+.PHONY: start-app
+start-app:
+	@docker-compose up start_core_dependencies
+	@docker-compose up start_api_dependencies
+	@docker-compose up start_api
+
 .PHONY: ci-app
 ci-app:
 	@./dpc-test.sh

--- a/README.md
+++ b/README.md
@@ -149,9 +149,7 @@ This request fails because the provider is not registered with the application a
 
 
 The recommended method for testing the Services is with the [Postman](https://www.getpostman.com) application.
-This allows easy visualization of responses, as well as simplifies adding the necessary HTTP Headers. 
-
-> Note: the CURL command strips off the trailing `$export` from any request URIs, which makes it impossible to correctly test the initial data export request.
+This allows easy visualization of responses, as well as simplifies adding the necessary HTTP Headers.
 
 Steps for testing the data export:
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Data @ The Point of Care
 Required services
 ---
 
-DPC requires an external Postgres database to be running.
-
-The `docker-compose` file includes the necessary applications and configurations, and can be started like so: 
+DPC requires an external Postgres database to be running. While a separate Postgres server can be used, the `docker-compose` file includes everything needed, and can be started like so: 
 
 ```bash
 docker-compose up start_core_dependencies
 ```
+
+> Warning: If you do have an existing Postgres database running on port 5342, docker-compose WILL NOT alert you to the port conflict. Ensure any local Postgres databases are stopped before starting docker-compose.
 
 By default, the application attempts to connect to the `dpc_attribution`, `dpc_queue`, and `dpc_auth` databases on the localhost as the `postgres` user with a password of `dpc-safe`.
 When using docker-compose, all the required databases will be created automatically. Upon container startup, the databases will be initialized automatically with all the correct data. If for some reason this behavior is not desired, set an environment variable of `DB_MIGRATION=0`.

--- a/dpc-web/app/views/public/_hero.html.erb
+++ b/dpc-web/app/views/public/_hero.html.erb
@@ -15,7 +15,7 @@
             <svg class="ds-u-margin-right--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" >
             <use xlink:href="/assets/solid.svg#key"></use>
           </svg>
-          Request acccess</a>
+          Request access</a>
           <% end %>
 
           <%= link_to docs_path, :class => "ds-c-button ds-c-button--inverse ds-c-button--inverse--alt ds-c-button--big" do %>


### PR DESCRIPTION
**Why**

When running builds with @embh and @DeirdreHolub we discovered some of the documentation is out of date.

**What Changed**

- Adds a new `make start-app` target to simplify starting the application through Docker.
- Removes all references to Redis (killed in DPC-499 ☠️) 
- Fixes some inaccuracies.
- Fixes a typo in our PR template.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**
