### PR TITLE
Update admin_url in test env smoke test config

### DIFF
--- a/src/test/test.smoke_test.yml
+++ b/src/test/test.smoke_test.yml
@@ -1,7 +1,7 @@
 settings:
   env:
     HOST: https://test.dpc.cms.gov/api/v1
-    ADMIN_URL: http://test.dpc.cms.gov:9900/tasks
+    ADMIN_URL: http://internal-dpc-test-frontend-internal-1526586094.us-east-1.elb.amazonaws.com:9900/tasks
     SEED_FILE: src/main/resources/test_associations-dpr.csv
     PROVIDER_BUNDLE: provider_bundle.json
     PATIENT_BUNDLE: patient_bundle-dpr.json


### PR DESCRIPTION
**Why**

The location of `test` env admin endpoint has changed.

**What Changed**

Updates `test/test.smoke_test.yml` with the new location.