### PR TITLE
DPC-307: Add update capability to Organization resources

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
@@ -1,6 +1,8 @@
 package gov.cms.dpc.api.resources;
 
 import gov.cms.dpc.fhir.annotations.FHIR;
+import gov.cms.dpc.fhir.annotations.Profiled;
+import gov.cms.dpc.fhir.validations.profiles.OrganizationProfile;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Organization;
 
@@ -25,5 +27,5 @@ public abstract class AbstractOrganizationResource {
 
     @PUT
     @Path("/{organizationID}")
-    public abstract Organization updateOrganization(UUID organizationID, @Valid Organization organization);
+    public abstract Organization updateOrganization(UUID organizationID, @Valid @Profiled(profile = OrganizationProfile.PROFILE_URI) Organization organization);
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
@@ -4,8 +4,10 @@ import gov.cms.dpc.fhir.annotations.FHIR;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Organization;
 
+import javax.validation.Valid;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import java.util.UUID;
 
@@ -21,5 +23,7 @@ public abstract class AbstractOrganizationResource {
     @Path("/{organizationID}")
     public abstract Organization getOrganization(UUID organizationID);
 
-
+    @PUT
+    @Path("/{organizationID}")
+    public abstract Organization updateOrganization(UUID organizationID, @Valid Organization organization);
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
@@ -9,6 +9,8 @@ import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractOrganizationResource;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.annotations.FHIRParameter;
+import gov.cms.dpc.fhir.annotations.Profiled;
+import gov.cms.dpc.fhir.validations.profiles.OrganizationProfile;
 import io.swagger.annotations.*;
 import org.hl7.fhir.dstu3.model.*;
 
@@ -92,7 +94,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
             @ApiResponse(code = 422, message = "Provided resource is not a valid FHIR Organization")
     })
     @Override
-    public Organization updateOrganization(@PathParam("organizationID") UUID organizationID, @Valid Organization organization) {
+    public Organization updateOrganization(@PathParam("organizationID") UUID organizationID, @Valid @Profiled(profile = OrganizationProfile.PROFILE_URI) Organization organization) {
         MethodOutcome outcome = this.client
                 .update()
                 .resource(organization)

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
@@ -83,8 +83,11 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @FHIR
     @Timed
     @ExceptionMetered
-    @ApiOperation(value = "Update Organization record", notes = "Update specific Organization record.")
+    @ApiOperation(value = "Update organization record",
+            notes = "Update specific Organization record.",
+            authorizations = @Authorization(value = "apiKey"))
     @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "An organization may update only their own Organization resource"),
             @ApiResponse(code = 404, message = "Unable to find Organization to update"),
             @ApiResponse(code = 422, message = "Provided resource is not a valid FHIR Organization")
     })

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
@@ -1,22 +1,26 @@
 package gov.cms.dpc.api.resources.v1;
 
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
+import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import gov.cms.dpc.testing.factories.OrganizationFactory;
 import gov.cms.dpc.testing.OrganizationHelpers;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Endpoint;
-import org.hl7.fhir.dstu3.model.Organization;
-import org.hl7.fhir.dstu3.model.Parameters;
+import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.util.Lists;
+import org.hl7.fhir.dstu3.model.*;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.util.UUID;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
@@ -129,5 +133,37 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
                 .encodedJson();
 
         assertThrows(InvalidRequestException.class, operation::execute, "Should be unprocessable");
