### PR TITLE
Hotfix: Make hapi-fhir-client available at runtime.

### DIFF
--- a/dpc-consent/pom.xml
+++ b/dpc-consent/pom.xml
@@ -72,6 +72,10 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-json-logging</artifactId>
         </dependency>
+        <dependency>
+            <groupId>${hapi.fhir.groupID}</groupId>
+            <artifactId>hapi-fhir-client</artifactId>
+        </dependency>
         <!--Testing dependencies-->
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -88,11 +92,6 @@
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${hapi.fhir.groupID}</groupId>
-            <artifactId>hapi-fhir-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Why**

The fhir client needs to be available for the consent service to talk to the attribution service. Flipping it from test scope should do it.

**What Changed**

Removed the test scope from the `hapi-fhir-client` jar.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
