### PR TITLE
DPC-784: Fix public key IDs

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/cli/tokens/TokenList.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/cli/tokens/TokenList.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.fliptables.FlipTable;
 import gov.cms.dpc.api.cli.AbstractAdminCommand;
 import gov.cms.dpc.api.entities.TokenEntity;
+import gov.cms.dpc.api.models.CollectionResponse;
 import io.dropwizard.setup.Bootstrap;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -19,6 +20,7 @@ import org.hl7.fhir.dstu3.model.IdType;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
 
 public class TokenList extends AbstractAdminCommand {
@@ -64,9 +66,9 @@ public class TokenList extends AbstractAdminCommand {
                     System.exit(1);
                 }
 
-                List<TokenEntity> tokens = mapper.readValue(response.getEntity().getContent(), new TypeReference<List<TokenEntity>>() {
+                CollectionResponse<TokenEntity> tokens = mapper.readValue(response.getEntity().getContent(), new TypeReference<CollectionResponse<TokenEntity>>() {
                 });
-                generateTable(tokens);
+                generateTable(new ArrayList<>(tokens.getEntities()));
             }
         }
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/converters/PublicKeyDeserializer.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/converters/PublicKeyDeserializer.java
@@ -1,0 +1,22 @@
+package gov.cms.dpc.api.converters;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import gov.cms.dpc.api.auth.jwt.PublicKeyHandler;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+
+/**
+ * {@link StdConverter} that de-serializes a {@link SubjectPublicKeyInfo} from a PEM encoded {@link String}
+ *
+ * Primarily used for testing and debugging.
+ */
+public class PublicKeyDeserializer extends StdConverter<String, SubjectPublicKeyInfo> {
+
+    PublicKeyDeserializer() {
+        // Not used
+    }
+
+    @Override
+    public SubjectPublicKeyInfo convert(String value) {
+        return PublicKeyHandler.parsePEMString(value);
+    }
+}

--- a/dpc-api/src/main/java/gov/cms/dpc/api/entities/PublicKeyEntity.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/entities/PublicKeyEntity.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import gov.cms.dpc.api.converters.PublicKeyBytesConverter;
+import gov.cms.dpc.api.converters.PublicKeyDeserializer;
 import gov.cms.dpc.api.converters.PublicKeySerializer;
 import gov.cms.dpc.common.converters.jackson.OffsetDateTimeToStringConverter;
+import gov.cms.dpc.common.converters.jackson.StringToOffsetDateTimeConverter;
 import io.swagger.annotations.ApiModelProperty;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.hibernate.annotations.CreationTimestamp;
@@ -33,6 +35,7 @@ public class PublicKeyEntity implements Serializable {
     @NotNull
     @Convert(converter = PublicKeyBytesConverter.class)
     @JsonSerialize(converter = PublicKeySerializer.class)
+    @JsonDeserialize(converter = PublicKeyDeserializer.class)
     @Column(name = "public_key")
     @ApiModelProperty(value = "PEM encoded public key", dataType = "String", example = "---PUBLIC KEY---......---END PUBLIC KEY---")
     private SubjectPublicKeyInfo publicKey;
@@ -40,7 +43,7 @@ public class PublicKeyEntity implements Serializable {
     @Column(name = "created_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
     @CreationTimestamp
     @JsonSerialize(converter = OffsetDateTimeToStringConverter.class)
-    @JsonDeserialize(converter = OffsetDateTimeToStringConverter.class)
+    @JsonDeserialize(converter = StringToOffsetDateTimeConverter.class)
     private OffsetDateTime createdAt;
 
     @NotEmpty

--- a/dpc-api/src/main/java/gov/cms/dpc/api/jdbi/PublicKeyDAO.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/jdbi/PublicKeyDAO.java
@@ -10,6 +10,7 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public class PublicKeyDAO extends AbstractDAO<PublicKeyEntity> {
@@ -32,13 +33,12 @@ public class PublicKeyDAO extends AbstractDAO<PublicKeyEntity> {
         return list(query);
     }
 
-    public List<PublicKeyEntity> fetchPublicKey(UUID keyID, UUID organizationID) {
-        return publicKeySearch(keyID, organizationID);
+    public Optional<PublicKeyEntity> fetchPublicKey(UUID keyID) {
+        return Optional.ofNullable(get(keyID));
     }
 
-    public void deletePublicKey(UUID keyID, UUID organizationID) {
-        publicKeySearch(keyID, organizationID)
-                .forEach(key -> currentSession().delete(key));
+    public void deletePublicKey(PublicKeyEntity keyEntity) {
+        currentSession().delete(keyEntity);
     }
 
     public PublicKeyEntity findKeyByLabel(String keyLabel) {
@@ -51,7 +51,7 @@ public class PublicKeyDAO extends AbstractDAO<PublicKeyEntity> {
         return currentSession().createQuery(query).getSingleResult();
     }
 
-    private List<PublicKeyEntity> publicKeySearch(UUID keyID, UUID organizationID) {
+    public List<PublicKeyEntity> publicKeySearch(UUID keyID, UUID organizationID) {
         final CriteriaBuilder builder = currentSession().getCriteriaBuilder();
         final CriteriaQuery<PublicKeyEntity> query = builder.createQuery(PublicKeyEntity.class);
         final Root<PublicKeyEntity> root = query.from(PublicKeyEntity.class);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/models/CollectionResponse.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/models/CollectionResponse.java
@@ -1,0 +1,62 @@
+package gov.cms.dpc.api.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import gov.cms.dpc.common.converters.jackson.OffsetDateTimeToStringConverter;
+import gov.cms.dpc.common.converters.jackson.StringToOffsetDateTimeConverter;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collection;
+
+/**
+ * Wrapper method for enclosing a given {@link Collection} of {@link T} with some additional metadata.
+ * @param <T> - type parameter of encompassed class
+ */
+public class CollectionResponse<T extends Serializable> implements Serializable {
+    public static final long serialVersionUID = 42L;
+
+    private Collection<T> entities;
+    private int count;
+
+    @JsonDeserialize(converter = StringToOffsetDateTimeConverter.class)
+    @JsonSerialize(converter = OffsetDateTimeToStringConverter.class)
+    @JsonProperty(value = "created_at")
+    private OffsetDateTime createdAt;
+
+    private CollectionResponse() {
+        // Jackson required
+    }
+
+    public CollectionResponse(Collection<T> entities) {
+        this.entities = entities;
+        this.count = entities.size();
+        this.createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    public Collection<T> getEntities() {
+        return entities;
+    }
+
+    public void setEntities(Collection<T> entities) {
+        this.entities = entities;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractKeyResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractKeyResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources;
 
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.entities.PublicKeyEntity;
+import gov.cms.dpc.api.models.CollectionResponse;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.NotNull;
@@ -10,7 +11,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,7 +18,7 @@ import java.util.UUID;
 public abstract class AbstractKeyResource {
 
     @GET
-    public abstract List<PublicKeyEntity> getPublicKeys(OrganizationPrincipal organizationPrincipal);
+    public abstract CollectionResponse<PublicKeyEntity> getPublicKeys(OrganizationPrincipal organizationPrincipal);
 
     @GET
     @Path("/{keyID}")
@@ -28,6 +28,7 @@ public abstract class AbstractKeyResource {
     @Path("/{keyID}")
     public abstract Response deletePublicKey(OrganizationPrincipal organizationPrincipal, @NotNull UUID keyID);
 
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     @POST
     public abstract PublicKeyEntity submitKey(OrganizationPrincipal organizationPrincipal, @NotEmpty String key, Optional<String> keyLabel);
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractTokenResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractTokenResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources;
 
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.entities.TokenEntity;
+import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.api.models.JWTAuthResponse;
 import io.dropwizard.jersey.jsr310.OffsetDateTimeParam;
 import org.hibernate.validator.constraints.NotEmpty;
@@ -31,7 +32,7 @@ public abstract class AbstractTokenResource {
      * @return - {@link List} {@link String} base64 (URL) encoded token
      */
     @GET
-    public abstract List<TokenEntity> getOrganizationTokens(OrganizationPrincipal organizationPrincipal);
+    public abstract CollectionResponse<TokenEntity> getOrganizationTokens(OrganizationPrincipal organizationPrincipal);
 
     /**
      * Create authentication token for {@link org.hl7.fhir.dstu3.model.Organization}.

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/KeyResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/KeyResource.java
@@ -67,11 +67,11 @@ public class KeyResource extends AbstractKeyResource {
     @ApiResponses(@ApiResponse(code = 404, message = "Cannot find public key for organization"))
     @Override
     public PublicKeyEntity getPublicKey(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, @NotNull @PathParam(value = "keyID") UUID keyID) {
-        final List<PublicKeyEntity> certificates = this.dao.fetchPublicKey(keyID, organizationPrincipal.getID());
-        if (certificates.isEmpty()) {
-            throw new WebApplicationException("Cannot find certificate", Response.Status.NOT_FOUND);
+        final List<PublicKeyEntity> publicKeys = this.dao.publicKeySearch(keyID, organizationPrincipal.getID());
+        if (publicKeys.isEmpty()) {
+            throw new WebApplicationException("Cannot find public key", Response.Status.NOT_FOUND);
         }
-        return certificates.get(0);
+        return publicKeys.get(0);
     }
 
     @DELETE
@@ -87,7 +87,12 @@ public class KeyResource extends AbstractKeyResource {
     })
     @Override
     public Response deletePublicKey(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, @NotNull @PathParam(value = "keyID") UUID keyID) {
-        this.dao.deletePublicKey(keyID, organizationPrincipal.getID());
+        final List<PublicKeyEntity> keys = this.dao.publicKeySearch(keyID, organizationPrincipal.getID());
+
+        if (keys.isEmpty()) {
+            throw new WebApplicationException("Cannot find certificate", Response.Status.NOT_FOUND);
+        }
+        keys.forEach(this.dao::deletePublicKey);
 
         return Response.ok().build();
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/KeyResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/KeyResource.java
@@ -8,6 +8,7 @@ import gov.cms.dpc.api.auth.jwt.PublicKeyHandler;
 import gov.cms.dpc.api.entities.PublicKeyEntity;
 import gov.cms.dpc.api.exceptions.PublicKeyException;
 import gov.cms.dpc.api.jdbi.PublicKeyDAO;
+import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.api.resources.AbstractKeyResource;
 import gov.cms.dpc.common.entities.OrganizationEntity;
 import io.dropwizard.auth.Auth;
@@ -52,8 +53,8 @@ public class KeyResource extends AbstractKeyResource {
                     "<p>The returned keys are serialized using PEM encoding.",
             authorizations = @Authorization(value = "apiKey"))
     @Override
-    public List<PublicKeyEntity> getPublicKeys(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal) {
-        return this.dao.fetchPublicKeys(organizationPrincipal.getID());
+    public CollectionResponse<PublicKeyEntity> getPublicKeys(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal) {
+        return new CollectionResponse<>(this.dao.fetchPublicKeys(organizationPrincipal.getID()));
     }
 
     @GET

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/TokenResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/TokenResource.java
@@ -8,6 +8,7 @@ import gov.cms.dpc.api.auth.annotations.Public;
 import gov.cms.dpc.api.auth.jwt.IJTICache;
 import gov.cms.dpc.api.entities.TokenEntity;
 import gov.cms.dpc.api.jdbi.TokenDAO;
+import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.api.models.JWTAuthResponse;
 import gov.cms.dpc.api.resources.AbstractTokenResource;
 import gov.cms.dpc.common.annotations.APIV1;
@@ -85,9 +86,9 @@ public class TokenResource extends AbstractTokenResource {
     @ExceptionMetered
     @ApiOperation(value = "Fetch client tokens", notes = "Method to retrieve the client tokens associated to the given Organization.")
     @ApiResponses(value = @ApiResponse(code = 404, message = "Could not find Organization"))
-    public List<TokenEntity> getOrganizationTokens(
+    public CollectionResponse<TokenEntity> getOrganizationTokens(
             @ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal) {
-        return this.dao.fetchTokens(organizationPrincipal.getID());
+        return new CollectionResponse<>(this.dao.fetchTokens(organizationPrincipal.getID()));
     }
 
     @GET

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/ListClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/ListClientTokens.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableMultimap;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.entities.TokenEntity;
+import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.api.resources.v1.TokenResource;
 import io.dropwizard.servlets.tasks.Task;
 import org.hl7.fhir.dstu3.model.Organization;
@@ -42,7 +43,7 @@ public class ListClientTokens extends Task {
         final Organization orgResource = new Organization();
         orgResource.setId(organizationID);
 
-        final List<TokenEntity> organizationTokens = this.resource.getOrganizationTokens(
+        final CollectionResponse<TokenEntity> organizationTokens = this.resource.getOrganizationTokens(
                 new OrganizationPrincipal(orgResource));
 
         this.mapper.writeValue(output, organizationTokens);

--- a/dpc-api/src/test/java/gov/cms/dpc/api/AbstractSecureApplicationTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/AbstractSecureApplicationTest.java
@@ -9,6 +9,7 @@ import gov.cms.dpc.testing.BufferedLoggerHandler;
 import gov.cms.dpc.testing.IntegrationTest;
 import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.DropwizardTestSupport;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.security.PrivateKey;
+import java.util.UUID;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
 import static gov.cms.dpc.api.APITestHelpers.TASK_URL;
@@ -33,7 +35,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ExtendWith(BufferedLoggerHandler.class)
 public class AbstractSecureApplicationTest {
     protected static final String OTHER_ORG_ID = "065fbe84-3551-4ec3-98a3-0d1198c3cb55";
-    protected static String KEY_ID = "test-key";
     // Application prefix, which we need in order to correctly override config values.
     private static final String KEY_PREFIX = "dpc.api";
     private static final ObjectMapper mapper = new ObjectMapper();
@@ -44,7 +45,8 @@ public class AbstractSecureApplicationTest {
     protected static String ORGANIZATION_TOKEN;
     // Macaroon to use for doing admin things (like creating tokens and keys)
     protected static String GOLDEN_MACAROON;
-    protected static PrivateKey privateKey;
+    protected static PrivateKey PRIVATE_KEY;
+    protected static UUID PUBLIC_KEY_ID;
 
     protected AbstractSecureApplicationTest() {
         // Not used
@@ -69,7 +71,9 @@ public class AbstractSecureApplicationTest {
         ORGANIZATION_TOKEN = FHIRHelpers.registerOrganization(attrClient, ctx.newJsonParser(), ORGANIZATION_ID, TASK_URL);
 
         // Register Public key
-        privateKey = APITestHelpers.generateAndUploadKey(KEY_ID, ORGANIZATION_ID, GOLDEN_MACAROON, "http://localhost:3002/v1/");
+        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APITestHelpers.generateAndUploadKey("integration-test-key", ORGANIZATION_ID, GOLDEN_MACAROON, "http://localhost:3002/v1/");
+        PRIVATE_KEY = uuidPrivateKeyPair.getRight();
+        PUBLIC_KEY_ID = uuidPrivateKeyPair.getLeft();
     }
 
     @BeforeEach

--- a/dpc-api/src/test/java/gov/cms/dpc/api/AuthenticationTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/AuthenticationTest.java
@@ -30,7 +30,7 @@ class AuthenticationTest extends AbstractSecureApplicationTest {
         final String macaroon = FHIRHelpers.registerOrganization(APITestHelpers.buildAttributionClient(ctx), ctx.newJsonParser(), ORGANIZATION_ID, getAdminURL());
 
         // Now, try to read the organization, which should succeed
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
 
         final Organization organization = client
                 .read()

--- a/dpc-api/src/test/java/gov/cms/dpc/api/auth/jwt/BackendServicesAuthTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/auth/jwt/BackendServicesAuthTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.security.NoSuchAlgorithmException;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -26,7 +25,7 @@ class BackendServicesAuthTest extends AbstractSecureApplicationTest {
     @Test
     void testRoundTrip() throws IOException, URISyntaxException {
         // Verify we can pull the Organization resource
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
 
         final Organization orgBundle = client
                 .read()

--- a/dpc-api/src/test/java/gov/cms/dpc/api/auth/jwt/JwtKeyResolverTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/auth/jwt/JwtKeyResolverTests.java
@@ -13,12 +13,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
-import javax.persistence.NoResultException;
 import javax.ws.rs.WebApplicationException;
 import java.io.IOException;
 import java.security.Key;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -28,6 +29,10 @@ class JwtKeyResolverTests {
 
     private static JwtKeyResolver resolver;
     private static KeyPair keyPair;
+
+    private final static UUID badKeyID = UUID.randomUUID();
+    private final static UUID correctKeyID = UUID.randomUUID();
+    private final static UUID notRealKeyID = UUID.randomUUID();
 
     @BeforeAll
     static void setup() throws IOException, NoSuchAlgorithmException {
@@ -45,9 +50,9 @@ class JwtKeyResolverTests {
         Mockito.when(goodInfo.getEncoded()).thenReturn(keyPair.getPublic().getEncoded());
         Mockito.when(goodEntity.getPublicKey()).thenReturn(goodInfo);
 
-        Mockito.when(dao.findKeyByLabel("malformed-key")).thenReturn(badEntity);
-        Mockito.when(dao.findKeyByLabel("correct-key")).thenReturn(goodEntity);
-        Mockito.when(dao.findKeyByLabel("not a real key")).thenThrow(NoResultException.class);
+        Mockito.when(dao.fetchPublicKey(badKeyID)).thenReturn(Optional.of(badEntity));
+        Mockito.when(dao.fetchPublicKey(correctKeyID)).thenReturn(Optional.of(goodEntity));
+        Mockito.when(dao.fetchPublicKey(notRealKeyID)).thenReturn(Optional.empty());
         resolver = new JwtKeyResolver(dao);
     }
 
@@ -55,7 +60,7 @@ class JwtKeyResolverTests {
     void testSigningKeyResolver() {
         final JwsHeader headerMock = mock(JwsHeader.class);
         final Claims mockClaims = mock(Claims.class);
-        Mockito.when(headerMock.getKeyId()).thenReturn("correct-key");
+        Mockito.when(headerMock.getKeyId()).thenReturn(correctKeyID.toString());
         final Key key = resolver.resolveSigningKey(headerMock, mockClaims);
 
         assertEquals(keyPair.getPublic(), key, "Keys should match");
@@ -79,23 +84,35 @@ class JwtKeyResolverTests {
     void testMissingSigningKey() {
         final JwsHeader headerMock = mock(JwsHeader.class);
         final Claims mockClaims = mock(Claims.class);
-        Mockito.when(headerMock.getKeyId()).thenReturn("not a real key");
+        Mockito.when(headerMock.getKeyId()).thenReturn(notRealKeyID.toString());
 
         final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> resolver.resolveSigningKey(headerMock, mockClaims));
 
         assertAll(() -> assertEquals(HttpStatus.UNAUTHORIZED_401, exception.getResponse().getStatus(), "Should be unauthorized"),
-                () -> assertTrue(exception.getMessage().contains("Cannot find public key with label"), "Should have KID message"));
+                () -> assertTrue(exception.getMessage().contains("Cannot find public key with id:"), "Should have KID message"));
     }
 
     @Test
     void testFailingKeyParsing() {
         final JwsHeader headerMock = mock(JwsHeader.class);
         final Claims mockClaims = mock(Claims.class);
-        Mockito.when(headerMock.getKeyId()).thenReturn("malformed-key");
+        Mockito.when(headerMock.getKeyId()).thenReturn(badKeyID.toString());
 
         final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> resolver.resolveSigningKey(headerMock, mockClaims));
 
         assertAll(() -> assertEquals(HttpStatus.INTERNAL_SERVER_ERROR_500, exception.getResponse().getStatus(), "Should be unauthorized"),
                 () -> assertEquals("Internal server error", exception.getMessage(), "Should have KID message"));
+    }
+
+    @Test
+    void testNonUUIDKeyID() {
+        final JwsHeader headerMock = mock(JwsHeader.class);
+        final Claims mockClaims = mock(Claims.class);
+        Mockito.when(headerMock.getKeyId()).thenReturn("This is not a real key id");
+
+        final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> resolver.resolveSigningKey(headerMock, mockClaims));
+
+        assertAll(() -> assertEquals(HttpStatus.UNAUTHORIZED_401, exception.getResponse().getStatus(), "Should be unauthorized"),
+                () -> assertEquals("Invalid Public Key ID", exception.getMessage(), "Should have non-UUID message"));
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/cli/TokenTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/cli/TokenTests.java
@@ -127,7 +127,7 @@ class TokenTests extends AbstractApplicationTest {
                 .collect(Collectors.toList());
 
         assertAll(() -> assertTrue(s2, "Should have succeeded"),
-                () -> assertTrue(stdErr.toString().isEmpty(), "Should be empty"));
+                () -> assertEquals("", stdErr.toString(), "Should be empty"));
 
         return matchedTokenIDs;
     }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/KeyResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/KeyResourceTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
+import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.common.converters.jackson.StringToOffsetDateTimeConverter;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -21,12 +22,14 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.time.OffsetDateTime;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
@@ -123,9 +126,9 @@ class KeyResourceTest extends AbstractSecureApplicationTest {
             keyGet.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
 
             try (CloseableHttpResponse response = client.execute(keyGet)) {
-                final List<KeyView> fetched = this.mapper.readValue(response.getEntity().getContent(), new TypeReference<List<KeyView>>() {
+                final CollectionResponse<KeyView> fetched = this.mapper.readValue(response.getEntity().getContent(), new TypeReference<CollectionResponse<KeyView>>() {
                 });
-                assertEquals(3, fetched.size(), "Should have multiple keys");
+                assertEquals(3, fetched.getCount(), "Should have multiple keys");
             }
 
             // Delete it
@@ -139,9 +142,9 @@ class KeyResourceTest extends AbstractSecureApplicationTest {
 
             // Check to see everything is gone.
             try (CloseableHttpResponse response = client.execute(keyGet)) {
-                final List<KeyView> fetched = this.mapper.readValue(response.getEntity().getContent(), new TypeReference<List<KeyView>>() {
+                final CollectionResponse<KeyView> fetched = this.mapper.readValue(response.getEntity().getContent(), new TypeReference<CollectionResponse<KeyView>>() {
                 });
-                assertEquals(2, fetched.size(), "Should have one less key");
+                assertEquals(2, fetched.getEntities().size(), "Should have one less key");
             }
         }
     }
@@ -156,7 +159,8 @@ class KeyResourceTest extends AbstractSecureApplicationTest {
     }
 
     @SuppressWarnings("WeakerAccess")
-    static class KeyView {
+    static class KeyView implements Serializable {
+        public static final long serialVersionUID = 42L;
 
         public UUID id;
         public String publicKey;

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/KeyResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/KeyResourceTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -42,7 +41,7 @@ class KeyResourceTest extends AbstractSecureApplicationTest {
         this.mapper = new ObjectMapper();
         // Do the JWT flow in order to get a correct ORGANIZATION_TOKEN, this is normally handled by the HAPI client
         try {
-            this.fullyAuthedToken = APITestHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey).accessToken;
+            this.fullyAuthedToken = APITestHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY).accessToken;
         } catch (IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
@@ -3,7 +3,6 @@ package gov.cms.dpc.api.resources.v1;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
-import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
@@ -32,7 +31,7 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
     void testOrganizationRegistration() throws IOException, URISyntaxException {
         // Generate a golden macaroon
         final String goldenMacaroon = APITestHelpers.createGoldenMacaroon();
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
 
 
         final String newOrgID = UUID.randomUUID().toString();
@@ -41,16 +40,16 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
 
         // Try again, should fail because it's a duplicate
         // Error handling is really bad right now, but it should get improved in DPC-540
-        assertThrows(InvalidRequestException.class, () -> OrganizationHelpers.createOrganization(ctx, APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, KEY_ID, privateKey), newOrgID, true));
+        assertThrows(InvalidRequestException.class, () -> OrganizationHelpers.createOrganization(ctx, APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, PUBLIC_KEY_ID, PRIVATE_KEY), newOrgID, true));
 
         // Now, try to create one again, but using an actual org token
-        assertThrows(AuthenticationException.class, () -> OrganizationHelpers.createOrganization(ctx, APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey), UUID.randomUUID().toString(), true));
+        assertThrows(AuthenticationException.class, () -> OrganizationHelpers.createOrganization(ctx, APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY), UUID.randomUUID().toString(), true));
     }
 
     @Test
     void testOrganizationFetch() throws IOException, URISyntaxException {
 
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
 
         final Organization organization = client
                 .read()
@@ -87,7 +86,7 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
     void testMissingEndpoint() throws IOException, URISyntaxException {
         // Generate a golden macaroon
         final String goldenMacaroon = APITestHelpers.createGoldenMacaroon();
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
         final Organization organization = OrganizationFactory.generateFakeOrganization();
 
         final Bundle bundle = new Bundle();
@@ -112,7 +111,7 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
     void testMissingOrganization() throws IOException, URISyntaxException {
         // Generate a golden macaroon
         final String goldenMacaroon = APITestHelpers.createGoldenMacaroon();
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), goldenMacaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
         final Endpoint endpoint = OrganizationFactory.createFakeEndpoint();
 
         final Bundle bundle = new Bundle();

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -8,6 +8,7 @@ import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.util.UUID;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
 import static org.junit.jupiter.api.Assertions.*;
@@ -30,7 +32,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     void ensurePatientsExist() throws IOException, URISyntaxException, NoSuchAlgorithmException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
-        IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey);
+        IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
         APITestHelpers.setupPatientTest(client, parser);
 
         final Bundle patients = client
@@ -68,10 +70,11 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
         final String m2 = FHIRHelpers.registerOrganization(attrClient, parser, OTHER_ORG_ID, getAdminURL());
         // Submit a new public key to use for JWT flow
         final String keyID = "new-key";
-        final PrivateKey privateKey = APITestHelpers.generateAndUploadKey(keyID, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APITestHelpers.generateAndUploadKey(keyID, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        PRIVATE_KEY = uuidPrivateKeyPair.getRight();
 
         // Update the authenticated client to use the new organization
-        client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), m2, keyID, privateKey);
+        client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), m2, uuidPrivateKeyPair.getLeft(), PRIVATE_KEY);
 
         final Bundle otherPatients = client
                 .search()
@@ -108,7 +111,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
         final String macaroon = FHIRHelpers.registerOrganization(attrClient, parser, ORGANIZATION_ID, getAdminURL());
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
 
         final Bundle patients = client
                 .search()
@@ -156,7 +159,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
         final String macaroon = FHIRHelpers.registerOrganization(attrClient, parser, ORGANIZATION_ID, getAdminURL());
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
 
         final Bundle patients = client
                 .search()

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -107,11 +107,13 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    void testPatientRemoval() throws IOException, URISyntaxException {
+    void testPatientRemoval() throws IOException, URISyntaxException, NoSuchAlgorithmException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
         final String macaroon = FHIRHelpers.registerOrganization(attrClient, parser, ORGANIZATION_ID, getAdminURL());
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
+        final String keyLabel = "patient-deletion-key";
+        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APITestHelpers.generateAndUploadKey(keyLabel, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight());
 
         final Bundle patients = client
                 .search()
@@ -155,11 +157,13 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    void testPatientUpdating() throws IOException, URISyntaxException {
+    void testPatientUpdating() throws IOException, URISyntaxException, NoSuchAlgorithmException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
         final String macaroon = FHIRHelpers.registerOrganization(attrClient, parser, ORGANIZATION_ID, getAdminURL());
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, PUBLIC_KEY_ID, PRIVATE_KEY);
+        final String keyLabel = "patient-update-key";
+        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APITestHelpers.generateAndUploadKey(keyLabel, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight());
 
         final Bundle patients = client
                 .search()

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PractitionerResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PractitionerResourceTest.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
+import org.apache.commons.lang3.tuple.Pair;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,7 +30,7 @@ class PractitionerResourceTest extends AbstractSecureApplicationTest {
     void ensurePractitionersExist() throws IOException, URISyntaxException, NoSuchAlgorithmException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
-        IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey);
+        IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
         APITestHelpers.setupPractitionerTest(client, parser);
 
         // Find everything attributed
@@ -81,10 +83,10 @@ class PractitionerResourceTest extends AbstractSecureApplicationTest {
         final String m2 = FHIRHelpers.registerOrganization(attrClient, parser, OTHER_ORG_ID, getAdminURL());
         // Submit a new public key to use for JWT flow
         final String keyID = "new-key";
-        final PrivateKey privateKey = APITestHelpers.generateAndUploadKey(keyID, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APITestHelpers.generateAndUploadKey(keyID, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
 
         // Update the authenticated client to use the new organization
-        client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), m2, keyID, privateKey);
+        client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), m2, uuidPrivateKeyPair.getLeft(), PRIVATE_KEY);
 
         final Bundle otherPractitioners = client
                 .search()

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PractitionerResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PractitionerResourceTest.java
@@ -82,11 +82,11 @@ class PractitionerResourceTest extends AbstractSecureApplicationTest {
         // Create a new org and make sure it has no providers
         final String m2 = FHIRHelpers.registerOrganization(attrClient, parser, OTHER_ORG_ID, getAdminURL());
         // Submit a new public key to use for JWT flow
-        final String keyID = "new-key";
-        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APITestHelpers.generateAndUploadKey(keyID, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        final String keyLabel = "new-key";
+        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APITestHelpers.generateAndUploadKey(keyLabel, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
 
         // Update the authenticated client to use the new organization
-        client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), m2, uuidPrivateKeyPair.getLeft(), PRIVATE_KEY);
+        client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), m2, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight());
 
         final Bundle otherPractitioners = client
                 .search()

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/TokenResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/TokenResourceTest.java
@@ -15,7 +15,6 @@ import org.apache.http.impl.client.HttpClients;
 import org.eclipse.jetty.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
-import javax.ws.rs.InternalServerErrorException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
@@ -40,7 +39,7 @@ class TokenResourceTest extends AbstractSecureApplicationTest {
 
         // Do the JWT flow in order to get a correct ORGANIZATION_TOKEN, this is normally handled by the HAPI client
         try {
-            this.fullyAuthedToken = APITestHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey).accessToken;
+            this.fullyAuthedToken = APITestHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY).accessToken;
         } catch (IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/TokenResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/TokenResourceTest.java
@@ -50,7 +50,9 @@ class TokenResourceTest extends AbstractSecureApplicationTest {
     void testTokenList() throws IOException {
 
         final CollectionResponse<TokenEntity> tokens = fetchTokens(ORGANIZATION_ID);
-        assertFalse(tokens.getEntities().isEmpty(), "Should have tokens");
+        assertAll(() -> assertFalse(tokens.getEntities().isEmpty(), "Should have tokens"),
+                () -> assertEquals(3, tokens.getCount(), "Should have 3 tokens"),
+                () -> assertEquals(LocalDate.now(ZoneOffset.UTC), tokens.getCreatedAt().atZoneSameInstant(ZoneOffset.UTC).toLocalDate(), "Should have created date"));
         final TokenEntity token = ((List<TokenEntity>) tokens.getEntities()).get(0);
 
         assertAll(() -> assertEquals(String.format("Token for organization %s.", ORGANIZATION_ID), token.getLabel(), "Should have auto-generated label"),
@@ -130,7 +132,7 @@ class TokenResourceTest extends AbstractSecureApplicationTest {
         }
 
         final CollectionResponse<TokenEntity> tokens = fetchTokens(ORGANIZATION_ID);
-        assertEquals(1, tokens.getEntities().stream().filter(token -> token.getExpiresAt().toLocalDate().equals(expiresFinal.toLocalDate())).count(), "Should have 1 token with matching expiration");
+        assertEquals(1, tokens.getEntities().stream().filter(token -> token.getExpiresAt().atZoneSameInstant(ZoneOffset.UTC).toLocalDate().equals(expiresFinal.toLocalDate())).count(), "Should have 1 token with matching expiration");
     }
 
     @Test

--- a/dpc-api/src/test/java/gov/cms/dpc/api/validations/ProfileTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/validations/ProfileTests.java
@@ -28,7 +28,7 @@ class ProfileTests extends AbstractSecureApplicationTest {
 
     @Test
     void testPatientProfile() throws IOException, URISyntaxException {
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
         // Create a new patient record
 
         final Patient invalidPatient = new Patient();
@@ -90,7 +90,7 @@ class ProfileTests extends AbstractSecureApplicationTest {
 
     @Test
     void testProviderProfile() throws IOException, URISyntaxException {
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
 
         final Practitioner invalidPractitioner = new Practitioner();
         invalidPractitioner.addName().addGiven("Test").setFamily("Practitioner");
@@ -147,7 +147,7 @@ class ProfileTests extends AbstractSecureApplicationTest {
     @Disabled
         // Disabled until DPC-614 and DPC-616 are merged.
     void testAttributionProfile() throws IOException, URISyntaxException {
-        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, KEY_ID, privateKey);
+        final IGenericClient client = APITestHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
 
         final Group invalidGroup = new Group();
         invalidGroup.addMember().setEntity(new Reference("Patient/strange-patient"));

--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -114,29 +114,33 @@ curl -v https://sandbox.dpc.cms.gov/api/v1/Token \
 **Response**
 
 ~~~json
-[
-  {
-    "id": "3c308f6e-0223-42f8-80c2-cab242d68afc",
-    "tokenType": "MACAROON",
-    "label": "Token for organization 46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0.",
-    "createdAt": "2019-11-04T11:49:55.126-05:00",
-    "expiresAt": "2020-11-04T11:49:55.095-05:00"
-  },
-  {
-    "id": "eef87627-db4b-4c08-8a27-e88a8343099d",
-    "tokenType": "MACAROON",
-    "label": "Token for organization 46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0.",
-    "createdAt": "2019-11-04T11:50:06.101-05:00",
-    "expiresAt": "2020-11-04T11:50:06.096-05:00"
-  },
-  {
-    "id": "ea314eaa-1cf5-4d01-9ea7-1646099ca9fd",
-    "tokenType": "MACAROON",
-    "label": "Token for organization 46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0.",
-    "createdAt": "2019-11-04T11:50:06.685-05:00",
-    "expiresAt": "2020-11-04T11:50:06.677-05:00"
-  }
-]
+{
+  "created_at": "2019-11-04T11:49:55.126-05:00",
+  "count": 3,
+  "entities": [
+    {
+      "id": "3c308f6e-0223-42f8-80c2-cab242d68afc",
+      "tokenType": "MACAROON",
+      "label": "Token for organization 46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0.",
+      "createdAt": "2019-11-04T11:49:55.126-05:00",
+      "expiresAt": "2020-11-04T11:49:55.095-05:00"
+    },
+    {
+      "id": "eef87627-db4b-4c08-8a27-e88a8343099d",
+      "tokenType": "MACAROON",
+      "label": "Token for organization 46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0.",
+      "createdAt": "2019-11-04T11:50:06.101-05:00",
+      "expiresAt": "2020-11-04T11:50:06.096-05:00"
+    },
+    {
+      "id": "ea314eaa-1cf5-4d01-9ea7-1646099ca9fd",
+      "tokenType": "MACAROON",
+      "label": "Token for organization 46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0.",
+      "createdAt": "2019-11-04T11:50:06.685-05:00",
+      "expiresAt": "2020-11-04T11:50:06.677-05:00"
+    }
+  ]
+}
 ~~~
 
 Specific client_tokens can be listed by making a `GET` request to the `Token/` endpoint using the unique id of the client_token.
@@ -269,14 +273,18 @@ curl -v http://localhost:3002/v1/Key \
 **Response**
 
 ~~~json
-[
-  {
-    "id": "b296f9d2-1aae-4c59-b6c7-c759b9db5226",
-    "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmyI+y8vAAFcV4deNdyKC\nH16ZPU7tgwnUzvtEYOp6s0DFjzgaqWmYZd/CNlb1psi+J0ChtcL9+Cx3v+HwDqVx\nToQrEqJ8hMavtXnxm2jPoRaxmbIGjHZ6jfyMot5+CdP8Vr5o9G2WIUgzjhFwMEXh\nlYg97uZadLLVKVXYTl4HtluVX5y7p1Wh4vkyJFBiqrX7qAJXvr6PK7OUeZDeVsse\nOMm33VwgbQSGRw7yWNOw+H/RbpGQkAUtHvGYvo/qLeb+iJsF2zBtjnkTmk5I8Vlo\n4xzbqaoqZqsHp4NgCw+bq0Y6AWLE2yUYi/DOatOdIBfLxlpf/FAY3f5FbNjISUuL\nmwIDAQAB\n-----END PUBLIC KEY-----\n",
-    "createdAt": "2019-11-04T13:16:29.008-05:00",
-    "label": "test-key"
-  }
-]
+{
+  "created_at": "2019-11-04T13:16:29.008-05:00",
+  "count": 1,
+  "entities": [
+    {
+      "id": "b296f9d2-1aae-4c59-b6c7-c759b9db5226",
+      "publicKey": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmyI+y8vAAFcV4deNdyKC\nH16ZPU7tgwnUzvtEYOp6s0DFjzgaqWmYZd/CNlb1psi+J0ChtcL9+Cx3v+HwDqVx\nToQrEqJ8hMavtXnxm2jPoRaxmbIGjHZ6jfyMot5+CdP8Vr5o9G2WIUgzjhFwMEXh\nlYg97uZadLLVKVXYTl4HtluVX5y7p1Wh4vkyJFBiqrX7qAJXvr6PK7OUeZDeVsse\nOMm33VwgbQSGRw7yWNOw+H/RbpGQkAUtHvGYvo/qLeb+iJsF2zBtjnkTmk5I8Vlo\n4xzbqaoqZqsHp4NgCw+bq0Y6AWLE2yUYi/DOatOdIBfLxlpf/FAY3f5FbNjISUuL\nmwIDAQAB\n-----END PUBLIC KEY-----\n",
+      "createdAt": "2019-11-04T13:16:29.008-05:00",
+      "label": "test-key"
+    }
+  ]
+}
 ~~~
 
 Specific public keys can be listed by making a `GET` request to the `Key/` endpoint using the unique id of the public key.
@@ -311,7 +319,7 @@ curl -v https://sandbox.dpc.cms.gov/api/v1/Key/{public key id} \
 Uploading a public key can be done by making a `POST` request to the `Key/` endpoint. 
 This endpoint requires one additional query param:
 
-* `label` sets a human readable label for the public key. This label will be used as the `kid` value of the self-signed JWT. 
+* `label` sets a human readable label for the public key (this must be less than 26 characters long). 
 
 The submitted public key must meet the following requirements:
 
@@ -344,6 +352,8 @@ curl -v https://sandbox.dpc.cms.gov/api/v1/Key?label={key label} \
     "label": "test-key"
 }
 ~~~
+
+The `id` field of the response will be used as the `kid` JWT header value, as described in a later [section](#creating-an-accesstoken)
 
 #### Deleting a public key
 
@@ -379,7 +389,7 @@ This token must be signed with a public key previously registered and contain th
 
 `alg`	_required_	- The JWA algorithm (e.g., `RS384`, `EC384`) used for signing the authentication JWT. (DPC only supports RS384)
 
-`kid`   _required_	- The identifier of the key-pair used to sign this JWT. This should make the `label` field of the previously registered public key
+`kid`   _required_	- The identifier of the key-pair used to sign this JWT. This must be the ID of a previously registered public key
 
 `typ`	_required_	- Fixed value: JWT.
 


### PR DESCRIPTION
**Why**

Work on #370 revealed a bug in our public key handler code where the JWTKeyResolver was expecting key labels to be unique, but that constraint was not enforced in the database. This meant that key labels have to be unique within the _environment_ rather than just the org, which was no good. That was a problem that turned out to have a solution that made things much, much better.

Also, @switzersc-usds pointed out that it's brittle to return raw arrays from REST methods and that we should be wrapping them in order to avoid situations in the future where we need to make a breaking change to the array structure.

**What Changed**

Public keys are now handled by their unique UUID key ids, rather than labels. This makes things MUCH less error prone and avoids the issue of having to rely on users inputting correct data for us. Not sure why I didn't think of this before.

Created a `CollectionResponse` helper class which wraps and underlying `entities` collection and adds some basic metadata such as count and created_at.

**Choices Made**

This ticket will need to be rebased once #323 is merged and is required for #363. This will be a breaking change (due to DPC-786) and will required the website to show the Key ID along side the label.

**Tickets closed**:

DPC-784: Fix public key IDs
DPC-786: Migrate GET methods to a wrapped array

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
