### PR TITLE
except null or blank npi from uniqueness

### DIFF
--- a/dpc-web/app/models/organization.rb
+++ b/dpc-web/app/models/organization.rb
@@ -14,7 +14,7 @@ class Organization < ApplicationRecord
   validates :organization_type, inclusion: { in: ORGANIZATION_TYPES.keys }
   validates :name, uniqueness: true, presence: true
   validate :api_environments_allowed
-  validates :npi, uniqueness: {allow_blank: true}
+  validates :npi, uniqueness: { allow_blank: true }
 
   delegate :street, :street_2, :city, :state, :zip, to: :address, allow_nil: true, prefix: true
   accepts_nested_attributes_for :address, :fhir_endpoints, reject_if: :all_blank

--- a/dpc-web/app/models/organization.rb
+++ b/dpc-web/app/models/organization.rb
@@ -14,7 +14,7 @@ class Organization < ApplicationRecord
   validates :organization_type, inclusion: { in: ORGANIZATION_TYPES.keys }
   validates :name, uniqueness: true, presence: true
   validate :api_environments_allowed
-  validates :npi, uniqueness: true
+  validates :npi, uniqueness: {allow_blank: true}
 
   delegate :street, :street_2, :city, :state, :zip, to: :address, allow_nil: true, prefix: true
   accepts_nested_attributes_for :address, :fhir_endpoints, reject_if: :all_blank


### PR DESCRIPTION
**Why**

From @amgleason: 

> Hey there is kind of a critical bug i found in test. if I go as an admin user and create an org, it is saying the null NPI is "not unique". so it won't let me save it without an NPI. Shelby had put in a fix to not require it when saving, but it is broken. assuming this isn't something you can fix in her absence?

**What Changed**

Updated the `organization` modal to allow blank in its uniqueness rule.

**Tickets closed**:

-  DPC-871