### PR TITLE
[WIP] DPC-264: Synchronous fetch of all patient resources ($everything)

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
@@ -37,6 +37,10 @@ public abstract class AbstractPatientResource {
     @Path("/{patientID}")
     public abstract Patient getPatient(UUID patientID);
 
+    @GET
+    @Path("/{patientID}/$everything")
+    public abstract Response everything(OrganizationPrincipal organization, String patientID);
+
     @DELETE
     @Path("/{patientID}")
     public abstract Response deletePatient(UUID patientID);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -250,7 +250,7 @@ public class PatientResource extends AbstractPatientResource {
             "All resources available for the Patient are included in the result bundle.")
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Cannot find Patient record with given ID"),
-            @ApiResponse(code = 408, message = "", response = OperationOutcome.class),
+            @ApiResponse(code = 504, message = "", response = OperationOutcome.class),
             @ApiResponse(code = 500, message = "A system error occurred", response = OperationOutcome.class)
     })
     @Override
@@ -290,7 +290,7 @@ public class PatientResource extends AbstractPatientResource {
                 }
                 break;
             case TIMED_OUT:
-                builder = Response.status(HttpStatus.REQUEST_TIMEOUT_408);
+                builder = Response.status(HttpStatus.GATEWAY_TIMEOUT_504);
                 break;
             case FAILED:
                 // is there an operation outcome to get here?
@@ -397,24 +397,11 @@ public class PatientResource extends AbstractPatientResource {
                 .flatMap(List::stream)
                 .forEach(batchFile -> {
                     java.nio.file.Path path = Paths.get(String.format("%s/%s.ndjson", exportPath, batchFile.getFileName()));
-                    // is there a better way to get the class type given the ResourceType?
-                    switch (batchFile.getResourceType()) {
-                        case Patient:
-                            addResourceEntries(Patient.class, path, bundle);
-                            break;
-                        case ExplanationOfBenefit:
-                            addResourceEntries(ExplanationOfBenefit.class, path, bundle);
-                            break;
-                        case Coverage:
-                            addResourceEntries(Coverage.class, path, bundle);
-                            break;
-                        default:
-                            logger.info("Ignoring unexpected resource type {} ", batchFile.getResourceType());
-                            break;
-                    }
+                    addResourceEntries(Resource.class, path, bundle);
                 });
 
         // set a bundle id here? anything else?
+        bundle.setId(UUID.randomUUID().toString());
         return bundle.setTotal(bundle.getEntry().size());
     }
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -390,8 +390,7 @@ public class PatientResource extends AbstractPatientResource {
     }
 
     Bundle assembleEverythingBundle(List<JobQueueBatch> batches) {
-        final Bundle bundle = new Bundle();
-        bundle.setType(Bundle.BundleType.SEARCHSET);
+        final Bundle bundle = new Bundle().setType(Bundle.BundleType.SEARCHSET);
 
         batches.stream()
                 .map(JobQueueBatch::getJobQueueBatchFiles)
@@ -401,15 +400,12 @@ public class PatientResource extends AbstractPatientResource {
                     // is there a better way to get the class type given the ResourceType?
                     switch (batchFile.getResourceType()) {
                         case Patient:
-                            System.out.println("\n\npatient count " + batchFile.getCount() + "\n\n");
                             addResourceEntries(Patient.class, path, bundle);
                             break;
                         case ExplanationOfBenefit:
-                            System.out.println("\n\npatient count " + batchFile.getCount() + "\n\n");
                             addResourceEntries(ExplanationOfBenefit.class, path, bundle);
                             break;
                         case Coverage:
-                            System.out.println("\n\npatient count " + batchFile.getCount() + "\n\n");
                             addResourceEntries(Coverage.class, path, bundle);
                             break;
                         default:
@@ -419,8 +415,7 @@ public class PatientResource extends AbstractPatientResource {
                 });
 
         // set a bundle id here? anything else?
-        bundle.setTotal(bundle.getEntry().size());
-        return bundle;
+        return bundle.setTotal(bundle.getEntry().size());
     }
 
     private void addResourceEntries(Class<? extends Resource> clazz, java.nio.file.Path path, Bundle bundle) {


### PR DESCRIPTION
**Why**

As a vendor, I want to be able to fetch all resources for a given patient, in a synchronous manner.

For a given patient, retrieves a bundle containing all resources available for that patient. Currently, the bundle can include Patient, ExplanationOfBenefit, and Coverage resources. If the bundle cannot be produced for some reason, an http error message is returned with an OperationOutcome. Failures can occur because of a processing error, because the job was taking too long to run, or because the patient id was invalid.

The endpoint creates an aggregation job that requests all resources for the patient. It then polls the job status until the job has either completed, failed or timed out. The timeout prevents the API from waiting forever for a job to complete. When the job completes, the batch results are evaluated and the corresponding output assembled.

The bundle contains the resources directly in it; that is, there are no links that must be followed.

**Open Questions**

Is the dpc patient profile different from the Patient resource? If yes, should they both be included?

The spec for $everything changes from FHIR version 3 to FHIR version 4. I would assume we are implementing version 3 because that is the FHIR version we otherwise support. However, the confluence doc links to version 4.

The main differences between the two specs are the supported parameters:

| Version 3 | Version 4 | Notes |
| --------- | --------- | ----- |
| start     | start     | All records after this care date. Exclusive?   |
| end       | end       | All records before this care date. Exclusive?   |
|           | _since    | All records updated on or after. Needs BFD and Rick to complete   |
|           | _type     | Allows request to specify the set of resources   |
|           | _count    | Controls data paging   |

Do we intend to support the unqualified (no patient ID) endpoint that returns all records for all patients? That seems inconsistent with the intent described, so I think not, but want to confirm.

In the event that partial results are found ---  i.e., one or two but not all three resources --- what do we return? a bundle with both results and an operation outcome?

**Technical Questions**

- is the endpoint specified correctly from an authorization PoV
- what is the correct priority for this job to have? is that something I can / should check?
- what is the difference among thee 3 ways of getting an organization id?
- why does any random uuid work for provider id in job creation?
- is it possible / worth it to validate the patientID before submitting the job?
- should the job polling timeout be configurable in some manner?
- does aggregation know how to do date filtering, or do we have to do that after getting the results?
- similarly, does aggregation support paging (only relevant if we support _count)?


**What Changed**

Added a new $everything endpoint.
Added an Executor-based poller of the job queue.
Added methods to read ndjson resource files into a Bundle or an OperationOutcome.

**Choices Made**

Justify changes made and any reasons for why a given path was taken, as opposed to an alternative option.

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additional fixes.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
