### PR TITLE
DPC-688: Remove old auth tables from attribution database

### DIFF
--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -395,11 +395,19 @@
         </addColumn>
         <renameColumn tableName="ATTRIBUTIONS" oldColumnName="created_at" newColumnName="period_begin"/>
     </changeSet>
-    
+
     <changeSet id="add-roster-idx" author="nickrobison-usds">
         <createIndex tableName="ATTRIBUTIONS" indexName="">
             <column name="roster_id"/>
             <column name="patient_id"/>
         </createIndex>
+    </changeSet>
+
+    <changeSet id="remove-old-auth-tables" author="nickrobison-usds">
+        <dropTable tableName="ROOT_KEYS"/>
+        <dropTable tableName="ORGANIZATION_TOKENS"/>
+        <sql>
+            DROP FUNCTION IF EXISTS expire_root_keys();
+        </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**Why**

Now that DPC-678 is merged, we no longer need the old auth tables in the attribution database.

**What Changed**

Removed the old auth tables and root key expiration triggers.

**Choices Made**


**Tickets closed**:

DPC-688

**Future Work**

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
