### PR TITLE
content updates

### DIFF
--- a/dpc-web/app/views/dashboard/_assigned_content.html.erb
+++ b/dpc-web/app/views/dashboard/_assigned_content.html.erb
@@ -30,10 +30,21 @@
                 New token
               <% end %>
             </div>
+<<<<<<< HEAD
           </div>
           <div class="ds-l-row">
             <div class="ds-l-col--12">
               <% organization.registered_organizations.each do |reg_org| %>
+=======
+          <% else %>
+            <p class="ds-u-color--muted">Before you can start testing in the sandbox, you must create a unique client token for each application or vendor that will have access to the sandbox on your behalf.</p>
+          <% end %>
+        </div>
+        <div class="ds-l-row">
+          <div class="ds-l-col--12">
+            <% organization.registered_organizations.each do |reg_org| %>
+              <% reg_org.client_tokens.each do |token| %>
+>>>>>>> content updates
                 <% if reg_org.client_tokens.count == 0 %>
                   <p class="ds-u-color--muted">
                     Before you can start testing in the sandbox, you must create a unique client token for each application or vendor that will have access to the sandbox on your behalf. <%= link_to "Create a client token", new_organization_client_token_path(organization_id: organization.id) %>.
@@ -72,8 +83,17 @@
                 Add key
               <% end %>
             </div>
+<<<<<<< HEAD
           </div>
           <% organization.registered_organizations.each do |reg_org| %>
+=======
+          <% else %>
+            <p class="ds-u-color--muted">Before you can start testing in the sandbox, add your public keys to get a UUID that you will use when you authenticate access.</p>
+          <% end %>
+        </div>
+        <% organization.registered_organizations.each do |reg_org| %>
+          <% reg_org.public_keys.each do |key| %>
+>>>>>>> content updates
             <% if reg_org.public_keys.count == 0 %>
               <p class="ds-u-color--muted">
                 Before you can start testing in the sandbox, add your public keys to get a UUID that you will use when you authenticate access. <%= link_to "Add a public key", new_organization_public_key_path(organization_id: organization.id) %>

--- a/dpc-web/app/views/dashboard/_assigned_content.html.erb
+++ b/dpc-web/app/views/dashboard/_assigned_content.html.erb
@@ -30,21 +30,10 @@
                 New token
               <% end %>
             </div>
-<<<<<<< HEAD
           </div>
           <div class="ds-l-row">
             <div class="ds-l-col--12">
               <% organization.registered_organizations.each do |reg_org| %>
-=======
-          <% else %>
-            <p class="ds-u-color--muted">Before you can start testing in the sandbox, you must create a unique client token for each application or vendor that will have access to the sandbox on your behalf.</p>
-          <% end %>
-        </div>
-        <div class="ds-l-row">
-          <div class="ds-l-col--12">
-            <% organization.registered_organizations.each do |reg_org| %>
-              <% reg_org.client_tokens.each do |token| %>
->>>>>>> content updates
                 <% if reg_org.client_tokens.count == 0 %>
                   <p class="ds-u-color--muted">
                     Before you can start testing in the sandbox, you must create a unique client token for each application or vendor that will have access to the sandbox on your behalf. <%= link_to "Create a client token", new_organization_client_token_path(organization_id: organization.id) %>.
@@ -83,17 +72,8 @@
                 Add key
               <% end %>
             </div>
-<<<<<<< HEAD
           </div>
           <% organization.registered_organizations.each do |reg_org| %>
-=======
-          <% else %>
-            <p class="ds-u-color--muted">Before you can start testing in the sandbox, add your public keys to get a UUID that you will use when you authenticate access.</p>
-          <% end %>
-        </div>
-        <% organization.registered_organizations.each do |reg_org| %>
-          <% reg_org.public_keys.each do |key| %>
->>>>>>> content updates
             <% if reg_org.public_keys.count == 0 %>
               <p class="ds-u-color--muted">
                 Before you can start testing in the sandbox, add your public keys to get a UUID that you will use when you authenticate access. <%= link_to "Add a public key", new_organization_public_key_path(organization_id: organization.id) %>

