### PR TITLE
DPC-247: New Relic APM for DPC services

### DIFF
--- a/dpc-aggregation/docker/entrypoint.sh
+++ b/dpc-aggregation/docker/entrypoint.sh
@@ -21,7 +21,11 @@ if [ -n "$BOOTSTRAP" ]; then
   bootstrap_config
 fi
 
-CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.aggregation.DPCAggregationService"
+if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
+    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.aggregation.DPCAggregationService"
+else
+    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.aggregation.DPCAggregationService"
+fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"

--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -113,9 +113,8 @@
         <dependency>
             <groupId>com.newrelic.agent.java</groupId>
             <artifactId>newrelic-java</artifactId>
-            <version>5.8.0</version>
-            <scope>provided</scope>
-            <type>zip</type>
+            <version>${newrelic.agent.version}</version>
+            <type>${newrelic.agent.type}</type>
         </dependency>
     </dependencies>
 
@@ -187,24 +186,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>unpack-newrelic</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
-                            <includeArtifactIds>newrelic-java</includeArtifactIds>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>

--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -110,6 +110,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.newrelic.agent.java</groupId>
+            <artifactId>newrelic-java</artifactId>
+            <version>5.8.0</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -178,6 +185,28 @@
             </plugin>
             <!-- For building docker image -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-newrelic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
+                            <includeArtifactIds>newrelic-java</includeArtifactIds>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
@@ -186,6 +215,7 @@
                             <path>${project.basedir}/../bbcerts</path>
                             <path>${project.basedir}/target/jacoco-agent</path>
                             <path>${project.basedir}/docker</path>
+                            <path>${project.basedir}/target/newrelic-agent</path>
                         </paths>
                         <permissions>
                             <permission>

--- a/dpc-api/docker/entrypoint.sh
+++ b/dpc-api/docker/entrypoint.sh
@@ -21,7 +21,11 @@ if [ -n "$BOOTSTRAP" ]; then
   bootstrap_config
 fi
 
-CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.api.DPCAPIService"
+if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
+    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.api.DPCAPIService"
+else
+    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.api.DPCAPIService"
+fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -144,6 +144,12 @@
             <artifactId>caffeine</artifactId>
             <version>2.8.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.newrelic.agent.java</groupId>
+            <artifactId>newrelic-java</artifactId>
+            <version>${newrelic.agent.version}</version>
+            <type>${newrelic.agent.type}</type>
+        </dependency>
         <!--Test resources-->
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -175,13 +181,6 @@
                     <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.newrelic.agent.java</groupId>
-            <artifactId>newrelic-java</artifactId>
-            <version>5.8.0</version>
-            <scope>provided</scope>
-            <type>zip</type>
         </dependency>
     </dependencies>
 
@@ -254,24 +253,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>unpack-newrelic</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
-                            <includeArtifactIds>newrelic-java</includeArtifactIds>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -176,6 +176,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.newrelic.agent.java</groupId>
+            <artifactId>newrelic-java</artifactId>
+            <version>5.8.0</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -245,6 +252,28 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-newrelic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
+                            <includeArtifactIds>newrelic-java</includeArtifactIds>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
@@ -265,6 +294,7 @@
                             <path>${project.basedir}/target/jacoco-agent</path>
                             <path>${project.basedir}/docker</path>
                             <path>${project.basedir}/../src/main/resources/keypair</path>
+                            <path>${project.basedir}/target/newrelic-agent</path>
                         </paths>
                         <permissions>
                             <permission>

--- a/dpc-attribution/docker/entrypoint.sh
+++ b/dpc-attribution/docker/entrypoint.sh
@@ -8,7 +8,11 @@ else
   JACOCO=""
 fi
 
-CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.attribution.DPCAttributionService"
+if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
+    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.attribution.DPCAttributionService"
+else
+    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.attribution.DPCAttributionService"
+fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -74,6 +74,12 @@
             <groupId>com.smoketurner</groupId>
             <artifactId>dropwizard-swagger</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.newrelic.agent.java</groupId>
+            <artifactId>newrelic-java</artifactId>
+            <version>${newrelic.agent.version}</version>
+            <type>${newrelic.agent.type}</type>
+        </dependency>
         <!--Testing dependencies-->
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -96,13 +102,6 @@
             <groupId>${hapi.fhir.groupID}</groupId>
             <artifactId>hapi-fhir-client</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.newrelic.agent.java</groupId>
-            <artifactId>newrelic-java</artifactId>
-            <version>5.8.0</version>
-            <scope>provided</scope>
-            <type>zip</type>
         </dependency>
     </dependencies>
 
