### PR TITLE
Smoke test config for prod-sbx

### DIFF
--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -1,6 +1,6 @@
 dpc.api {
 
-    publicURL = "https://dpc.cms.gov/v1" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
+    publicURL = "https://dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
     server {
         applicationContextPath = "/api"

--- a/src/test/prod-sbx.smoke_test.yml
+++ b/src/test/prod-sbx.smoke_test.yml
@@ -1,7 +1,7 @@
 settings:
   env:
     HOST: https://dpc.cms.gov/api/v1
-    ADMIN_URL: http://dpc.cms.gov:9900/tasks
+    ADMIN_URL: http://internal-dpc-prod-sbx-frontend-internal-1307956475.us-east-1.elb.amazonaws.com:9900/tasks
     SEED_FILE: src/main/resources/test_associations-dpr.csv
     PROVIDER_BUNDLE: provider_bundle.json
     PATIENT_BUNDLE: patient_bundle-dpr.json


### PR DESCRIPTION
**Why**

Tweaks for prod-sbx deployment.

**What Changed**

* Updates the smoke tests to use the newly deployed internal ALB in prod-sbx
* Fixes an incorrect configuration of the API URL for prod-sbx

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
