### PR TITLE
DPC-850: Bugfix - Save number of providers on registration

### DIFF
--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
 import org.slf4j.Logger;
@@ -134,7 +135,7 @@ public class ClientUtils {
                     final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule());
                     // If we're done, make sure we completed successfully, otherwise, throw an error
                     if (statusCode > 300) {
-                        throw new IllegalStateException(String.format("Awaiting export results failed: %s", mapper.readValue(response.getEntity().getContent(), String.class)));
+                        throw new IllegalStateException(String.format("Awaiting export results failed with status %d: %s", statusCode, EntityUtils.toString(response.getEntity())));
                     }
                     String responseBody = "";
                     try {

--- a/dpc-web/app/controllers/application_controller.rb
+++ b/dpc-web/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
       user.permit(
         :first_name, :last_name, :requested_organization, :requested_organization_type,
         :address_1, :address_2, :city, :state, :zip, :agree_to_terms,
-        :email, :password, :current_password, :num_providers
+        :email, :password, :current_password, :requested_num_providers
       )
     end
 
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
       user.permit(
         :first_name, :last_name, :requested_organization, :requested_organization_type,
         :address_1, :address_2, :city, :state, :zip, :agree_to_terms,
-        :email, :password, :current_password, :num_providers
+        :email, :password, :current_password, :requested_num_providers
       )
     end
   end

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -23,7 +23,8 @@ class User < ApplicationRecord
   validates :requested_organization_type, inclusion: { in: ORGANIZATION_TYPES.keys }
   validates :last_name, :first_name, presence: true
   validates :requested_organization, presence: true
-  validates :requested_num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true },
+  validates :requested_num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0,
+                                                      allow_nil: true },
                                       if: -> { health_it_vendor? }
   validates :requested_num_providers, numericality: { only_integer: true, greater_than: 0 },
                                       unless: -> { health_it_vendor? }

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   validates :requested_organization_type, inclusion: { in: ORGANIZATION_TYPES.keys }
   validates :last_name, :first_name, presence: true
   validates :requested_organization, presence: true
-  validates :requested_num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true }
+  validates :requested_num_providers, numericality: { only_integer: true, greater_than: 0 }
   validates :address_1, presence: true
   validates :city, presence: true
   validates :state, inclusion: { in: Address::STATES.keys.map(&:to_s) }

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -23,7 +23,10 @@ class User < ApplicationRecord
   validates :requested_organization_type, inclusion: { in: ORGANIZATION_TYPES.keys }
   validates :last_name, :first_name, presence: true
   validates :requested_organization, presence: true
-  validates :requested_num_providers, numericality: { only_integer: true, greater_than: 0 }
+  validates :requested_num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0 },
+                                      if: -> { health_it_vendor? }
+  validates :requested_num_providers, numericality: { only_integer: true, greater_than: 0 },
+                                      unless: -> { health_it_vendor? }
   validates :address_1, presence: true
   validates :city, presence: true
   validates :state, inclusion: { in: Address::STATES.keys.map(&:to_s) }

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   validates :requested_organization_type, inclusion: { in: ORGANIZATION_TYPES.keys }
   validates :last_name, :first_name, presence: true
   validates :requested_organization, presence: true
-  validates :requested_num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0 },
+  validates :requested_num_providers, numericality: { only_integer: true, greater_than_or_equal_to: 0, allow_nil: true },
                                       if: -> { health_it_vendor? }
   validates :requested_num_providers, numericality: { only_integer: true, greater_than: 0 },
                                       unless: -> { health_it_vendor? }

--- a/dpc-web/app/views/devise/registrations/new.html.erb
+++ b/dpc-web/app/views/devise/registrations/new.html.erb
@@ -54,7 +54,7 @@
           %>
           <div class="field field--follow-up" hidden>
             <%= f.label :requested_num_providers, class: "ds-c-label" do %>
-            Number of Providers at Your Organization (optional)
+            Number of Providers at Your Organization
             <span class="ds-c-field__hint">You may use an approximate number.</span>
             <% end %>
             <%= f.number_field :requested_num_providers, value: '', min: 0, class: "ds-c-field ds-c-field--small" %>

--- a/dpc-web/spec/factories/users.rb
+++ b/dpc-web/spec/factories/users.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
 
     requested_organization { 'Amalgamated Lint' }
     requested_organization_type { 'primary_care_clinic' }
+    requested_num_providers { 5 }
 
     address_1 { '1234 Shut the Door Ave.' }
     city { 'Pecoima' }

--- a/dpc-web/spec/features/registration/new_user_signs_up_for_account_spec.rb
+++ b/dpc-web/spec/features/registration/new_user_signs_up_for_account_spec.rb
@@ -3,120 +3,111 @@
 require 'rails_helper'
 
 RSpec.feature 'new user signs up for account' do
-  let(:user) { build :user }
-
   before(:each) do
     visit new_user_session_path
     click_link 'sign-up'
   end
 
   context 'when successful' do
