### PR TITLE
DPC-921: Update request filters to reject non-FHIR content types

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilter.java
@@ -20,10 +20,10 @@ public class FHIRRequestFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) {
-        // Ensure the Accepts header is set to a FHIR media type
+        // Ensure the `Accept` header is set to a FHIR media type
         checkAccepts(requestContext);
         // The content type header is optional, but if it's present, it has to be a FHIR resource type
-        // HAPI does NOT set the Content-Type, so we can't require it as part of our requests, otherwise our test suite breaks
+        // HAPI does NOT set the Content-Type by default, so we can't require it as part of our requests, otherwise our test suite breaks
         checkContentType(requestContext);
     }
 

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilter.java
@@ -6,26 +6,50 @@ import org.eclipse.jetty.server.Response;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 
 public class FHIRRequestFilter implements ContainerRequestFilter {
 
+    FHIRRequestFilter() {
+        // Not used
+    }
+
     @Override
     public void filter(ContainerRequestContext requestContext) {
+        // Ensure the Accepts header is set to a FHIR media type
+        checkAccepts(requestContext);
+        // Ensure the Content-Type header is set to a FHIR media type
+        checkContentType(requestContext);
+    }
+
+    private void checkAccepts(ContainerRequestContext requestContext) {
         final List<MediaType> contentHeader = requestContext.getAcceptableMediaTypes();
 
-        boolean valid = false;
+        if (!shortCircuitBooleanCheck(contentHeader, FHIRMediaTypes::isFHIRContent)) {
+            throw new WebApplicationException("`Accept:` header must specify valid FHIR content type", Response.SC_UNSUPPORTED_MEDIA_TYPE);
+        }
+    }
 
-        for (MediaType header : contentHeader) {
-            valid = FHIRMediaTypes.isFHIRContent(header);
+    private void checkContentType(ContainerRequestContext requestContext) {
+        final List<String> typeHeaders = requestContext.getHeaders().get(HttpHeaders.CONTENT_TYPE);
+
+        if (!shortCircuitBooleanCheck(typeHeaders, (typeHeader) -> FHIRMediaTypes.isFHIRContent(MediaType.valueOf(typeHeader)))) {
+            throw new WebApplicationException("`Accept:` header must specify valid FHIR content type", Response.SC_UNSUPPORTED_MEDIA_TYPE);
+        }
+    }
+
+    private static <T> boolean shortCircuitBooleanCheck(Collection<T> collection, Predicate<T> checker) {
+        boolean valid = false;
+        for (T element : collection) {
+            valid = checker.test(element);
             if (valid)
                 break;
         }
 
-        if (!valid) {
-            final IllegalArgumentException cause = new IllegalArgumentException("Must specify valid FHIR content type");
-            throw new WebApplicationException(cause, Response.SC_UNSUPPORTED_MEDIA_TYPE);
-        }
+        return valid;
     }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilterTest.java
@@ -53,7 +53,16 @@ public class FHIRRequestFilterTest {
     }
 
     @Test
-    void testMissingContentHeader() {
+    void testNullAcceptsHeader() {
+        final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+        Mockito.when(request.getAcceptableMediaTypes()).thenReturn(null);
+
+        final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> filter.filter(request));
+        assertEquals(Response.SC_UNSUPPORTED_MEDIA_TYPE, exception.getResponse().getStatus(), "Should have 415 error");
+    }
+
+    @Test
+    void testIncorrectContentHeader() {
         final MultivaluedMap headerMap = Mockito.mock(MultivaluedMap.class);
         Mockito.when(headerMap.get(HttpHeaders.CONTENT_TYPE)).thenReturn(Collections.singletonList("application/fire+json"));
         final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
@@ -62,6 +71,18 @@ public class FHIRRequestFilterTest {
 
         final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> filter.filter(request));
         assertEquals(Response.SC_UNSUPPORTED_MEDIA_TYPE, exception.getResponse().getStatus(), "Should have 415 error");
+    }
+
+    @Test
+
+    void testNullContentHeader() {
+        final MultivaluedMap headerMap = Mockito.mock(MultivaluedMap.class);
+        Mockito.when(headerMap.get(HttpHeaders.CONTENT_TYPE)).thenReturn(null);
+        final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+        Mockito.when(request.getAcceptableMediaTypes()).thenReturn(Collections.singletonList(MediaType.valueOf(FHIRMediaTypes.FHIR_JSON)));
+        Mockito.when(request.getHeaders()).thenReturn(headerMap);
+
+        filter.filter(request);
     }
 
     @Test

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilterTest.java
@@ -1,0 +1,78 @@
+package gov.cms.dpc.fhir.dropwizard.filters;
+
+import gov.cms.dpc.fhir.FHIRMediaTypes;
+import org.eclipse.jetty.server.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class FHIRRequestFilterTest {
+
+    private static final FHIRRequestFilter filter = new FHIRRequestFilter();
+
+    @Test
+    void testSuccess() {
+        final MultivaluedMap headerMap = Mockito.mock(MultivaluedMap.class);
+        Mockito.when(headerMap.get(HttpHeaders.CONTENT_TYPE)).thenReturn(Collections.singletonList(FHIRMediaTypes.FHIR_JSON));
+        final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+        Mockito.when(request.getAcceptableMediaTypes()).thenReturn(Collections.singletonList(MediaType.valueOf(FHIRMediaTypes.FHIR_JSON)));
+        Mockito.when(request.getHeaders()).thenReturn(headerMap);
+
+        filter.filter(request);
+    }
+
+    @Test
+    void testMissingAcceptsHeader() {
+        final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+        Mockito.when(request.getAcceptableMediaTypes()).thenReturn(Collections.singletonList(MediaType.APPLICATION_JSON_TYPE));
+
+        final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> filter.filter(request));
+        assertEquals(Response.SC_UNSUPPORTED_MEDIA_TYPE, exception.getResponse().getStatus(), "Should have 415 error");
+    }
+
+    @Test
+    void testNestedAcceptsHeader() {
+        final MultivaluedMap headerMap = Mockito.mock(MultivaluedMap.class);
+        Mockito.when(headerMap.get(HttpHeaders.CONTENT_TYPE)).thenReturn(Collections.singletonList(FHIRMediaTypes.FHIR_JSON));
+        final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+        Mockito.when(request.getAcceptableMediaTypes()).thenReturn(List.of(MediaType.APPLICATION_JSON_TYPE, MediaType.valueOf(FHIRMediaTypes.FHIR_JSON)));
+        Mockito.when(request.getHeaders()).thenReturn(headerMap);
+
+        filter.filter(request);
+    }
+
+    @Test
+    void testMissingContentHeader() {
+        final MultivaluedMap headerMap = Mockito.mock(MultivaluedMap.class);
+        Mockito.when(headerMap.get(HttpHeaders.CONTENT_TYPE)).thenReturn(Collections.singletonList("application/fire+json"));
+        final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+        Mockito.when(request.getAcceptableMediaTypes()).thenReturn(Collections.singletonList(MediaType.valueOf(FHIRMediaTypes.FHIR_JSON)));
+        Mockito.when(request.getHeaders()).thenReturn(headerMap);
+
+        final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> filter.filter(request));
+        assertEquals(Response.SC_UNSUPPORTED_MEDIA_TYPE, exception.getResponse().getStatus(), "Should have 415 error");
+    }
+
+    @Test
+    void testTestedContentHeader() {
+        final MultivaluedMap headerMap = Mockito.mock(MultivaluedMap.class);
+        Mockito.when(headerMap.get(HttpHeaders.CONTENT_TYPE)).thenReturn(List.of("application/fire+json", FHIRMediaTypes.FHIR_JSON));
+        final ContainerRequestContext request = Mockito.mock(ContainerRequestContext.class);
+        Mockito.when(request.getAcceptableMediaTypes()).thenReturn(Collections.singletonList(MediaType.valueOf(FHIRMediaTypes.FHIR_JSON)));
+        Mockito.when(request.getHeaders()).thenReturn(headerMap);
+
+        filter.filter(request);
+
+    }
+}

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4b4ccc16-fbbf-4d39-8186-9a1da5bef04f",
+		"_postman_id": "33c79dd6-30a2-4f92-a571-d13d56feba16",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1151,7 +1151,7 @@
 									"pm.test(\"Body matches expected response\", function() {",
 									"    var respJson = pm.response.json();",
 									"    pm.expect(respJson.issue).to.have.length(1)",