--- a/dpc-web/app/views/dashboard/_unassigned_content.html.erb
+++ b/dpc-web/app/views/dashboard/_unassigned_content.html.erb
@@ -2,10 +2,7 @@
   <div class="box__content">
     <h2 class="box__heading">We've received your access request. What's next?</h2>
     <p class="ds-text--lead ds-u-measure--base">
-      A Data at the Point of Care administrator will assign you to an organization
-      when it is ready to start using the API. After that, you will be able to add your public keys
-      and create client tokens. If you have any questions or feel that your assignment is taking
-      longer than necessary, contact an administrator in the Google Group.
+      A Data at the Point of Care administrator will assign you to an organization in the next 1 - 2 business days. After that, you will be able to add your organizational NPI, upload public keys, and create client tokens. If you have any questions or feel that your assignment is taking longer than necessary, contact an administrator in the Google Group.
     </p>
     <a class="ds-c-button ds-c-button--primary" href="https://groups.google.com/d/forum/dpc-api">DPC Google Group
       <svg class="ds-u-margin-left--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" >

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -218,7 +218,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
         <li>Once you have a working solution that has been well tested, email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> to request a demo.</li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
         <li>The provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
-        <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
+        <li>The DPC team provides production access and gets feedback from the provider as the solution is implemented.</li>
         <li>Updates will be posted to the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a> as CMS progresses through the pilot process.</li>
       </ul>
     </div>

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -59,7 +59,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
         </li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
         <li>The provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
-        <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
+        <li>The DPC team provides production access and gets feedback from the provider as the solution is implemented.</li>
         <li>There is not a limit to the number of providers who can test in the sandbox or who can go into production. However, the production access will move very slowly and may discontinue if the pilot is not successful.</li>
       </ul>
     </div>

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -58,7 +58,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
           </ul>
         </li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
-        <li>Provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+        <li>The provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
         <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
         <li>There is not a limit to the number of providers who can test in the sandbox or who can go into production. However, the production access will move very slowly and may discontinue if the pilot is not successful.</li>
       </ul>
@@ -217,7 +217,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
         <li>Within 1 - 2 business days of your request, you will receive an email with instructions on how to access the synthetic (or test data) sandbox.</li>
         <li>Once you have a working solution that has been well tested, email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> to request a demo.</li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
-        <li>Provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+        <li>The provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
         <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
         <li>Updates will be posted to the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a> as CMS progresses through the pilot process.</li>
       </ul>

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -51,7 +51,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
         <li>The provider and/or their vendor develops and tests the functionality in the synthetic sandbox.</li>
         <li>When the provider/vendor feel that they are ready to request production access, they can email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> and include the following:
           <ul>
-            <li>Summary of the rostering process</li>
+            <li>Written summary of the rostering process and logic of how patients are added and removed from rosters and when physician intervention is required to renew an expired roster</li>
             <li>HITRUST validation or certification (or be prepared to share the HHS ONC HIT Technology certification information for the version you are using, including the CHPL ID and version)</li>
             <li>Confirmation of understanding the Terms of Service</li>
             <li>The initial providers NPIs for production use</li>

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -46,7 +46,11 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
     </h2>
     <div id="a3" class="usa-accordion__content">
       <ul>
+<<<<<<< HEAD
         <li>Any FFS provider can request access to synthetic data</li>
+=======
+        <li>Any FFS provider can request access access to synthetic data</li>
+>>>>>>> content updates
         <li>Providers will receive an email with instructions on how to access the synthetic (test data) sandbox. This usually happens in 1 - 2 business days after the request.</li>
         <li>The provider and/or their vendor develops and tests the functionality in the synthetic sandbox.</li>
         <li>When the provider/vendor feel that they are ready to request production access, they can email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> and include the following:
@@ -58,7 +62,11 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
           </ul>
         </li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
+<<<<<<< HEAD
         <li>The provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+=======
+        <li>Provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+>>>>>>> content updates
         <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
         <li>There is not a limit to the number of providers who can test in the sandbox or who can go into production. However, the production access will move very slowly and may discontinue if the pilot is not successful.</li>
       </ul>