-    before(:each) do
-      fill_in :user_first_name, with: user.first_name
-      fill_in :user_last_name, with: user.last_name
-      fill_in :user_email, with: user.email
-      fill_in :user_password, with: user.password
-      fill_in :user_password_confirmation, with: user.password_confirmation
-      fill_in :user_requested_organization, with: user.requested_organization
-      find('#user_requested_organization_type').find("option[value=#{User.requested_organization_types.keys.first}]").select_option
-      fill_in :user_address_1, with: user.address_1
-      fill_in :user_address_2, with: user.address_2
-      fill_in :user_city, with: user.city
-      find('#user_state').find("option[value=#{user.state}]").select_option
-      fill_in :user_zip, with: user.zip
+    scenario 'is redirected to dashboard and can see profile' do
+      fill_in :user_first_name, with: 'Clarissa'
+      fill_in :user_last_name, with: 'Dalloway'
+      fill_in :user_email, with: 'clarissa@example.com'
+      fill_in :user_password, with: '1234567890'
+      fill_in :user_password_confirmation, with: '1234567890'
+      fill_in :user_requested_organization, with: 'London Health System'
+      select 'Primary Care Clinic', from: :user_requested_organization_type
+      fill_in :user_requested_num_providers, visible: false, with: '777'
+      fill_in :user_address_1, with: '1 Hampton Heath Drive'
+      fill_in :user_address_2, with: 'Suite 5'
+      fill_in :user_city, with: 'London'
+      select 'New York', from: :user_state
+      fill_in :user_zip, with: '10033'
       check :user_agree_to_terms
 
       click_on('Sign up')
-    end
 
-    scenario 'adds a new record to the users table' do
-      expect(User.find_by(email: user.email)).to_not be_nil
-    end
-
-    scenario 'is brought to the registrations dashboard' do
       expect(page).to have_http_status(200)
       expect(page).to have_css('[data-test="my-account-menu"]')
-    end
 
-    scenario 'can see profile information' do
       find('[data-test="my-account-menu"]').click
       find('[data-test="dpc-registrations-profile-link"]', visible: false).click
 
       email_field = find('#user_email')
-      expect(email_field.value).to eq(user.email)
+      expect(email_field.value).to eq('clarissa@example.com')
     end
   end
 
   context 'when not agreeing to terms' do
-    before(:each) do
-      fill_in :user_first_name, with: user.first_name
-      fill_in :user_last_name, with: user.last_name
-      fill_in :user_email, with: user.email
-      fill_in :user_password, with: user.password
-      fill_in :user_password_confirmation, with: user.password_confirmation
-      fill_in :user_requested_organization, with: user.requested_organization
-      find('#user_requested_organization_type').find("option[value=#{User.requested_organization_types.keys.first}]").select_option
-      fill_in :user_address_1, with: user.address_1
-      fill_in :user_address_2, with: user.address_2
-      fill_in :user_city, with: user.city
-      find('#user_state').find("option[value=#{user.state}]").select_option
-      fill_in :user_zip, with: user.zip
+    scenario 'returns to the sign in page' do
+      fill_in :user_first_name, with: 'Clarissa'
+      fill_in :user_last_name, with: 'Dalloway'
+      fill_in :user_email, with: 'clarissa@example.com'
+      fill_in :user_password, with: '1234567890'
+      fill_in :user_password_confirmation, with: '1234567890'
+      fill_in :user_requested_organization, with: 'London Health System'
+      select 'Primary Care Clinic', from: :user_requested_organization_type
+      fill_in :user_requested_num_providers, visible: false, with: '777'
+      fill_in :user_address_1, with: '1 Hampton Heath Drive'
+      fill_in :user_address_2, with: 'Suite 5'
+      fill_in :user_city, with: 'London'
+      select 'New York', from: :user_state
+      fill_in :user_zip, with: '10033'
+      fill_in :user_zip, with: '10033'
+
       uncheck :user_agree_to_terms
 
       click_on('Sign up')
-    end
 
-    scenario 'returns to the sign in page' do
       expect(page).to have_content('Log in')
       expect(page).to have_content('you must agree')
     end
   end
 
   context 'when missing information on form' do
-    before(:each) do
-      fill_in :user_first_name, with: user.first_name
-      fill_in :user_email, with: user.email
-      fill_in :user_password, with: user.password
-      fill_in :user_password_confirmation, with: user.password_confirmation
-      fill_in :user_requested_organization, with: user.requested_organization
-      find('#user_requested_organization_type').find("option[value=#{User.requested_organization_types.keys.first}]").select_option
-      fill_in :user_address_1, with: user.address_1
-      fill_in :user_address_2, with: user.address_2
-      fill_in :user_city, with: user.city
-      find('#user_state').find("option[value=#{user.state}]").select_option
-      fill_in :user_zip, with: user.zip
+    scenario 'returns to the sign in page with error message' do
+      fill_in :user_first_name, with: 'Clarissa'
+      fill_in :user_email, with: 'clarissa@example.com'
+      fill_in :user_password, with: '1234567890'
+      fill_in :user_password_confirmation, with: '1234567890'
+      fill_in :user_requested_organization, with: 'London Health System'
+      select 'Primary Care Clinic', from: :user_requested_organization_type
+      fill_in :user_requested_num_providers, visible: false, with: '777'
+      fill_in :user_address_1, with: '1 Hampton Heath Drive'
+      fill_in :user_address_2, with: 'Suite 5'
+      fill_in :user_city, with: 'London'
+      select 'New York', from: :user_state
+      fill_in :user_zip, with: '10033'
       check :user_agree_to_terms
 
       click_on('Sign up')
