### PR TITLE
DPC-750: Encode golden macaroon as a Base64 String

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/GenerateClientTokens.java
@@ -16,6 +16,8 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -30,12 +32,14 @@ public class GenerateClientTokens extends Task {
 
     private final MacaroonBakery bakery;
     private final TokenResource resource;
+    private final Base64.Encoder encoder;
 
     @Inject
     GenerateClientTokens(MacaroonBakery bakery, TokenResource resource) {
         super("generate-token");
         this.bakery = bakery;
         this.resource = resource;
+        this.encoder = Base64.getUrlEncoder();
     }
 
     @Override
@@ -45,7 +49,8 @@ public class GenerateClientTokens extends Task {
         if (organizationCollection.isEmpty()) {
             logger.warn("CREATING UNRESTRICTED MACAROON. ENSURE THIS IS OK");
             final Macaroon macaroon = bakery.createMacaroon(Collections.emptyList());
-            output.write(macaroon.serialize(MacaroonVersion.SerializationVersion.V2_JSON));
+            final byte[] serialized = macaroon.serialize(MacaroonVersion.SerializationVersion.V2_JSON).getBytes(StandardCharsets.UTF_8);
+            output.write(this.encoder.encodeToString(serialized));
         } else {
             final String organization = organizationCollection.asList().get(0);
             final Organization orgResource = new Organization();


### PR DESCRIPTION
**Why**

The Website uncovered a bug where we weren't Base64 encoding the Golden Macaroon. Which makes it awkward and error prone to pass around as a string.

**What Changed**

Base64 the golden macaroon

**Choices Made**

Base64 the golden macaroon

**Tickets closed**:

DPC-750: This ticket

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
