### PR TITLE
DPC-824: Fix fragile test strategy for synthetic 1-800 files

### DIFF
--- a/dpc-consent/src/test/resources/synthetic-1800-files/copy/.gitignore
+++ b/dpc-consent/src/test/resources/synthetic-1800-files/copy/.gitignore
@@ -1,3 +1,0 @@
-# This directory is necessary for 1-800-MEDICARE ETL tests. This .gitignore file has been added so the directory can be added to the repository.
-*
-!.gitignore


### PR DESCRIPTION
**Why**
The tests for the 1-800-MEDICARE ETL involve importing synthetic files. Because the ETL cleans up the import directory, the synthetic files need to be copied before the tests are run to preserve the originals. A `/copy` directory with only a `.gitignore` file was created for that purpose, but the `.gitignore` file ends up deleted after tests run, causing a bit of a mess when looking at changes in Git.

**What Changed**
The `/copy` directory in `src/test/resources/synthetic-1800-files` is now created and deleted in the testing process.

**Tickets closed**:
[DPC-824](https://jiraent.cms.gov/browse/DPC-824)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
