### PR TITLE
Add some simple DB seeds to speed up development

### DIFF
--- a/dpc-web/db/seeds.rb
+++ b/dpc-web/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+wash = FactoryBot.create(:user, email: 'washirv@example.com', first_name: 'Washington', last_name: 'Irving')
+jane = FactoryBot.create(:user, email: 'janeaus@example.com', first_name: 'Jane', last_name: 'Austen')
+
+org = FactoryBot.create(:organization, name: 'Hollow Health')
+wash.organizations << org
+
+tag = FactoryBot.create(:tag, name: 'Contacted')
+jane.tags << tag


### PR DESCRIPTION
**Why**

Right now when we are developing the app, if we need to reset the database, we have to go through the process of creating users and organizations all over again. 

**What Changed**

This PR adds seeds that create an assigned user and an unassigned user, and the unassigned user also has a tag. This should be enough for getting basic dev up and running for UI changes or QA. 

**Choices Made**

Adds seeds. The seeds file gets run whenever you run `rails db:reset` in terminal.
