### PR TITLE
DPC-808: Add environment variable overriding to Docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The individual services can be started (along with their dependencies) by passin
 docker-compose up {db,dpc-aggregation,dpc-attribution,dpc-api}
 ``` 
 
+By default, the Docker containers start with minimal authentication enabled, meaning that some functionality (such as extracting the organization_id from the access token) will not work as expected and always return the same value.
+This can be overriding during startup by setting the `AUTH_DISABLED=false` environment variable. 
+
 ## Manual JAR execution
 
 Alternatively, the individual services can be manually executing the `server` command for the various services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - ENV=local
       - JACOCO=${REPORT_COVERAGE}
       - exportPath=/app/data
+      - JVM_FLAGS=-Ddpc.api.authenticationDisabled=${AUTH_DISABLED:-true}
     depends_on:
       - attribution
     volumes:


### PR DESCRIPTION
**Why**

As we've been developing the website, @switzersc-usds has run into a number of issues that were tracked back to having the full authentication disabled by default in the docker containers.
While this is the required configuration for the Postman tests, it breaks functionality when working with multiple organizations. Previously, you had to modify a config file and rebuilt, in order for the auth to come back up.

**What Changed**

Added an environment variable to Docker compose which allows enabling full authentication on the API service. `AUTH_DISABLED=false`

The default is disabled, but now we can easily switch it.

**Choices Made**

This ticket is pretty much required by #379 

**Tickets closed**:

DPC-808

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
