### PR TITLE
DPC-937: Add MBI hashing support

### DIFF
--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -422,4 +422,10 @@
                 columnName="gender"
                 defaultNullValue="3"/>
     </changeSet>
+
+    <changeSet id="add-mbi-hash" author="embh">
+        <addColumn tableName="PATIENTS">
+            <column name="mbi_hash" type="VARCHAR"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/dpc-attribution/src/main/resources/migrations.xml
+++ b/dpc-attribution/src/main/resources/migrations.xml
@@ -425,7 +425,7 @@
 
     <changeSet id="add-mbi-hash" author="embh">
         <addColumn tableName="PATIENTS">
-            <column name="mbi_hash" type="VARCHAR"/>
+            <column name="mbi_hash" type="VARCHAR(64)"/>
         </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClient.java
@@ -6,6 +6,8 @@ import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
 
+import java.security.GeneralSecurityException;
+
 
 public interface BlueButtonClient {
 
@@ -20,5 +22,7 @@ public interface BlueButtonClient {
     Bundle requestNextBundleFromServer(Bundle bundle) throws ResourceNotFoundException;
 
     CapabilityStatement requestCapabilityStatement() throws ResourceNotFoundException;
+
+    String hashMbi(String mbi) throws GeneralSecurityException;
 }
 

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.security.GeneralSecurityException;
 import java.util.List;
 
 public class MockBlueButtonClient implements BlueButtonClient {
@@ -77,6 +78,11 @@ public class MockBlueButtonClient implements BlueButtonClient {
     public CapabilityStatement requestCapabilityStatement() throws ResourceNotFoundException {
         final var path = SAMPLE_METADATA_PATH_PREFIX + "meta.xml";
         return loadOne(CapabilityStatement.class, path, null);
+    }
+
+    @Override
+    public String hashMbi(String mbi) throws GeneralSecurityException {
+        return "";
     }
 
     /**

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/config/BBClientConfiguration.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/config/BBClientConfiguration.java
@@ -31,6 +31,12 @@ public class BBClientConfiguration {
     @JsonProperty("keyStore")
     private KeystoreConfiguration keystore = new KeystoreConfiguration();
 
+    @NotEmpty
+    private String bfdHashPepper;
+
+    private int bfdHashIter;
+
+
     public TimeoutConfiguration getTimeouts() {
         return timeouts;
     }
@@ -60,6 +66,10 @@ public class BBClientConfiguration {
     public void setHealthcheckName(String healthcheckName) {
         this.healthcheckName = healthcheckName;
     }
+
+    public String getBfdHashPepper() { return bfdHashPepper; }
+
+    public int getBfdHashIter() { return bfdHashIter; }
 
     public static class TimeoutConfiguration {
 

--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
@@ -233,6 +233,15 @@ class BlueButtonClientTest {
         assertEquals("ec49dc08f8dd8b4e189f623ab666cfc8b81f201cc94fe6aef860a4c3bd57f278", hash);
     }
 
+    @Test
+    void shouldNotHashMbi() throws GeneralSecurityException {
+        String hash = bbc.hashMbi(null);
+        assertEquals("", hash);
+
+        hash = bbc.hashMbi("");
+        assertEquals("", hash);
+    }
+
     /**
      * Helper method that configures the mock server to respond to a given GET request
      *

--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
@@ -27,6 +27,7 @@ import org.mockserver.model.Parameter;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.sql.Date;
 import java.util.Collections;
 import java.util.List;
@@ -220,6 +221,16 @@ class BlueButtonClientTest {
                 () -> bbc.requestEOBFromServer(TEST_NONEXISTENT_PATIENT_ID),
                 "BlueButton client should throw exceptions when asked to retrieve EOBs for a non-existent patient"
         );
+    }
+
+    @Test
+    void shouldHashMbi() throws GeneralSecurityException {
+        // Cases from BFD tests https://github.com/CMSgov/beneficiary-fhir-data/blob/master/apps/bfd-pipeline/bfd-pipeline-rif-load/src/test/java/gov/cms/bfd/pipeline/rif/load/RifLoaderTest.java
+        String hash = bbc.hashMbi("123456789A");
+        assertEquals("d95a418b0942c7910fb1d0e84f900fe12e5a7fd74f312fa10730cc0fda230e9a", hash);
+
+        hash = bbc.hashMbi("3456789");
+        assertEquals("ec49dc08f8dd8b4e189f623ab666cfc8b81f201cc94fe6aef860a4c3bd57f278", hash);
     }
 
     /**

--- a/dpc-bluebutton/src/test/resources/test.application.conf
+++ b/dpc-bluebutton/src/test/resources/test.application.conf
@@ -13,7 +13,7 @@ bbclient {
 
   serverBaseUrl = "http://localhost:8083/v1/fhir/"
   resourcesCount = 10
-  bfdHashPepper=6E6F747468657265616C706570706572 // https://github.com/CMSgov/bluebutton-ansible-playbooks-data-sandbox/blob/master/etl_server_redeploy.yml#L151
+  bfdHashPepper=6E6F747468657265616C706570706572 // Not a real pepper. Used by BB for testing: https://github.com/CMSgov/bluebutton-ansible-playbooks-data-sandbox/blob/master/etl_server_redeploy.yml#L151
   bfdHashIter=1000
 }
 

--- a/dpc-bluebutton/src/test/resources/test.application.conf
+++ b/dpc-bluebutton/src/test/resources/test.application.conf
@@ -13,7 +13,7 @@ bbclient {
 
   serverBaseUrl = "http://localhost:8083/v1/fhir/"
   resourcesCount = 10
-  bfdHashPepper=6E6F747468657265616C706570706572
+  bfdHashPepper=6E6F747468657265616C706570706572 // https://github.com/CMSgov/bluebutton-ansible-playbooks-data-sandbox/blob/master/etl_server_redeploy.yml#L151
   bfdHashIter=1000
 }
 

--- a/dpc-bluebutton/src/test/resources/test.application.conf
+++ b/dpc-bluebutton/src/test/resources/test.application.conf
@@ -13,6 +13,8 @@ bbclient {
 
   serverBaseUrl = "http://localhost:8083/v1/fhir/"
   resourcesCount = 10
+  bfdHashPepper=6E6F747468657265616C706570706572
+  bfdHashIter=1000
 }
 
 test {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
@@ -31,6 +31,9 @@ public class PatientEntity implements Serializable {
     @Column(name = "beneficiary_id", unique = true)
     private String beneficiaryID;
 
+    @Column(name = "mbi_hash")
+    private String mbiHash;
+
     @Column(name = "first_name")
     private String patientFirstName;
     @Column(name = "last_name")
@@ -74,6 +77,14 @@ public class PatientEntity implements Serializable {
 
     public void setBeneficiaryID(String beneficiaryID) {
         this.beneficiaryID = beneficiaryID;
+    }
+
+    public String getMbiHash() {
+        return mbiHash;
+    }
+
+    public void setMbiHash(String mbiHash) {
+        this.mbiHash = mbiHash;
     }
 
     public String getPatientFirstName() {


### PR DESCRIPTION
**Why**
In order to request Patient resources from BFD by MBI, the MBIs must be hashed.

**What Changed**
* Created `hashMbi()` in `BlueButtonClient`
* Updated attribution `patients` table to add `mbi_hash` column

**Tickets closed**:
[DPC-937](https://jiraent.cms.gov/browse/DPC-937)

**Future Work**
Work is continuing on adding MBIs (Patient profile, retrieving bene ID by MBI before EOB and Coverage requests).

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
