### PR TITLE
Smoke test existing organizations

### DIFF
--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -100,12 +100,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>${bouncey.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>${bouncey.version}</version>
         </dependency>
         <!--        Validations use the R4 validator, even for STU3 resources-->
         <dependency>

--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -58,6 +58,16 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>${bouncey.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncey.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -3,6 +3,8 @@ package gov.cms.dpc.testing.smoketests;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import com.github.nitram509.jmacaroons.Macaroon;
+import com.github.nitram509.jmacaroons.MacaroonsBuilder;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import org.apache.commons.lang3.tuple.Pair;
@@ -23,6 +25,10 @@ import org.slf4j.LoggerFactory;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -124,7 +130,8 @@ public class SmokeTest extends AbstractJavaSamplerClient {
             }
         } else {
             // Parse the private key and create a new ID/PrivateKey tuple
-            try (final PEMParser pemParser = new PEMParser(new FileReader(privateKeyPath))) {
+            final Path path = Paths.get(privateKeyPath);
+            try (final PEMParser pemParser = new PEMParser(Files.newBufferedReader(path, StandardCharsets.UTF_8))) {
                 JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
                 Object object = pemParser.readObject();
                 KeyPair kp = converter.getKeyPair((PEMKeyPair) object);

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <jacoco.version>0.8.5</jacoco.version>
         <jooq.version>3.12.1</jooq.version>
+        <bouncey.version>1.64</bouncey.version>
     </properties>
 
     <developers>

--- a/src/main/resources/SmokeTest.jmx
+++ b/src/main/resources/SmokeTest.jmx
@@ -65,7 +65,7 @@
               </elementProp>
               <elementProp name="client-token" elementType="Argument">
                 <stringProp name="Argument.name">client-token</stringProp>
-                <stringProp name="Argument.value">${__P(admin-url,)}</stringProp>
+                <stringProp name="Argument.value">${__P(client-token,)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
               <elementProp name="private-key" elementType="Argument">

--- a/src/main/resources/SmokeTest.jmx
+++ b/src/main/resources/SmokeTest.jmx
@@ -58,6 +58,26 @@
                 <stringProp name="Argument.value">${__P(admin-url,)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
+              <elementProp name="organization-id" elementType="Argument">
+                <stringProp name="Argument.name">organization-id</stringProp>
+                <stringProp name="Argument.value">${__P(organization-id,)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="client-token" elementType="Argument">
+                <stringProp name="Argument.name">client-token</stringProp>
+                <stringProp name="Argument.value">${__P(admin-url,)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="private-key" elementType="Argument">
+                <stringProp name="Argument.name">private-key</stringProp>
+                <stringProp name="Argument.value">${__P(private-key,)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
+              <elementProp name="key-id" elementType="Argument">
+                <stringProp name="Argument.name">key-id</stringProp>
+                <stringProp name="Argument.value">${__P(key-id,)}</stringProp>
+                <stringProp name="Argument.metadata">=</stringProp>
+              </elementProp>
             </collectionProp>
           </elementProp>
           <stringProp name="classname">gov.cms.dpc.testing.smoketests.SmokeTest</stringProp>

--- a/src/test/smoke_test.yml
+++ b/src/test/smoke_test.yml
@@ -2,7 +2,7 @@ settings:
   artifacts-dir: bzt-out/%Y-%m-%d_%H-%M-%S.%f
 
 execution:
-  - iterations: 3
+  - iterations: 1
     concurrency: 3
     scenario: jmeter
     ramp-up: 60s
@@ -15,6 +15,10 @@ scenarios:
       seed-file: ${SEED_FILE}
       provider-bundle: ${PROVIDER_BUNDLE}
       patient-bundle: ${PATIENT_BUNDLE}
+      organization-id: ""
+      client-token: ""
+      private-key: ""
+      key-id: ""
     script: src/main/resources/SmokeTest.jmx
 
 reporting:


### PR DESCRIPTION
**Why**

We want to run smoke tests against organizations that already exist, so we can test that the website security works.

**What Changed**

Added custom parameters to smoke tests, which allow us to specify our org id, client_token, private key path, etc. Here they are:

```javascript
      organization-id: "{organization UUID}"
      client-token: "{client_token}"
      private-key: "{path to private key}"
```

You can find them in `src/test/resources/smoke_test.yml`, the empty values cause an organization to be created automatically.

**Choices Made**

It's a giant ball of hot garbage, but it works, and we need to rework the smoke tests anyways, so this should be ok.
