### PR TITLE
Smoke Test Logging Improvements

### DIFF
--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -5,12 +5,14 @@ import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import gov.cms.dpc.common.models.JobCompletionModel;
 import gov.cms.dpc.common.utils.SeedProcessor;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.FHIRExtractors;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -21,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +136,15 @@ public class ClientUtils {
                     if (statusCode > 300) {
                         throw new IllegalStateException(String.format("Awaiting export results failed: %s", mapper.readValue(response.getEntity().getContent(), String.class)));
                     }
-                    jobResponse = mapper.readValue(response.getEntity().getContent(), JobCompletionModel.class);
+                    String responseBody = "";
+                    try {
+                        responseBody = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+                        jobResponse = mapper.readValue(responseBody, JobCompletionModel.class);
+                    } catch ( JsonParseException e ) {
+                        logger.error(String.format("Failed to parse job status response: %s", responseBody));
+                        throw e;
+                    }
+
                 }
             }
         }

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -218,7 +218,7 @@ public class ClientUtils {
         try {
             return monitorExportRequest(exportOperation, client);
         } catch (IOException | InterruptedException e) {
-            throw new RuntimeException("Error monitoring export", e);
+            throw new RuntimeException(String.format("Error monitoring export groupID: %s", group.getId()), e);
         }
     }
 


### PR DESCRIPTION
**Why**

Adds some better logging for some failure situations were seeing with the smoke tests.

**What Changed**

* Adds the groupId to the exception message, to better track down the exact export having issues
* Outputs the raw response body on a JobCompletionModel parsing failure

**Choices Made**

Justify changes made and any reasons for why a given path was taken, as opposed to an alternative option.

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additional fixes.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