+    }
+
+    @Test
+    void testUpdateOrganization() throws IOException, URISyntaxException, NoSuchAlgorithmException {
+        final String orgID = UUID.randomUUID().toString();
+        final IParser parser = ctx.newJsonParser();
+        final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
+        final String macaroon = FHIRHelpers.registerOrganization(attrClient, parser, orgID, getAdminURL());
+        final Pair<UUID, PrivateKey> uuidPrivateKeyPair = APIAuthHelpers.generateAndUploadKey("org-update-key", orgID, GOLDEN_MACAROON, getBaseURL());
+        final IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight());
+
+        Organization organization = client
+                .read()
+                .resource(Organization.class)
+                .withId(orgID)
+                .encodedJson()
+                .execute();
+
+        assertNotNull(organization);
+
+        organization.setName("New Org Name");
+        organization.setContact(Lists.emptyList());
+
+        final MethodOutcome outcome = client
+                .update()
+                .resource(organization)
+                .execute();
+
+        Organization result = (Organization) outcome.getResource();
+        assertEquals(organization.getName(), result.getName(), "Name should be updated");
+        assertTrue(organization.getContact().isEmpty(), "Contact list should be updated");
+        assertEquals(1, result.getEndpoint().size(), "Endpoint list should be unchanged");
     }
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/OrganizationDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/OrganizationDAO.java
@@ -3,7 +3,6 @@ package gov.cms.dpc.attribution.jdbi;
 import gov.cms.dpc.common.entities.EndpointEntity;
 import gov.cms.dpc.common.entities.OrganizationEntity;
 import gov.cms.dpc.common.hibernate.attribution.DPCManagedSessionFactory;
-import gov.cms.dpc.fhir.FHIRExtractors;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hl7.fhir.dstu3.model.Organization;
 
@@ -44,9 +43,10 @@ public class OrganizationDAO extends AbstractDAO<OrganizationEntity> {
         return list(query);
     }
 
