### PR TITLE
DPC-865: Correct scopes to match SMART spec and documentation

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/TokenResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/TokenResource.java
@@ -52,7 +52,7 @@ public class TokenResource extends AbstractTokenResource {
 
     public static final String CLIENT_ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
     // This will be removed as part of DPC-747
-    private static final String DEFAULT_ACCESS_SCOPE = "system/*:*";
+    private static final String DEFAULT_ACCESS_SCOPE = "system/*.*";
     private static final Logger logger = LoggerFactory.getLogger(TokenResource.class);
     private static final String ORG_NOT_FOUND = "Cannot find Organization: %s";
     private static final String INVALID_JWT_MSG = "Invalid JWT";
@@ -185,7 +185,7 @@ public class TokenResource extends AbstractTokenResource {
     @Public
     @Override
     public JWTAuthResponse authorizeJWT(
-            @ApiParam(name = "scope", allowableValues = "system/*:*", value = "Requested access scope", required = true)
+            @ApiParam(name = "scope", allowableValues = "system/*.*", value = "Requested access scope", required = true)
             @QueryParam(value = "scope") @NotEmpty(message = "Scope is required") String scope,
             @ApiParam(name = "grant_type", value = "Authorization grant type", required = true, allowableValues = "client_credentials")
             @QueryParam(value = "grant_type") @NotEmpty(message = "Grant type is required") String grantType,

--- a/dpc-api/src/test/java/gov/cms/dpc/api/auth/jwt/JWTUnitTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/auth/jwt/JWTUnitTests.java
@@ -78,7 +78,7 @@ class JWTUnitTests {
             assertEquals(3, validationErrorResponse.getErrors().size(), "Should have three validations");
 
             // Add the missing scope value and try again
-            response = RESOURCE.target("/Token/auth").queryParam("scope", "system/*:*")
+            response = RESOURCE.target("/Token/auth").queryParam("scope", "system/*.*")
                     .request()
                     .post(Entity.entity(payload, MediaType.APPLICATION_FORM_URLENCODED));
 
@@ -90,7 +90,7 @@ class JWTUnitTests {
 
             // Add the grant type
             response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .request()
                     .post(Entity.entity(payload, MediaType.APPLICATION_FORM_URLENCODED));
@@ -103,7 +103,7 @@ class JWTUnitTests {
 
             // Add the assertion type and try again
             response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .request()
@@ -117,7 +117,7 @@ class JWTUnitTests {
         void testInvalidGrantTypeValue() {
             final String payload = "not a real payload";
             Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "wrong_grant_type")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .request()
@@ -130,7 +130,7 @@ class JWTUnitTests {
         @Test
         void testEmptyGrantTypeValue() {
             final Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .request()
@@ -145,7 +145,7 @@ class JWTUnitTests {
         void testInvalidClientAssertionType() {
             final String payload = "not a real payload";
             Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", "Not a real assertion_type")
                     .request()
@@ -158,7 +158,7 @@ class JWTUnitTests {
         @Test
         void testEmptyClientAssertionType() {
             final Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", "")
                     .request()
@@ -180,7 +180,7 @@ class JWTUnitTests {
                     .post(Entity.entity(payload, MediaType.APPLICATION_FORM_URLENCODED));
 
             assertEquals(400, response.getStatus(), "Should have failed, but for different reasons");
-            assertTrue(response.readEntity(String.class).contains("Access Scope must be 'system/*:*'"), "Should have correct error message");
+            assertTrue(response.readEntity(String.class).contains("Access Scope must be 'system/*.*'"), "Should have correct error message");
         }
 
         @Test
@@ -220,7 +220,7 @@ class JWTUnitTests {
 
             // Submit the JWT
             Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .queryParam("client_assertion", jwt)
@@ -247,7 +247,7 @@ class JWTUnitTests {
 
             // Submit the JWT
             Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .queryParam("client_assertion", jwt)
@@ -274,7 +274,7 @@ class JWTUnitTests {
 
             // Submit the JWT
             Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .queryParam("client_assertion", jwt)
@@ -301,7 +301,7 @@ class JWTUnitTests {
 
             // Submit the JWT
             Response response = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .queryParam("client_assertion", jwt)
@@ -313,7 +313,7 @@ class JWTUnitTests {
 
             // Try to submit again
             Response r2 = RESOURCE.target("/Token/auth")
-                    .queryParam("scope", "system/*:*")
+                    .queryParam("scope", "system/*.*")
                     .queryParam("grant_type", "client_credentials")
                     .queryParam("client_assertion_type", TokenResource.CLIENT_ASSERTION_TYPE)
                     .queryParam("client_assertion", jwt)

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
@@ -103,7 +103,7 @@ public class APIAuthHelpers {
         final AuthResponse authResponse;
         try (final CloseableHttpClient client = createCustomHttpClient().trusting().build()) {
             final URIBuilder builder = new URIBuilder(String.format("%s/Token/auth", baseURL));
-            builder.addParameter("scope", "system/*:*");
+            builder.addParameter("scope", "system/*.*");
             builder.addParameter("grant_type", "client_credentials");
             builder.addParameter("client_assertion_type", CLIENT_ASSERTION_TYPE);
             builder.addParameter("client_assertion", jwt);


### PR DESCRIPTION
**Why**

@embh reported an issue where the SMART scopes were separated by a semi-colon, rather than a period, per the docs and the specs.

**What Changed**

Updated internal checks and tests to account for new delimiter.

**Choices Made**

**Tickets closed**:

DPC-865

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
