### PR TITLE
Fix failing smoke tests in dev.

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/converters/BakeryKeyPairDeserializer.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/converters/BakeryKeyPairDeserializer.java
@@ -7,13 +7,9 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import gov.cms.dpc.macaroons.thirdparty.BakeryKeyPair;
 
 import java.io.IOException;
-import java.util.Base64;
 
 public class BakeryKeyPairDeserializer extends StdDeserializer<BakeryKeyPair> {
-
     public static final long serialVersionUID = 42L;
-
-    private final Base64.Decoder decoder;
 
     BakeryKeyPairDeserializer() {
         this(null);
@@ -21,7 +17,6 @@ public class BakeryKeyPairDeserializer extends StdDeserializer<BakeryKeyPair> {
 
     private BakeryKeyPairDeserializer(Class<?> vc) {
         super(vc);
-        this.decoder = Base64.getMimeDecoder();
     }
 
     @Override
@@ -36,9 +31,7 @@ public class BakeryKeyPairDeserializer extends StdDeserializer<BakeryKeyPair> {
         if (privateKeyNode == null) {
             throw new IllegalArgumentException("Keypair must have private key value");
         }
-        final byte[] publicKey = this.decoder.decode(publicKeyNode.asText());
-        final byte[] privateKey = this.decoder.decode(privateKeyNode.asText());
 
-        return new BakeryKeyPair(publicKey, privateKey);
+        return new BakeryKeyPair(publicKeyNode.binaryValue(), publicKeyNode.binaryValue());
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/converters/BakeryKeyPairSerializer.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/converters/BakeryKeyPairSerializer.java
@@ -6,13 +6,10 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import gov.cms.dpc.macaroons.thirdparty.BakeryKeyPair;
 
 import java.io.IOException;
-import java.util.Base64;
 
 public class BakeryKeyPairSerializer extends StdSerializer<BakeryKeyPair> {
 
     public static final long serialVersionUID = 42L;
-
-    private final Base64.Encoder encoder;
 
     BakeryKeyPairSerializer() {
         this(null);
@@ -20,16 +17,13 @@ public class BakeryKeyPairSerializer extends StdSerializer<BakeryKeyPair> {
 
     private BakeryKeyPairSerializer(Class<BakeryKeyPair> t) {
         super(t);
-        this.encoder = Base64.getMimeEncoder();
     }
 
     @Override
     public void serialize(BakeryKeyPair value, JsonGenerator gen, SerializerProvider provider) throws IOException {
-        final byte[] publicKey = this.encoder.encode(value.getPublicKey());
-        final byte[] privateKey = this.encoder.encode(value.getPrivateKey());
         gen.writeStartObject();
-        gen.writeBinaryField("public_key", publicKey);
-        gen.writeBinaryField("private_key", privateKey);
+        gen.writeBinaryField("public_key", value.getPublicKey());
+        gen.writeBinaryField("private_key", value.getPrivateKey());
         gen.writeEndObject();
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/GenerateClientTokens.java
@@ -32,14 +32,12 @@ public class GenerateClientTokens extends Task {
 
     private final MacaroonBakery bakery;
     private final TokenResource resource;
-    private final Base64.Encoder encoder;
 
     @Inject
     GenerateClientTokens(MacaroonBakery bakery, TokenResource resource) {
         super("generate-token");
         this.bakery = bakery;
         this.resource = resource;
-        this.encoder = Base64.getUrlEncoder();
     }
 
     @Override
@@ -49,8 +47,7 @@ public class GenerateClientTokens extends Task {
         if (organizationCollection.isEmpty()) {
             logger.warn("CREATING UNRESTRICTED MACAROON. ENSURE THIS IS OK");
             final Macaroon macaroon = bakery.createMacaroon(Collections.emptyList());
-            final byte[] serialized = macaroon.serialize(MacaroonVersion.SerializationVersion.V1_BINARY).getBytes(StandardCharsets.UTF_8);
-            output.write(this.encoder.encodeToString(serialized));
+            output.write(macaroon.serialize(MacaroonVersion.SerializationVersion.V1_BINARY));
         } else {
             final String organization = organizationCollection.asList().get(0);
             final Organization orgResource = new Organization();

--- a/dpc-api/src/main/resources/local.application.conf
+++ b/dpc-api/src/main/resources/local.application.conf
@@ -29,6 +29,6 @@ dpc.api {
 
     attributionURL = "http://attribution:8080/v1/"
     exportPath = /app/data
-    authenticationDisabled = true
+    authenticationDisabled = false
     keyPairLocation = "/bakery_keypair.json"
 }

--- a/dpc-api/src/main/resources/local.application.conf
+++ b/dpc-api/src/main/resources/local.application.conf
@@ -29,6 +29,6 @@ dpc.api {
 
     attributionURL = "http://attribution:8080/v1/"
     exportPath = /app/data
-    authenticationDisabled = false
+    authenticationDisabled = true
     keyPairLocation = "/bakery_keypair.json"
 }

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -71,7 +71,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
             throw new RuntimeException("Failed creating Macaroon", e);
         }
         // Create admin client for registering organization
-        final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, hostParam, goldenMacaroon);
+        final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, hostParam, goldenMacaroon, true);
 
         final SampleResult smokeTestResult = new SampleResult();
         smokeTestResult.sampleStart();
@@ -102,7 +102,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         // Create an authenticated and async client (the async part is ignored by other endpoints)
         final IGenericClient exportClient;
         try {
-            exportClient = APIAuthHelpers.buildAuthenticatedClient(ctx, String.format("%s/", hostParam), token, keyTuple.getLeft(), keyTuple.getRight());
+            exportClient = APIAuthHelpers.buildAuthenticatedClient(ctx, String.format("%s/", hostParam), token, keyTuple.getLeft(), keyTuple.getRight(), true);
         } catch (IOException | URISyntaxException e) {
             throw new RuntimeException("Cannot create export client", e);
         }

--- a/src/main/resources/keypair/bakery_keypair.json
+++ b/src/main/resources/keypair/bakery_keypair.json
@@ -2,9 +2,9 @@
   "algorithm": "X25519",
   "environment": "local",
   "keyPair": {
-    "public_key": "FluVlInJ1Cr0oxikxK095SJCEP6ngzCwgz6r6cCyF1k=",
-    "private_key": "ODzuQTKYEFqwoM//sKUnRs9n6XLnnfJfBLS7QvOozXk="
+    "public_key": "bSRaz/g7ppjsAEZ99aekCw5eCLxBtQUz4xE5/QctIH4=",
+    "private_key": "aKcacJ1/I/07oAyLqv660q3eVAD5MJFFd93iSBKYnEU="
   },
-  "createdOn": "2019-10-28T19:41:42.244+00:00",
+  "createdOn": "2019-11-13T20:10:19.030+00:00",
   "createdBy": "nickrobison-usds"
 }


### PR DESCRIPTION
**Why**

Smoketests were failing hard in dev. There were a couple of reasons for this. But most of them were pretty simple to address.

Confirmed passing locally, confirmed passing when I addressed the key pair issue happening in dev.

**What Changed**

Disables strict SSL checking, so we can run our tests against the internal ALBs and in Dev, which doesn't have a DNS record yet. We had to manually override the SSL Context in the tests, but that wasn't too terrible.

Fixed bad serialization of Bakery Keypairs, they were double base64 encoded.

Likewise, fixed double encoding of V1 binary macaroons, which are automatically base64 encoded.

**Choices Made**

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
