### PR TITLE
Hotfix: Fix publicURL root for prod sbx.

### DIFF
--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -1,6 +1,6 @@
 dpc.api {
 
-    publicURL = "http://dpc.cms.gov/v1" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
+    publicURL = "http://dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
     server {
         applicationContextPath = "/api"


### PR DESCRIPTION
**Why**

I fat fingered the publicURL, it should end with /api rather than /v1. This means progress and download url's won't work correctly.

**What Changed**

Fixed the publicURL to be correct.

**Choices Made**

Shame.

**Tickets closed**:

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
