### PR TITLE
DPC-585: Have smoke tests cleanup after themselves

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
@@ -53,7 +53,6 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
         binder.bind(EndpointResource.class);
         binder.bind(GroupResource.class);
         binder.bind(JobResource.class);
-        binder.bind(OrganizationResource.class);
         binder.bind(PatientResource.class);
         binder.bind(PractitionerResource.class);
 
@@ -96,6 +95,16 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
                                 this.getConfiguration().getTokenPolicy(),
                                 resolver,
                                 cache, publicURL});
+    }
+
+    @Provides
+    public OrganizationResource provideOrganizationResource(IGenericClient client, TokenDAO tokenDAO, PublicKeyDAO keyDAO) {
+        return new UnitOfWorkAwareProxyFactory(authHibernateBundle)
+                .create(OrganizationResource.class,
+                        new Class<?>[]{IGenericClient.class,
+                        TokenDAO.class,
+                        PublicKeyDAO.class},
+                        new Object[]{client, tokenDAO, keyDAO});
     }
 
     @Provides

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
@@ -7,10 +7,8 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Organization;
 
 import javax.validation.Valid;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
 import java.util.UUID;
 
 @Path("/Organization")
@@ -24,6 +22,10 @@ public abstract class AbstractOrganizationResource {
     @GET
     @Path("/{organizationID}")
     public abstract Organization getOrganization(UUID organizationID);
+
+    @DELETE
+    @Path("/{organizationID}")
+    public abstract Response deleteOrganization(UUID organizationID);
 
     @PUT
     @Path("/{organizationID}")

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractOrganizationResource.java
@@ -7,6 +7,7 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Organization;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
@@ -17,17 +18,17 @@ public abstract class AbstractOrganizationResource {
 
     @POST
     @Path("/$submit")
-    public abstract Organization submitOrganization(Bundle organizationBundle);
+    public abstract Organization submitOrganization(@NotNull Bundle organizationBundle);
 
     @GET
     @Path("/{organizationID}")
-    public abstract Organization getOrganization(UUID organizationID);
+    public abstract Organization getOrganization(@NotNull UUID organizationID);
 
     @DELETE
     @Path("/{organizationID}")
-    public abstract Response deleteOrganization(UUID organizationID);
+    public abstract Response deleteOrganization(@NotNull UUID organizationID);
 
     @PUT
     @Path("/{organizationID}")
-    public abstract Organization updateOrganization(UUID organizationID, @Valid @Profiled(profile = OrganizationProfile.PROFILE_URI) Organization organization);
+    public abstract Organization updateOrganization(@NotNull UUID organizationID, @Valid @Profiled(profile = OrganizationProfile.PROFILE_URI) Organization organization);
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
@@ -19,6 +19,7 @@ import org.hl7.fhir.dstu3.model.*;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.util.List;
@@ -49,7 +50,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @ApiOperation(hidden = true, value = "Create organization by submitting Bundle")
     @AdminOperation
     @Override
-    public Organization submitOrganization(@FHIRParameter(name = "resource") Bundle organizationBundle) {
+    public Organization submitOrganization(@FHIRParameter(name = "resource") @NotNull Bundle organizationBundle) {
         // Validate bundle
         validateOrganizationBundle(organizationBundle);
 
@@ -77,7 +78,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
             authorizations = @Authorization(value = "apiKey"))
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "An organization is only allowed to see their own Organization resource")})
-    public Organization getOrganization(@PathParam("organizationID") UUID organizationID) {
+    public Organization getOrganization(@NotNull @PathParam("organizationID") UUID organizationID) {
         return this.client
                 .read()
                 .resource(Organization.class)
@@ -93,8 +94,14 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @ExceptionMetered
     @AdminOperation
     @UnitOfWork
+    @ApiOperation(value = "Delete Organization",
+            notes = "FHIR endpoint which removes the organization currently registered with the application.\n" +
+                    "This also removes all associated resources",
+            authorizations = @Authorization(value = "apiKey"))
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Cannot find organization to remove")})
     @Override
-    public Response deleteOrganization(@PathParam("organizationID") UUID organizationID) {
+    public Response deleteOrganization(@NotNull @PathParam("organizationID") UUID organizationID) {
         // Delete from the attribution service
         this.client
                 .delete()
@@ -130,7 +137,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
             @ApiResponse(code = 422, message = "Provided resource is not a valid FHIR Organization")
     })
     @Override
-    public Organization updateOrganization(@PathParam("organizationID") UUID organizationID, @Valid @Profiled(profile = OrganizationProfile.PROFILE_URI) Organization organization) {
+    public Organization updateOrganization(@NotNull @PathParam("organizationID") UUID organizationID, @Valid @Profiled(profile = OrganizationProfile.PROFILE_URI) Organization organization) {
         MethodOutcome outcome = this.client
                 .update()
                 .resource(organization)

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
@@ -4,18 +4,36 @@ import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
+import ca.uhn.fhir.rest.gclient.IReadExecutable;
 import ca.uhn.fhir.rest.gclient.IUpdateTyped;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.nitram509.jmacaroons.Macaroon;
+import com.github.nitram509.jmacaroons.MacaroonVersion;
+import com.github.nitram509.jmacaroons.MacaroonsBuilder;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
+import gov.cms.dpc.api.entities.PublicKeyEntity;
+import gov.cms.dpc.api.entities.TokenEntity;
+import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
+import gov.cms.dpc.macaroons.MacaroonBakery;
 import gov.cms.dpc.testing.APIAuthHelpers;
-import gov.cms.dpc.testing.factories.OrganizationFactory;
 import gov.cms.dpc.testing.OrganizationHelpers;
+import gov.cms.dpc.testing.factories.OrganizationFactory;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.assertj.core.util.Lists;
-import org.hl7.fhir.dstu3.model.*;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Endpoint;
+import org.hl7.fhir.dstu3.model.Organization;
+import org.hl7.fhir.dstu3.model.Parameters;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -25,12 +43,15 @@ import java.security.PrivateKey;
 import java.util.UUID;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
+import static gov.cms.dpc.testing.APIAuthHelpers.TASK_URL;
 import static org.junit.jupiter.api.Assertions.*;
 
 class OrganizationResourceTest extends AbstractSecureApplicationTest {
 
+    private final ObjectMapper mapper;
+
     OrganizationResourceTest() {
-        // not used
+        this.mapper = new ObjectMapper();
     }
 
     @Test
@@ -52,6 +73,7 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
         assertThrows(AuthenticationException.class, () -> OrganizationHelpers.createOrganization(ctx, APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY), UUID.randomUUID().toString(), true));
     }
 
+    @Test
     void testOrganizationFetch() {
 
         final IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
@@ -176,5 +198,80 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
 
         IUpdateTyped update = org2Client.update().resource(organization);
         assertThrows(AuthenticationException.class, update::execute);
+    }
+
+    @Test
+    void testOrganizationDeletion() throws IOException, URISyntaxException, NoSuchAlgorithmException {
+//        // Generate a golden macaroon
+        final UUID orgDeletionID = UUID.randomUUID();
+        final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
+        FHIRHelpers.registerOrganization(attrClient, ctx.newJsonParser(), orgDeletionID.toString(), TASK_URL);
+
+        // Register Public key
+        APIAuthHelpers.generateAndUploadKey("org-deletion-key", orgDeletionID.toString(), GOLDEN_MACAROON, "http://localhost:3002/v1/");
+        final IGenericClient client = APIAuthHelpers.buildAdminClient(ctx, getBaseURL(), GOLDEN_MACAROON, false);
+
+        // Delegate the Macaroon
+        final Macaroon macaroon = MacaroonBakery.deserializeMacaroon(GOLDEN_MACAROON).get(0);
+        final String delegatedMacaroon = MacaroonsBuilder.modify(macaroon)
+                .add_first_party_caveat(String.format("organization_id = %s", orgDeletionID.toString()))
+                .getMacaroon()
+                .serialize(MacaroonVersion.SerializationVersion.V2_JSON);
+
+        // Verify the delegated token works
+        final CollectionResponse<TokenEntity> tokens = fetchTokens(delegatedMacaroon);
+        assertEquals(1, tokens.getEntities().size(), "Should have access token");
+
+        final CollectionResponse<PublicKeyEntity> keys = fetchKeys(delegatedMacaroon);
+        assertEquals(1, keys.getEntities().size(), "Should have public key");
+
+
+        // Now, delete it
+        client
+                .delete()
+                .resourceById("Organization", orgDeletionID.toString())
+                .encodedJson()
+                .execute();
+
+        // Ensure it actually is gone
+        final IReadExecutable<Organization> readRequest = client
+                .read()
+                .resource(Organization.class)
+                .withId(orgDeletionID.toString())
+                .encodedJson();
+
+        assertThrows(AuthenticationException.class, readRequest::execute, "Should not have organization");
+
+        // Look for tokens that might exist
+
+        final CollectionResponse<TokenEntity> emptyTokens = fetchTokens(delegatedMacaroon);
+        assertTrue(emptyTokens.getEntities().isEmpty(), "Should not have access tokens");
+
+        final CollectionResponse<PublicKeyEntity> emptyKeys = fetchKeys(delegatedMacaroon);
+        assertTrue(emptyKeys.getEntities().isEmpty(), "Should not have keys");
+    }
+
+    CollectionResponse<TokenEntity> fetchTokens(String token) throws IOException {
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getBaseURL() + "/Token");
+            httpGet.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", token));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                return this.mapper.readValue(response.getEntity().getContent(), new TypeReference<CollectionResponse<TokenEntity>>() {
+                });
+            }
+        }
+    }
+
+    CollectionResponse<PublicKeyEntity> fetchKeys(String token) throws IOException {
+        try (final CloseableHttpClient client = HttpClients.createDefault()) {
+            final HttpGet httpGet = new HttpGet(getBaseURL() + "/Key");
+            httpGet.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", token));
+
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
+                return this.mapper.readValue(response.getEntity().getContent(), new TypeReference<CollectionResponse<PublicKeyEntity>>() {
+                });
+            }
+        }
     }
 }

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.attribution.resources;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.gclient.IUpdateTyped;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
@@ -9,13 +10,16 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import gov.cms.dpc.attribution.AbstractAttributionTest;
 import gov.cms.dpc.attribution.AttributionTestHelpers;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