-    public OrganizationEntity updateOrganization(Organization resource) {
+    public OrganizationEntity updateOrganization(UUID organizationID, Organization resource) {
+        OrganizationEntity organization = fetchOrganization(organizationID)
+                .orElseThrow(() -> new IllegalArgumentException("Cannot find organization"));
         final OrganizationEntity updatedOrg = new OrganizationEntity().fromFHIR(resource);
-        OrganizationEntity organization = get(FHIRExtractors.getEntityUUID(resource.getId()));
         organization.update(updatedOrg);
         currentSession().merge(organization);
         return organization;

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/OrganizationDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/OrganizationDAO.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.attribution.jdbi;
 import gov.cms.dpc.common.entities.EndpointEntity;
 import gov.cms.dpc.common.entities.OrganizationEntity;
 import gov.cms.dpc.common.hibernate.attribution.DPCManagedSessionFactory;
+import gov.cms.dpc.fhir.FHIRExtractors;
 import io.dropwizard.hibernate.AbstractDAO;
 import org.hl7.fhir.dstu3.model.Organization;
 
@@ -43,8 +44,12 @@ public class OrganizationDAO extends AbstractDAO<OrganizationEntity> {
         return list(query);
     }
 
-    public void updateOrganization(OrganizationEntity entity) {
-        persist(entity);
+    public OrganizationEntity updateOrganization(Organization resource) {
+        final OrganizationEntity updatedOrg = new OrganizationEntity().fromFHIR(resource);
+        OrganizationEntity organization = get(FHIRExtractors.getEntityUUID(resource.getId()));
+        organization.update(updatedOrg);
+        currentSession().merge(organization);
+        return organization;
     }
 
     public void deleteOrganization(OrganizationEntity entity) {

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractOrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractOrganizationResource.java
@@ -5,10 +5,7 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Parameters;
 
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
 
@@ -49,6 +46,18 @@ public abstract class AbstractOrganizationResource {
     @FHIR
     @Path("/{organizationID}")
     public abstract Organization getOrganization(UUID organizationID);
+
+    /**
+     * Update the {@link Organization} with the given ID
+     *
+     * @param organizationID {@link UUID} of organization
+     * @param organization {@link Organization}
+     * @return
+     */
+    @PUT
+    @FHIR
+    @Path("/{organizationID}")
+    public abstract Response updateOrganization(UUID organizationID, Organization organization);
 
     /**
      * Delete the {@link Organization} from the system.

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -121,11 +121,31 @@ public class OrganizationResource extends AbstractOrganizationResource {
         return organizationEntity.toFHIR();
     }
 
+    @PUT
+    @Path("/{organizationID}")
+    @FHIR
+    @UnitOfWork
+    @ApiOperation(value = "Update Organization record", notes = "Update specific Organization record.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Unable to find Organization to update"),
+            @ApiResponse(code = 422, message = "The provided Organization bundle is invalid")
+    })
+    @Override
+    public Response updateOrganization(@ApiParam(value = "Organization resource ID", required = true) @PathParam("organizationID") UUID organizationID, Organization organization) {
+        try {
+            OrganizationEntity orgEntity = this.dao.updateOrganization(organization);
+            return Response.status(Response.Status.OK).entity(orgEntity.toFHIR()).build();
+        } catch (Exception e) {
+            logger.error("Error: ", e);
+            throw e;
+        }
+    }
+
     @DELETE
     @Path("/{organizationID}")
     @FHIR
     @UnitOfWork
-    @ApiOperation(value = "Delete organization", notes = "FHIR endpoint to deleta an Organization with the given Resource ID." +
+    @ApiOperation(value = "Delete organization", notes = "FHIR endpoint to delete an Organization with the given Resource ID." +
             "<p>This also drops ALL resources associated to the given entity.")
     @ApiResponses(value = @ApiResponse(code = 404, message = "Could not find Organization", response = OperationOutcome.class))
     @Override

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -133,7 +133,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @Override
     public Response updateOrganization(@ApiParam(value = "Organization resource ID", required = true) @PathParam("organizationID") UUID organizationID, Organization organization) {
         try {
-            OrganizationEntity orgEntity = this.dao.updateOrganization(organization);
+            OrganizationEntity orgEntity = this.dao.updateOrganization(organizationID, organization);
             return Response.status(Response.Status.OK).entity(orgEntity.toFHIR()).build();
         } catch (Exception e) {
             logger.error("Error: ", e);

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
@@ -118,6 +118,19 @@ class OrganizationResourceTest extends AbstractAttributionTest {
                 .execute(), "Should not have found organization");
     }
 
+    @Test
+    void testUpdateOrganization() {
+        final IGenericClient client = AttributionTestHelpers.createFHIRClient(ctx, getServerURL());
+        Organization organization = OrganizationHelpers.createOrganization(ctx, AttributionTestHelpers.createFHIRClient(ctx, getServerURL()));
+
+        organization.setName("An Updated Organization");
+
+        MethodOutcome outcome = client.update().resource(organization).execute();
+        Organization orgResult = (Organization) outcome.getResource();
+
+        assertTrue(organization.equalsDeep(orgResult));
+    }
+
     private Practitioner createFakePractitioner(Organization organization) {
         final Practitioner practitioner = new Practitioner();
         practitioner.addName().setFamily("Test").addGiven("Practitioner");

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IUpdateTyped;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import gov.cms.dpc.attribution.AbstractAttributionTest;
 import gov.cms.dpc.attribution.AttributionTestHelpers;
@@ -141,7 +142,7 @@ class OrganizationResourceTest extends AbstractAttributionTest {
 
         organization2.setIdentifier(Arrays.asList(identifier));
         IUpdateTyped update = client.update().resource(organization2);
-        assertThrows(Exception.class, update::execute);
+        assertThrows(InvalidRequestException.class, update::execute);
     }
 
     private Practitioner createFakePractitioner(Organization organization) {

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.io.InputStream;
 import java.sql.Date;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -123,6 +124,10 @@ class OrganizationResourceTest extends AbstractAttributionTest {
         final IGenericClient client = AttributionTestHelpers.createFHIRClient(ctx, getServerURL());
         Organization organization = OrganizationHelpers.createOrganization(ctx, AttributionTestHelpers.createFHIRClient(ctx, getServerURL()));
 
+        Identifier identifier = new Identifier();
+        identifier.setSystem(DPCIdentifierSystem.NPPES.getSystem());
+        identifier.setValue("UPDATED012345");
+        organization.setIdentifier(Arrays.asList(identifier));
         organization.setName("An Updated Organization");
 
         MethodOutcome outcome = client.update().resource(organization).execute();

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
@@ -208,6 +208,21 @@ public class OrganizationEntity implements Serializable, FHIRConvertable<Organiz
         return org;
     }
 
+    /**
+     * Update {@link Organization} fields.
+     *
+     * @param updated - {@link OrganizationEntity} with new values
+     * @return - {@link OrganizationEntity} existing record with updated fields.
+     */
+    public OrganizationEntity update(OrganizationEntity updated) {
+        this.setOrganizationName(updated.getOrganizationName());
+        this.setOrganizationAddress(updated.getOrganizationAddress());
+        this.setContacts(updated.getContacts());
+        this.setPatients(updated.getPatients());
+        this.setProviders(updated.getProviders());
+        return this;
+    }
+
     @Embeddable
     public static class OrganizationID implements Serializable {
         public static final long serialVersionUID = 42L;

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
@@ -215,11 +215,13 @@ public class OrganizationEntity implements Serializable, FHIRConvertable<Organiz
      * @return - {@link OrganizationEntity} existing record with updated fields.
      */
     public OrganizationEntity update(OrganizationEntity updated) {
+        this.setOrganizationID(updated.getOrganizationID());
         this.setOrganizationName(updated.getOrganizationName());
         this.setOrganizationAddress(updated.getOrganizationAddress());
         this.setContacts(updated.getContacts());
         this.setPatients(updated.getPatients());
         this.setProviders(updated.getProviders());
+
         return this;
     }
 

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/ProfileValidator.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/ProfileValidator.java
@@ -51,6 +51,7 @@ public class ProfileValidator implements ConstraintValidator<Profiled, BaseResou
                                 VALIDATION_CONSTANT +
                                         msg.getMessage() + "}")
                         .addConstraintViolation());
+
         return false;
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/profiles/OrganizationProfile.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/profiles/OrganizationProfile.java
@@ -2,7 +2,7 @@ package gov.cms.dpc.fhir.validations.profiles;
 
 public class OrganizationProfile implements IProfileLoader {
 
-    public static String PROFILE_URI = "https://dpc.cms.gov/api/v1/StructureDefinition/dpc-profile-organization";
+    public static final String PROFILE_URI = "https://dpc.cms.gov/api/v1/StructureDefinition/dpc-profile-organization";
 
     @Override
     public String getPath() {

--- a/src/main/resources/organization.tmpl.json
+++ b/src/main/resources/organization.tmpl.json
@@ -21,7 +21,8 @@
           ],
           "city": "Washington",
           "state": "DC",
-          "postalCode": "20008"
+          "postalCode": "20008",
+          "country": "US"
         }],
         "contact": [
           {

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "25b0d817-05c2-45b2-9946-b6ed2dbf7ebb",
+		"_postman_id": "c110c114-cf23-4b5a-a7c8-33ce5b4304cf",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -24,8 +24,10 @@
 									"",
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+json\", function() {",
-									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+json\"); ",
-									"});"
+									"    pm.response.to.have.header(\"Content-Type\", \"application/fhir+json\");",
+									"});",
+									"",
+									"pm.globals.set(\"organization_id\", pm.response.json().id);"
 								],
 								"type": "text/javascript"
 							}
@@ -894,6 +896,71 @@
 							]
 						},
 						"description": "The coverage data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one coverage."
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Updating",
+			"item": [
+				{
+					"name": "Update organization",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "96f38c80-8b9d-4761-b66c-a02bd1de7408",
+								"exec": [
+									"pm.test(\"Status is OK\", function () {",
+									"    pm.response.to.have.be.ok;",
+									"});",
+									"",
+									"pm.test(\"Body matches expected response\", function() {",
+									"    var respJson = pm.response.json();",
+									"    pm.expect(respJson.name).equals(\"Beth Israel Deaconess HealthCare - Chestnut Hill\");",
+									"    ",
+									"    var address = respJson.address[0];",
+									"    pm.expect(address.line[0]).equals(\"200 Boylston Street, 4th Floor\");",
+									"    pm.expect(address.city).equals(\"Chestnut Hill\");",
+									"    pm.expect(address.state).equals(\"MA\");",
+									"    pm.expect(address.postalCode).equals(\"02467\");",
+									"    ",
+									"    pm.expect(respJson.endpoint.length).equals(3);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/fhir+json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"resourceType\": \"Organization\",\n    \"id\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\",\n    \"identifier\": [\n        {\n            \"system\": \"http://hl7.org/fhir/sid/us-npi\",\n            \"value\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\"\n        }\n    ],\n    \"name\": \"Beth Israel Deaconess HealthCare - Chestnut Hill\",\n    \"address\": [\n        {\n            \"use\": \"work\",\n            \"type\": \"both\",\n            \"line\": [\n                \"200 Boylston Street, 4th Floor\"\n            ],\n            \"city\": \"Chestnut Hill\",\n            \"state\": \"MA\",\n            \"postalCode\": \"02467\",\n            \"country\": \"US\"\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Organization/{{organization_id}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Organization",
+								"{{organization_id}}"
+							]
+						}
 					},
 					"response": []
 				}

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c110c114-cf23-4b5a-a7c8-33ce5b4304cf",
+		"_postman_id": "665bcdc6-0a21-450f-b41a-6e61a5076cfc",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -946,7 +946,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"resourceType\": \"Organization\",\n    \"id\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\",\n    \"identifier\": [\n        {\n            \"system\": \"http://hl7.org/fhir/sid/us-npi\",\n            \"value\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\"\n        }\n    ],\n    \"name\": \"Beth Israel Deaconess HealthCare - Chestnut Hill\",\n    \"address\": [\n        {\n            \"use\": \"work\",\n            \"type\": \"both\",\n            \"line\": [\n                \"200 Boylston Street, 4th Floor\"\n            ],\n            \"city\": \"Chestnut Hill\",\n            \"state\": \"MA\",\n            \"postalCode\": \"02467\",\n            \"country\": \"US\"\n        }\n    ]\n}"
+							"raw": "{\n    \"resourceType\": \"Organization\",\n    \"id\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\",\n    \"identifier\": [\n        {\n            \"system\": \"http://hl7.org/fhir/sid/us-npi\",\n            \"value\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\"\n        }\n    ],\n    \"name\": \"Beth Israel Deaconess HealthCare - Chestnut Hill\",\n    \"address\": [\n        {\n            \"use\": \"work\",\n            \"type\": \"both\",\n            \"line\": [\n                \"200 Boylston Street, 4th Floor\"\n            ],\n            \"city\": \"Chestnut Hill\",\n            \"state\": \"MA\",\n            \"postalCode\": \"02467\",\n            \"country\": \"US\"\n        }\n    ],\n    \"endpoint\": [\n        {\n            \"reference\": \"Endpoint/0a60c95c-48b4-4f39-8bf4-09f7dfe2e3cc\"\n        }\n    ]\n}"
 						},
 						"url": {
 							"raw": "http://{{hostname}}:{{api_port}}/v1/Organization/{{organization_id}}",


### PR DESCRIPTION
**Why**
There should be a way to update Organization resources.

**What Changed**
`PUT` methods added to dpc-api and dpc-attribution for submitting updates.

**Choices Made**
When updating an organization, no changes can be made to its endpoints. Any endpoint references provided in the request body will be ignored. The existing endpoint references will remain unchanged.

**Tickets closed**:
[DPC-307](https://jiraent.cms.gov/browse/DPC-307)

**Future Work**
[DPC-857](https://jiraent.cms.gov/browse/DPC-857) will add create, update, and delete methods for Endpoint resources.

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
