### PR TITLE
Maven / IntelliJ Error Fixes

### DIFF
--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -84,6 +84,16 @@
             <artifactId>httpclient</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!--Test resources-->
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,21 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.7.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -443,7 +458,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
**Why**

Our Maven project when imported into IntelliJ complained of several warnings and errors. This was due to missing Maven plugins and a plugin incompatibility.

Additionally, our dpc-common tests were not running because they were missing the dropwizard tests dependency.

**What Changed**

- Adds missing Maven plugins.
- Updates a Maven plugin to be compatible with the other plugins.
- Adds missing test dependencies to dpc-common.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**