@@ -217,7 +225,11 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
         <li>Within 1 - 2 business days of your request, you will receive an email with instructions on how to access the synthetic (or test data) sandbox.</li>
         <li>Once you have a working solution that has been well tested, email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> to request a demo.</li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
+<<<<<<< HEAD
         <li>The provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+=======
+        <li>Provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+>>>>>>> content updates
         <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
         <li>Updates will be posted to the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a> as CMS progresses through the pilot process.</li>
       </ul>

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -46,11 +46,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
     </h2>
     <div id="a3" class="usa-accordion__content">
       <ul>
-<<<<<<< HEAD
         <li>Any FFS provider can request access to synthetic data</li>
-=======
-        <li>Any FFS provider can request access access to synthetic data</li>
->>>>>>> content updates
         <li>Providers will receive an email with instructions on how to access the synthetic (test data) sandbox. This usually happens in 1 - 2 business days after the request.</li>
         <li>The provider and/or their vendor develops and tests the functionality in the synthetic sandbox.</li>
         <li>When the provider/vendor feel that they are ready to request production access, they can email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> and include the following:
@@ -62,11 +58,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
           </ul>
         </li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
-<<<<<<< HEAD
         <li>The provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
-=======
-        <li>Provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
->>>>>>> content updates
         <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
         <li>There is not a limit to the number of providers who can test in the sandbox or who can go into production. However, the production access will move very slowly and may discontinue if the pilot is not successful.</li>
       </ul>
@@ -225,11 +217,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
         <li>Within 1 - 2 business days of your request, you will receive an email with instructions on how to access the synthetic (or test data) sandbox.</li>
         <li>Once you have a working solution that has been well tested, email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> to request a demo.</li>
         <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
-<<<<<<< HEAD
         <li>The provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
-=======
-        <li>Provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
->>>>>>> content updates
         <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
         <li>Updates will be posted to the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a> as CMS progresses through the pilot process.</li>
       </ul>

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -41,15 +41,26 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
     <!-- Use the accurate heading level to maintain the document outline -->
     <h2 class="usa-accordion__heading">
       <button class="usa-accordion__button" aria-expanded="false" aria-controls="a3">
-        How will the pilot project work? How many providers can join and how long does it last?
+        How will the pilot work? How many providers can join and how long does it last?
       </button>
     </h2>
     <div id="a3" class="usa-accordion__content">
       <ul>
-        <li>After the announcement, any FFS provider can request access access to synthetic data.</li>
-        <li>CMS will slowly roll out the tokens to providers based on order of request, their readiness, their experience with FHIR, claims data, Blue Button and BCDA, and our ability to respond.</li>
-        <li>The team is aiming for a September test with a few providers who are have built, tested, and can demonstrate their readiness to test with production data.</li>
-        <li>CMS will slowly roll out the tokens to these providers based on readiness and the team's ability to respond.</li>
+        <li>Any FFS provider can request access access to synthetic data</li>
+        <li>Providers will receive an email with instructions on how to access the synthetic (test data) sandbox. This usually happens in 1 - 2 business days after the request.</li>
+        <li>The provider and/or their vendor develops and tests the functionality in the synthetic sandbox.</li>
+        <li>When the provider/vendor feel that they are ready to request production access, they can email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> and include the following:
+          <ul>
+            <li>Summary of the rostering process</li>
+            <li>HITRUST validation or certification (or be prepared to share the HHS ONC HIT Technology certification information for the version you are using, including the CHPL ID and version)</li>
+            <li>Confirmation of understanding the Terms of Service</li>
+            <li>The initial providers NPIs for production use</li>
+          </ul>
+        </li>
+        <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
+        <li>Provider and their vendor will demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+        <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
+        <li>There is not a limit to the number of providers who can test in the sandbox or who can go into production. However, the production access will move very slowly and may discontinue if the pilot is not successful.</li>
       </ul>
     </div>
 
@@ -203,7 +214,11 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
     </h2>
     <div id="a15" class="usa-accordion__content">
       <ul>
