### PR TITLE
add missing word to the token alert

### DIFF
--- a/dpc-web/app/views/client_tokens/show.html.erb
+++ b/dpc-web/app/views/client_tokens/show.html.erb
@@ -6,7 +6,7 @@
     <div class="box__content">
       <div class="ds-c-alert ds-u-margin-bottom--7">
         <div class="ds-c-alert__body">
-          <h2 class="ds-c-alert__heading">Copy or download your token right now! You won’t be able to see again.</h2>
+          <h2 class="ds-c-alert__heading">Copy or download your token right now! You won’t be able to see it again.</h2>
         </div>
       </div>
       <h2 class="box__heading ds-u-margin-bottom--0"><%= @client_token['label'] %></h2>


### PR DESCRIPTION
**Why**

Needed the word "it"

**What Changed**

Added "it"

**Choices Made**

Decided proper grammar was better