### PR TITLE
DPC-873: Add custom logging filter to avoid logging client_tokens

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/TokenLoggingFilter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/TokenLoggingFilter.java
@@ -1,0 +1,32 @@
+package gov.cms.dpc.api.auth;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.logging.filter.FilterFactory;
+
+/**
+ * Implementation of {@link FilterFactory} that ensures client_tokens are not logged when requests are made to the /Token/auth endpoint
+ */
+@JsonTypeName("token-filter-factory")
+public class TokenLoggingFilter implements FilterFactory<IAccessEvent> {
+
+    private TokenLoggingFilter() {
+        // Not used
+    }
+
+    @Override
+    public Filter<IAccessEvent> build() {
+        return new Filter<>() {
+            @Override
+            public FilterReply decide(IAccessEvent event) {
+                // Ensure that any auth requests are NOT directly logged
+                if (event.getRequestURI().equals("/v1/Token/auth")) {
+                    return FilterReply.DENY;
+                }
+                return FilterReply.ACCEPT;
+            }
+        };
+    }
+}

--- a/dpc-api/src/main/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
+++ b/dpc-api/src/main/resources/META-INF/services/io.dropwizard.logging.filter.FilterFactory
@@ -1,0 +1,1 @@
+gov.cms.dpc.api.auth.TokenLoggingFilter

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -14,6 +14,13 @@ dpc.api {
         maxSize = 10
     }
 
+    server.requestLog.appenders = [{
+        type: "console"
+        filterFactories =[{
+            type: token-filter-factory
+        }]
+    }]
+
     attributionURL = "http://localhost:3500/v1/"
     exportPath = "/tmp"
 


### PR DESCRIPTION
**Why**

We've noticed that client_tokens are being logged into CloudWatch, while not immediately useful in and of themselves, they are one part of our two-phased API auth, so they definitely should not be in the log output.

**What Changed**

Dropwizard has this nifty mechanism for filtering out log events that we don't want. Which we can use to ensure that the request/response of our `Token/auth` endpoint is never logged. Added a custom `FilterFactory` which simply ignores any log events coming from the `Token/auth` endpoint. Internal log messages are still passed along, as is, by the actual request/response logging is disabled.

We can add additional filters as we go along, to ensure we're not spamming ourselves with too many issues. (e.g. healthchecks)

**Choices Made**

Manually verified log events are omitted for both successful and unsuccessful authentication requests.

**Tickets closed**:

DPC-873

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
