### PR TITLE
Update access token documentation

### DIFF
--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -394,7 +394,7 @@ This token must be signed with a public key previously registered and contain th
 
 **Authentication JWT Header Values**
 
-`alg`	_required_	- Fixed value: RSA384
+`alg`	_required_	- Fixed value: RS384
 
 `kid`   _required_	- The identifier of the key-pair used to sign this JWT. This must be the ID of a previously registered public key
 
@@ -451,8 +451,9 @@ POST /api/v1/Token/auth
 **cURL command**
 
 ~~~sh
-curl -v https://sandbox.dpc.cms.gov/api/v1/Token/auth?grant_type=client_credentials&scope=system%2F*.*&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion={self-signed JWT} \
+curl -v "https://sandbox.dpc.cms.gov/api/v1/Token/auth?grant_type=client_credentials&scope=system%2F*.*&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion={self-signed JWT}" \
 -H 'Content-Type: application/x-www-form-urlencoded' \
+-H 'Accept: application/json' \
 -X POST
 ~~~
 


### PR DESCRIPTION
**Why**

A couple more issues cropped up in the documentation, a user was trying to execute one the access token request using the curl command, and it wasn't working as expected.

**What Changed**

- The JWT algorithm type is RS384, not RSA384
- The access token request needs to be completely wrapped in double quotes, and have the accept header set correctly.

**Choices Made**

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
