### PR TITLE
trap focus in modals, dialogs, etc.

### DIFF
--- a/dpc-web/app/assets/javascripts/application.js
+++ b/dpc-web/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require accordions
 //= require rails-ujs
 //= require activestorage
+//= require_tree ./utils
 //= require_tree .
 
 svg4everybody();

--- a/dpc-web/app/assets/javascripts/components/_modals.js
+++ b/dpc-web/app/assets/javascripts/components/_modals.js
@@ -8,10 +8,13 @@
 if(typeof(trigger) != 'undefined' && trigger != null){
     trigger.addEventListener("click", function(e){
       modalEl.setAttribute('aria-hidden', false);
+      closeModals[0].focus();
+      trapFocus(modalEl);
     },false);
 
     for (var i = closeModals.length - 1; i >= 0; --i)
       closeModals[i].addEventListener("click", function(e){
+        trigger.focus();
         modalEl.setAttribute('aria-hidden', true);
       });}
     });

--- a/dpc-web/app/assets/javascripts/components/navbar.js
+++ b/dpc-web/app/assets/javascripts/components/navbar.js
@@ -36,5 +36,7 @@ if(typeof(open_mobile_nav_button) != 'undefined' && open_mobile_nav_button != nu
     setTimeout(function(){
       overlay.classList.add(visible_class);
     }, 100);
+
+    trapFocus(mobile_nav);
   })
 };

--- a/dpc-web/app/assets/javascripts/utils/_trap-focus.js
+++ b/dpc-web/app/assets/javascripts/utils/_trap-focus.js
@@ -1,0 +1,32 @@
+// When dialogs, modals, or any other areas that appear on top
+// of the main canvas, we want to trap the focusable areas
+// for folks using keyboard navigation so that the focused
+// elements are not lost.
+
+function trapFocus(element) {
+    var focusableEls = element.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled]), input[type="submit"]:not([disabled])'),
+        firstFocusableEl = focusableEls[0];
+        lastFocusableEl = focusableEls[focusableEls.length - 1];
+        KEYCODE_TAB = 9;
+
+    element.addEventListener('keydown', function(e) {
+        var isTabPressed = (e.key === 'Tab' || e.keyCode === KEYCODE_TAB);
+
+        if (!isTabPressed) {
+            return;
+        }
+
+        if ( e.shiftKey ) /* shift + tab */ {
+            if (document.activeElement === firstFocusableEl) {
+                lastFocusableEl.focus();
+                e.preventDefault();
+            }
+        } else /* tab */ {
+            if (document.activeElement === lastFocusableEl) {
+                firstFocusableEl.focus();
+                e.preventDefault();
+            }
+        }
+
+    });
+}


### PR DESCRIPTION
**Why**

For keyboard users, whenever a modal, flyout or any other "top layer" element is enabled, the focus state should be confined to that element. Otherwise, the focus state is lost. 

In addition, when that element is triggered, the focus state should also be moved to the close button for that element in the event that it was accidentally opened.

**What Changed**

- Added a javascript utility to trap focus
- Updated modal js so that focus state is transferred to the close button when it is opened

The keyboard navigation should function as such:

![Screen Recording 2019-11-19 at 08 56 PM](https://user-images.githubusercontent.com/25435289/69202338-582d4c00-0b0f-11ea-991d-35fd2d63c5a2.gif)

![Screen Recording 2019-11-19 at 08 57 PM](https://user-images.githubusercontent.com/25435289/69202344-5d8a9680-0b0f-11ea-97c3-b4b7f7ea695e.gif)


**Choices Made**

A JS utility is generic and can be used in a number of different instances.

