### PR TITLE
Use fhir media type for organization API calls

### DIFF
--- a/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
+++ b/dpc-web/spec/features/internal/organization_management/creating_and_updating_organizations_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature 'creating and updating organizations' do
     allow(ENV).to receive(:fetch).with('API_METADATA_URL_SANDBOX').and_return('http://dpc.example.com')
     allow(ENV).to receive(:fetch).with('GOLDEN_MACAROON_SANDBOX').and_return('112233')
     stub_request(:post, 'http://dpc.example.com/Organization/$submit').with(
-      headers: { 'Content-Type' => 'application/json', 'Authorization' => 'Bearer 112233' },
+      headers: { 'Content-Type' => 'application/fhir+json', 'Authorization' => 'Bearer 112233' },
       body: {
         resourceType: 'Parameters',
         parameter: [{

--- a/dpc-web/spec/services/api_client_spec.rb
+++ b/dpc-web/spec/services/api_client_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe APIClient do
     context 'successful API request' do
       it 'sends data to API and sets response instance variables' do
         stub_request(:post, 'http://dpc.example.com/Organization/$submit').with(
-          headers: { 'Content-Type' => 'application/json', 'Authorization' => 'Bearer MDAyM2xvY2F0aW9uIGh0dHA6Ly9sb2NhbGhvc3Q6MzAwMgowMDM0aWRlbnRpZmllciBiODY2NmVjMi1lOWY1LTRjODctYjI0My1jMDlhYjgyY2QwZTMKMDAyZnNpZ25hdHVyZSA1hzDOqfW_1hasj-tOps9XEBwMTQIW9ACQcZPuhAGxwwo' },
+          headers: { 'Content-Type' => 'application/fhir+json', 'Authorization' => 'Bearer MDAyM2xvY2F0aW9uIGh0dHA6Ly9sb2NhbGhvc3Q6MzAwMgowMDM0aWRlbnRpZmllciBiODY2NmVjMi1lOWY1LTRjODctYjI0My1jMDlhYjgyY2QwZTMKMDAyZnNpZ25hdHVyZSA1hzDOqfW_1hasj-tOps9XEBwMTQIW9ACQcZPuhAGxwwo' },
           body: {
             resourceType: 'Parameters',
             parameter: [{
@@ -101,7 +101,7 @@ RSpec.describe APIClient do
 
       it 'sends data to API and sets response instance variables' do
         stub_request(:post, 'http://dpc.example.com/Organization/$submit').with(
-          headers: { 'Content-Type' => 'application/json', 'Authorization' => 'Bearer MDAyM2xvY2F0aW9uIGh0dHA6Ly9sb2NhbGhvc3Q6MzAwMgowMDM0aWRlbnRpZmllciBiODY2NmVjMi1lOWY1LTRjODctYjI0My1jMDlhYjgyY2QwZTMKMDAyZnNpZ25hdHVyZSA1hzDOqfW_1hasj-tOps9XEBwMTQIW9ACQcZPuhAGxwwo' },
+          headers: { 'Content-Type' => 'application/fhir+json', 'Authorization' => 'Bearer MDAyM2xvY2F0aW9uIGh0dHA6Ly9sb2NhbGhvc3Q6MzAwMgowMDM0aWRlbnRpZmllciBiODY2NmVjMi1lOWY1LTRjODctYjI0My1jMDlhYjgyY2QwZTMKMDAyZnNpZ25hdHVyZSA1hzDOqfW_1hasj-tOps9XEBwMTQIW9ACQcZPuhAGxwwo' },
           body: {
             resourceType: 'Parameters',
             parameter: [{

--- a/dpc-web/spec/services/organization_registrar_spec.rb
+++ b/dpc-web/spec/services/organization_registrar_spec.rb
@@ -15,14 +15,12 @@ RSpec.describe OrganizationRegistrar do
       allow(deletion_api_client).to receive(:delete_organization).with(sandbox_reg_org).and_return(true)
 
       allow(APIClient).to receive(:new).with('production').and_return(prod_creation_api_client)
-      allow(prod_creation_api_client).to receive(:create_organization).with(org).
-        and_return(prod_creation_api_client)
+      allow(prod_creation_api_client).to receive(:create_organization)
+        .with(org).and_return(prod_creation_api_client)
       allow(prod_creation_api_client).to receive(:response_successful?).and_return(true)
       allow(prod_creation_api_client).to receive(:response_body).and_return(
-        {
-          'id' => '8453e48b-0b42-4ddf-8b43-07c7aa2a3d8d',
-          'endpoint' => [{ 'reference' => 'Endpoint/d385cfb4-dc36-4cd0-b8f8-400a6dea2d66' }]
-        }
+        'id' => '8453e48b-0b42-4ddf-8b43-07c7aa2a3d8d',
+        'endpoint' => [{ 'reference' => 'Endpoint/d385cfb4-dc36-4cd0-b8f8-400a6dea2d66' }]
       )
 
       initial_fhir_endpoint_count = FhirEndpoint.count


### PR DESCRIPTION
The API requires application/fhir+json for FHIR endpoints. The web app
hits one FHIR endpoint right now, organization $submit.
Also clean up some styles in the tests.
