### PR TITLE
Remove inconsistent Postman test expectation

### DIFF
--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -926,8 +926,6 @@
 									"    pm.expect(address.city).equals(\"Chestnut Hill\");",
 									"    pm.expect(address.state).equals(\"MA\");",
 									"    pm.expect(address.postalCode).equals(\"02467\");",
-									"    ",
-									"    pm.expect(respJson.endpoint.length).equals(3);",
 									"});"
 								],
 								"type": "text/javascript"


### PR DESCRIPTION
In the Postman test for updating organizations, the number of endpoints cannot be assumed to be the same in every environment. This PR removes that expectation.