### PR TITLE
Add internal feature to download CSV of all users

### DIFF
--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -40,6 +40,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'climate_control'
   gem 'rails-controller-testing'
+  gem 'fakefs', require: 'fakefs/safe'
 end
 
 group :development do

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    fakefs (0.20.1)
     faker (2.6.0)
       i18n (>= 1.6, < 1.8)
     faraday (0.15.4)
@@ -343,6 +344,7 @@ DEPENDENCIES
   delayed_job_active_record
   devise
   factory_bot_rails
+  fakefs
   faker
   health_check
   jbuilder (~> 2.5)

--- a/dpc-web/app/controllers/internal/users_controller.rb
+++ b/dpc-web/app/controllers/internal/users_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 module Internal
   class UsersController < ApplicationController
     before_action :authenticate_internal_user!
@@ -51,6 +53,13 @@ module Internal
       else
         flash[:alert] = "Please correct errrors: #{@user.errors.full_messages.join(', ')}"
         render :edit
+      end
+    end
+
+    def download
+      respond_to do |format|
+        filename = "users-#{Time.now.strftime('%Y%m%dT%H%M')}.csv"
+        format.csv { send_data User.all.to_csv, filename: filename }
       end
     end
 

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -29,9 +29,8 @@ class User < ApplicationRecord
   }
 
   def self.to_csv
-    attrs = ['id', 'first_name', 'last_name', 'email', 'organization', 'organization_type',
-      'address_1', 'address_2', 'city', 'state', 'zip', 'agree_to_terms', 'num_providers',
-      'created_at', 'updated_at']
+    attrs = %w[id first_name last_name email organization organization_type address_1 address_2
+               city state zip agree_to_terms num_providers created_at updated_at]
 
     CSV.generate(headers: true) do |csv|
       csv << attrs

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'csv'
+
 class User < ApplicationRecord
   include OrganizationTypable
   has_one :dpc_registration, inverse_of: :user
@@ -25,6 +27,19 @@ class User < ApplicationRecord
   validates :agree_to_terms, inclusion: {
     in: [true], message: 'you must agree to the terms of service to create an account'
   }
+
+  def self.to_csv
+    attrs = ['id', 'first_name', 'last_name', 'email', 'organization', 'organization_type',
+      'address_1', 'address_2', 'city', 'state', 'zip', 'agree_to_terms', 'num_providers',
+      'created_at', 'updated_at']
+
+    CSV.generate(headers: true) do |csv|
+      csv << attrs
+      all.each do |user|
+        csv << user.attributes.values_at(*attrs)
+      end
+    end
+  end
 
   def name
     "#{first_name} #{last_name}"

--- a/dpc-web/app/views/internal/users/index.html.erb
+++ b/dpc-web/app/views/internal/users/index.html.erb
@@ -14,6 +14,8 @@
       <%= submit_tag "Search", data: { test: 'users-keyword-search-submit' }, class: "ds-c-button ds-c-button--primary ds-u-margin-left--1" %>
     <% end %>
 
+    <p><%= link_to "Download CSV of all users", download_internal_users_path(format: :csv) %> - Note: The download will consist of all users regardless of current search or filter.</p>
+
     <div class="ds-u-margin-top--5 ds-u-margin-bottom--2">
 
     <button type="button" id="filter-modal-trigger" class="list-control-button" data-modal-show="filter-modal" data-test="filter-modal-trigger">

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -10,7 +10,9 @@ Rails.application.routes.draw do
   }
 
   namespace 'internal' do
-    resources :users, only: [:index, :show, :edit, :update]
+    resources :users, only: [:index, :show, :edit, :update] do
+      collection { get :download }
+    end
     resources :taggings, only: [:create, :destroy]
     resources :tags, only: [:index, :create, :destroy]
     resources :organizations

--- a/dpc-web/spec/controllers/internal/users_controller_spec.rb
+++ b/dpc-web/spec/controllers/internal/users_controller_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe Internal::UsersController, type: :controller do
     it_behaves_like 'an internal user authenticable controller action',
                     :put, :update, :user, params: { user: { first_name: 'Riley' } }
   end
