### PR TITLE
Update consent configs to point to the correct database.

### DIFF
--- a/dpc-consent/src/main/resources/prod-sbx.application.conf
+++ b/dpc-consent/src/main/resources/prod-sbx.application.conf
@@ -2,7 +2,7 @@ dpc.consent {
 
     consentdb = {
         driverClass = org.postgresql.Driver
-        url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_consent"
+        url = "jdbc:postgresql://db.dpc-prod-sbx.local:5432/dpc_consent"
         user = ${CONSENT_DB_USER}
         password = ${CONSENT_DB_PASS}
     }

--- a/dpc-consent/src/main/resources/test.application.conf
+++ b/dpc-consent/src/main/resources/test.application.conf
@@ -2,7 +2,7 @@ dpc.consent {
 
     consentdb = {
         driverClass = org.postgresql.Driver
-        url = "jdbc:postgresql://db.dpc-dev.local:5432/dpc_consent"
+        url = "jdbc:postgresql://db.dpc-test.local:5432/dpc_consent"
         user = ${CONSENT_DB_USER}
         password = ${CONSENT_DB_PASS}
     }


### PR DESCRIPTION
**Why**

Another copy-paste error on my part, this should point the consent service to the test and dev DBs in AWS.

**What Changed**

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