@@ -177,24 +176,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>unpack-newrelic</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
-                            <includeArtifactIds>newrelic-java</includeArtifactIds>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -97,6 +97,13 @@
             <artifactId>hapi-fhir-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.newrelic.agent.java</groupId>
+            <artifactId>newrelic-java</artifactId>
+            <version>5.8.0</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -168,6 +175,28 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-newrelic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
+                            <includeArtifactIds>newrelic-java</includeArtifactIds>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
@@ -188,6 +217,7 @@
                         <paths>
                             <path>${project.basedir}/docker</path>
                             <path>${project.basedir}/target/jacoco-agent</path>
+                            <path>${project.basedir}/target/newrelic-agent</path>
                         </paths>
                         <permissions>
                             <permission>

--- a/dpc-consent/docker/entrypoint.sh
+++ b/dpc-consent/docker/entrypoint.sh
@@ -8,7 +8,11 @@ else
   JACOCO=""
 fi
 
-CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.consent.DPCConsentService"
+if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
+    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.consent.DPCConsentService"
+else
+    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.consent.DPCConsentService"
+fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"

--- a/dpc-consent/pom.xml
+++ b/dpc-consent/pom.xml
@@ -127,9 +127,8 @@
         <dependency>
             <groupId>com.newrelic.agent.java</groupId>
             <artifactId>newrelic-java</artifactId>
-            <version>5.8.0</version>
-            <scope>provided</scope>
-            <type>zip</type>
+            <version>${newrelic.agent.version}</version>
+            <type>${newrelic.agent.type}</type>
         </dependency>
     </dependencies>
 
@@ -200,24 +199,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.1.1</version>
-                <executions>
-                    <execution>
-                        <id>unpack-newrelic</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
-                            <includeArtifactIds>newrelic-java</includeArtifactIds>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>

--- a/dpc-consent/pom.xml
+++ b/dpc-consent/pom.xml
@@ -124,6 +124,13 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.newrelic.agent.java</groupId>
+            <artifactId>newrelic-java</artifactId>
+            <version>5.8.0</version>
+            <scope>provided</scope>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -191,6 +198,28 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-newrelic</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
+                            <includeArtifactIds>newrelic-java</includeArtifactIds>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <configuration>
@@ -211,6 +240,7 @@
                         <paths>
                             <path>${project.basedir}/docker</path>
                             <path>${project.basedir}/target/jacoco-agent</path>
+                            <path>${project.basedir}/target/newrelic-agent</path>
                         </paths>
                         <permissions>
                             <permission>

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -65,3 +65,5 @@ gem 'octokit'
 gem 'kaminari'
 gem 'active_model_serializers'
 gem 'macaroons'
+
+gem "newrelic_rpm", "~> 6.7"

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -66,4 +66,4 @@ gem 'kaminari'
 gem 'active_model_serializers'
 gem 'macaroons'
 
-gem "newrelic_rpm", "~> 6.7"
+gem 'newrelic_rpm', '~> 6.7'

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -171,6 +171,7 @@ GEM
     multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
+    newrelic_rpm (6.7.0.359)
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
@@ -368,6 +369,7 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.3)
   macaroons
+  newrelic_rpm (~> 6.7)
   octokit
   omniauth-github
   omniauth-rails_csrf_protection (~> 0.1)

--- a/dpc-web/config/newrelic.yml
+++ b/dpc-web/config/newrelic.yml
@@ -1,0 +1,3 @@
+common: &default_settings
+  log_level: info
+  log_file_name: STDOUT

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <jooq.version>3.12.1</jooq.version>
         <bouncey.version>1.64</bouncey.version>
         <pitest.version>1.4.10</pitest.version>
+        <newrelic.agent.version>5.9.0</newrelic.agent.version>
+        <newrelic.agent.type>zip</newrelic.agent.type>
     </properties>
 
     <developers>
@@ -184,6 +186,13 @@
                 <groupId>org.knowm</groupId>
                 <artifactId>dropwizard-sundial</artifactId>
                 <version>1.3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.newrelic.agent.java</groupId>
+                <artifactId>newrelic-java</artifactId>
+                <version>${newrelic.agent.version}</version>
+                <scope>provided</scope>
+                <type>${newrelic.agent.type}</type>
             </dependency>
             <!--Test dependencies-->
             <dependency>
@@ -411,6 +420,28 @@
                     <version>3.8.1</version>
                 </plugin>
                 <!-- Base configuration for Docker images -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <executions>
