### PR TITLE
Fix auth misinformation in reference.md

### DIFF
--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -394,7 +394,7 @@ This token must be signed with a public key previously registered and contain th
 
 **Authentication JWT Header Values**
 
-`alg`	_required_	- The JWA algorithm (e.g., `RS384`, `EC384`) used for signing the authentication JWT. (DPC only supports RS384)
+`alg`	_required_	- Fixed value: RSA384
 
 `kid`   _required_	- The identifier of the key-pair used to sign this JWT. This must be the ID of a previously registered public key
 
@@ -406,7 +406,7 @@ This token must be signed with a public key previously registered and contain th
 
 `sub`	_required_	Issuer of the JWT -- the `client_token` provided by DPC (note that this is the same as the value for the `iss` claim)
 
-`aud`	_required_	The DPC "token URL" (the same URL to which this authentication JWT will be posted. e.g. https://sandbox.dpc.cms.gov/api/v1/Token/auth)
+`aud`	_required_	The DPC "token URL" (the same URL to which this authentication JWT will be posted. e.g. https://dpc.cms.gov/api/v1/Token/auth)
 
 `exp`	_required_	Expiration time integer for this authentication JWT, expressed in seconds since the "Epoch" (1970-01-01T00:00:00Z UTC). This time SHALL be no more than five minutes in the future.
 

--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -331,7 +331,7 @@ This endpoint requires one additional query param:
 The submitted public key must meet the following requirements:
 
 * Be an `RSA` key (ECC keys will be supported in a future release)
-* Have a key length of at least 3072 bits
+* Have a key length of at least 4096 bits
 * Be unique to each environment
 
 ~~~sh
@@ -433,7 +433,7 @@ POST /api/v1/Token/auth
 **cURL command**
 
 ~~~sh
-curl -v https://sandbox.dpc.cms.gov/api/v1/Token/auth?grant_type=client_credentials&scope=system%2F*.*&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_asssertions={self-signed JWT} \
+curl -v https://sandbox.dpc.cms.gov/api/v1/Token/auth?grant_type=client_credentials&scope=system%2F*.*&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion={self-signed JWT} \
 -H 'Content-Type: application/x-www-form-urlencoded' \
 -X POST
 ~~~


### PR DESCRIPTION
**Why**

At the FHIR connectathon we had a nightmare of a time getting an organization onboarded, it turns out, it was mostly documentation issues.

**What Changed**

Fix the _client_assertion_ typo in the curl example.

Increase the required key length spec to 4096.

**Choices Made**

Justify changes made and any reasons for why a given path was taken, as opposed to an alternative option.

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additional fixes.

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