+import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.testing.OrganizationHelpers;
 import org.hl7.fhir.dstu3.model.*;
 import org.junit.jupiter.api.Test;
 
 import java.sql.Date;
 import java.util.Arrays;
+import java.util.Collections;
 
+import static gov.cms.dpc.common.utils.SeedProcessor.createBaseAttributionGroup;
 import static org.junit.jupiter.api.Assertions.*;
 
 class OrganizationResourceTest extends AbstractAttributionTest {
@@ -81,8 +85,22 @@ class OrganizationResourceTest extends AbstractAttributionTest {
         final Patient createdPatient = (Patient) patCreated.getResource();
         assertTrue(patCreated.getCreated(), "Should have been created");
 
-        // Then delete the organization
+        // Attribute them
+        final Group newRoster = createBaseAttributionGroup(FHIRExtractors.getProviderNPI(createdPractitioner), organization.getIdElement().getIdPart());
+        final Reference patientReference = new Reference(createdPatient.getId());
+        newRoster.addMember().setEntity(patientReference);
 
+        final Parameters addParam = new Parameters();
+        addParam.addParameter().setResource(newRoster);
+
+        // Update the roster
+        client
+                .create()
+                .resource(newRoster)
+                .encodedJson()
+                .execute();
+
+        // Then delete the organization
         client
                 .delete()
                 .resourceById(new IdType(organization.getId()))
@@ -90,7 +108,6 @@ class OrganizationResourceTest extends AbstractAttributionTest {
                 .execute();
 
         // Try to read the resources, should get 404s
-
         assertThrows(ResourceNotFoundException.class, () -> client
                 .read()
                 .resource(Patient.class)
@@ -121,7 +138,7 @@ class OrganizationResourceTest extends AbstractAttributionTest {
         Identifier identifier = new Identifier();
         identifier.setSystem(DPCIdentifierSystem.NPPES.getSystem());
         identifier.setValue("UPDATED012345");
-        organization.setIdentifier(Arrays.asList(identifier));
+        organization.setIdentifier(Collections.singletonList(identifier));
         organization.setName("An Updated Organization");
 
         MethodOutcome outcome = client.update().resource(organization).execute();
@@ -140,7 +157,7 @@ class OrganizationResourceTest extends AbstractAttributionTest {
         identifier.setSystem(DPCIdentifierSystem.NPPES.getSystem());
         identifier.setValue("org-update-npi-duplicate1");
 
-        organization2.setIdentifier(Arrays.asList(identifier));
+        organization2.setIdentifier(Collections.singletonList(identifier));
         IUpdateTyped update = client.update().resource(organization2);
         assertThrows(InvalidRequestException.class, update::execute);
     }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java
@@ -52,6 +52,9 @@ public class OrganizationEntity implements Serializable, FHIRConvertable<Organiz
     @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "organization")
     private List<PatientEntity> patients;
 
+    @OneToMany(cascade = CascadeType.REMOVE, mappedBy = "managingOrganization")
+    private List<RosterEntity> rosters;
+
     public OrganizationEntity() {
         // Not used
     }
@@ -118,6 +121,14 @@ public class OrganizationEntity implements Serializable, FHIRConvertable<Organiz
 
     public void setPatients(List<PatientEntity> patients) {
         this.patients = patients;
+    }
+
+    public List<RosterEntity> getRosters() {
+        return rosters;
+    }
+
+    public void setRosters(List<RosterEntity> rosters) {
+        this.rosters = rosters;
     }
 
     @Override

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/ProviderEntity.java
@@ -45,8 +45,7 @@ public class ProviderEntity implements Serializable {
             })
     private List<PatientEntity> attributedPatients;
 
-    @OneToMany
-    @JoinColumn(name = "provider_id", referencedColumnName = "id")
+    @OneToMany(cascade = CascadeType.REMOVE, orphanRemoval = true, mappedBy = "attributedProvider")
     private List<RosterEntity> attributionRosters;
 
     @Column(name = "created_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -42,12 +42,10 @@ public class SmokeTest extends AbstractJavaSamplerClient {
 
     private FhirContext ctx;
     private String organizationID;
-    private Pair<UUID, PrivateKey> keyTuple;
-    private String clientToken;
     private String goldenMacaroon;
 
     public SmokeTest() {
-        System.out.println("Calling constructor");
+        // Not used
     }
 
     @Override
@@ -105,7 +103,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         logger.info("Running with {} threads", JMeterContextService.getNumberOfThreads());
 
         this.organizationID = javaSamplerContext.getParameter("organization-id");
-        this.clientToken = javaSamplerContext.getParameter("client-token");
+        String clientToken = javaSamplerContext.getParameter("client-token");
         String privateKeyPath = javaSamplerContext.getParameter("private-key");
         final String keyID = javaSamplerContext.getParameter("key-id");
 
@@ -121,6 +119,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         ctx.getRestfulClientFactory().setConnectTimeout(1800);
 
         // If we're not supplied all the init parameters, create a new org
+        Pair<UUID, PrivateKey> keyTuple;
         if (organizationID.equals("") || clientToken.equals("") || privateKeyPath.equals("") || keyID.equals("")) {
             this.organizationID = UUID.randomUUID().toString();
 
@@ -150,7 +149,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
 
             // Create a new public key
             try {
-                this.keyTuple = APIAuthHelpers.generateAndUploadKey(KEY_ID, organizationID, goldenMacaroon, hostParam);
+                keyTuple = APIAuthHelpers.generateAndUploadKey(KEY_ID, organizationID, goldenMacaroon, hostParam);
             } catch (IOException | NoSuchAlgorithmException | URISyntaxException e) {
                 throw new IllegalStateException("Failed uploading public key", e);
             }
@@ -165,7 +164,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
                 if (privateKey == null) {
                     throw new IllegalStateException("Key cannot be null");
                 }
-                this.keyTuple = Pair.of(UUID.fromString(keyID), privateKey);
+                keyTuple = Pair.of(UUID.fromString(keyID), privateKey);
             } catch (IOException e) {
                 throw new IllegalArgumentException(String.format("Cannot read private key from: %s", privateKeyPath));
             }


### PR DESCRIPTION
**Why**

Each time the smoke tests run (and on each iteration), they create a new organization to test with. This means that we have a bunch of fake organizations left over in the database which makes it difficult to see what actually is real or fake, plus it takes up space in the DB.

**What Changed**

Added a teardown task to the JMeter test script which removes the organization when the test run terminates, regardless of whether or not the test passed or failed.

This revealed some issues with our current org deletion logic which meant we couldn't actually clean anything up.

I updated some of the Hibernate entities to ensure that they cascade deletions correctly, also verified that removing patients does not remove any of the groups they're a part of, it just removes them from the member list.

**Choices Made**

**Tickets closed**:

DPC-585: Cleanup after smoke tests

**Future Work**

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
