### PR TITLE
DPC-644: Fix provider deletion

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/ProviderDAO.java
@@ -1,14 +1,11 @@
 package gov.cms.dpc.attribution.jdbi;
 
-import gov.cms.dpc.common.entities.ProviderEntity;
+import gov.cms.dpc.common.entities.*;
 import gov.cms.dpc.common.hibernate.attribution.DPCManagedSessionFactory;
 import io.dropwizard.hibernate.AbstractDAO;
 
 import javax.inject.Inject;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import javax.persistence.criteria.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -71,7 +68,18 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> {
         return this.list(query);
     }
 
+    /**
+     * Remove the {@link ProviderEntity} and all associated resources.
+     *
+     * @param provider - {@link ProviderEntity} to remove
+     */
     public void deleteProvider(ProviderEntity provider) {
+
+        // For each roster remove the attributions and the roster itself
+        provider.getAttributionRosters()
+                .forEach(roster -> removeRoster(roster.getId()));
+
+        // Remove the provider
         this.currentSession().remove(provider);
     }
 
@@ -83,5 +91,25 @@ public class ProviderDAO extends AbstractDAO<ProviderEntity> {
 
         currentSession().merge(fullyUpdated);
         return fullyUpdated;
+    }
+
+    private void removeRoster(UUID rosterID) {
+
+        // Remove relationships
+        final CriteriaBuilder builder = currentSession().getCriteriaBuilder();
+        final CriteriaDelete<AttributionRelationship> query = builder.createCriteriaDelete(AttributionRelationship.class);
+        final Root<AttributionRelationship> root = query.from(AttributionRelationship.class);
+
+        query.where(builder.equal(root.get(AttributionRelationship_.roster).get(RosterEntity_.id), rosterID));
+
+        this.currentSession().createQuery(query).executeUpdate();
+
+        // Remove roster
+        final CriteriaDelete<RosterEntity> rosterQuery = builder.createCriteriaDelete(RosterEntity.class);
+        final Root<RosterEntity> rosterRoot = rosterQuery.from(RosterEntity.class);
+
+        rosterQuery.where(builder.equal(rosterRoot.get(RosterEntity_.id), rosterID));
+
+        this.currentSession().createQuery(rosterQuery).executeUpdate();
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
@@ -52,6 +52,10 @@ public class ProviderEntity implements Serializable {
             })
     private List<PatientEntity> attributedPatients;
 
