### PR TITLE
DPC-857: Add create, update, and delete operations for Endpoint resources

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractEndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractEndpointResource.java
@@ -1,6 +1,8 @@
 package gov.cms.dpc.api.resources;
 
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
+import gov.cms.dpc.fhir.annotations.Profiled;
+import gov.cms.dpc.fhir.validations.profiles.EndpointProfile;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiParam;
@@ -8,6 +10,7 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Endpoint;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
@@ -21,20 +24,20 @@ public abstract class AbstractEndpointResource {
     }
 
     @POST
-    public abstract Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organization, @Valid Endpoint endpoint);
+    public abstract Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organization, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint);
 
     @GET
     public abstract Bundle getEndpoints(OrganizationPrincipal organization);
 
     @GET
     @Path("/{endpointID}")
-    public abstract Endpoint fetchEndpoint(UUID endpointID);
+    public abstract Endpoint fetchEndpoint(@NotNull UUID endpointID);
 
     @PUT
     @Path("/{endpointID}")
-    public abstract Endpoint updateEndpoint(UUID endpointID, @Valid Endpoint endpoint);
+    public abstract Endpoint updateEndpoint(@NotNull UUID endpointID, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint);
 
     @DELETE
     @Path("/{endpointID}")
-    public abstract Response deleteEndpoint(UUID endpointID);
+    public abstract Response deleteEndpoint(@NotNull UUID endpointID);
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractEndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractEndpointResource.java
@@ -1,12 +1,15 @@
 package gov.cms.dpc.api.resources;
 
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
+import io.dropwizard.auth.Auth;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Endpoint;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+import javax.validation.Valid;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 @Path("/Endpoint")
@@ -17,10 +20,21 @@ public abstract class AbstractEndpointResource {
         // Not used
     }
 
+    @POST
+    public abstract Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organization, @Valid Endpoint endpoint);
+
     @GET
     public abstract Bundle getEndpoints(OrganizationPrincipal organization);
 
     @GET
     @Path("/{endpointID}")
     public abstract Endpoint fetchEndpoint(UUID endpointID);
+
+    @PUT
+    @Path("/{endpointID}")
+    public abstract Endpoint updateEndpoint(UUID endpointID, @Valid Endpoint endpoint);
+
+    @DELETE
+    @Path("/{endpointID}")
+    public abstract Response deleteEndpoint(UUID endpointID);
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
+import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
@@ -7,17 +8,14 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractEndpointResource;
 import gov.cms.dpc.fhir.annotations.FHIR;
+import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.*;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Endpoint;
-import org.hl7.fhir.dstu3.model.IdType;
-import org.hl7.fhir.dstu3.model.ResourceType;
+import org.hl7.fhir.dstu3.model.*;
 
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 @Api(value = "Endpoint", authorizations = @Authorization(value = "apiKey"))
@@ -29,6 +27,24 @@ public class EndpointResource extends AbstractEndpointResource {
     @Inject
     EndpointResource(IGenericClient client) {
         this.client = client;
+    }
+
+    @POST
+    @FHIR
+    @Timed
+    @ExceptionMetered
+    @ApiOperation(value = "Create an Endpoint", notes = "Create an Endpoint resource for an Organization")
+    @ApiResponses(@ApiResponse(code = 204, message = "Endpoint created"))
+    @Override
+    public Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, Endpoint endpoint) {
+        endpoint.setManagingOrganization(new Reference(new IdType("Organization", organizationPrincipal.getID().toString())));
+        MethodOutcome outcome = this.client
+                .create()
+                .resource(endpoint)
+                .encodedJson()
+                .execute();
+
+        return FHIRHelpers.handleMethodOutcome(outcome);
     }
 
     @GET
