### PR TITLE
DPC-788: Ability to disable metrics logging

### DIFF
--- a/dpc-aggregation/src/main/resources/prod-sbx.application.conf
+++ b/dpc-aggregation/src/main/resources/prod-sbx.application.conf
@@ -22,4 +22,12 @@ dpc.aggregation {
   }
 
   exportPath = "/app/data"
+
+  metrics {
+    frequency = 1 minute
+    reporters = [{
+      type = log
+      logger = metrics-aggregation
+    }]
+  }
 }

--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -27,4 +27,12 @@ dpc.api {
     attributionURL = "http://backend.dpc-prod-sbx.local:8080/v1/"
     exportPath = "/app/data"
     keyPairLocation = ${BAKERY_KEYPAIR_LOCATION}
+
+    metrics {
+      frequency = 1 minute
+      reporters = [{
+        type = log
+        logger = metrics-api
+      }]
+    }
 }

--- a/dpc-attribution/src/main/resources/prod-sbx.application.conf
+++ b/dpc-attribution/src/main/resources/prod-sbx.application.conf
@@ -12,4 +12,12 @@ dpc.attribution {
       port = 8080
     }]
   }
+
+  metrics {
+    frequency = 1 minute
+    reporters = [{
+      type = log
+      logger = metrics-attribution
+    }]
+  }
 }

--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -48,11 +48,3 @@ logging {
     logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m - organization_id=%X{organization_id}\n){'\n','\r'}\r%replace(%rEx){'\n','\r'}"
   }]
 }
-
-metrics {
-  frequency = 1 minute
-  reporters = [{
-    type = log
-    logger = metrics
-  }]
-}


### PR DESCRIPTION
**Draft.** Removing the metrics properties from server.conf, I was able to enable/disable local metrics logging by configuring it in modules' `local.application.conf` files. Leaving this as a draft for now, since I'm not sure if this fully meets the ticket expectations.

**Why**

Explain the motivation for this PR.

**What Changed**

Describe the changes made to the code base including new features, refactoring of existing services and user visible API changes.

**Choices Made**

Justify changes made and any reasons for why a given path was taken, as opposed to an alternative option.

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

List any additional tickets that have either been created due to work in this PR, or existing tickets that expand upon the feature or provide additional fixes.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