+
+  describe '#download' do
+    let!(:internal_user) { create(:internal_user) }
+
+    before(:each) do
+      sign_in internal_user, scope: :internal_user
+    end
+
+    it 'sends file from User.to_csv' do
+      allow(User).to receive(:to_csv).and_return('test_file')
+
+      get :download, format: :csv
+
+      expect(response.body).to eq('test_file')
+    end
+  end
 end

--- a/dpc-web/spec/fixtures/users.csv
+++ b/dpc-web/spec/fixtures/users.csv
@@ -1,2 +1,2 @@
 id,first_name,last_name,email,organization,organization_type,address_1,address_2,city,state,zip,agree_to_terms,num_providers,created_at,updated_at
-1,Clarissa,Dalloway,cd@example.com,Amalgamated Lint,primary_care_clinic,1234 Shut the Door Ave.,Ste 1000,Pecoima,AZ,12345,true,5,2019-10-15 18:29:35 UTC,2019-10-15 18:29:35 UTC
+50000,Clarissa,Dalloway,cd@example.com,Amalgamated Lint,primary_care_clinic,1234 Shut the Door Ave.,Ste 1000,Pecoima,AZ,12345,true,5,2019-10-15 18:29:35 UTC,2019-10-15 18:29:35 UTC

--- a/dpc-web/spec/fixtures/users.csv
+++ b/dpc-web/spec/fixtures/users.csv
@@ -1,0 +1,2 @@
+id,first_name,last_name,email,organization,organization_type,address_1,address_2,city,state,zip,agree_to_terms,num_providers,created_at,updated_at
+1,Clarissa,Dalloway,cd@example.com,Amalgamated Lint,primary_care_clinic,1234 Shut the Door Ave.,Ste 1000,Pecoima,AZ,12345,true,5,2019-10-15 18:29:35 UTC,2019-10-15 18:29:35 UTC

--- a/dpc-web/spec/models/user_spec.rb
+++ b/dpc-web/spec/models/user_spec.rb
@@ -1,10 +1,28 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
+require 'fakefs/spec_helpers'
+
 RSpec.describe User, type: :model do
   subject { create :user }
 
   describe 'factory' do
     it { is_expected.to be_valid }
+  end
+
+  describe '.to_csv' do
+    it 'generates CSV of all users' do
+      create(:user, first_name: 'Clarissa', last_name: 'Dalloway', email: 'cd@example.com',
+                    organization: 'Amalgamated Lint', organization_type: 'primary_care_clinic',
+                    address_1: '1234 Shut the Door Ave.', address_2: 'Ste 1000', city: 'Pecoima',
+                    state: 'AZ', zip: '12345', agree_to_terms: true, num_providers: 5,
+                    created_at: '2019-10-15 18:29:35 UTC', updated_at: '2019-10-15 18:29:35 UTC')
+
+      fixture_csv_content = File.read('spec/fixtures/users.csv')
+      FakeFS.with_fresh do
+        expect(User.to_csv).to eq(fixture_csv_content)
+      end
+    end
   end
 
   describe '#last_name' do

--- a/dpc-web/spec/models/user_spec.rb
+++ b/dpc-web/spec/models/user_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe User, type: :model do
 
   describe '.to_csv' do
     it 'generates CSV of all users' do
-      create(:user, first_name: 'Clarissa', last_name: 'Dalloway', email: 'cd@example.com',
+      create(:user, id: 50000, first_name: 'Clarissa', last_name: 'Dalloway', email: 'cd@example.com',
                     organization: 'Amalgamated Lint', organization_type: 'primary_care_clinic',
                     address_1: '1234 Shut the Door Ave.', address_2: 'Ste 1000', city: 'Pecoima',
                     state: 'AZ', zip: '12345', agree_to_terms: true, num_providers: 5,


### PR DESCRIPTION
**Why**

Right now if Amy wants to get data about users and run her own queries or analytics in Excel, she has to request a download from developers. This feature lets her get what she needs herself.

**What Changed**

Adds a link to the users index page for internal users to download a CSV of all users.
<img width="1204" alt="image" src="https://user-images.githubusercontent.com/54290681/67035466-b49fe480-f0e7-11e9-9336-4243ce7a1110.png">


**Choices Made**

* Make this a separate controller action because we don't want to
  apply search/filters that might be set in the index action (request
  from Amy)
* Introduce Fake FS gem to mock the file system in tests so we're not
  addign files to the test host when running

**Tickets closed**:

Give a list of tickets closed in this PR.
