### PR TITLE
DPC-859: Smoke Tests are submitting incorrect patient IDs

### DIFF
--- a/src/main/resources/SmokeTest.jmx
+++ b/src/main/resources/SmokeTest.jmx
@@ -30,17 +30,17 @@
             <collectionProp name="Arguments.arguments">
               <elementProp name="seed-file" elementType="Argument">
                 <stringProp name="Argument.name">seed-file</stringProp>
-                <stringProp name="Argument.value">src/main/resources/test_associations.csv</stringProp>
+                <stringProp name="Argument.value">${__P(seed-file,)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
               <elementProp name="provider-bundle" elementType="Argument">
                 <stringProp name="Argument.name">provider-bundle</stringProp>
-                <stringProp name="Argument.value">provider_bundle.json</stringProp>
+                <stringProp name="Argument.value">${__P(provider-bundle,)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
               <elementProp name="patient-bundle" elementType="Argument">
                 <stringProp name="Argument.name">patient-bundle</stringProp>
-                <stringProp name="Argument.value">patient_bundle.json</stringProp>
+                <stringProp name="Argument.value">${__P(patient-bundle,)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
               <elementProp name="host" elementType="Argument">


### PR DESCRIPTION
**Why**

Smoke tests do not appear to be submitting the correct patient IDs form DPR environment, we'll need to investigate this further.

**What Changed**

* Passes the config files through the .jmx file. Somehow I missed this in the original PR.

**Choices Made**

**Tickets closed**:

DPC-859

**Future Work**


**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
