### PR TITLE
DPC-908: Update DPC's BB client to support requesting Patient with hashed identifier 

### DIFF
--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClient.java
@@ -11,6 +11,8 @@ public interface BlueButtonClient {
 
     Patient requestPatientFromServer(String patientID) throws ResourceNotFoundException;
 
+    Bundle requestPatientFromServerByMbiHash(String mbiHash) throws ResourceNotFoundException;
+
     Bundle requestEOBFromServer(String patientID) throws ResourceNotFoundException;
 
     Bundle requestCoverageFromServer(String patientID) throws ResourceNotFoundException;

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClientImpl.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClientImpl.java
@@ -9,11 +9,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import gov.cms.dpc.bluebutton.config.BBClientConfiguration;
 import gov.cms.dpc.common.utils.MetricMaker;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.CapabilityStatement;
-import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.Coverage;
+import gov.cms.dpc.fhir.DPCIdentifierSystem;
+import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,6 +62,23 @@ public class BlueButtonClientImpl implements BlueButtonClient {
                 .read()
                 .resource(Patient.class)
                 .withId(patientID)
+                .execute());
+    }
+
+    /**
+     * Queries Blue Button server for patient data by hashed Medicare Beneficiary Identifier (MBI).
+     *
+     * @param mbiHash The hashed MBI
+     * @return {@link Bundle} A FHIR Bundle of Patient resources
+     */
+    @Override
+    public Bundle requestPatientFromServerByMbiHash(String mbiHash) throws ResourceNotFoundException {
+        logger.debug("Attempting to fetch patient with MBI hash {} from baseURL: {}", mbiHash, client.getServerBase());
+        return instrumentCall(REQUEST_PATIENT_METRIC, () -> client
+                .search()
+                .forResource(Patient.class)
+                .where(Patient.IDENTIFIER.exactly().systemAndIdentifier(DPCIdentifierSystem.MBI_HASH.getSystem(), mbiHash))
+                .returnBundle(Bundle.class)
                 .execute());
     }
 

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
@@ -39,6 +39,14 @@ public class MockBlueButtonClient implements BlueButtonClient {
     }
 
     @Override
+    public Bundle requestPatientFromServerByMbiHash(String mbiHash) throws ResourceNotFoundException {
+        Patient patient = loadOne(Patient.class, SAMPLE_PATIENT_PATH_PREFIX, TEST_PATIENT_IDS.get(0));
+        Bundle bundle = new Bundle();
+        bundle.addEntry().setResource(patient);
+        return bundle;
+    }
+
+    @Override
     public Bundle requestEOBFromServer(String patientID) throws ResourceNotFoundException {
         return loadBundle(SAMPLE_EOB_PATH_PREFIX, patientID);
     }

--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
@@ -10,6 +10,7 @@ import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
 import gov.cms.dpc.bluebutton.BlueButtonClientModule;
 import gov.cms.dpc.bluebutton.config.BBClientConfiguration;
+import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.testing.BufferedLoggerHandler;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
@@ -38,6 +39,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class BlueButtonClientTest {
     // A random example patient (Jane Doe)
     private static final String TEST_PATIENT_ID = "20140000008325";
+    private static final String TEST_PATIENT_MBI_HASH = "abadf57ff8dc94610ca0d479feadb1743c9cd3c77caf1eafde5719a154379fb6";
     // A patient that only has a single EOB record in bluebutton
     private static final String TEST_SINGLE_EOB_PATIENT_ID = "20140000009893";
     // A patient id that should not exist in bluebutton
@@ -86,6 +88,13 @@ class BlueButtonClientTest {
             );
         }
 
