### PR TITLE
DPC-872: Add redirect support to get info from existing API org

### DIFF
--- a/dpc-web/app/services/api_client.rb
+++ b/dpc-web/app/services/api_client.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class APIClient
-  attr_reader :api_env, :response_body, :response_status
+  attr_reader :api_env, :response, :response_body, :response_status
 
   def initialize(api_env)
     @api_env = api_env
@@ -116,6 +116,12 @@ class APIClient
     end
 
     response = http.request(request)
+
+    if response.kind_of?(Net::HTTPRedirection)
+      uri = URI.parse response.header['Location']
+      response = http.get uri, request.each_header.to_h
+    end
+
     @response_status = response.code.to_i
     @response_body = parsed_response(response)
   rescue Errno::ECONNREFUSED

--- a/dpc-web/app/services/api_client.rb
+++ b/dpc-web/app/services/api_client.rb
@@ -117,7 +117,7 @@ class APIClient
 
     response = http.request(request)
 
-    if response.kind_of?(Net::HTTPRedirection)
+    if response.is_a?(Net::HTTPRedirection)
       uri = URI.parse response.header['Location']
       response = http.get uri, request.each_header.to_h
     end


### PR DESCRIPTION
**Why**

If the org already exists on the API side but not on the website side, we need to save that information on the website so future API requests can be made for that org (e.g. so that org's user can create client tokens or keys). 

**What Changed**

Right now the API returns an error message and the website just accepts the error and does nothing; this pull request changes the functionality so that if the API returns a redirection response (e.g. a 303) with a URL in the Location header, the website API client will follow the redirect and use the returned organization body to save in the website.

**Choices Made**

This adds a single redirect follow to every initial HTTP request the website makes to the API so that we will also follow redirects in other scenarios too. 

For the organization creation/update resolution to happen, this PR assumes that the response the API gives for a POST request is the same as what it returns for a GET request for an org. This should be the case in order to follow of RESTful API conventions but I want to call it out here in case it's not. 

For more info on why I would expect a redirect rather than another error message (e.g. 409 Conflict, 202 Accepted, or other message), see this RFC: https://tools.ietf.org/html/rfc7231#section-4.3.3. Furthermore a redirect is more actionable out of the box for the client than another response (e.g. a 409 Conflict doesn't necessarily have a Location header so we'd have to establish our own convention for this; Redirects already have it though).

**Tickets closed**:

DPC-872


