### PR TITLE
DPC-763: Generate V1 encoded Golden Macaroons

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/GenerateClientTokens.java
@@ -49,7 +49,7 @@ public class GenerateClientTokens extends Task {
         if (organizationCollection.isEmpty()) {
             logger.warn("CREATING UNRESTRICTED MACAROON. ENSURE THIS IS OK");
             final Macaroon macaroon = bakery.createMacaroon(Collections.emptyList());
-            final byte[] serialized = macaroon.serialize(MacaroonVersion.SerializationVersion.V2_JSON).getBytes(StandardCharsets.UTF_8);
+            final byte[] serialized = macaroon.serialize(MacaroonVersion.SerializationVersion.V1_BINARY).getBytes(StandardCharsets.UTF_8);
             output.write(this.encoder.encodeToString(serialized));
         } else {
             final String organization = organizationCollection.asList().get(0);

--- a/dpc-macaroons/src/main/java/gov/cms/dpc/macaroons/MacaroonBakery.java
+++ b/dpc-macaroons/src/main/java/gov/cms/dpc/macaroons/MacaroonBakery.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  */
 public class MacaroonBakery {
 
-    public static final Charset CAVEAT_CHARSET = StandardCharsets.UTF_8;
+    private static final Charset CAVEAT_CHARSET = StandardCharsets.UTF_8;
     private static final Base64.Encoder encoder = Base64.getUrlEncoder();
     private static final Base64.Decoder decoder = Base64.getUrlDecoder();
 
@@ -225,9 +225,9 @@ public class MacaroonBakery {
         }
         // Determine if we're Base64 encoded or not
         byte[] decodedString;
-        // For a V2 JSON macaroon, either '{' or '[' will be the starting value, so we check for the base64 encoded value
+        // For a JSON macaroon, either '{' or '[' will be the starting value, for V1 binary it's 'T', so we check for the base64 encoded value
         final char indexChar = serializedString.charAt(0);
-        if (indexChar == 'e' || indexChar == 'W') {
+        if (indexChar == 'e' || indexChar == 'W' || indexChar == 'T') {
             decodedString = decoder.decode(serializedString.getBytes(CAVEAT_CHARSET));
         } else {
             decodedString = serializedString.getBytes(CAVEAT_CHARSET);
@@ -555,7 +555,7 @@ public class MacaroonBakery {
          * @param caveatSupplier - {@link CaveatSupplier} which generates caveat
          * @return - {@link MacaroonBakeryBuilder}
          */
-        public MacaroonBakeryBuilder addDefaultCaveatSupplier(CaveatSupplier caveatSupplier) {
+        MacaroonBakeryBuilder addDefaultCaveatSupplier(CaveatSupplier caveatSupplier) {
             this.caveatSuppliers.add(caveatSupplier);
             return this;
         }
@@ -566,12 +566,12 @@ public class MacaroonBakery {
          * @param caveatVerifier - {@link CaveatVerifier} to apply to each {@link Macaroon}
          * @return - {@link MacaroonBakeryBuilder}
          */
-        public MacaroonBakeryBuilder addDefaultVerifier(CaveatVerifier caveatVerifier) {
+        MacaroonBakeryBuilder addDefaultVerifier(CaveatVerifier caveatVerifier) {
             this.caveatVerifiers.add(caveatVerifier);
             return this;
         }
 
-        public MacaroonBakeryBuilder withKeyPair(BakeryKeyPair keyPair) {
+        MacaroonBakeryBuilder withKeyPair(BakeryKeyPair keyPair) {
             this.keyPair = keyPair;
             return this;
         }
@@ -594,10 +594,7 @@ public class MacaroonBakery {
         }
 
         private BakeryKeyPair getKeyPair() {
-            if (this.keyPair != null) {
-                return this.keyPair;
-            }
-            return BakeryKeyPair.generate();
+            return Objects.requireNonNullElseGet(this.keyPair, BakeryKeyPair::generate);
         }
     }
 


### PR DESCRIPTION
**Why**

We discovered that the Ruby Macaroons library does not support V2 encoded Macaroons. Which is annoying, but manageable. That means we need to generate the appropriate Macaroons in the API services.

This is required by #363 

**What Changed**

Updated the GenrateClientTokens task to generate V1 binary encoded Macaroons, rather than V2 JSON.

**Choices Made**

**Tickets closed**:

DPC-673

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
