### PR TITLE
DPC-653: Create custom Docker image for services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,3 @@ smoke/prod-sbx: ${JMETER}
 .PHONY: docker-base
 docker-base:
 	@docker-compose -f ./docker-compose.base.yml build base
-	# TODO: push image to ECR?

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ start-app:
 	@docker-compose up start_api
 
 .PHONY: ci-app
-ci-app:
+ci-app: docker-base
 	@./dpc-test.sh
 
 .PHONY: ci-web
@@ -57,3 +57,8 @@ smoke/test: ${JMETER}
 smoke/prod-sbx: ${JMETER}
 	@echo "Running Smoke Tests against Sandbox env"
 	@${JMETER} -p src/main/resources/prod-sbx.properties -Jthreads=${SMOKE_THREADS} -n -t src/main/resources/SmokeTest.jmx -l out.jtl
+
+.PHONY: docker-base
+docker-base:
+	@docker-compose -f ./docker-compose.base.yml build base
+	# TODO: push image to ECR?

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Run `make ci-app`. This will start the dependencies, build all components, run i
 
 ### Option 2: Manually
 
-Run `make docker-base` to build the common, baseline Docker image used across DPC services.
+Run `make docker-base` to build the common, baseline Docker image (i.e., `dpc-base:latest`) used across DPC services.
 
 Then, run `mvn clean install` to build and test the application. Dependencies will need to be up and running for this option to succeed.
 
 Running `mvn clean install` will also construct the *Docker* images for the individual services. To skip the Docker build pass `-Djib.skip=True`
+
+Note that the `dpc-base` image produced by `make docker-base` is not stored in a remote repository. The `mvn clean install` process relies on the base image being available via the local Docker daemon.
 
 Running DPC
 --- 

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ Run `make ci-app`. This will start the dependencies, build all components, run i
 
 ### Option 2: Manually
 
-Run `mvn clean install` after cloning to build and test the application. Dependencies will need to be up and running for this option to succeed.
+Run `make docker-base` to build the common, baseline Docker image used across DPC services.
 
-This will also construct the *Docker* images for the various services. To skip the Docker build pass `-Djib.skip=True`
+Then, run `mvn clean install` to build and test the application. Dependencies will need to be up and running for this option to succeed.
+
+Running `mvn clean install` will also construct the *Docker* images for the individual services. To skip the Docker build pass `-Djib.skip=True`
 
 Running DPC
 --- 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   base:
-    image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-base}:latest
+    image: dpc-base:latest
     build:
       context: .
       dockerfile: docker/Dockerfiles/Dockerfile.base

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  base:
+    image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-base}:latest
+    build:
+      context: .
+      dockerfile: docker/Dockerfiles/Dockerfile.base

--- a/docker/Dockerfiles/Dockerfile.base
+++ b/docker/Dockerfiles/Dockerfile.base
@@ -1,0 +1,8 @@
+# See: https://github.com/docker-library/openjdk/blob/master/11/jdk/slim/Dockerfile
+FROM openjdk:11-jdk-slim
+
+# Install additional packages used acros DPC images
+RUN  apt-get update && apt-get -y install awscli
+
+# Use the openjdk:11-jdk-slim default command/entrypoint
+CMD ["jshell"]

--- a/dpc-aggregation/docker/entrypoint.sh
+++ b/dpc-aggregation/docker/entrypoint.sh
@@ -3,10 +3,6 @@
 set -e
 
 bootstrap_config() {
-  # Install the AWS CLI
-  apt-get update
-  apt-get -y install awscli
-
   # Create the config directory
   mkdir -p /config
 

--- a/dpc-api/docker/entrypoint.sh
+++ b/dpc-api/docker/entrypoint.sh
@@ -3,10 +3,6 @@
 set -e
 
 bootstrap_config() {
-  # Install the AWS CLI
-  apt-get update
-  apt-get -y install awscli
-
   # Create the config directory
   mkdir -p /config
 

--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
                             </tags>
                         </to>
                         <from>
-                            <image>docker://755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-base</image>
+                            <image>docker://dpc-base:latest</image>
                         </from>
                     </configuration>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -400,7 +400,7 @@
                             </tags>
                         </to>
                         <from>
-                            <image>openjdk:11-jdk-slim</image>
+                            <image>docker://755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-base</image>
                         </from>
                     </configuration>
                     <executions>


### PR DESCRIPTION
**Why**

Rather than installing common dependencies via each service's `entrypoint.sh`, we want to build a baseline image with said dependencies that individual service images can be based on.

Assuming the base image changes infrequently, this should mean marginally faster build times for individual services. It also reduces external requirements for services to start successfully.

**What Changed**

- Added `docker-compose.base.yml` and `docker/Dockerfiles/Dockerfile.base`
- `Dockerfile.base` builds from the `openjdk:11-jdk-slim` (same that was previously used in `pom.xml` as the base for jib builds)
- Moved `apt-get` commands out of api and aggregation `entrypoint.sh` files
- Added `make docker-base`, made `docker-base` part of `make ci-app` target to ensure the base image is available when jib builds images for services
- Updated base config for Docker images in `pom.xml` to use `docker://dpc-base:lastest` (uses the image from local Docker daemon)
- Updated `README.md`

**Choices Made**

Probably the most notable choice was to use local Docker daemon to source `dpc-base:latest` when jib builds images, rather than shouldering the additional complexity of pushing to/pulling from a remote repo (e.g., Docker Hub or ECR).

**Tickets closed**:

https://jiraent.cms.gov/browse/DPC-653

**Future Work**

None planned at present.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
