### PR TITLE
DPC-814: Fix invalid job state

### DIFF
--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
@@ -169,6 +169,7 @@ public class DistributedBatchQueue extends JobQueueCommon {
             final List<JobQueueBatch> stuckJobList = session.createQuery(query).getResultList();
 
             for ( JobQueueBatch stuckJob : stuckJobList ) {
+                logger.warn(String.format("Restarting stuck batch... batchID=%s", stuckJob.getBatchID()));
                 stuckJob.restartBatch();
                 session.merge(stuckJob);
             }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatch.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatch.java
@@ -360,6 +360,8 @@ public class JobQueueBatch implements Serializable {
         this.patientIndex = null;
         this.startTime = null;
         this.completeTime = null;
+        this.aggregatorID = null;
+        this.getJobQueueBatchFiles().clear();
 
         this.setUpdateTime();
     }

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/models/JobQueueBatchTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/models/JobQueueBatchTest.java
@@ -245,6 +245,25 @@ public class JobQueueBatchTest {
         assertNull(job.patientIndex);
         assertNull(job.startTime);
         assertNull(job.completeTime);
+        assertNull(job.aggregatorID);
+        assertTrue(job.getJobQueueBatchFiles().isEmpty());
+    }
+
+    @Test
+    void testRestartBatch_Stuck() {
+        final var job = createJobQueueBatch();
+        job.setRunningStatus(aggregatorID);
+        job.patientIndex = 2;
+        job.getJobQueueBatchFiles().add(new JobQueueBatchFile());
+
+        job.restartBatch();
+
+        assertEquals(JobStatus.QUEUED, job.getStatus());
+        assertNull(job.patientIndex);
+        assertNull(job.startTime);
+        assertNull(job.completeTime);
+        assertNull(job.aggregatorID);
+        assertTrue(job.getJobQueueBatchFiles().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
**Why**

We are finding cases of aggregator jobs that fail into a status of queued with the aggregatorID still set. This is an invalid state, and leads to further issues in the application.

**What Changed**

The issue turned out to be the stuck batch logic. It was resetting the status without resetting the aggregatorID (or clearing files, which could have led to a separate issues). Both of those issues have been fixed and tests were written to verify.

The fact that the stuck batch logic was triggering is concerning, so I added additional logging as well for us to hopefully track down the reason these batches get stuck. We had a ton of issues with deployments lately, so it could be related to those, but I would not be surprised if there are more cases that lead to stuck batches.

**Choices Made**


**Tickets closed**:

DPC-814: Aggregator jobs can fail into an invalid state

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