-        <li>CMS will slowly roll out the tokens to providers based on order of request, their readiness, their experience with FHIR, claims data, Blue Button and BCDA, and our ability to respond.</li>
+        <li>Within 1 - 2 business days of your request, you will receive an email with instructions on how to access the synthetic (or test data) sandbox.</li>
+        <li>Once you have a working solution that has been well tested, email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> to request a demo.</li>
+        <li>The DPC team will schedule a demo session.  Remember, this is a pilot project and scheduling will move slowly.</li>
+        <li>Provider and their vendor demonstrate the functionality and review the implementation decisions with the DPC team. </li>
+        <li>The DPC team provides production access and gets feedback as the solution is implemented.</li>
         <li>Updates will be posted to the <a href="https://groups.google.com/d/forum/dpc-api">Google Group</a> as CMS progresses through the pilot process.</li>
       </ul>
     </div>

--- a/dpc-web/app/views/pages/faq.html.erb
+++ b/dpc-web/app/views/pages/faq.html.erb
@@ -46,7 +46,7 @@ Already using or testing wth FHIR, especially Bulk FHIR</li>
     </h2>
     <div id="a3" class="usa-accordion__content">
       <ul>
-        <li>Any FFS provider can request access access to synthetic data</li>
+        <li>Any FFS provider can request access to synthetic data</li>
         <li>Providers will receive an email with instructions on how to access the synthetic (test data) sandbox. This usually happens in 1 - 2 business days after the request.</li>
         <li>The provider and/or their vendor develops and tests the functionality in the synthetic sandbox.</li>
         <li>When the provider/vendor feel that they are ready to request production access, they can email <a href="mailto:DPCInfo@cms.hhs.gov">DPCInfo@cms.hhs.gov</a> and include the following:

--- a/dpc-web/app/views/public/home.html.erb
+++ b/dpc-web/app/views/public/home.html.erb
@@ -126,13 +126,13 @@
         <li class="site-process-list__item">
           <h3 class="site-process-list__heading">Request access to the pilot</h3>
           <div class="site-process-list__body">
-            <p>Do this on the <%= link_to "Request access page", new_registration_path(User) %>. Remember, this is a pilot and and the process may move slowly. You can prepare for connection by asking your software developer to read the <%= link_to "developer documentation", docs_path %>.</p>
+            <p>Do this on the <%= link_to "Request access page", new_registration_path(User) %>.</p>
           </div>
         </li>
         <li class="site-process-list__item">
-          <h3 class="site-process-list__heading">We’ll reach out to you</h3>
+          <h3 class="site-process-list__heading">You will receive an email</h3>
           <div class="site-process-list__body">
-            <p>Based on the specification and sample data, build and test with synthetic data.</p>
+            <p>Within 1 - 2 business days, you will receive an email with instructions on how to access the synthetic (test data) sandbox.</p>
           </div>
         </li>
         <li class="site-process-list__item">
@@ -144,7 +144,7 @@
         <li class="site-process-list__item">
           <h3 class="site-process-list__heading">Provide a demo</h3>
           <div class="site-process-list__body">
-            <p>The Data at the Point of Care team will review your implementation to determine whether you’re ready for production.</p>
+            <p>The Data at the Point of Care team will review your implementation to determine whether you’re ready for production. Remember, this is a pilot process that will move slowly. </p>
           </div>
         </li>
         <li class="site-process-list__item">


### PR DESCRIPTION
**Why**

Need to modify some of the of the copy to include references to the sandbox

**What Changed**

- Landing page
- FAQs
- Dashboard

**Tickets closed**:

No tickets, but the copy is in this Confluence doc: 
https://confluenceent.cms.gov/pages/viewpage.action?spaceKey=DAPC&title=Updates+to+screen+text+after+token+changes

Added all content except the updates under:
- Text for the top of the screen when an organization is assigned but no NPI or vendor (added in other branch)
- When editing an organization, the NPI field can have help text (added in other branch)
- Developer Documentation Updates (not sure where to place)
- OpenAPI Documentation (not sure where to place)
