### PR TITLE
add z-index to topnav__dropdown

### DIFF
--- a/dpc-web/app/assets/stylesheets/components/_navbar.scss
+++ b/dpc-web/app/assets/stylesheets/components/_navbar.scss
@@ -190,6 +190,7 @@
     position: absolute;
     right: 0;
     width: 100%;
+    z-index: $z-index-nav;
   }
 }
 


### PR DESCRIPTION
**Why**

Flash messages were covering parts of the nav bar dropdown. 
<img width="1060" alt="Screen Shot 2019-11-22 at 10 35 50 AM" src="https://user-images.githubusercontent.com/25435289/69439345-bd9e5a00-0d14-11ea-91c1-baf836f44e49.png">


**What Changed**

Updated CSS to the topnav fixes the issue

<img width="1478" alt="Screen Shot 2019-11-22 at 10 42 58 AM" src="https://user-images.githubusercontent.com/25435289/69439395-de66af80-0d14-11ea-9e30-46533d3c8ce9.png">


**Choices Made**

Applied a z-index to the topnav dropdown
