### PR TITLE
Hotfix: Use the internal ALB for smoke tests

### DIFF
--- a/src/test/dev.smoke_test.yml
+++ b/src/test/dev.smoke_test.yml
@@ -1,6 +1,6 @@
 settings:
   env:
-    HOST: https://dpc-dev-815423886.us-east-1.elb.amazonaws.com/api/v1
+    HOST: http://internal-dpc-dev-frontend-internal-1469809887.us-east-1.elb.amazonaws.com/api/v1
     ADMIN_URL: http://internal-dpc-dev-frontend-internal-1469809887.us-east-1.elb.amazonaws.com:9900/tasks
     SEED_FILE: src/main/resources/test_associations.csv
     PROVIDER_BUNDLE: provider_bundle.json


### PR DESCRIPTION
**Why**

We're still having issues running the smoke tests in DEV due to the dev.dpc.cms.gov DNS entry not existing yet. We came up with the solution to allow the smoke tests to run over HTTP via the internal load balancer.

**What Changed**

* Uses the internal ALB to run smoke tests: https://github.com/CMSgov/dpc-ops/pull/78

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