+    @OneToMany
+    @JoinColumn(name = "provider_id", referencedColumnName = "id")
+    private List<RosterEntity> attributionRosters;
+
     @Column(name = "created_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
     private OffsetDateTime createdAt;
 
@@ -100,6 +104,14 @@ public class ProviderEntity implements Serializable {
 
     public void setAttributedPatients(List<PatientEntity> attributedPatients) {
         this.attributedPatients = attributedPatients;
+    }
+
+    public List<RosterEntity> getAttributionRosters() {
+        return attributionRosters;
+    }
+
+    public void setAttributionRosters(List<RosterEntity> attributionRosters) {
+        this.attributionRosters = attributionRosters;
     }
 
     public OrganizationEntity getOrganization() {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
@@ -2,8 +2,6 @@ package gov.cms.dpc.common.entities;
 
 import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.converters.entities.ProviderEntityConverter;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
 import org.hl7.fhir.dstu3.model.HumanName;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Practitioner;
@@ -18,11 +16,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Entity(name = "providers")
-@NamedQueries(value = {
-        @NamedQuery(name = "getProvider", query = "select 1 from providers a where a.providerNPI = :provID"),
-        @NamedQuery(name = "findByProvider", query = "from providers a where a.providerNPI = :id"),
-        @NamedQuery(name = "getAllProviders", query = "from providers p")
-})
 public class ProviderEntity implements Serializable {
 
     public static final long serialVersionUID = 42L;

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "56162763-cb03-4d1d-8fe2-b53b3d3df354",
+		"_postman_id": "8f0544ab-077c-4ebb-b749-1188eff6449b",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -619,262 +619,493 @@
 			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "Try export after submitting roster",
-			"event": [
+			"name": "Bulk Export",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"id": "5497fa12-aefd-44c2-9254-2beb51c52e31",
-						"exec": [
-							"// Status should be 204",
-							"pm.test(\"Status is 202\", function () {",
-							"    pm.response.to.have.status(202);",
-							"});",
-							"",
-							"// Url for job response should be in content-location header.",
-							"pm.test(\"Content-Location header is present\", function () {",
-							"    pm.response.to.have.header(\"Content-Location\");",
-							"});",
-							"",
-							"if (pm.response.headers.get(\"Content-Location\")) {",
-							"  pm.environment.set(\"content_location\", pm.response.headers.get(\"Content-Location\"));",
-							"} else {",
-							"  // Fail the test, no content location.",
-							"  postman.setNextRequest(null);",
-							"}"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "8b8d6363-b490-428a-bfee-663b184ae05d",
-						"exec": [
-							"console.log(\"Group:\", pm.environment.get(\"attribution_group\"));"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Accept",
-						"type": "text",
-						"value": "application/fhir+json"
-					},
-					{
-						"key": "Prefer",
-						"type": "text",
-						"value": "respond-async"
-					}
-				],
-				"url": {
-					"raw": "http://{{hostname}}:{{api_port}}/v1/Group/{{attribution_group_id}}/$export",
-					"protocol": "http",
-					"host": [
-						"{{hostname}}"
+					"name": "Try export after submitting roster",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5497fa12-aefd-44c2-9254-2beb51c52e31",
+								"exec": [
+									"// Status should be 204",
+									"pm.test(\"Status is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"// Url for job response should be in content-location header.",
+									"pm.test(\"Content-Location header is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Location\");",
+									"});",
+									"",
+									"if (pm.response.headers.get(\"Content-Location\")) {",
+									"  pm.environment.set(\"content_location\", pm.response.headers.get(\"Content-Location\"));",
+									"} else {",
+									"  // Fail the test, no content location.",
+									"  postman.setNextRequest(null);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "8b8d6363-b490-428a-bfee-663b184ae05d",
+								"exec": [
+									"console.log(\"Group:\", pm.environment.get(\"attribution_group\"));"
+								],
+								"type": "text/javascript"
+							}
+						}
 					],
-					"port": "{{api_port}}",
-					"path": [
-						"v1",
-						"Group",
-						"{{attribution_group_id}}",
-						"$export"
-					]
-				},
-				"description": "After submitting the roster, the export request should succeed, with a 204 status and the location for the job response in the `content-location` header."
-			},
-			"response": []
-		},
-		{
-			"name": "Job response",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "28fe7a36-50ab-4e7d-bf21-312b5f5777f3",
-						"exec": [
-							"// Wait between pings",
-							"setTimeout(function() {}, 1000);"
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/fhir+json"
+							},
+							{
+								"key": "Prefer",
+								"type": "text",
+								"value": "respond-async"
+							}
 						],
-						"type": "text/javascript"
-					}
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Group/{{attribution_group_id}}/$export",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Group",
+								"{{attribution_group_id}}",
+								"$export"
+							]
+						},
+						"description": "After submitting the roster, the export request should succeed, with a 204 status and the location for the job response in the `content-location` header."
+					},
+					"response": []
 				},
 				{
-					"listen": "test",
-					"script": {
-						"id": "70688a82-d0cf-4802-b1e5-b6ad7357c926",
-						"exec": [
-							"if (pm.response.code == 200) {",
-							"    // Response should have FHIR Content-Type",
-							"    pm.test(\"Content-type is application/json\", function() {",
-							"       pm.response.to.have.header(\"Content-Type\", \"application/json\"); ",
-							"    });",
-							"    ",
-							"    // If response code is 200, check the response and load the urls.",
-							"    pm.test(\"Patient, EOB, and Coverage in response but no errors\", function() {",
-							"        pm.expect(pm.response.json().error).to.have.lengthOf(0);",
-							"        pm.expect(pm.response.json().output).to.have.lengthOf(3);",
-							"        pm.expect(pm.response.json().output[0].type).to.equal(\"Patient\");",
-							"        pm.expect(pm.response.json().output[0].count).to.equal(3);",
-							"        pm.environment.set(\"patient_url\", pm.response.json().output[0].url);",
-							"        pm.expect(pm.response.json().output[1].type).to.equal(\"ExplanationOfBenefit\");",
-							"        pm.expect(pm.response.json().output[1].count).to.equal(102);",
-							"        pm.environment.set(\"eob_url\", pm.response.json().output[1].url);",
-							"        pm.expect(pm.response.json().output[2].type).to.equal(\"Coverage\");",
-							"        pm.expect(pm.response.json().output[2].count).to.equal(12);",
-							"        pm.environment.set(\"coverage_url\", pm.response.json().output[2].url);",
-							"    });",
-							"} else {",
-							"    // If response code is not 200, it should be 202. Assert that, and retry.",
-							"    pm.test(\"Status code is 202\", function () {",
-							"        pm.response.to.have.status(202);",
-							"    });",
-							"    postman.setNextRequest(\"Job response\");",
-							"}"
-						],
-						"type": "text/javascript"
-					}
+					"name": "Job response",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "28fe7a36-50ab-4e7d-bf21-312b5f5777f3",
+								"exec": [
+									"// Wait between pings",
+									"setTimeout(function() {}, 1000);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "70688a82-d0cf-4802-b1e5-b6ad7357c926",
+								"exec": [
+									"if (pm.response.code == 200) {",
+									"    // Response should have FHIR Content-Type",
+									"    pm.test(\"Content-type is application/json\", function() {",
+									"       pm.response.to.have.header(\"Content-Type\", \"application/json\"); ",
+									"    });",
+									"    ",
+									"    // If response code is 200, check the response and load the urls.",
+									"    pm.test(\"Patient, EOB, and Coverage in response but no errors\", function() {",
+									"        pm.expect(pm.response.json().error).to.have.lengthOf(0);",
+									"        pm.expect(pm.response.json().output).to.have.lengthOf(3);",
+									"        pm.expect(pm.response.json().output[0].type).to.equal(\"Patient\");",
+									"        pm.expect(pm.response.json().output[0].count).to.equal(3);",
+									"        pm.environment.set(\"patient_url\", pm.response.json().output[0].url);",
+									"        pm.expect(pm.response.json().output[1].type).to.equal(\"ExplanationOfBenefit\");",
+									"        pm.expect(pm.response.json().output[1].count).to.equal(102);",
+									"        pm.environment.set(\"eob_url\", pm.response.json().output[1].url);",
+									"        pm.expect(pm.response.json().output[2].type).to.equal(\"Coverage\");",
+									"        pm.expect(pm.response.json().output[2].count).to.equal(12);",
+									"        pm.environment.set(\"coverage_url\", pm.response.json().output[2].url);",
+									"    });",
+									"} else {",
+									"    // If response code is not 200, it should be 202. Assert that, and retry.",
+									"    pm.test(\"Status code is 202\", function () {",
+									"        pm.response.to.have.status(202);",
+									"    });",
+									"    postman.setNextRequest(\"Job response\");",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{content_location}}",
+							"host": [
+								"{{content_location}}"
+							]
+						},
+						"description": "While the export request is being processed, the job url will return a 202 status. When it is completed, a 200 status will be returned, along with JSON containing the patient, explanation of benefits, and coverage data."
+					},
+					"response": []
+				},
+				{
+					"name": "Patient data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "3e50ce2a-4322-4723-981b-31251393b449",
+								"exec": [
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"});",
+									"",
+									"// There should be 2 patients.",
+									"pm.test(\"Patient data correct\", function() {",
+									"    var responseOutput = pm.response.text();",
+									"    var responseLines = responseOutput.trim().split('\\n');",
+									"    pm.expect(responseLines).to.have.lengthOf(3);",
+									"    for (var line of responseLines) {",
+									"        var lineData = JSON.parse(line);",
+									"        pm.expect(lineData.resourceType).to.equal(\"Patient\");",
+									"    }",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{patient_url}}",
+							"host": [
+								"{{patient_url}}"
+							]
+						},
+						"description": "The patient data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one patient."
+					},
+					"response": []
+				},
+				{
+					"name": "Explanation of Benefit data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "64383543-afd0-4aed-8e62-533892909b98",
+								"exec": [
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"});",
+									"",
+									"// There should be 86 Explanations of Benefits.",
+									"pm.test(\"Explanation of Benefits data correct\", function() {",
+									"    var responseOutput = pm.response.text();",
+									"    var responseLines = responseOutput.trim().split('\\n');",
+									"    pm.expect(responseLines).to.have.lengthOf(102);",
+									"    for (var line of responseLines) {",
+									"        var lineData = JSON.parse(line);",
+									"        pm.expect(lineData.resourceType).to.equal(\"ExplanationOfBenefit\");",
+									"    }",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{eob_url}}",
+							"host": [
+								"{{eob_url}}"
+							]
+						},
+						"description": "The explanation of benefits data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one explanation of benefits."
+					},
+					"response": []
+				},
+				{
+					"name": "Coverage data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "756f4c51-bce2-4a77-b3b9-bd7e96d844e5",
+								"exec": [
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"});",
+									"",
+									"// There should be 8 coverage.",
+									"pm.test(\"Coverage data correct\", function() {",
+									"    var responseOutput = pm.response.text();",
+									"    var responseLines = responseOutput.trim().split('\\n');",
+									"    pm.expect(responseLines).to.have.lengthOf(12);",
+									"    for (var line of responseLines) {",
+									"        var lineData = JSON.parse(line);",
+									"        pm.expect(lineData.resourceType).to.equal(\"Coverage\");",
+									"    }",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{coverage_url}}",
+							"host": [
+								"{{coverage_url}}"
+							]
+						},
+						"description": "The coverage data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one coverage."
+					},
+					"response": []
 				}
 			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{content_location}}",
