### PR TITLE
Remove Mailchimp data from mailer template

### DIFF
--- a/dpc-web/app/views/layouts/mailer.html.erb
+++ b/dpc-web/app/views/layouts/mailer.html.erb
@@ -13,7 +13,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>*|MC:SUBJECT|*</title>
+        <title>Data at the Point of Care</title>
 
     <style type="text/css">
     p{
@@ -548,11 +548,6 @@
 }</style>
 </head>
   <body>
-    <!--*|IF:MC_PREVIEW_TEXT|*-->
-    <!--[if !gte mso 9]><!---->
-    <span class="mcnPreviewText" style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">*|MC_PREVIEW_TEXT|*</span>
-    <!--<![endif]-->
-    <!--*|END:IF|*-->
     <center>
       <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
         <tr>
@@ -577,15 +572,6 @@
                         <!--[if mso]>
                         <td valign="top" width="600" style="width:600px;">
                         <![endif]-->
-                        <table align="left" border="0" cellpadding="0" cellspacing="0" style="max-width:100%; min-width:100%;" width="100%" class="mcnTextContentContainer">
-                          <tbody>
-                            <tr>
-                              <td valign="top" class="mcnTextContent" style="padding: 0px 18px 9px; text-align: center;">
-                                  <span style="font-size:10px" ;=""><a href="*|ARCHIVE|*" target="_blank">View this email in your browser</a></span>
-                              </td>
-                            </tr>
-                          </tbody>
-                        </table>
                         <!--[if mso]>
                         </td>
                         <![endif]-->
@@ -726,8 +712,7 @@
                           200 Independence Ave., S.W.<br>
                           Washington, DC &nbsp;20001<br>
                           <br>
-                          Want to change how you receive these emails?<br>
-                          You can <a href="*|UPDATE_PROFILE|*">update your preferences</a> or <a href="*|UNSUB|*">unsubscribe from this list</a>.
+                          You can unsubscribe from DPC account emails by emailing the team at DPCInfo@cms.hhs.gov.
                         </td>
                       </tr>
                     </tbody>


### PR DESCRIPTION
Leftover maybe from a copypasta job. This PR gets rid of MC template
tags and links. Adds unsubscribe language instructing folks to email us.

