### PR TITLE
create consent command

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
@@ -1,9 +1,7 @@
 package gov.cms.dpc.common.consent.entities;
 
 import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.Source;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -63,7 +61,6 @@ public class ConsentEntity implements Serializable {
     @Column(name = "mbi")
     private String mbi;
 
-    @NotEmpty
     @Column(name = "hicn")
     private String hicn;
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.common.consent.entities;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.Source;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -10,8 +11,12 @@ import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
 
 @Entity(name = "consent")
 public class ConsentEntity implements Serializable {
@@ -23,6 +28,28 @@ public class ConsentEntity implements Serializable {
     public static final String SCOPE_CODE = "patient-privacy";
 
     private static final long serialVersionUID = 8702499693412507926L;
+
+    public enum SourceCode {
+        ETL_1800("1-800"),
+        DPC("DPC");
+
+        private final String code;
+        private static final Map<String, SourceCode> stringToCode = Stream.of(values()).collect(toMap(Object::toString, e -> e ));
+
+        SourceCode(String code) {
+            this.code = code;
+        }
+
+        public static SourceCode fromString(String code) {
+            // consider returning Optional?
+            return stringToCode.get(code);
+        }
+
+        @Override
+        public String toString() {
+            return code;
+        }
+    }
 
     public ConsentEntity() {
         // Hibernate required
@@ -66,6 +93,12 @@ public class ConsentEntity implements Serializable {
     @Column(name = "updated_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
     @UpdateTimestamp
     private OffsetDateTime updatedAt;
+
+    @Column(name = "custodian", columnDefinition = "uuid")
+    private UUID custodian;
+
+    @Column(name = "source_code")
+    private String sourceCode;
 
     public UUID getId() {
         return id;
@@ -151,6 +184,15 @@ public class ConsentEntity implements Serializable {
         this.updatedAt = updatedAt;
     }
 
+    public UUID getCustodian() { return custodian; }
+
+    public void setCustodian(UUID custodian) { this.custodian = custodian; }
+
+    public String getSourceCode() { return sourceCode; }
+
+    public void setSourceCode(String sourceCode) { this.sourceCode = sourceCode; }
+
+
     public static ConsentEntity defaultConsentEntity(Optional<UUID> id, Optional<String> hicn, Optional<String> mbi) {
         ConsentEntity ce = new ConsentEntity();
 
@@ -168,6 +210,7 @@ public class ConsentEntity implements Serializable {
         ce.setPolicyCode(OPT_IN);
         ce.setPurposeCode(TREATMENT);
         ce.setScopeCode(SCOPE_CODE);
+        ce.setSourceCode(SourceCode.DPC.toString());
 
         return ce;
     }

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/converters/entities/ConsentEntityConverter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/converters/entities/ConsentEntityConverter.java
@@ -97,7 +97,11 @@ public class ConsentEntityConverter {
 
         c.setCategory(category(consentEntity.getLoincCode()));
 
-        c.setOrganization(List.of(new Reference().setReference(orgURL).setDisplay("Data at the Point of Care")));
+        if (consentEntity.getCustodian() == null) {
+            c.setOrganization(List.of(new Reference().setReference(orgURL).setDisplay("Data at the Point of Care")));
+        } else {
+            c.setOrganization(List.of(new Reference(new IdType("Organization", consentEntity.getCustodian().toString()))));
+        }
 
         return c;
     }

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/converters/entities/ConsentEntityConverterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/converters/entities/ConsentEntityConverterTest.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.dstu3.model.Consent;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,6 +42,19 @@ public class ConsentEntityConverterTest {
         final Consent result = ConsentEntityConverter.convert(ce, TEST_DPC_URL, TEST_FHIR_URL);
 
         assertEquals(ConsentEntityConverter.OPT_OUT_MAGIC, result.getPolicyRule());
+        assertDoesNotThrow(() -> {
+            FhirContext.forDstu3().newJsonParser().encodeResourceToString(result);
+        });
+    }
+
+    @Test
+    final void convert_correctlyConverts_fromCustodianEntity() {
+        ConsentEntity ce = ConsentEntity.defaultConsentEntity(Optional.empty(), Optional.of(TEST_HICN), Optional.of(TEST_MBI));
+        UUID uuid = UUID.randomUUID();
+        ce.setCustodian(uuid);
+        final Consent result = ConsentEntityConverter.convert(ce, TEST_DPC_URL, TEST_FHIR_URL);
+
+        assertEquals("Organization/" + uuid.toString(), result.getOrganizationFirstRep().getReference());
         assertDoesNotThrow(() -> {
             FhirContext.forDstu3().newJsonParser().encodeResourceToString(result);
         });

--- a/dpc-consent/src/main/java/gov/cms/dpc/consent/DPCConsentService.java
+++ b/dpc-consent/src/main/java/gov/cms/dpc/consent/DPCConsentService.java
@@ -7,6 +7,7 @@ import com.squarespace.jersey2.guice.JerseyGuiceUtils;
 import gov.cms.dpc.common.hibernate.consent.DPCConsentHibernateBundle;
 import gov.cms.dpc.common.hibernate.consent.DPCConsentHibernateModule;
 import gov.cms.dpc.common.utils.EnvironmentParser;
+import gov.cms.dpc.consent.cli.ConsentCommands;
 import gov.cms.dpc.consent.cli.SeedCommand;
 import gov.cms.dpc.fhir.FHIRModule;
 import io.dropwizard.Application;
@@ -43,9 +44,9 @@ public class DPCConsentService extends Application<DPCConsentConfiguration> {
 
         GuiceBundle<DPCConsentConfiguration> guiceBundle = GuiceBundle.defaultBuilder(DPCConsentConfiguration.class)
                 .modules(
-                        new ConsentAppModule(),
                         new DPCConsentHibernateModule<>(hibernateBundle),
-                        new FHIRModule<>()
+                        new FHIRModule<>(),
+                        new ConsentAppModule()
                 ).build();
 
         bootstrap.addBundle(hibernateBundle);
@@ -70,6 +71,7 @@ public class DPCConsentService extends Application<DPCConsentConfiguration> {
             }
         });
         bootstrap.addCommand(new SeedCommand(bootstrap.getApplication()));
+        bootstrap.addCommand(new ConsentCommands());
     }
 
     @Override

--- a/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/ConsentCommand.java
+++ b/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/ConsentCommand.java
@@ -1,0 +1,37 @@
+package gov.cms.dpc.consent.cli;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import gov.cms.dpc.consent.DPCConsentConfiguration;
+import io.dropwizard.cli.Command;
+import io.dropwizard.cli.ConfiguredCommand;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+/**
+ * Parent class for CLI {@link Command} which make use of the attribution service
+ */
+public abstract class ConsentCommand extends ConfiguredCommand<DPCConsentConfiguration> {
+
+    protected static final String ATTRIBUTION_HOST = "attribution_host";
+    protected final FhirContext ctx;
+
+    protected ConsentCommand(String name, String description) {
+        super(name, description);
+        this.ctx = FhirContext.forDstu3();
+        this.ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+    }
+
+    @Override
+    public void configure(Subparser subparser) {
+        addAdditionalOptions(subparser);
+
+        subparser
+                .addArgument("--host")
+                .dest(ATTRIBUTION_HOST)
+                .required(true)
+                .setDefault("http://localhost:3500/v1")
+                .help("URL of the Attribution Service (used to verify ids)");
+    }
+
+    public abstract void addAdditionalOptions(Subparser subparser);
+}

--- a/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/ConsentCommands.java
+++ b/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/ConsentCommands.java
@@ -1,0 +1,45 @@
+package gov.cms.dpc.consent.cli;
+
+import gov.cms.dpc.consent.DPCConsentConfiguration;
+import io.dropwizard.Application;
+import io.dropwizard.cli.Command;
+import io.dropwizard.cli.ConfiguredCommand;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class ConsentCommands extends ConfiguredCommand<DPCConsentConfiguration> {
+    private static final String COMMAND_NAME_ATTR = "subcommand";
+    private final SortedMap<String, ConsentCommand> subcommands = new TreeMap<>();
+
+    public ConsentCommands() {
+        super("consent", "Consent related commands");
+        registerSubCommand(new CreateConsentRecord());
+    }
+
+    @Override
+    public void configure(Subparser subparser) {
+        this.subcommands.values().forEach(command -> {
+            final Subparser cmdParser = subparser.addSubparsers()
+                    .addParser(command.getName())
+                    .setDefault(COMMAND_NAME_ATTR, command.getName())
+                    .description(command.getDescription());
+
+            command.configure(cmdParser);
+        });
+    }
+
+    @Override
+    protected void run(Bootstrap<DPCConsentConfiguration> bootstrap, Namespace namespace, DPCConsentConfiguration dpcConsentConfiguration) throws Exception {
+        final Command command = subcommands.get(namespace.getString(COMMAND_NAME_ATTR));
+        command.run(bootstrap, namespace);
+    }
+
+    protected void registerSubCommand(ConsentCommand command) {
+        subcommands.put(command.getName(), command);
+    }
+
+}

--- a/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/ConsentCommands.java
+++ b/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/ConsentCommands.java
@@ -1,7 +1,6 @@
 package gov.cms.dpc.consent.cli;
 
 import gov.cms.dpc.consent.DPCConsentConfiguration;
-import io.dropwizard.Application;
 import io.dropwizard.cli.Command;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;

--- a/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/CreateConsentRecord.java
+++ b/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/CreateConsentRecord.java
@@ -1,0 +1,126 @@
+package gov.cms.dpc.consent.cli;
+
+
+import com.google.inject.Inject;
+import gov.cms.dpc.common.consent.entities.ConsentEntity;
+import gov.cms.dpc.common.hibernate.consent.DPCConsentManagedSessionFactory;
+import gov.cms.dpc.consent.DPCConsentConfiguration;
+import gov.cms.dpc.consent.dao.tables.Consent;
+import gov.cms.dpc.consent.dao.tables.records.ConsentRecord;
+import gov.cms.dpc.consent.jdbi.ConsentDAO;
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.db.PooledDataSourceFactory;
+import io.dropwizard.setup.Bootstrap;
+import net.sourceforge.argparse4j.impl.Arguments;
+import net.sourceforge.argparse4j.inf.MutuallyExclusiveGroup;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
+import org.jooq.DSLContext;
+import org.jooq.conf.RenderNameStyle;
+import org.jooq.conf.Settings;
+import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static gov.cms.dpc.consent.dao.tables.Consent.CONSENT;
+
+/**
+ * CreateConsentRecord adds a consent record for a specific beneficiary to the consent database. While most consent
+ * records are recorded through our consent ETL process, we want to be ready to create single consent records on
+ * demand where the custodian can be an external organization or DPC.
+ * <p>
+ * The command takes the following arguments:
+ * <ul>
+ * <li>-p, --patient - (required) a patient MBI (currently the BB bene_id) known to DPC</li>
+ * <li>-i, --in - indicates this is in an optin event</li>
+ * <li>-o, --out - indicates this is an optout event</li>
+ * <li>-d, --date - (required) sets the effective date of the record</li>
+ * <li>--org - (optional) if provided, must be an organization uuid known to DPC</li>
+ * </ul>
+ */
+public class CreateConsentRecord extends ConsentCommand {
+
+    private static Logger logger = LoggerFactory.getLogger(CreateConsentRecord.class);
+    private final Settings settings;
+
+
+    CreateConsentRecord() {
+        super("create", "Create a new consent record");
+        this.settings = new Settings().withRenderNameStyle(RenderNameStyle.AS_IS);
+    }
+
+    @Override
+    public void addAdditionalOptions(Subparser subparser) {
+        addSingleArgument(subparser, true, "mbi", "MBI of patient in this record", "-p", "--patient");
+
+        addSingleArgument(subparser, true, "effective-date", "effective date of this record (e.g., 2019-11-20)", "-d", "--date");
+
+        MutuallyExclusiveGroup group = subparser.addMutuallyExclusiveGroup();
+        group
+                .addArgument("-i", "--in")
+                .dest("inOrOut")
+                .action(Arguments.storeConst()).setConst(ConsentEntity.OPT_IN)
+                .help("flag indicating this is an optin record; mutually exclusive with -o");
+        group
+                .addArgument("-o", "--out")
+                .dest("inOrOut")
+                .action(Arguments.storeConst()).setConst(ConsentEntity.OPT_OUT)
+                .help("flag indicating this is an optout record; mutually exclusive with -i");
+        group.required(true);
+
+        addSingleArgument(subparser, false, "org-uuid", "DPC UUID of an external org that originated this record", "--org");
+    }
+
+    private void addSingleArgument(Subparser subparser, boolean required, String dest, String help, String... flags) {
+        subparser.addArgument(flags)
+                .required(required)
+                .dest(dest)
+                .help(help);
+    }
+
+    @Override
+    protected void run(Bootstrap<DPCConsentConfiguration> bootstrap, Namespace namespace, DPCConsentConfiguration dpcConsentConfiguration) throws Exception {
+        final String mbi = namespace.getString("mbi");
+        final LocalDate effectiveDate = LocalDate.parse(namespace.getString("effective-date"));
+        final String inOrOut = namespace.getString("inOrOut");
+
+        final String orgUuid = namespace.getString("org-uuid");
+        if (orgUuid != null && !orgUuid.isBlank()) {
+            UUID.fromString(orgUuid);
+            // using UUID conversion to verify the UUID provided is valid; will throw IllegalArgumentException if invalid
+        }
+
+        // TODO verify mbi / org exist in DPC attribution
+
+        logger.info(
+                String.format("Creating %s consent entry for patient %s, custodian is %s, effective %s",
+                        inOrOut, mbi, orgUuid == null ? "DPC" : orgUuid, effectiveDate));
+
+        final PooledDataSourceFactory dataSourceFactory = dpcConsentConfiguration.getConsentDatabase();
+        final ManagedDataSource dataSource = dataSourceFactory.build(bootstrap.getMetricRegistry(), "consent-cli");
+
+        try (final Connection connection = dataSource.getConnection();
+             DSLContext context = DSL.using(connection, this.settings)) {
+
+            ConsentEntity ce = ConsentEntity.defaultConsentEntity(Optional.empty(), Optional.empty(), Optional.of(mbi));
+            ce.setEffectiveDate(effectiveDate);
+            ce.setPolicyCode(inOrOut);
+
+            if (orgUuid != null && !orgUuid.isBlank()) {
+                ce.setCustodian(UUID.fromString(orgUuid));
+            }
+
+            ConsentRecord record = context.newRecord(CONSENT, ce);
+            context.executeInsert(record);
+
+            logger.info(
+                    String.format("Creating %s consent entry for patient %s, custodian is %s, effective %s",
+                            inOrOut, mbi, orgUuid == null ? "DPC" : orgUuid, effectiveDate));
+        }
+    }
+}

--- a/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/CreateConsentRecord.java
+++ b/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/CreateConsentRecord.java
@@ -1,13 +1,9 @@
 package gov.cms.dpc.consent.cli;
 
 
-import com.google.inject.Inject;
 import gov.cms.dpc.common.consent.entities.ConsentEntity;
-import gov.cms.dpc.common.hibernate.consent.DPCConsentManagedSessionFactory;
 import gov.cms.dpc.consent.DPCConsentConfiguration;
-import gov.cms.dpc.consent.dao.tables.Consent;
 import gov.cms.dpc.consent.dao.tables.records.ConsentRecord;
-import gov.cms.dpc.consent.jdbi.ConsentDAO;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Bootstrap;

--- a/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/CreateConsentRecord.java
+++ b/dpc-consent/src/main/java/gov/cms/dpc/consent/cli/CreateConsentRecord.java
@@ -14,11 +14,13 @@ import net.sourceforge.argparse4j.inf.Subparser;
 import org.jooq.DSLContext;
 import org.jooq.conf.RenderNameStyle;
 import org.jooq.conf.Settings;
+import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
@@ -89,7 +91,7 @@ public class CreateConsentRecord extends ConsentCommand {
     }
 
     @Override
-    protected void run(Bootstrap<DPCConsentConfiguration> bootstrap, Namespace namespace, DPCConsentConfiguration dpcConsentConfiguration) throws Exception {
+    protected void run(Bootstrap<DPCConsentConfiguration> bootstrap, Namespace namespace, DPCConsentConfiguration dpcConsentConfiguration) throws DataAccessException, SQLException  {
         final String mbi = namespace.getString("mbi");
         final LocalDate effectiveDate = LocalDate.parse(namespace.getString("effective-date"));
         final String inOrOut = namespace.getString(IN_OR_OUT_ARG);
@@ -121,7 +123,7 @@ public class CreateConsentRecord extends ConsentCommand {
                 ce.getPolicyCode(), ce.getMbi(), custodian, ce.getEffectiveDate()));
     }
 
-    private void saveEntity(Bootstrap<DPCConsentConfiguration> bootstrap, DPCConsentConfiguration dpcConsentConfiguration, ConsentEntity entity) throws Exception {
+    private void saveEntity(Bootstrap<DPCConsentConfiguration> bootstrap, DPCConsentConfiguration dpcConsentConfiguration, ConsentEntity entity) throws DataAccessException, SQLException {
         final PooledDataSourceFactory dataSourceFactory = dpcConsentConfiguration.getConsentDatabase();
         final ManagedDataSource dataSource = dataSourceFactory.build(bootstrap.getMetricRegistry(), "consent-cli");
 

--- a/dpc-consent/src/main/resources/consent.migrations.xml
+++ b/dpc-consent/src/main/resources/consent.migrations.xml
@@ -38,4 +38,24 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet id="change-type-consent-effective-date" author="embh">
+        <dropColumn tableName="CONSENT" columnName="effective_date"/>
+        <addColumn tableName="CONSENT">
+            <column name="effective_date" type="DATE">
+                <constraints nullable="false" />
+            </column>
+        </addColumn>
+    </changeSet>
+    <changeSet id="nullable-hicn" author="deirdre">
+        <dropNotNullConstraint
+                tableName="CONSENT"
+                columnName="hicn"
+        />
+    </changeSet>
+    <changeSet id="add-custodian-and-source-code" author="deirdre">
+        <addColumn tableName="CONSENT">
+            <column name="custodian" type="UUID"/>
+            <column name="source_code" type="VARCHAR"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dpc-consent/src/test/java/gov/cms/dpc/consent/cli/ConsentCommandsTest.java
+++ b/dpc-consent/src/test/java/gov/cms/dpc/consent/cli/ConsentCommandsTest.java
@@ -1,0 +1,134 @@
+package gov.cms.dpc.consent.cli;
+
+import gov.cms.dpc.consent.DPCConsentConfiguration;
+import gov.cms.dpc.consent.DPCConsentService;
+import io.dropwizard.cli.Cli;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.POJOConfigurationFactory;
+import io.dropwizard.util.JarLocation;
+import org.junit.jupiter.api.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ConsentCommandsTest {
+
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+    private final InputStream originalIn = System.in;
+
+    private final ByteArrayOutputStream stdOut = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream stdErr = new ByteArrayOutputStream();
+
+    private static final DPCConsentService app = new DPCConsentService();
+    private static final Bootstrap<DPCConsentConfiguration> bs = setupBootstrap(app);
+
+    private Cli cli;
+
+    private static Bootstrap<DPCConsentConfiguration> setupBootstrap(DPCConsentService app) {
+        // adapted from DropwizardTestSupport
+        Bootstrap<DPCConsentConfiguration> bootstrap = new Bootstrap<>(app) {
+            public void run(DPCConsentConfiguration configuration, Environment environment) throws Exception {
+                super.run(configuration, environment);
+                setConfigurationFactoryFactory((klass, validator, objectMapper, propertyPrefix) -> {
+                    return new POJOConfigurationFactory(configuration);
+                });
+            }
+        };
+        app.initialize(bootstrap);
+        return bootstrap;
+    }
+
+    @BeforeAll
+    void cliSetup() throws Exception {
+
+        app.run("db", "migrate");
+
+        // Redirect stdout and stderr to our byte streams
+        System.setOut(new PrintStream(stdOut));
+        System.setErr(new PrintStream(stdErr));
+
+        final JarLocation location = mock(JarLocation.class);
+        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+
+        cli = new Cli(location, bs, stdOut, stdErr);
+    }
+
+    @AfterAll
+    void teardown() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+        System.setIn(originalIn);
+    }
+
+    @AfterEach
+    void resetIO() {
+        stdOut.reset();
+        stdErr.reset();
+    }
+
+    @Test
+    final void pertinentHelpMessageDisplayed() throws Exception {
+        final boolean t1 = cli.run("consent", "create", "-h");
+        String errorMsg = String.format("Should have pertinent help message, got: %s", stdOut.toString());
+        assertAll(() -> assertTrue(t1, "Should have succeeded"),
+                () -> assertEquals("", stdErr.toString(), "Should not have errors"),
+                () -> assertTrue(stdOut.toString().contains("Create a new consent record"), errorMsg));
+    }
+
+    @Test
+    final void onlyAllowsInOrOut() throws Exception {
+        final boolean t1 = cli.run("consent", "create", "-p", "t2-mbi", "-d", "2019-11-22", "-i", "-o", "--host", "http://localhost:3500/v1");
+        assertAll(() -> assertFalse(t1, "Should have failed"),
+                () -> assertEquals("", stdOut.toString(), "Should not have output"),
+                () -> assertNotEquals("", stdErr.toString(), "Should have errors"),
+                () -> assertTrue(stdErr.toString().contains("argument -o/--out: not allowed with argument -i/--in"), "Should have '-o not allowed with -i' help message"));
+    }
+
+    @Test
+    final void detectsInvalidDate() throws Exception {
+        final boolean t5 = cli.run("consent", "create", "-p", "tA-mbi", "-d", "Nov 22 2019", "-i", "--host", "http://localhost:3500/v1");
+        assertAll(() -> assertFalse(t5, "Should have failed"),
+                () -> assertEquals("", stdOut.toString(), "Should not have output"),
+                () -> assertNotEquals("", stdErr.toString(), "Should have errors"),
+                () -> assertTrue(stdErr.toString().contains("java.time.format.DateTimeParseException"), "Should have date parsing error"));
+    }
+
+    @Test
+    final void detectsInvalidUUID() throws Exception {
+        final boolean t5 = cli.run("consent", "create", "-p", "tA-mbi", "-d", "2019-11-22", "-i", "--org", "1", "--host", "http://localhost:3500/v1");
+        assertAll(() -> assertFalse(t5, "Should have failed"),
+                () -> assertEquals("", stdOut.toString(), "Should not have output"),
+                () -> assertNotEquals("", stdErr.toString(), "Should have errors"),
+                () -> assertTrue(stdErr.toString().contains("java.lang.IllegalArgumentException"), "Should have date parsing error"));
+    }
+
+    @Test
+    final void createDefaultOptInRecord() throws Exception {
+        final boolean t2 = cli.run("consent", "create", "-p", "t2-mbi", "-d", "2019-11-22", "-i", "--host", "http://localhost:3500/v1");
+        assertAll(() -> assertTrue(t2, "Should have succeeded"),
+                () -> assertEquals("", stdErr.toString(), "Should not have errors"));
+    }
+
+    @Test
+    final void createDefaultOptOutRecord() throws Exception {
+        final boolean t3 = cli.run("consent", "create", "-p", "t3-mbi", "-d", "2019-11-23", "-o", "--host", "http://localhost:3500/v1");
+        assertAll(() -> assertTrue(t3, "Should have succeeded"),
+                () -> assertEquals("", stdErr.toString(), "Should not have errors"));
+    }
+
+    @Test
+    final void createExternalOrgRecord() throws Exception {
+        final boolean t4 = cli.run("consent", "create", "-p", "t4-mbi", "-d", "2019-11-24", "-i", "--org", "46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0", "--host", "http://localhost:3500/v1");
+        assertAll(() -> assertTrue(t4, "Should have succeeded"),
+                () -> assertEquals("", stdErr.toString(), "Should not have errors"));
+    }
+}


### PR DESCRIPTION
**Why**

Until we have our consent pipeline fully functional, including ACO OS integration, we need a way to manually opt-out patients if we receive notice from a pilot site, or CMS.

**What Changed**

A CLI command has been added to create new consent records. The command has been added in such a way as to support additional commands, like list or delete.

**Choices Made**

- In order to know how a record was created --- manually or via an ETL import --- I added a source_code column. We wanted explicit identification of the import source to make audit trails and problem investigation easier.

- Added a custodian column to hold the organization id when the consent record was provided to DPC by a DPC provider organization.

**Tickets closed**:

DPC-821

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additional fixes.

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