-    end
 
-    scenario 'returns to the sign in page' do
       expect(page).to have_content('Log in')
       expect(page).to have_content("Last name can't be blank")
     end
   end
 
   context 'when using an email already registered' do
-    before(:each) do
-      user.save!
-      fill_in :user_first_name, with: user.first_name
-      fill_in :user_last_name, with: user.last_name
-      fill_in :user_email, with: user.email
-      fill_in :user_password, with: user.password
-      fill_in :user_password_confirmation, with: user.password_confirmation
-      fill_in :user_requested_organization, with: user.requested_organization
-      find('#user_requested_organization_type').find("option[value=#{User.requested_organization_types.keys.first}]").select_option
-      fill_in :user_address_1, with: user.address_1
-      fill_in :user_address_2, with: user.address_2
-      fill_in :user_city, with: user.city
-      find('#user_state').find("option[value=#{user.state}]").select_option
-      fill_in :user_zip, with: user.zip
+    scenario 'returns to the sign in page with error' do
+      create(:user, email: 'clarissa@example.com')
+
+      fill_in :user_first_name, with: 'Clarissa'
+      fill_in :user_last_name, with: 'Dalloway'
+      fill_in :user_email, with: 'clarissa@example.com'
+      fill_in :user_password, with: '1234567890'
+      fill_in :user_password_confirmation, with: '1234567890'
+      fill_in :user_requested_organization, with: 'London Health System'
+      select 'Primary Care Clinic', from: :user_requested_organization_type
+      fill_in :user_requested_num_providers, visible: false, with: '777'
+      fill_in :user_address_1, with: '1 Hampton Heath Drive'
+      fill_in :user_address_2, with: 'Suite 5'
+      fill_in :user_city, with: 'London'
+      select 'New York', from: :user_state
+      fill_in :user_zip, with: '10033'
       check :user_agree_to_terms
 
       click_on('Sign up')
-    end
 
-    scenario 'returns to the sign in page' do
       expect(page).to have_content('Log in')
       expect(page).to have_content('Email has already been taken')
     end

--- a/dpc-web/spec/models/user_spec.rb
+++ b/dpc-web/spec/models/user_spec.rb
@@ -64,10 +64,6 @@ RSpec.describe User, type: :model do
   end
 
   describe '#requested_num_providers' do
-    it 'defaults to 0' do
-      expect(subject.requested_num_providers).to be_zero
-    end
-
     it 'must be greater than or equal to 0' do
       subject.requested_num_providers = -1
       expect(subject).to_not be_valid

--- a/dpc-web/spec/models/user_spec.rb
+++ b/dpc-web/spec/models/user_spec.rb
@@ -64,14 +64,41 @@ RSpec.describe User, type: :model do
   end
 
   describe '#requested_num_providers' do
-    it 'must be greater than or equal to 0' do
-      subject.requested_num_providers = -1
-      expect(subject).to_not be_valid
+    context 'health_it_vendor' do
+      before(:each) do
+        subject.requested_organization_type = 'health_it_vendor'
+      end
+
+      it 'may be 0' do
+        subject.requested_num_providers = 0
+        expect(subject).to be_valid
+      end
+
+      it 'must be greater than or equal to 0' do
+        subject.requested_num_providers = -1
+        expect(subject).to_not be_valid
+      end
+
+      it 'must be an integer' do
+        subject.requested_num_providers = 1.23
+        expect(subject).to_not be_valid
+      end
     end
 
-    it 'must be an integer' do
-      subject.requested_num_providers = 1.23
-      expect(subject).to_not be_valid
+    context 'not health_it_vendor' do
+      before(:each) do
+        subject.requested_organization_type = 'primary_care_clinic'
+      end
+
+      it 'must be greater than 0' do
+        subject.requested_num_providers = 0
+        expect(subject).to_not be_valid
+      end
+
+      it 'must be an integer' do
+        subject.requested_num_providers = 1.23
+        expect(subject).to_not be_valid
+      end
     end
   end
 


### PR DESCRIPTION
**Why**

We're not saving number of providers when users register. The param needed to be added to the devise params in Application Controller from when I renamed this column.

**What Changed**

Updated allowed devise params. Changed validation to require number be greater than 0 (not greater than or equal to).

**Choices Made**

See commit messages.

**Tickets closed**:

DPC-850