-					"host": [
-						"{{content_location}}"
-					]
-				},
-				"description": "While the export request is being processed, the job url will return a 202 status. When it is completed, a 200 status will be returned, along with JSON containing the patient, explanation of benefits, and coverage data."
-			},
-			"response": []
+			"protocolProfileBehavior": {}
 		},
 		{
-			"name": "Patient data",
-			"event": [
+			"name": "Deletion",
+			"item": [
 				{
-					"listen": "test",
-					"script": {
-						"id": "3e50ce2a-4322-4723-981b-31251393b449",
-						"exec": [
-							"// Response should have FHIR Content-Type",
-							"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
-							"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
-							"});",
-							"",
-							"// There should be 2 patients.",
-							"pm.test(\"Patient data correct\", function() {",
-							"    var responseOutput = pm.response.text();",
-							"    var responseLines = responseOutput.trim().split('\\n');",
-							"    pm.expect(responseLines).to.have.lengthOf(3);",
-							"    for (var line of responseLines) {",
-							"        var lineData = JSON.parse(line);",
-							"        pm.expect(lineData.resourceType).to.equal(\"Patient\");",
-							"    }",
-							"});"
-						],
-						"type": "text/javascript"
-					}
+					"name": "Find Practitioner by NPI",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "788bc2c3-ccf4-44cc-bd6b-1874ecfb26dc",
+								"exec": [
+									"// Status should be 200",
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+json\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+json\"); ",
+									"});",
+									"",
+									"pm.test(\"Bundle should have a single entry\", function() {",
+									"    var response = pm.response.json();",
+									"",
+									"    // Should be a search set with 1 entry",
+									"    pm.expect(response.type).to.equal(\"searchset\")",
+									"    pm.expect(response.total).to.equal(1);",
+									"",
+									"    pm.globals.set(\"single_practitioner_id\", response.entry[0].resource.id);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Practitioner?identifier=3116145044854423862",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Practitioner"
+							],
+							"query": [
+								{
+									"key": "identifier",
+									"value": "3116145044854423862"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete patient",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/{{single_patient_id}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"{{single_patient_id}}"
+							]
+						},
+						"description": "Ensure we can successfully remove patients."
+					},
+					"response": []
+				},
+				{
+					"name": "Patient should be missing from group",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9c5751fb-9adb-49fb-9c24-a094f48c4396",
+								"exec": [
+									"// Status should be 200",
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+json\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+json\"); ",
+									"});",
+									"",
+									"pm.test(\"Response Body is correct\", () => {",
+									"    console.log(\"Body correct?\");",
+									"    const patient_id = pm.globals.get(\"single_patient_id\")",
+									"    // Check to ensure that each member id matches what we previously had",
+									"    var response = pm.response.json();",
+									"    ",
+									"    // Ensure that the Patient IDs is less than the original submission number",
+									"    pm.expect(response.member.length).to.equal(3);",
+									"    var ids = new Set(JSON.parse(pm.globals.get(\"patient_ids\")));",
+									"    const matchingPatient = response.member.filter(member => {",
+									"        pm.expect(ids.has(member.entity.reference)).to.be.true;",
+									"        return member.entity.referenced === patient_id",
+									"    });",
+									"    pm.expect(matchingPatient).to.be.empty;",
+									"",
+									"    pm.globals.set(\"attribution_group_id\", response.id);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Group/{{attribution_group_id}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Group",
+								"{{attribution_group_id}}"
+							]
+						},
+						"description": "Ensure that when we remove a patient, the corresponding attribution values are removed as well."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Practitioner",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "a9c75e9e-6c5d-4566-b2ee-cd7a3ab08b1c",
+								"exec": [
+									"// Status should be 200",
+									"pm.test(\"Status is 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Practitioner/{{single_practitioner_id}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Practitioner",
+								"{{single_practitioner_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Provider group should be missing",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "cea56747-f597-4f44-a387-d097e2a3e396",
+								"exec": [
+									"pm.test(\"Bundle should be empty\", function() {",
+									"    var response = pm.response.json();",
+									"",
+									"    // Should be a search set with 0 entries",
+									"    pm.expect(response.type).to.equal(\"searchset\")",
+									"    pm.expect(response.total).to.equal(0);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Group?characteristic-value=|attributed-to$|3116145044854423862",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Group"
+							],
+							"query": [
+								{
+									"key": "characteristic-value",
+									"value": "|attributed-to$|3116145044854423862"
+								}
+							]
+						},
+						"description": "When a provider is deleted their patient roster is removed as well."
+					},
+					"response": []
 				}
 			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{patient_url}}",
