### PR TITLE
Smoke test cleanups

### DIFF
--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -129,6 +129,10 @@ public class ClientUtils {
                 done = statusCode == HttpStatus.OK_200 || statusCode > 300;
                 if (done) {
                     final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
+                    // If we're done, make sure we completed successfully, otherwise, throw an error
+                    if (statusCode > 300) {
+                        throw new IllegalStateException(String.format("Awaiting export results failed: %s", mapper.readValue(response.getEntity().getContent(), String.class)));
+                    }
                     jobResponse = mapper.readValue(response.getEntity().getContent(), JobCompletionModel.class);
                 }
             }

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -52,7 +52,7 @@ public class ClientUtils {
                 .map(group -> jobCompletionLambda(exportClient, httpClient, group))
                 .peek(jobResponse -> {
                     if (jobResponse.getError().size() > 0)
-                        throw new IllegalStateException("Errors reported during export");
+                        throw new IllegalStateException("Export job completed, but with errors");
                 })
                 .forEach(jobResponse -> jobResponse.getOutput().forEach(entry -> {
                     jobResponseHandler(httpClient, entry);

--- a/src/test/smoke_test.yml
+++ b/src/test/smoke_test.yml
@@ -5,7 +5,7 @@ execution:
   - iterations: 3
     concurrency: 3
     scenario: jmeter
-    ramp-up: 120s
+    ramp-up: 60s
 
 scenarios:
   jmeter:


### PR DESCRIPTION
**Why**

As we've been in the perennial debug loop for our JMeter tests, I made a couple of small tweaks to make life better.

**What Changed**

Reduced the test ramp-up time from 120s to 60s, this was a change that I missed on an earlier branch, still catches the threading issues but makes the tests run a bit quicker.

Improved the error message when an export job completes but has error outcomes.

Updated the `done` handling in the export job monitoring. Now, if a non-202 status is returned we check to see if it's an error response and if so, parse out the error as a string.
