### PR TITLE
DPC-813: Improve log format

### DIFF
--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -104,6 +104,10 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-testing</artifactId>
         </dependency>
         <dependency>

--- a/dpc-aggregation/src/main/resources/application.conf
+++ b/dpc-aggregation/src/main/resources/application.conf
@@ -21,4 +21,13 @@ dpc.aggregation {
   retryCount = 3 // Number of times to retry reach BB request
   resourcesPerFile = 5000 // Max number of resources that a export file will have before creating a new file
   exportPath = "/tmp"
+
+  server.requestLog.appenders = [{
+    type = console
+    timeZone = UTC
+    layout {
+      type = access-json
+      timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    }
+  }]
 }

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -150,6 +150,10 @@
             <version>${newrelic.agent.version}</version>
             <type>${newrelic.agent.type}</type>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
         <!--Test resources-->
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -15,10 +15,15 @@ dpc.api {
     }
 
     server.requestLog.appenders = [{
-        type: "console"
+        type = console
+        timeZone = UTC
         filterFactories =[{
-            type: token-filter-factory
+            type = token-filter-factory
         }]
+        layout {
+          type = access-json
+          timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        }
     }]
 
     attributionURL = "http://localhost:3500/v1/"

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -80,6 +80,10 @@
             <version>${newrelic.agent.version}</version>
             <type>${newrelic.agent.type}</type>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
         <!--Testing dependencies-->
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dpc-attribution/src/main/resources/application.conf
+++ b/dpc-attribution/src/main/resources/application.conf
@@ -13,6 +13,16 @@ dpc.attribution {
       "org.hibernate.SQL" = TRACE
     }
   }
+
+  server.requestLog.appenders = [{
+    type = console
+    timeZone = UTC
+    layout {
+      type = access-json
+      timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    }
+  }]
+
   publicServerURL = "https://dpc.cms.gov"
 
   tokens {

--- a/dpc-consent/pom.xml
+++ b/dpc-consent/pom.xml
@@ -68,6 +68,10 @@
             <groupId>com.smoketurner</groupId>
             <artifactId>dropwizard-swagger</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-json-logging</artifactId>
+        </dependency>
         <!--Testing dependencies-->
         <dependency>
             <groupId>io.dropwizard</groupId>

--- a/dpc-consent/src/main/resources/application.conf
+++ b/dpc-consent/src/main/resources/application.conf
@@ -19,4 +19,13 @@ dpc.consent {
 
   // Disable FHIR validation
   fhir.validation.enabled = false
+
+  server.requestLog.appenders = [{
+    type = console
+    timeZone = UTC
+    layout {
+      type = access-json
+      timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    }
+  }]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>io.dropwizard</groupId>
+                <artifactId>dropwizard-json-logging</artifactId>
+                <version>${dropwizard.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>${hapi.fhir.groupID}</groupId>
                 <artifactId>hapi-fhir-base</artifactId>
                 <version>${hapi.fhir.version}</version>

--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -45,7 +45,11 @@ server {
 logging {
   appenders = [{
     type = console
-    logFormat = "%-5p [%d{ISO8601,UTC} - %t] %c: %replace(%m - organization_id=%X{organization_id}\n){'\n','\r'}\r%replace(%rEx){'\n','\r'}"
+    timeZone = UTC
+    layout {
+      type = json
+      timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    }
   }]
 }
 


### PR DESCRIPTION
**Why**
Logs are difficult to scan and search due to the current format, which complicates debugging.

**What Changed**
This branch adds `dropwizard-json-logging` to format log output as JSON. General logging is configured in `server.conf`, and request logs are configured in individual applications' `application.conf` files.

<img width="1251" alt="Screen Shot 2020-01-16 at 3 53 37 PM" src="https://user-images.githubusercontent.com/1923441/72563509-d5f5a580-387b-11ea-816c-9341ba6659cf.png">
<img width="1235" alt="Screen Shot 2020-01-16 at 4 19 43 PM" src="https://user-images.githubusercontent.com/1923441/72563623-0d645200-387c-11ea-8524-5039d13cd504.png">
<img width="1239" alt="Screen Shot 2020-01-16 at 4 08 22 PM" src="https://user-images.githubusercontent.com/1923441/72563512-d857ff80-387b-11ea-9e67-3196e034b3d4.png">

**Tickets closed**:
[DPC-813](https://jiraent.cms.gov/browse/DPC-813)

**Future Work**
Additional logging improvements will be made with [DPC-835](https://jiraent.cms.gov/browse/DPC-835).

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