+                        <execution>
+                            <id>unpack-newrelic</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>unpack-dependencies</goal>
+                            </goals>
+                            <configuration>
+                                <includeGroupIds>com.newrelic.agent.java</includeGroupIds>
+                                <includeArtifactIds>newrelic-java</includeArtifactIds>
+                                <overWriteReleases>false</overWriteReleases>
+                                <overWriteSnapshots>false</overWriteSnapshots>
+                                <overWriteIfNewer>true</overWriteIfNewer>
+                                <outputDirectory>${project.build.directory}/newrelic-agent</outputDirectory>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>

--- a/src/main/resources/newrelic.yml
+++ b/src/main/resources/newrelic.yml
@@ -1,0 +1,76 @@
+common: &default_settings
+  agent_enabled: true
+  app_name: Data at the Point of Care
+  enable_auto_app_naming: false
+  enable_auto_transaction_naming: true
+  log_level: info
+  audit_mode: false
+  log_file_count: 1
+  log_limit_in_kbytes: 0
+  log_daily: false
+  log_file_name: STDOUT
+
+  # Limits the number of lines to capture for each stack trace.
+  # Default is 30
+  max_stack_trace_lines: 100
+
+  # Transaction tracer captures deep information about slow
+  # transactions and sends this to the New Relic service once a
+  # minute. Included in the transaction is the exact call sequence of
+  # the transactions including any SQL statements issued.
+  transaction_tracer:
+    enabled: true
+    transaction_threshold: apdex_f
+    record_sql: obfuscated
+    log_sql: false
+    stack_trace_threshold: 0.5
+    explain_enabled: true
+    explain_threshold: 0.5
+    top_n: 20
+
+  error_collector:
+    enabled: true
+
+    # Use this property to exclude specific exceptions from being reported as errors
+    # by providing a comma separated list of full class names.
+    # The default is to exclude akka.actor.ActorKilledException. If you want to override
+    # this, you must provide any new value as an empty list is ignored.
+    ignore_errors: akka.actor.ActorKilledException
+    ignore_status_codes: 404
+
+  transaction_events:
+    enabled: true
+    max_samples_stored: 2000
+
+  distributed_tracing:
+    enabled: false
+
+  cross_application_tracer:
+    enabled: true
+
+  thread_profiler:
+    enabled: true
+
+  browser_monitoring:
+    auto_instrument: false
+
+  class_transformer:
+    com.newrelic.instrumentation.servlet-user:
+      enabled: false
+
+    com.newrelic.instrumentation.spring-aop-2:
+      enabled: false
+
+    com.newrelic.instrumentation.jdbc-resultset:
+      enabled: false
+
+    # Classes loaded by classloaders in this list will not be instrumented.
+    # This is a useful optimization for runtimes which use classloaders to
+    # load dynamic classes which the agent would not instrument.
+    classloader_excludes:
+      groovy.lang.GroovyClassLoader$InnerLoader,
+      org.codehaus.groovy.runtime.callsite.CallSiteClassLoader,
+      com.collaxa.cube.engine.deployment.BPELClassLoader,
+      org.springframework.data.convert.ClassGeneratingEntityInstantiator$ObjectInstantiatorClassGenerator,
+      org.mvel2.optimizers.impl.asm.ASMAccessorOptimizer$ContextClassLoader,
+      gw.internal.gosu.compiler.SingleServingGosuClassLoader,


### PR DESCRIPTION
**Why**

We intend to use New Relic APM to monitor application performance (e.g., response times, throughput, end-user satisfaction metrics, error types and rates) for the suite of DPC services.

**What Changed**

The New Relic agent has been added as a dependency to each service via the service's respective dependency manager (e.g., pom.xml for Java applications, Gemfile for the website).

At build time, the New Relic agent and associated configuration file (i.e., `newrelic.yml`) are included in the resultant Docker image.

Some notes on ops changes required to use the agent --

The New Relic agent requires environment variables set, including: `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_APP_NAME`.

For Java applications, static value of `/app/resources/newrelic.yml` for env var  `NEW_RELIC_FILE` must be set. Additionally, the `javaagent` flag must be set in the java invocation: `-javaagent:/newrelic/newrelic.jar`.

See also: https://github.com/CMSgov/dpc-ops/pull/112

**Choices Made**

The implementation of these changes follows the instructions/recommendations from New Relic for the [Java](https://docs.newrelic.com/docs/agents/java-agent/installation/install-java-agent) and [Ruby](https://docs.newrelic.com/docs/agents/ruby-agent/installation/install-new-relic-ruby-agent) agents almost exactly.

The most significant design choice/challenge was configuring Java dependencies to avoid unnecessary duplication of knowledge across pom.xml files.

**Related tickets**:

https://jiraent.cms.gov/browse/DPC-247

**Future Work**

Requisite operational changes to be made elsewhere.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