@@ -54,7 +70,7 @@ public class EndpointResource extends AbstractEndpointResource {
     @Timed
     @ExceptionMetered
     @ApiOperation(value = "Fetch Endpoint resource", notes = "Fetch a specific Endpoint associated to an Organization.")
-    @ApiResponses(@ApiResponse(code = 404, message = "Resource not found"))
+    @ApiResponses(@ApiResponse(code = 404, message = "Endpoint not found"))
     @Override
     public Endpoint fetchEndpoint(@PathParam("endpointID") UUID endpointID) {
         return this.client
@@ -63,5 +79,49 @@ public class EndpointResource extends AbstractEndpointResource {
                 .withId(new IdType("Organization", endpointID.toString()))
                 .encodedJson()
                 .execute();
+    }
+
+    @PUT
+    @Path("/{endpointID}")
+    @PathAuthorizer(type = ResourceType.Endpoint, pathParam = "endpointID")
+    @FHIR
+    @Timed
+    @ExceptionMetered
+    @ApiOperation(value = "Update an Endpoint", notes = "Update an Endpoint resource")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Endpoint updated"),
+            @ApiResponse(code = 404, message = "Endpoint not found")
+    })
+    @Override
+    public Endpoint updateEndpoint(@PathParam("endpointID") UUID endpointID, Endpoint endpoint) {
+        MethodOutcome outcome = this.client
+                .update()
+                .resource(endpoint)
+                .withId(endpointID.toString())
+                .encodedJson()
+                .execute();
+
+       return (Endpoint) outcome.getResource();
+    }
+
+    @DELETE
+    @Path("/{endpointID}")
+    @PathAuthorizer(type = ResourceType.Endpoint, pathParam = "endpointID")
+    @FHIR
+    @Timed
+    @ExceptionMetered
+    @ApiOperation(value = "Delete an Endpoint", notes = "Delete an Endpoint resource")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "Endpoint deleted"),
+            @ApiResponse(code = 404, message = "Endpoint not found")
+    })
+    @Override
+    public Response deleteEndpoint(@PathParam("endpointID") UUID endpointID) {
+        this.client
+                .delete()
+                .resourceById("Endpoint", endpointID.toString())
+                .execute();
+
+        return Response.ok().build();
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
@@ -8,12 +8,16 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractEndpointResource;
 import gov.cms.dpc.fhir.annotations.FHIR;
+import gov.cms.dpc.fhir.annotations.Profiled;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
+import gov.cms.dpc.fhir.validations.profiles.EndpointProfile;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.*;
 import org.hl7.fhir.dstu3.model.*;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
@@ -36,7 +40,7 @@ public class EndpointResource extends AbstractEndpointResource {
     @ApiOperation(value = "Create an Endpoint", notes = "Create an Endpoint resource for an Organization")
     @ApiResponses(@ApiResponse(code = 204, message = "Endpoint created"))
     @Override
-    public Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, Endpoint endpoint) {
+    public Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint) {
         endpoint.setManagingOrganization(new Reference(new IdType("Organization", organizationPrincipal.getID().toString())));
         MethodOutcome outcome = this.client
                 .create()
@@ -72,7 +76,7 @@ public class EndpointResource extends AbstractEndpointResource {
     @ApiOperation(value = "Fetch Endpoint resource", notes = "Fetch a specific Endpoint associated to an Organization.")
     @ApiResponses(@ApiResponse(code = 404, message = "Endpoint not found"))
     @Override
-    public Endpoint fetchEndpoint(@PathParam("endpointID") UUID endpointID) {
+    public Endpoint fetchEndpoint(@NotNull @PathParam("endpointID") UUID endpointID) {
         return this.client
                 .read()
                 .resource(Endpoint.class)
@@ -93,7 +97,7 @@ public class EndpointResource extends AbstractEndpointResource {
             @ApiResponse(code = 404, message = "Endpoint not found")
     })
     @Override
-    public Endpoint updateEndpoint(@PathParam("endpointID") UUID endpointID, Endpoint endpoint) {
+    public Endpoint updateEndpoint(@NotNull @PathParam("endpointID") UUID endpointID, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint) {
         MethodOutcome outcome = this.client
                 .update()
                 .resource(endpoint)
@@ -116,7 +120,7 @@ public class EndpointResource extends AbstractEndpointResource {
             @ApiResponse(code = 404, message = "Endpoint not found")
     })
     @Override
-    public Response deleteEndpoint(@PathParam("endpointID") UUID endpointID) {
+    public Response deleteEndpoint(@NotNull @PathParam("endpointID") UUID endpointID) {
         this.client
                 .delete()
                 .resourceById("Endpoint", endpointID.toString())

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
@@ -13,6 +13,7 @@ import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import gov.cms.dpc.fhir.validations.profiles.EndpointProfile;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.*;
+import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
 
 import javax.inject.Inject;
@@ -98,6 +99,11 @@ public class EndpointResource extends AbstractEndpointResource {
     })
     @Override
     public Endpoint updateEndpoint(@NotNull @PathParam("endpointID") UUID endpointID, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint) {
+        Endpoint currEndpoint = fetchEndpoint(endpointID);
+        if (!endpoint.getManagingOrganization().getReference().equals(currEndpoint.getManagingOrganization().getReference())) {
+            throw new WebApplicationException("An Endpoint's Organization cannot be changed", HttpStatus.UNPROCESSABLE_ENTITY_422);
+        }
+
         MethodOutcome outcome = this.client
                 .update()
                 .resource(endpoint)

--- a/dpc-api/src/test/java/gov/cms/dpc/api/APITestHelpers.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/APITestHelpers.java
@@ -38,10 +38,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.glassfish.jersey.test.grizzly.GrizzlyWebTestContainerFactory;
 import org.hl7.fhir.dstu3.hapi.ctx.DefaultProfileValidationSupport;
 import org.hl7.fhir.dstu3.hapi.validation.ValidationSupportChain;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Organization;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Practitioner;
+import org.hl7.fhir.dstu3.model.*;
 
 import javax.validation.Validation;
 import javax.validation.Validator;
@@ -206,6 +203,16 @@ public class APITestHelpers {
                 assertEquals(HttpStatus.OK_200, execute.getStatusLine().getStatusCode(), "Should be healthy");
             }
         }
+    }
+
+    public static Endpoint makeEndpoint() {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("Test Endpoint");
+        endpoint.setAddress("http://www.example.com/endpoint");
+        endpoint.setConnectionType(new Coding("http://terminology.hl7.org/CodeSystem/endpoint-connection-type", "hl7-fhir-rest", ""));
+        endpoint.setManagingOrganization(new Reference(new IdType("Organization", ORGANIZATION_ID)));
+        endpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
+        return endpoint;
     }
 
     private static Validator provideValidator(InjectingConstraintValidatorFactory factory) {

--- a/dpc-api/src/test/java/gov/cms/dpc/api/APITestHelpers.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/APITestHelpers.java
@@ -205,16 +205,6 @@ public class APITestHelpers {
         }
     }
 
-    public static Endpoint makeEndpoint() {
-        Endpoint endpoint = new Endpoint();
-        endpoint.setName("Test Endpoint");
-        endpoint.setAddress("http://www.example.com/endpoint");
-        endpoint.setConnectionType(new Coding("http://terminology.hl7.org/CodeSystem/endpoint-connection-type", "hl7-fhir-rest", ""));
-        endpoint.setManagingOrganization(new Reference(new IdType("Organization", ORGANIZATION_ID)));
-        endpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
-        return endpoint;
-    }
-
     private static Validator provideValidator(InjectingConstraintValidatorFactory factory) {
         return Validation.byDefaultProvider()
                 .configure().constraintValidatorFactory(factory)

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
@@ -41,9 +41,13 @@ public class EndpointResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    void testCreateEndpointWithoutOrg() {
+    void testCreateEndpointDifferentOrg() throws IOException {
+        final String goldenMacaroon = APIAuthHelpers.createGoldenMacaroon();
+        final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, getBaseURL(), goldenMacaroon, false);
+        final Organization organization = OrganizationHelpers.createOrganization(ctx, adminClient, "create-endpoint-different-org", true);
+
         Endpoint endpoint = OrganizationFactory.createValidFakeEndpoint();
-        endpoint.setManagingOrganization((Reference)null);
+        endpoint.setManagingOrganization(new Reference("Organization/"+ organization.getId()));
         ICreateTyped createExec = client.create().resource(endpoint);
         assertThrows(UnprocessableEntityException.class, createExec::execute);
     }
@@ -98,7 +102,7 @@ public class EndpointResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    void testUpdateEndpointNewOrg() throws IOException {
+    void testUpdateEndpointDifferentOrg() throws IOException {
         final String goldenMacaroon = APIAuthHelpers.createGoldenMacaroon();
         final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, getBaseURL(), goldenMacaroon, false);
 

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
@@ -1,0 +1,69 @@
+package gov.cms.dpc.api.resources.v1;
+
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import gov.cms.dpc.api.APITestHelpers;
+import gov.cms.dpc.api.AbstractSecureApplicationTest;
+import gov.cms.dpc.fhir.FHIRExtractors;
+import gov.cms.dpc.testing.APIAuthHelpers;
+import org.hl7.fhir.dstu3.model.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EndpointResourceTest extends AbstractSecureApplicationTest {
+
+    final IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
+
+    @Test
+    void testCreateEndpoint() {
+        Endpoint endpoint = APITestHelpers.makeEndpoint();
+
+        MethodOutcome outcome = client.create().resource(endpoint).execute();
+        assertTrue(outcome.getCreated());
+        Endpoint createdEndpoint = (Endpoint) outcome.getResource();
+        assertNotNull(createdEndpoint.getId());
+        assertEquals(endpoint.getName(), createdEndpoint.getName());
+        assertEquals(endpoint.getAddress(), createdEndpoint.getAddress());
+        assertEquals(APITestHelpers.ORGANIZATION_ID, FHIRExtractors.getEntityUUID(createdEndpoint.getManagingOrganization().getReference()).toString());
+    }
+
+    @Test
+    void testGetEndpoints() {
+        Bundle result = client.search().forResource(Endpoint.class).returnBundle(Bundle.class).execute();
+        assertTrue(result.getTotal() > 0);
+        for (Bundle.BundleEntryComponent component : result.getEntry()) {
+            Resource resource = component.getResource();
+            assertEquals(ResourceType.Endpoint, resource.getResourceType());
+            Endpoint endpoint = (Endpoint) resource;
+            assertEquals(APITestHelpers.ORGANIZATION_ID, FHIRExtractors.getEntityUUID(endpoint.getManagingOrganization().getReference()).toString());
+        }
+    }
+
+    @Test
+    void testFetchEndpoint() {
+        Endpoint endpoint = APITestHelpers.makeEndpoint();
+        MethodOutcome outcome = client.create().resource(endpoint).execute();
+        Endpoint createdEndpoint = (Endpoint) outcome.getResource();
+
+        Endpoint readEndpoint = client.read().resource(Endpoint.class).withId(createdEndpoint.getId()).execute();
+        assertEquals(createdEndpoint.getId(), readEndpoint.getId());
+        assertEquals(createdEndpoint.getName(), readEndpoint.getName());
+        assertEquals(createdEndpoint.getAddress(), readEndpoint.getAddress());
+    }
+
+    @Test
+    void testUpdateEndpoint() {
+        Endpoint endpoint = APITestHelpers.makeEndpoint();
+        MethodOutcome createOutcome = client.create().resource(endpoint).execute();
+        Endpoint createdEndpoint = (Endpoint) createOutcome.getResource();
+        createdEndpoint.setName("Test Update Endpoint");
+
+        MethodOutcome updateOutcome = client.update().resource(createdEndpoint).withId(createdEndpoint.getId()).execute();
+
+        Endpoint updatedEndpoint = (Endpoint) updateOutcome.getResource();
+        assertEquals(createdEndpoint, updatedEndpoint);
+    }
+
+    void testDeleteEndpoint() {}
+}

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/EndpointDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/EndpointDAO.java
@@ -19,6 +19,10 @@ public class EndpointDAO extends AbstractDAO<EndpointEntity> {
         super(factory.getSessionFactory());
     }
 
+    public EndpointEntity persistEndpoint(EndpointEntity endpointEntity) {
+        return persist(endpointEntity);
+    }
+
     public Optional<EndpointEntity> fetchEndpoint(UUID endpointID) {
         return Optional.ofNullable(get(endpointID));
     }
@@ -34,5 +38,9 @@ public class EndpointDAO extends AbstractDAO<EndpointEntity> {
         query.where(builder.equal(root.get("organization").get("id"), organizationID));
 
         return list(query);
+    }
+
+    public void deleteEndpoint(EndpointEntity endpointEntity) {
+        currentSession().delete(endpointEntity);
     }
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/OrganizationDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/OrganizationDAO.java
@@ -43,11 +43,10 @@ public class OrganizationDAO extends AbstractDAO<OrganizationEntity> {
         return list(query);
     }
 
-    public OrganizationEntity updateOrganization(UUID organizationID, Organization resource) {
+    public OrganizationEntity updateOrganization(UUID organizationID, OrganizationEntity updatedOrganization) {
         OrganizationEntity organization = fetchOrganization(organizationID)
                 .orElseThrow(() -> new IllegalArgumentException("Cannot find organization"));
-        final OrganizationEntity updatedOrg = new OrganizationEntity().fromFHIR(resource);
-        organization.update(updatedOrg);
+        organization.update(updatedOrganization);
         currentSession().merge(organization);
         return organization;
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
@@ -23,13 +23,13 @@ public abstract class AbstractEndpointResource {
 
     @GET
     @Path("/{endpointID}")
-    public abstract Endpoint fetchEndpoint(UUID endpointID);
+    public abstract Endpoint fetchEndpoint(@NotNull UUID endpointID);
 
     @PUT
     @Path("/{endpointID}")
-    public abstract Endpoint updateEndpoint(UUID endpointID, Endpoint endpoint);
+    public abstract Endpoint updateEndpoint(@NotNull UUID endpointID, Endpoint endpoint);
 
     @DELETE
     @Path("/{endpointID}")
-    public abstract Response deleteEndpoint(UUID endpointID);
+    public abstract Response deleteEndpoint(@NotNull UUID endpointID);
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
@@ -4,8 +4,8 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Endpoint;
 
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 @Path("/Endpoint")
@@ -15,10 +15,21 @@ public abstract class AbstractEndpointResource {
         // Not used
     }
 
+    @POST
+    public abstract Response createEndpoint(Endpoint endpoint);
+
     @GET
     public abstract Bundle searchEndpoints(@NotNull String organizationID);
 
     @GET
     @Path("/{endpointID}")
     public abstract Endpoint fetchEndpoint(UUID endpointID);
+
+    @PUT
+    @Path("/{endpointID}")
+    public abstract Endpoint updateEndpoint(UUID endpointID, Endpoint endpoint);
+
+    @DELETE
+    @Path("/{endpointID}")
+    public abstract Response deleteEndpoint(UUID endpointID);
 }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
@@ -16,7 +16,7 @@ public abstract class AbstractEndpointResource {
     }
 
     @POST
-    public abstract Response createEndpoint(Endpoint endpoint);
+    public abstract Response createEndpoint(@NotNull Endpoint endpoint);
 
     @GET
     public abstract Bundle searchEndpoints(@NotNull String organizationID);
@@ -27,7 +27,7 @@ public abstract class AbstractEndpointResource {
 
     @PUT
     @Path("/{endpointID}")
-    public abstract Endpoint updateEndpoint(@NotNull UUID endpointID, Endpoint endpoint);
+    public abstract Endpoint updateEndpoint(@NotNull UUID endpointID, @NotNull Endpoint endpoint);
 
     @DELETE
     @Path("/{endpointID}")

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
@@ -101,9 +101,8 @@ public class EndpointResource extends AbstractEndpointResource {
     @ApiResponses(value = { @ApiResponse(code = 404, message = "Cannot find Endpoint") })
     @Override
     public Endpoint updateEndpoint(@NotNull @PathParam("endpointID") UUID endpointID, @NotNull Endpoint endpoint) {
-        endpoint.setId(endpointID.toString());
-        EndpointEntity entity = this.endpointDAO.persistEndpoint(EndpointConverter.convert(endpoint));
-        return EndpointEntityConverter.convert(entity);
+        EndpointEntity updatedEntity = this.endpointDAO.persistEndpoint(EndpointConverter.convert(endpoint));
+        return EndpointEntityConverter.convert(updatedEntity);
     }
 
     @FHIR

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
@@ -112,7 +112,10 @@ public class EndpointResource extends AbstractEndpointResource {
     @ExceptionMetered
     @UnitOfWork
     @ApiOperation(value = "Delete an Endpoint", notes = "Delete an Endpoint resource")
-    @ApiResponses(value = {})
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Cannot find Endpoint"),
+            @ApiResponse(code = 422, message = "Endpoint cannot be deleted")
+    })
     @Override
     public Response deleteEndpoint(@NotNull @PathParam("endpointID") UUID endpointID) {
         final EndpointEntity endpoint = this.endpointDAO.fetchEndpoint(endpointID)

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
@@ -45,7 +45,7 @@ public class EndpointResource extends AbstractEndpointResource {
     @UnitOfWork
     @ApiOperation(value = "Create an Endpoint", notes = "Create an Endpoint resource")
     @Override
-    public Response createEndpoint(Endpoint endpoint) {
+    public Response createEndpoint(@NotNull Endpoint endpoint) {
         EndpointEntity entity = endpointDAO.persistEndpoint(EndpointConverter.convert(endpoint));
         return Response.status(Response.Status.CREATED).entity(EndpointEntityConverter.convert(entity)).build();
     }
@@ -100,7 +100,7 @@ public class EndpointResource extends AbstractEndpointResource {
     @ApiOperation(value = "Update an Endpoint", notes = "Update an Endpoint resource")
     @ApiResponses(value = { @ApiResponse(code = 404, message = "Cannot find Endpoint") })
     @Override
-    public Endpoint updateEndpoint(@NotNull @PathParam("endpointID") UUID endpointID, Endpoint endpoint) {
+    public Endpoint updateEndpoint(@NotNull @PathParam("endpointID") UUID endpointID, @NotNull Endpoint endpoint) {
         endpoint.setId(endpointID.toString());
         EndpointEntity entity = this.endpointDAO.persistEndpoint(EndpointConverter.convert(endpoint));
         return EndpointEntityConverter.convert(entity);

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -139,7 +139,8 @@ public class OrganizationResource extends AbstractOrganizationResource {
         try {
             OrganizationEntity orgEntity = new OrganizationEntity().fromFHIR(organization);
             // OrganizationEntity.fromFHIR() ignores endpoints in submitted resource; they must be copied from original
-            List<EndpointEntity> endpointEntities = organization.getEndpoint().stream().map(
+            Organization original = getOrganization(organizationID);
+            List<EndpointEntity> endpointEntities = original.getEndpoint().stream().map(
                     r -> {
                         UUID endpointID = FHIRExtractors.getEntityUUID(r.getReference());
                         Optional<EndpointEntity> endpointOpt = endpointDAO.fetchEndpoint(endpointID);

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -146,7 +146,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
                         Optional<EndpointEntity> endpointOpt = endpointDAO.fetchEndpoint(endpointID);
                         return endpointOpt;
                     }
-            ).filter(eo -> eo.isPresent()).map(eo -> eo.get()).collect(Collectors.toList());
+            ).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
             orgEntity.setEndpoints(endpointEntities);
             orgEntity = this.dao.updateOrganization(organizationID, orgEntity);
             return Response.status(Response.Status.OK).entity(orgEntity.toFHIR()).build();

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -2,10 +2,12 @@ package gov.cms.dpc.attribution.resources.v1;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import gov.cms.dpc.attribution.jdbi.EndpointDAO;
 import gov.cms.dpc.attribution.jdbi.OrganizationDAO;
 import gov.cms.dpc.attribution.resources.AbstractOrganizationResource;
 import gov.cms.dpc.common.entities.EndpointEntity;
 import gov.cms.dpc.common.entities.OrganizationEntity;
+import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.converters.EndpointConverter;
 import io.dropwizard.hibernate.UnitOfWork;
@@ -30,10 +32,12 @@ public class OrganizationResource extends AbstractOrganizationResource {
 
     private static final Logger logger = LoggerFactory.getLogger(OrganizationResource.class);
     private final OrganizationDAO dao;
+    private final EndpointDAO endpointDAO;
 
     @Inject
-    OrganizationResource(OrganizationDAO dao) {
+    OrganizationResource(OrganizationDAO dao, EndpointDAO endpointDAO) {
         this.dao = dao;
+        this.endpointDAO = endpointDAO;
     }
 
     @Override
@@ -133,7 +137,17 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @Override
     public Response updateOrganization(@ApiParam(value = "Organization resource ID", required = true) @PathParam("organizationID") UUID organizationID, Organization organization) {
         try {
-            OrganizationEntity orgEntity = this.dao.updateOrganization(organizationID, organization);
+            OrganizationEntity orgEntity = new OrganizationEntity().fromFHIR(organization);
+            // OrganizationEntity.fromFHIR() ignores endpoints in submitted resource; they must be copied from original
+            List<EndpointEntity> endpointEntities = organization.getEndpoint().stream().map(
+                    r -> {
+                        UUID endpointID = FHIRExtractors.getEntityUUID(r.getReference());
+                        Optional<EndpointEntity> endpointOpt = endpointDAO.fetchEndpoint(endpointID);
+                        return endpointOpt.get();
+                    }
+            ).collect(Collectors.toList());
+            orgEntity.setEndpoints(endpointEntities);
+            orgEntity = this.dao.updateOrganization(organizationID, orgEntity);
             return Response.status(Response.Status.OK).entity(orgEntity.toFHIR()).build();
         } catch (Exception e) {
             logger.error("Error: ", e);

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/OrganizationResource.java
@@ -144,9 +144,9 @@ public class OrganizationResource extends AbstractOrganizationResource {
                     r -> {
                         UUID endpointID = FHIRExtractors.getEntityUUID(r.getReference());
                         Optional<EndpointEntity> endpointOpt = endpointDAO.fetchEndpoint(endpointID);
-                        return endpointOpt.get();
+                        return endpointOpt;
                     }
-            ).collect(Collectors.toList());
+            ).filter(eo -> eo.isPresent()).map(eo -> eo.get()).collect(Collectors.toList());
             orgEntity.setEndpoints(endpointEntities);
             orgEntity = this.dao.updateOrganization(organizationID, orgEntity);
             return Response.status(Response.Status.OK).entity(orgEntity.toFHIR()).build();

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionTestHelpers.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionTestHelpers.java
@@ -42,17 +42,6 @@ public class AttributionTestHelpers {
         return patient;
     }
 
-    public static Endpoint createEndpoint(String organizationId) {
-        Endpoint endpoint = new Endpoint();
-        endpoint.setName("Test Endpoint");
-        endpoint.setAddress("http://www.example.com/endpoint");
-        endpoint.setConnectionType(new Coding("http://terminology.hl7.org/CodeSystem/endpoint-connection-type", "hl7-fhir-rest", ""));
-        endpoint.setManagingOrganization(new Reference(new IdType("Organization", organizationId)));
-        endpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
-
-        return endpoint;
-    }
-
     public static IGenericClient createFHIRClient(FhirContext ctx, String serverURL) {
         ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
         return ctx.newRestfulGenericClient(serverURL);

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionTestHelpers.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionTestHelpers.java
@@ -42,6 +42,17 @@ public class AttributionTestHelpers {
         return patient;
     }
 
+    public static Endpoint createEndpoint(String organizationId) {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("Test Endpoint");
+        endpoint.setAddress("http://www.example.com/endpoint");
+        endpoint.setConnectionType(new Coding("http://terminology.hl7.org/CodeSystem/endpoint-connection-type", "hl7-fhir-rest", ""));
+        endpoint.setManagingOrganization(new Reference(new IdType("Organization", organizationId)));
+        endpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
+
+        return endpoint;
+    }
+
     public static IGenericClient createFHIRClient(FhirContext ctx, String serverURL) {
         ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
         return ctx.newRestfulGenericClient(serverURL);

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/EndpointResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/EndpointResourceTest.java
@@ -88,27 +88,6 @@ public class EndpointResourceTest extends AbstractAttributionTest {
         assertTrue(updatedEndpoint.equalsDeep(endpoint));
     }
 
-    void testUpdateEndpointNewOrg() {
-        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-update-endpoint", false);
-        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
-
-        Endpoint endpoint = client
-                .read()
-                .resource(Endpoint.class)
-                .withId(endpointId)
-                .execute();
-
-        Organization organization2 = OrganizationHelpers.createOrganization(ctx, client, "test-update-endpoint", false);
-        endpoint.setManagingOrganization(new Reference(new IdType("Organization", organization2.getId())));
-
-        IUpdateExecutable updateExec = client
-                .update()
-                .resource(endpoint)
-                .withId(endpoint.getId());
-
-        assertThrows(UnprocessableEntityException.class, updateExec::execute);
-    }
-
     @Test
     void testDeleteEndpoint() {
         Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-delete-endpoint", false);

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/EndpointResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/EndpointResourceTest.java
@@ -1,0 +1,127 @@
+package gov.cms.dpc.attribution.resources;
+
+import ca.uhn.fhir.rest.api.MethodOutcome;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IDeleteTyped;
+import ca.uhn.fhir.rest.gclient.IReadExecutable;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import gov.cms.dpc.attribution.AbstractAttributionTest;
+import gov.cms.dpc.attribution.AttributionTestHelpers;
+import gov.cms.dpc.fhir.FHIRExtractors;
+import gov.cms.dpc.testing.OrganizationHelpers;
+import org.hl7.fhir.dstu3.model.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EndpointResourceTest extends AbstractAttributionTest {
+
+    final IGenericClient client = AttributionTestHelpers.createFHIRClient(ctx, getServerURL());
+
+    @Test
+    void testCreateEndpoint() {
+        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-create-endpoint", false);
+        Endpoint endpoint = AttributionTestHelpers.createEndpoint(organization.getId());
+
+        MethodOutcome outcome = client
+                .create()
+                .resource(endpoint)
+                .encodedJson()
+                .execute();
+
+        assertTrue(outcome.getCreated());
+    }
+
+    @Test
+    void testSearchEndpoints() {
+        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-search-endpoints", false);
+        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
+
+        final Bundle bundle = client
+                .search()
+                .forResource(Endpoint.class)
+                .where(Endpoint.ORGANIZATION.hasId("Organization/" + AttributionTestHelpers.DEFAULT_ORG_ID))
+                .returnBundle(Bundle.class)
+                .execute();
+
+        assertTrue(bundle.hasEntry());
+        assertFalse(bundle.getEntry().isEmpty());
+    }
+
+    @Test
+    void testFetchEndpoint() {
+        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-fetch-endpoint", false);
+        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
+
+        Endpoint result = client
+                .read()
+                .resource(Endpoint.class)
+                .withId(endpointId)
+                .execute();
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testUpdateEndpoint() {
+        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-update-endpoint", false);
+        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
+
+        Endpoint endpoint = client
+                .read()
+                .resource(Endpoint.class)
+                .withId(endpointId)
+                .execute();
+
+        endpoint.setName("New Endpoint Name");
+
+        MethodOutcome outcome = client
+                .update()
+                .resource(endpoint)
+                .withId(endpoint.getId())
+                .execute();
+
+        Endpoint updatedEndpoint = (Endpoint) outcome.getResource();
+        assertEquals(endpoint.getId(), updatedEndpoint.getId());
+        assertEquals("New Endpoint Name", updatedEndpoint.getName());
+        assertEquals(endpoint.getAddress(), updatedEndpoint.getAddress());
+    }
+
+    @Test
+    void testDeleteEndpoint() {
+        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-delete-endpoint", false);
+        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
+
+        // Add another endpoint to organization
+        client
+                .create()
+                .resource(AttributionTestHelpers.createEndpoint(organization.getId()))
+                .execute();
+
+        // Delete original endpoint
+        client
+                .delete()
+                .resourceById("Endpoint", endpointId)
+                .execute();
+
+        IReadExecutable readExec = client
+                .read()
+                .resource(Endpoint.class)
+                .withId(endpointId);
+
+        assertThrows(ResourceNotFoundException.class, readExec::execute);
+    }
+
+    @Test
+    void testDeleteOnlyEndpoint() {
+        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-delete-only-endpoint", false);
+        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
+
+        IDeleteTyped delete = client
+                .delete()
+                .resourceById("Endpoint", endpointId);
+
+        assertThrows(InternalErrorException.class, delete::execute);
+    }
+}

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/EndpointResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/EndpointResourceTest.java
@@ -4,8 +4,8 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IDeleteTyped;
 import ca.uhn.fhir.rest.gclient.IReadExecutable;
-import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import gov.cms.dpc.attribution.AbstractAttributionTest;
 import gov.cms.dpc.attribution.AttributionTestHelpers;
 import gov.cms.dpc.fhir.FHIRExtractors;
@@ -111,17 +111,5 @@ public class EndpointResourceTest extends AbstractAttributionTest {
                 .withId(endpointId);
 
         assertThrows(ResourceNotFoundException.class, readExec::execute);
-    }
-
-    @Test
-    void testDeleteOnlyEndpoint() {
-        Organization organization = OrganizationHelpers.createOrganization(ctx, client, "test-delete-only-endpoint", false);
-        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
-
-        IDeleteTyped delete = client
-                .delete()
-                .resourceById("Endpoint", endpointId);
-
-        assertThrows(InternalErrorException.class, delete::execute);
     }
 }

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
@@ -116,7 +116,7 @@ class OrganizationResourceTest extends AbstractAttributionTest {
     @Test
     void testUpdateOrganization() {
         final IGenericClient client = AttributionTestHelpers.createFHIRClient(ctx, getServerURL());
-        Organization organization = OrganizationHelpers.createOrganization(ctx, AttributionTestHelpers.createFHIRClient(ctx, getServerURL()));
+        Organization organization = OrganizationHelpers.createOrganization(ctx, AttributionTestHelpers.createFHIRClient(ctx, getServerURL()), "test-update-organization", false);
 
         Identifier identifier = new Identifier();
         identifier.setSystem(DPCIdentifierSystem.NPPES.getSystem());

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/EndpointEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/EndpointEntity.java
@@ -112,6 +112,17 @@ public class EndpointEntity implements Serializable {
         this.validationMessage = validationMessage;
     }
 
+    public EndpointEntity update(EndpointEntity endpointEntity) {
+        this.setName(endpointEntity.getName());
+        this.setAddress(endpointEntity.getAddress());
+        this.setConnectionType(endpointEntity.getConnectionType());
+        this.setStatus(endpointEntity.getStatus());
+        this.setValidationMessage(endpointEntity.getValidationMessage());
+        this.setValidationStatus(endpointEntity.getValidationStatus());
+
+        return this;
+    }
+
     @Embeddable
     public static class ConnectionType implements Serializable {
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
@@ -104,6 +104,10 @@ public class OrganizationEntity implements Serializable, FHIRConvertable<Organiz
         this.endpoints = endpoints;
     }
 
+    public void addEndpoint(EndpointEntity endpoint) {
+        this.endpoints.add(endpoint);
+    }
+
     public List<ProviderEntity> getProviders() {
         return providers;
     }
@@ -219,6 +223,7 @@ public class OrganizationEntity implements Serializable, FHIRConvertable<Organiz
         this.setOrganizationName(updated.getOrganizationName());
         this.setOrganizationAddress(updated.getOrganizationAddress());
         this.setContacts(updated.getContacts());
+        this.setEndpoints(updated.getEndpoints());
         this.setPatients(updated.getPatients());
         this.setProviders(updated.getProviders());
 

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/converters/entities/EndpointEntityConverter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/converters/entities/EndpointEntityConverter.java
@@ -23,7 +23,7 @@ public class EndpointEntityConverter {
 
         endpoint.setId(new IdType("Endpoint", entity.getId().toString()));
         endpoint.setName(entity.getName());
-        endpoint.setAddress(endpoint.getAddress());
+        endpoint.setAddress(entity.getAddress());
 
         endpoint.setManagingOrganization(new Reference(new IdType("Organization", entity.getOrganization().getId().toString())));
         endpoint.setStatus(entity.getStatus());

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/profiles/EndpointProfile.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/profiles/EndpointProfile.java
@@ -1,7 +1,7 @@
 package gov.cms.dpc.fhir.validations.profiles;
 
 public class EndpointProfile implements IProfileLoader {
-    public static String PROFILE_URI = "https://dpc.cms.gov/api/v1/StructureDefinition/dpc-profile-endpoint";
+    public static final String PROFILE_URI = "https://dpc.cms.gov/api/v1/StructureDefinition/dpc-profile-endpoint";
 
     @Override
     public String getPath() {

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/OrganizationHelpers.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/OrganizationHelpers.java
@@ -2,9 +2,7 @@ package gov.cms.dpc.testing;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Organization;
-import org.hl7.fhir.dstu3.model.Parameters;
+import org.hl7.fhir.dstu3.model.*;
 
 import java.io.InputStream;
 

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/OrganizationFactory.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/OrganizationFactory.java
@@ -52,4 +52,13 @@ public class OrganizationFactory {
         endpoint.setStatus(Endpoint.EndpointStatus.ACTIVE);
         return endpoint;
     }
+
+    public static Endpoint createValidFakeEndpoint() {
+        Endpoint endpoint = createFakeEndpoint();
+        endpoint.setId((String)null);
+        endpoint.setName("Fake Endpoint");
+        endpoint.setManagingOrganization(new Reference(new IdType("Organization", "46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0")));
+        endpoint.setAddress("http://www.example.com/endpoint");
+        return endpoint;
+    }
 }

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/OrganizationFactory.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/OrganizationFactory.java
@@ -61,4 +61,10 @@ public class OrganizationFactory {
         endpoint.setAddress("http://www.example.com/endpoint");
         return endpoint;
     }
+
+    public static Endpoint createValidFakeEndpoint(String organizationId) {
+        Endpoint endpoint = createValidFakeEndpoint();
+        endpoint.setManagingOrganization(new Reference(new IdType("Organization", organizationId)));
+        return endpoint;
+    }
 }

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1090,7 +1090,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint Update\",\n\t\"address\": \"http://www.example.com/endpoint\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t},\n\t\"payloadType\": [\n\t\t{\n\t\t\t\"coding\": {\n\t\t\t\t\"code\": setCode(\"test\"),\n\t\t\t\t\"system\": \"http://www.example.com/test\"\n\t\t\t}\n\t\t}\n\t]\n}\n    "
+							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint Update\",\n\t\"address\": \"http://www.example.com/endpoint\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"Organization/{{organization_id}}\"\n\t},\n\t\"payloadType\": [\n\t\t{\n\t\t\t\"coding\": {\n\t\t\t\t\"code\": \"test\",\n\t\t\t\t\"system\": \"http://www.example.com/test\"\n\t\t\t}\n\t\t}\n\t]\n}\n    "
 						},
 						"url": {
 							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint/{{endpoint_id}}",

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -138,7 +138,7 @@
 									"    var respJson = pm.response.json();",
 									"    pm.expect(respJson.name).equals(\"Test Organization Endpoint\");",
 									"    pm.expect(respJson.status).equals(\"test\");",
-									"    pm.expect(respJson.address).equals(\"http://www.example.com/endpoint\");",
+									"    pm.expect(respJson.address).equals(\"http://test-address.nope\");",
 									"    pm.expect(respJson.connectionType.system).equals(\"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\");",
 									"    pm.expect(respJson.connectionType.code).equals(\"hl7-fhir-rest\");",
 									"});"

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -74,6 +74,53 @@
 						"description": "Create a default organization to run the tests with.\n\nThese organizations are normally created by the DPC team and are pre-existing."
 					},
 					"response": []
+				},
+				{
+					"name": "Create endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b30d587b-5747-4b41-9325-0a868e56210a",
+								"exec": [
+									"pm.test(\"Status is 201 Created\", function () {",
+									"    pm.expect(pm.response.code).equals(201);",
+									"});",
+									"",
+									"pm.globals.set(\"endpoint_id\", pm.response.json().id);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/fhir+json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://test-address.nope\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t}\n}\n    "
+						},
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Endpoint"
+							]
+						}
+					},
+					"response": []
 				}
 			],
 			"protocolProfileBehavior": {}
@@ -963,15 +1010,15 @@
 					"response": []
 				},
 				{
-					"name": "Create endpoint",
+					"name": "Update endpoint",
 					"event": [
 						{
 							"listen": "test",
 							"script": {
 								"id": "b30d587b-5747-4b41-9325-0a868e56210a",
 								"exec": [
-									"pm.test(\"Status is 201 Created\", function () {",
-									"    pm.expect(pm.response.code).equals(201);",
+									"pm.test(\"Status is OK\", function () {",
+									"    pm.response.to.be.ok;",
 									"});"
 								],
 								"type": "text/javascript"
@@ -979,21 +1026,21 @@
 						}
 					],
 					"request": {
-						"method": "POST",
+						"method": "PUT",
 						"header": [
 							{
 								"key": "Content-Type",
 								"name": "Content-Type",
-								"value": "application/fhir+json",
-								"type": "text"
+								"type": "text",
+								"value": "application/fhir+json"
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://test-address.nope\"\n}\n    "
+							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://www.example.com/endpoint\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t}\n}\n    "
 						},
 						"url": {
-							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint",
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint/{{endpoint_id}}",
 							"protocol": "http",
 							"host": [
 								"{{hostname}}"
@@ -1001,7 +1048,8 @@
 							"port": "{{api_port}}",
 							"path": [
 								"v1",
-								"Endpoint"
+								"Endpoint",
+								"{{endpoint_id}}"
 							]
 						}
 					},
@@ -1228,6 +1276,48 @@
 							]
 						},
 						"description": "When a provider is deleted their patient roster is removed as well."
+					},
+					"response": []
+				},
+				{
+					"name": "Delete endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b30d587b-5747-4b41-9325-0a868e56210a",
+								"exec": [
+									"pm.test(\"Status is OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/fhir+json"
+							}
+						],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint/{{endpoint_id}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Endpoint",
+								"{{endpoint_id}}"
+							]
+						}
 					},
 					"response": []
 				}

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "665bcdc6-0a21-450f-b41a-6e61a5076cfc",
+		"_postman_id": "80645c4c-5755-4dd4-9d38-29e42eb77ae8",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -914,7 +914,7 @@
 								"id": "96f38c80-8b9d-4761-b66c-a02bd1de7408",
 								"exec": [
 									"pm.test(\"Status is OK\", function () {",
-									"    pm.response.to.have.be.ok;",
+									"    pm.response.to.be.ok;",
 									"});",
 									"",
 									"pm.test(\"Body matches expected response\", function() {",
@@ -957,6 +957,51 @@
 								"v1",
 								"Organization",
 								"{{organization_id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b30d587b-5747-4b41-9325-0a868e56210a",
+								"exec": [
+									"pm.test(\"Status is 201 Created\", function () {",
+									"    pm.expect(pm.response.code).equals(201);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/fhir+json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://test-address.nope\"\n}\n    "
+						},
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Endpoint"
 							]
 						}
 					},

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "80645c4c-5755-4dd4-9d38-29e42eb77ae8",
+		"_postman_id": "c51ecc99-c009-4f7b-8067-8c73e371e97f",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -105,15 +105,15 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://test-address.nope\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t},\n\t\"payloadType\": [\n\t\t{\n\t\t\t\"coding\": {\n\t\t\t\t\"code\": setCode(\"test\"),\n\t\t\t\t\"system\": \"http://www.example.com/test\"\n\t\t\t}\n\t\t}\n\t]\n}\n    "
+							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://test-address.nope\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t},\n\t\"payloadType\": [\n\t\t{\n\t\t\t\"coding\": {\n\t\t\t\t\"code\": \"test\",\n\t\t\t\t\"system\": \"http://www.example.com/test\"\n\t\t\t}\n\t\t}\n\t]\n}\n    "
 						},
 						"url": {
-							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint",
+							"raw": "http://{{hostname}}:{{attribution_port}}/v1/Endpoint",
 							"protocol": "http",
 							"host": [
 								"{{hostname}}"
 							],
-							"port": "{{api_port}}",
+							"port": "{{attribution_port}}",
 							"path": [
 								"v1",
 								"Endpoint"

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -105,7 +105,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://test-address.nope\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t}\n}\n    "
+							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://test-address.nope\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t},\n\t\"payloadType\": [\n\t\t{\n\t\t\t\"coding\": {\n\t\t\t\t\"code\": setCode(\"test\"),\n\t\t\t\t\"system\": \"http://www.example.com/test\"\n\t\t\t}\n\t\t}\n\t]\n}\n    "
 						},
 						"url": {
 							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint",
@@ -117,6 +117,50 @@
 							"path": [
 								"v1",
 								"Endpoint"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get endpoint",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "50437cf8-aaf6-4f9b-9e40-4ea50c788820",
+								"exec": [
+									"pm.test(\"Status is OK\", function () {",
+									"    pm.response.to.be.ok;",
+									"});",
+									"",
+									"pm.test(\"Body matches expected response\", function() {",
+									"    var respJson = pm.response.json();",
+									"    pm.expect(respJson.name).equals(\"Test Organization Endpoint\");",
+									"    pm.expect(respJson.status).equals(\"test\");",
+									"    pm.expect(respJson.address).equals(\"http://www.example.com/endpoint\");",
+									"    pm.expect(respJson.connectionType.system).equals(\"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\");",
+									"    pm.expect(respJson.connectionType.code).equals(\"hl7-fhir-rest\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint/{{endpoint_id}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Endpoint",
+								"{{endpoint_id}}"
 							]
 						}
 					},
@@ -1019,6 +1063,15 @@
 								"exec": [
 									"pm.test(\"Status is OK\", function () {",
 									"    pm.response.to.be.ok;",
+									"});",
+									"",
+									"pm.test(\"Body matches expected response\", function() {",
+									"    var respJson = pm.response.json();",
+									"    pm.expect(respJson.name).equals(\"Test Organization Endpoint Update\");",
+									"    pm.expect(respJson.status).equals(\"test\");",
+									"    pm.expect(respJson.address).equals(\"http://www.example.com/endpoint\");",
+									"    pm.expect(respJson.connectionType.system).equals(\"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\");",
+									"    pm.expect(respJson.connectionType.code).equals(\"hl7-fhir-rest\");",
 									"});"
 								],
 								"type": "text/javascript"
@@ -1037,7 +1090,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint\",\n\t\"address\": \"http://www.example.com/endpoint\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t}\n}\n    "
+							"raw": "{\n\t\"resourceType\": \"Endpoint\",\n\t\"status\": \"test\",\n\t\"connectionType\": {\n\t\t\"system\": \"http://terminology.hl7.org/CodeSystem/endpoint-connection-type\",\n\t\t\"code\": \"hl7-fhir-rest\"\n\t},\n\t\"name\": \"Test Organization Endpoint Update\",\n\t\"address\": \"http://www.example.com/endpoint\",\n\t\"managingOrganization\": {\n\t\t\"reference\": \"{{organization_id}}\"\n\t},\n\t\"payloadType\": [\n\t\t{\n\t\t\t\"coding\": {\n\t\t\t\t\"code\": setCode(\"test\"),\n\t\t\t\t\"system\": \"http://www.example.com/test\"\n\t\t\t}\n\t\t}\n\t]\n}\n    "
 						},
 						"url": {
 							"raw": "http://{{hostname}}:{{api_port}}/v1/Endpoint/{{endpoint_id}}",


### PR DESCRIPTION
**Why**
Endpoints can be created as part of an Organization or read directly, but cannot be created separately, updated, or deleted.

**What Changed**
This branch adds create, update, and delete operations for Endpoint resources in dpc-attribution and dpc-api.

**Tickets closed**:
[DPC-857](https://jiraent.cms.gov/browse/DPC-857)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
