### PR TITLE
Add a make target to build the smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ ci-app: docker-base
 ci-web:
 	@./dpc-web-test.sh
 
+.PHONY: smoke
+smoke:
+	@mvn clean install -DskipTests -Djib.skip=True
+
 .PHONY: smoke/local
 smoke/local: venv
 	@echo "Running Smoke Tests against Local env"


### PR DESCRIPTION
**Why**

The smoke tests are not running on Jenkins because the SmokeTest class is not compiled.

**What Changed**

* Adds a make target to build the application without tests and no docker images (for fast compiling). This will be used in dpc-ops change.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [X] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
