### PR TITLE
Resolve Smoke Test Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Ignore smoke tests
+jmeter.log
+smoke.out

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ ci-web:
 .PHONY: smoke/local
 smoke/local: venv
 	@echo "Running Smoke Tests against Local env"
+	@read -p "`echo '\n=====\nThe Smoke Tests require an authenticated environment!\nVerify your local API environment has \"authenticationDisabled = false\" or these tests will fail.\n=====\n\nPress ENTER to run the tests...'`"
 	. venv/bin/activate; bzt src/test/local.smoke_test.yml
 
 .PHONY: smoke/dev

--- a/src/test/smoke_test.yml
+++ b/src/test/smoke_test.yml
@@ -16,4 +16,4 @@ scenarios:
 reporting:
   - module: passfail
     criteria:
-      - "fail>50% for 10s, stop as failed"
+      - "fail>50%, stop as failed"


### PR DESCRIPTION
**Why**

The smoke test is currently failing in Jenkins. These changes attempt to correct this issues with running the smoke test.

**What Changed**

* Removes failure time constraint from Taurus passfail module.
  * When tests were quickly failing, like is in the case of DEV due to BFD peering, the failure scenario was not being triggered.
* Adds a prompt when running local smoke tests to ensure authentication is enabled.
  * The API requires a token to derive the organizationID that is sent to the attribution server. If authentication is disabled, the API sends an empty organizationID to the attribution server and the tests fail.
* Links with https://github.com/CMSgov/dpc-ops/pull/69 to re-install virtualenv on Jenkins.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
