### PR TITLE
DPC-548: Add build version to application

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
@@ -106,7 +106,7 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
             @Override
             protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(DPCAPIConfiguration dpcapiConfiguration) {
                 final SwaggerBundleConfiguration swaggerBundleConfiguration = dpcapiConfiguration.getSwaggerBundleConfiguration();
-                swaggerBundleConfiguration.setVersion(propertiesProvider.getBuildVersion());
+                swaggerBundleConfiguration.setVersion(propertiesProvider.getApplicationVersion());
                 return swaggerBundleConfiguration;
             }
         });

--- a/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/core/Capabilities.java
@@ -62,8 +62,8 @@ public class Capabilities {
 
             final CapabilityStatement capabilityStatement = FhirContext.forDstu3().newJsonParser().parseResource(CapabilityStatement.class, resource);
             return capabilityStatement
-                    .setVersion(pp.getBuildVersion())
-                    .setSoftware(generateSoftwareComponent(releaseDate, pp.getBuildVersion()));
+                    .setVersion(pp.getApplicationVersion())
+                    .setSoftware(generateSoftwareComponent(releaseDate, pp.getApplicationVersion()));
         } catch (IOException e) {
             throw new IllegalStateException("Unable to read capability statement", e);
         }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/BaseResource.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.api.resources.v1;
 import gov.cms.dpc.api.auth.annotations.Public;
 import gov.cms.dpc.api.core.Capabilities;
 import gov.cms.dpc.api.resources.*;
+import gov.cms.dpc.common.utils.PropertiesProvider;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
@@ -26,6 +27,7 @@ public class BaseResource extends AbstractBaseResource {
     private final AbstractPatientResource par;
     private final AbstractPractitionerResource pr;
     private final AbstractDefinitionResource sdr;
+    private final PropertiesProvider pp;
 
     @Inject
     public BaseResource(KeyResource kr,
@@ -48,15 +50,16 @@ public class BaseResource extends AbstractBaseResource {
         this.par = par;
         this.pr = pr;
         this.sdr = sdr;
+        this.pp = new PropertiesProvider();
     }
 
     @Override
     @Public
     @GET
     @Path("/version")
-    @ApiOperation(value = "Return the software version", hidden = true)
+    @ApiOperation(value = "Return the application build version")
     public String version() {
-        return "Version 1";
+        return this.pp.getBuildVersion();
     }
 
     @Override

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/DPCAttributionService.java
@@ -17,13 +17,10 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.federecio.dropwizard.swagger.SwaggerBundle;
 import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
-import liquibase.exception.DatabaseException;
 import org.knowm.dropwizard.sundial.SundialBundle;
 import org.knowm.dropwizard.sundial.SundialConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.sql.SQLException;
 
 public class DPCAttributionService extends Application<DPCAttributionConfiguration> {
 
@@ -102,7 +99,7 @@ public class DPCAttributionService extends Application<DPCAttributionConfigurati
                 @Override
                 protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(DPCAttributionConfiguration configuration) {
                     final SwaggerBundleConfiguration config = configuration.getSwaggerBundleConfiguration();
-                    config.setVersion(propertiesProvider.getBuildVersion());
+                    config.setVersion(propertiesProvider.getApplicationVersion());
                     return config;
                 }
             });

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractAttributionResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractAttributionResource.java
@@ -1,16 +1,19 @@
 package gov.cms.dpc.attribution.resources;
 
+import gov.cms.dpc.common.utils.PropertiesProvider;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
-@Api(value = "Health")
+@Api(value = "Metadata")
 public abstract class AbstractAttributionResource {
 
+    private final PropertiesProvider pp;
+
     protected AbstractAttributionResource() {
-//        Not used
+        this.pp = new PropertiesProvider();
     }
 
     @Path("/Group")
@@ -34,5 +37,13 @@ public abstract class AbstractAttributionResource {
             "\n\nMeaning, are all endpoints functioning and is the attribution database reachable.")
     public boolean checkHealth() {
         return true;
+    }
+
+    @GET
+    @Path("/version")
+    @ApiOperation(value = "Get application build version", notes = "Returns the application build version. " +
+            "Which is the git sha abbreviation and the build timestamp.")
+    public String getVersion() {
+        return this.pp.getBuildVersion();
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PropertiesProvider.java
@@ -2,36 +2,56 @@ package gov.cms.dpc.common.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.MissingResourceException;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 public class PropertiesProvider {
 
-    private static final String PROPERTIES_FILE = "app.properties";
+    private static final String[] PROPERTIES_FILES = {"app.properties", "git.properties"};
     private static final DateTimeFormatter MAVEN_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX");
 
     private final Properties properties;
 
     public PropertiesProvider() {
         this.properties = new Properties();
-        try (final InputStream is = PropertiesProvider.class.getClassLoader().getResourceAsStream(PROPERTIES_FILE)) {
-            if (is == null) {
-                throw new MissingResourceException("Cannot find application properties file", PropertiesProvider.class.getName(), PROPERTIES_FILE);
-            }
-            this.properties.load(is);
-        } catch (IOException e) {
-            throw new IllegalStateException(String.format("Cannot load properties file: %s", PROPERTIES_FILE), e);
-        }
+        Stream.of(PROPERTIES_FILES)
+                .forEach(this::loadPropertyFile);
     }
 
     public OffsetDateTime getBuildTimestamp() {
         return OffsetDateTime.parse(this.properties.getProperty("application.builddate"), MAVEN_FORMATTER);
     }
 
-    public String getBuildVersion() {
+    /**
+     * Returns the application version (e.g. The maven version 0.4.0-SNAPSHOT)
+     *
+     * @return - {@link String} application version
+     */
+    public String getApplicationVersion() {
         return this.properties.getProperty("application.version");
+    }
+
+    /**
+     * Returns the application build version, which is the first 7 characters of the commit sha, and the build timestamp.
+     *
+     * @return - {@link String} application build version
+     */
+    public String getBuildVersion() {
+        final String commitAbbrev = this.properties.getProperty("git.commit.id.abbrev");
+        return String.format("%s.%s", commitAbbrev, getBuildTimestamp());
+    }
+
+    private void loadPropertyFile(String file) {
+        try (final InputStream is = PropertiesProvider.class.getClassLoader().getResourceAsStream(file)) {
+            if (is == null) {
+                throw new MissingResourceException("Cannot find application properties file", PropertiesProvider.class.getName(), file);
+            }
+            this.properties.load(is);
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format("Cannot load properties file: %s", file), e);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>git-commit</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <configuration>
+                            <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
**Why**

As we now have 3 environments that could have 3 different application versions deployed, we need a way to distinguish between them. We previously had a `/v1/version` endpoint, but it always returned the wrong value. This fixes that endpoint to return the build version of the application.

**What Changed**

Updated our Properties Provider to output the application build version.

This is the first 7 characters of the git sha, followed by the build timestamp. The git value is provided by a maven [plugin](https://www.github.com/git-commit-id/maven-git-commit-id-plugin).

Both the Attribution service and the API service return this value correctly.

**Choices Made**

**Tickets closed**:

DPC-548

**Future Work**

DPC-475: Add the build version to the Rails website.

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