-					"host": [
-						"{{patient_url}}"
-					]
-				},
-				"description": "The patient data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one patient."
-			},
-			"response": []
-		},
-		{
-			"name": "Explanation of Benefit data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"id": "64383543-afd0-4aed-8e62-533892909b98",
-						"exec": [
-							"// Response should have FHIR Content-Type",
-							"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
-							"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
-							"});",
-							"",
-							"// There should be 86 Explanations of Benefits.",
-							"pm.test(\"Explanation of Benefits data correct\", function() {",
-							"    var responseOutput = pm.response.text();",
-							"    var responseLines = responseOutput.trim().split('\\n');",
-							"    pm.expect(responseLines).to.have.lengthOf(102);",
-							"    for (var line of responseLines) {",
-							"        var lineData = JSON.parse(line);",
-							"        pm.expect(lineData.resourceType).to.equal(\"ExplanationOfBenefit\");",
-							"    }",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{eob_url}}",
-					"host": [
-						"{{eob_url}}"
-					]
-				},
-				"description": "The explanation of benefits data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one explanation of benefits."
-			},
-			"response": []
-		},
-		{
-			"name": "Coverage data",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"id": "756f4c51-bce2-4a77-b3b9-bd7e96d844e5",
-						"exec": [
-							"// Response should have FHIR Content-Type",
-							"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
-							"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
-							"});",
-							"",
-							"// There should be 8 coverage.",
-							"pm.test(\"Coverage data correct\", function() {",
-							"    var responseOutput = pm.response.text();",
-							"    var responseLines = responseOutput.trim().split('\\n');",
-							"    pm.expect(responseLines).to.have.lengthOf(12);",
-							"    for (var line of responseLines) {",
-							"        var lineData = JSON.parse(line);",
-							"        pm.expect(lineData.resourceType).to.equal(\"Coverage\");",
-							"    }",
-							"});"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "{{coverage_url}}",
-					"host": [
-						"{{coverage_url}}"
-					]
-				},
-				"description": "The coverage data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one coverage."
-			},
-			"response": []
+			"description": "Test that we can remove various resource and that everything cleans up appropriately.",
+			"protocolProfileBehavior": {}
 		}
 	],
 	"event": [


### PR DESCRIPTION
**Why**

A bug was reported where calling `DELETE` on a provider was resulting in a 500 error. This was because the deletion logic wasn't correctly remove attribution relationships. So our unit tests were passing, but the actual functionality was borked.

**What Changed**

Simple tweak to iterate through the rosters linked to a given provider and remove all the attribution relationships and the rosters themselves.

Also verified that patient removal is working as well.

**Choices Made**

**Tickets closed**:

DPC-644: This ticket

**Future Work**

**Checklist**

- [x] Demo and Seed commands are working
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