-									"    pm.expect(respJson.issue[0].details.text).to.be.equal(\"`Accept:` header must specify valid FHIR content type\")",
+									"    pm.expect(respJson.issue[0].details.text).to.be.equal(\"`Content-Type:` header must specify valid FHIR content type\")",
 									"});"
 								],
 								"type": "text/javascript"

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "c51ecc99-c009-4f7b-8067-8c73e371e97f",
+		"_postman_id": "4b4ccc16-fbbf-4d39-8186-9a1da5bef04f",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1136,6 +1136,59 @@
 		{
 			"name": "Updating",
 			"item": [
+				{
+					"name": "Check update invalid content type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "96f38c80-8b9d-4761-b66c-a02bd1de7408",
+								"exec": [
+									"pm.test(\"Status is 415\", function () {",
+									"    pm.response.to.have.status(415);",
+									"});",
+									"",
+									"pm.test(\"Body matches expected response\", function() {",
+									"    var respJson = pm.response.json();",
+									"    pm.expect(respJson.issue).to.have.length(1)",
+									"    pm.expect(respJson.issue[0].details.text).to.be.equal(\"`Accept:` header must specify valid FHIR content type\")",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/fire+json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"resourceType\": \"Organization\",\n    \"id\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\",\n    \"identifier\": [\n        {\n            \"system\": \"http://hl7.org/fhir/sid/us-npi\",\n            \"value\": \"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0\"\n        }\n    ],\n    \"name\": \"Beth Israel Deaconess HealthCare - Chestnut Hill\",\n    \"address\": [\n        {\n            \"use\": \"work\",\n            \"type\": \"both\",\n            \"line\": [\n                \"200 Boylston Street, 4th Floor\"\n            ],\n            \"city\": \"Chestnut Hill\",\n            \"state\": \"MA\",\n            \"postalCode\": \"02467\",\n            \"country\": \"US\"\n        }\n    ],\n    \"endpoint\": [\n        {\n            \"reference\": \"Endpoint/0a60c95c-48b4-4f39-8bf4-09f7dfe2e3cc\"\n        }\n    ]\n}"
+						},
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Organization/{{organization_id}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Organization",
+								"{{organization_id}}"
+							]
+						},
+						"description": "Attempt to update the organization value, but via an incorrect Content-Type header"
+					},
+					"response": []
+				},
 				{
 					"name": "Update organization",
 					"event": [


### PR DESCRIPTION
**Why**

On the Google Group, a user reported an issue where they were getting a weird exception when trying to submit their practitioners. It turned out to be due to our request filters accepting incorrect content types, but then it gets delegated to the Jackson parser which fails to deserialize it.

**What Changed**

Improved the request checking in the `FHIRRequestFilter` class to verify that both the `Accepts` header and the `Content-Type` header are correct. Really, content-type is the most important one, because it's the one that determines which `MessageBodyReader` gets called, and we need it to correctly call our custom FHIR reader.

**Choices Made**

**Tickets closed**:

DPC-921: Reject non-FHIR requests to FHIR endpoints.

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
