### PR TITLE
use current class in providers menu when org is selected

### DIFF
--- a/dpc-web/app/views/shared/internal/_sidenav.html.erb
+++ b/dpc-web/app/views/shared/internal/_sidenav.html.erb
@@ -11,7 +11,7 @@
 
 <ul class="ds-c-vertical-nav">
   <li class="ds-c-vertical-nav__item usa-accordion">
-    <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--parent <%= current_sidenav_class?(:users, current) %>" aria-controls="nav-providers-main" aria-expanded="true">
+    <button class="usa-accordion__button ds-c-vertical-nav__label ds-c-vertical-nav__label--parent <%= current_sidenav_class?(:users, current) %> <%= current_sidenav_class?(:organizations, current) %>" aria-controls="nav-providers-main" aria-expanded="true">
     Providers
     </button>
     <ul id="nav-providers-main" class="ds-c-vertical-nav__subnav">


### PR DESCRIPTION
**Why**

The providers left nav dropdown should use the `current_class` when viewing organizations 

**What Changed**

<img width="1093" alt="Screen Shot 2019-11-07 at 8 25 27 AM" src="https://user-images.githubusercontent.com/25435289/68392677-44a9da80-0138-11ea-84b1-2abb8f93a76e.png">

