### PR TITLE
DPC-728: Remove default HTTPS port from public export paths.

### DIFF
--- a/dpc-api/src/main/resources/dev.application.conf
+++ b/dpc-api/src/main/resources/dev.application.conf
@@ -1,5 +1,5 @@
 dpc.api {
-    publicURL = "https://dev.dpc.cms.gov:443/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
+    publicURL = "https://dev.dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
     database = {
         url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_attribution"

--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -1,6 +1,6 @@
 dpc.api {
 
-    publicURL = "http://dpc.cms.gov:443/v1" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
+    publicURL = "http://dpc.cms.gov/v1" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
     server {
         applicationContextPath = "/api"

--- a/dpc-api/src/main/resources/test.application.conf
+++ b/dpc-api/src/main/resources/test.application.conf
@@ -1,6 +1,6 @@
 dpc.api {
 
-    publicURL = "http://test.dpc.cms.gov:443/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
+    publicURL = "http://test.dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
     server {
         applicationContextPath = "/api"


### PR DESCRIPTION
**Why**

Per a discussion with pilot users, including the default HTTPS port in our file output response seems to be causing some issues. I'm assuming it has to do with corporate proxies, but since we're just being explicit about the default port, it seems fine to remove it. This was confirmed to solve the issue at the pilot site.

**What Changed**

Removed the default HTTPS port (443) from the publicURL value in the application configs.

**Choices Made**

**Tickets closed**:

DPC-728

**Future Work**

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
