### PR TITLE
DPC-849: Fix thread safety issue with HAPI Validator

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/dropwizard/FHIRValidationModule.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/dropwizard/FHIRValidationModule.java
@@ -3,12 +3,10 @@ package gov.cms.dpc.fhir.validations.dropwizard;
 import ca.uhn.fhir.validation.FhirValidator;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.Singleton;
+import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
 import gov.cms.dpc.fhir.configuration.DPCFHIRConfiguration.FHIRValidationConfiguration;
-import gov.cms.dpc.fhir.dropwizard.handlers.exceptions.HAPIExceptionHandler;
-import gov.cms.dpc.fhir.dropwizard.handlers.exceptions.JerseyExceptionHandler;
 import gov.cms.dpc.fhir.validations.DPCProfileSupport;
 import gov.cms.dpc.fhir.validations.ProfileValidator;
 import org.glassfish.jersey.server.internal.inject.ConfiguredValidator;
@@ -41,11 +39,11 @@ public class FHIRValidationModule extends AbstractModule {
         Multibinder<ConstraintValidator<?, ?>> constraintBinder = Multibinder.newSetBinder(binder(), constraintType);
         constraintBinder.addBinding().to(ProfileValidator.class);
 
-        bind(ConstraintValidatorFactory.class).to(InjectingConstraintValidatorFactory.class).asEagerSingleton();
+        bind(ConstraintValidatorFactory.class).to(InjectingConstraintValidatorFactory.class);
         bind(ValidatorFactory.class).toProvider(ValidatorFactoryProvider.class);
-        bind(ConfiguredValidator.class).to(InjectingConfiguredValidator.class).asEagerSingleton();
+        bind(ConfiguredValidator.class).to(InjectingConfiguredValidator.class);
 
-        bind(DPCProfileSupport.class).asEagerSingleton();
+        bind(DPCProfileSupport.class).in(Scopes.SINGLETON);
         bind(FhirValidator.class).toProvider(FHIRValidatorProvider.class);
     }
 
@@ -60,7 +58,6 @@ public class FHIRValidationModule extends AbstractModule {
     }
 
     @Provides
-    @Singleton
     ValidationSupportChain provideSupportChain(DPCProfileSupport dpcModule) {
         return new ValidationSupportChain(new DefaultProfileValidationSupport(), dpcModule);
     }

--- a/src/test/smoke_test.yml
+++ b/src/test/smoke_test.yml
@@ -2,9 +2,10 @@ settings:
   artifacts-dir: bzt-out/%Y-%m-%d_%H-%M-%S.%f
 
 execution:
-  - iterations: 1
-    concurrency: 3
+  - iterations: 3
+    concurrency: 10
     scenario: jmeter
+    ramp-up: 120s
 
 scenarios:
   jmeter:

--- a/src/test/smoke_test.yml
+++ b/src/test/smoke_test.yml
@@ -3,7 +3,7 @@ settings:
 
 execution:
   - iterations: 3
-    concurrency: 10
+    concurrency: 3
     scenario: jmeter
     ramp-up: 120s
 


### PR DESCRIPTION
**Why**

A user reported in the Google group that they were experiencing issues with the validator rejecting resources because it was associating them with an incorrect profile.

This issue occurred previously and is related to the fact that none of the HAPI validator classes are thread-safe. I had thought it was fixed, but apparently not.

In addition, our smoke tests are passing even though the validator was throwing a 422 exception.

**What Changed**

Updated the smoke tests to _hopefully_ improve error handling, we're now throwing errors from the main `SmokeTest` class, rather than deeper in the helper utils.

Also, staggered the startup time so the tests ramp up a bit slower and hopefully surface more threading and resource issues.

The SmokeTests now use FHIR creations when uploading resources, previously we were using the `$submit` operation, which was fine, but now we're stressing the system a bit more.

Updated the ClientUtils class to ensure that there aren't any errors returned as part of the export process, this should hopefully catch the patient ID issue that we're tracking with DPC-850.

**Choices Made**

Still not sure what's the root cause of the exception swallowing, but at least I've been able to verify that some exceptions are actually thrown correctly.

**Tickets closed**:

DPC-849

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
