### PR TITLE
Remove Bootstrap: We are not using it

### DIFF
--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -17,7 +17,6 @@ gem 'rouge-rails'
 gem 'kramdown', '~> 2.1'
 
 gem 'jquery-rails'
-gem 'bootstrap'
 gem 'devise'
 gem 'brakeman'
 gem 'health_check'

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -51,16 +51,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.6.0)
-      execjs
     bcrypt (3.1.13)
     bindex (0.7.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
-    bootstrap (4.3.1)
-      autoprefixer-rails (>= 9.1.0)
-      popper_js (>= 1.14.3, < 2)
-      sassc-rails (>= 2.0.0)
     brakeman (4.7.2)
     builder (3.2.3)
     bundler-audit (0.6.1)
@@ -205,7 +199,6 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
-    popper_js (1.14.5)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -353,7 +346,6 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   bootsnap (>= 1.1.0)
-  bootstrap
   brakeman
   bundler-audit
   byebug


### PR DESCRIPTION
**Why**

We don't use this so let's prune it. 

**What Changed**

Remove bootstrap gem. 

**Choices Made**

Unnecessary. I did a quick click-through locally to confirm no UI changes. We never included the bootstrap assets in the app/assets dir so never even loaded them. 

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additional fixes.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