+        createMockServerExpectation(
+                "/v1/fhir/Patient",
+                HttpStatus.OK_200,
+                getRawXML(SAMPLE_PATIENT_PATH_PREFIX + TEST_PATIENT_ID + "-bundle.xml"),
+                Collections.singletonList(Parameter.param("identifier", DPCIdentifierSystem.MBI_HASH.getSystem() + "|" + TEST_PATIENT_MBI_HASH))
+        );
+
         // Create mocks for pages of the results
         for(String startIndex: List.of("10", "20", "30")) {
             createMockServerExpectation(
@@ -117,6 +126,23 @@ class BlueButtonClientTest {
         assertEquals(ret.getName().size(), 1, patientDataCorrupted);
         assertEquals(ret.getName().get(0).getFamily(), "Doe", patientDataCorrupted);
         assertEquals(ret.getName().get(0).getGiven().get(0).toString(), "Jane", patientDataCorrupted);
+    }
+
+    @Test
+    void shouldGetFHIRFromPatientMbiHash() {
+        Bundle ret = bbc.requestPatientFromServerByMbiHash(TEST_PATIENT_MBI_HASH);
+
+        assertNotNull(ret, "Bundle returned from BlueButtonClient should not be null");
+        assertTrue(ret.hasEntry(), "Bundle should have an entry");
+        assertEquals(1, ret.getEntry().size(), "Entry should have size 1");
+        Patient pt = (Patient) ret.getEntryFirstRep().getResource();
+
+        String patientDataCorrupted = "The demo Patient object data differs from what is expected";
+        assertEquals(pt.getBirthDate(), Date.valueOf("2014-06-01"), patientDataCorrupted);
+        assertEquals(pt.getGender().getDisplay(), "Unknown", patientDataCorrupted);
+        assertEquals(pt.getName().size(), 1, patientDataCorrupted);
+        assertEquals(pt.getName().get(0).getFamily(), "Doe", patientDataCorrupted);
+        assertEquals(pt.getName().get(0).getGiven().get(0).toString(), "Jane", patientDataCorrupted);
     }
 
     @Test

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/DPCIdentifierSystem.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/DPCIdentifierSystem.java
@@ -10,6 +10,7 @@ public enum DPCIdentifierSystem {
     PECOS("http://bluebutton.cms.hhs.gov/identifier#pecos"),
     NPPES("http://hl7.org/fhir/sid/us-npi"),
     MBI("https://bluebutton.cms.gov/resources/variables/bene_id"),
+    MBI_HASH("https://bluebutton.cms.gov/resources/identifier/mbi-hash"),
     DPC("https://dpc.cms.gov/organization_id#"),
     HICN("http://bluebutton.cms.hhs.gov/identifier#hicnHash"),
     UNKNOWN ("");

--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -51,6 +51,9 @@ logging {
       timestampFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
     }
   }]
+  loggers = {
+    "liquibase" = WARN
+  }
 }
 
 metrics {

--- a/src/test/resources/bb-test-data/patient/20140000008325-bundle.xml
+++ b/src/test/resources/bb-test-data/patient/20140000008325-bundle.xml
@@ -1,0 +1,51 @@
+<Bundle xmlns="http://hl7.org/fhir">
+    <id value="eb3894fc-ca04-44d4-adab-a9fb0a6f1976"/>
+    <meta>
+        <lastUpdated value="2020-01-01T00:01:23.456-04:00"/>
+    </meta>
+    <type value="searchset"/>
+    <total value="1"/>
+    <link>
+        <relation value="self"/>
+        <url value="http://localhost:8083/v1/fhir/Patient?identifier=https://bluebutton.cms.gov/resources/identifier/mbi-hash|abadf57ff8dc94610ca0d479feadb1743c9cd3c77caf1eafde5719a154379fb6"/>
+    </link>
+    <entry>
+        <resource>
+            <Patient xmlns="http://hl7.org/fhir">
+                <id value="20140000008325"/>
+                <extension url="https://bluebutton.cms.gov/resources/variables/race">
+                    <valueCoding>
+                        <system value="https://bluebutton.cms.gov/resources/variables/race"/>
+                        <code value="1"/>
+                        <display value="White"/>
+                    </valueCoding>
+                </extension>
+                <identifier>
+                    <system value="https://bluebutton.cms.gov/resources/variables/bene_id"/>
+                    <value value="20140000008325"/>
+                </identifier>
+                <identifier>
+                    <system value="https://bluebutton.cms.gov/resources/identifier/hicn-hash"/>
+                    <value value="2025fbc612a884853f0c245e686780bf748e5652360ecd7430575491f4e018c5"/>
+                </identifier>
+                <identifier>
+                    <system value="https://bluebutton.cms.gov/resources/identifier/mbi-hash"/>
+                    <value value="abadf57ff8dc94610ca0d479feadb1743c9cd3c77caf1eafde5719a154379fb6"/>
+                </identifier>
+                <name>
+                    <use value="usual"/>
+                    <family value="Doe"/>
+                    <given value="Jane"/>
+                    <given value="X"/>
+                </name>
+                <gender value="unknown"/>
+                <birthDate value="2014-06-01"/>
+                <address>
+                    <district value="999"/>
+                    <state value="15"/>
+                    <postalCode value="99999"/>
+                </address>
+            </Patient>
+        </resource>
+    </entry>
+</Bundle>


### PR DESCRIPTION
**Why**
Because rosters identify beneficiaries by MBI, DPC needs a way to obtain data from BFD with that identifier. This can be done by requesting Patient resources from BFD by hashed MBI.

**What Changed**
Added `requestPatientFromServerByMbiHash()` to `BlueButtonClient`.

**Tickets closed**:
[DPC-908](https://jiraent.cms.gov/browse/DPC-908)

**Future Work**
Additional tickets exist for hashing MBIs, setting up test data with MBI, and using the returned Patient to get the CCW bene ID for other resource requests (ExplanationOfBenefit, Coverage).

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
