### PR TITLE
DPC-956: Modify BFD client to use excludeSAMHSA=true when making EOB requests

### DIFF
--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
@@ -78,7 +78,8 @@ class BlueButtonClientTest {
                     "/v1/fhir/ExplanationOfBenefit",
                     HttpStatus.OK_200,
                     getRawXML(SAMPLE_EOB_PATH_PREFIX + patientId + ".xml"),
-                    Collections.singletonList(Parameter.param("patient", patientId))
+                    List.of(Parameter.param("patient", patientId),
+                        Parameter.param("excludeSAMHSA", "true"))
             );
 
             createMockServerExpectation(
@@ -104,7 +105,8 @@ class BlueButtonClientTest {
                 getRawXML(SAMPLE_EOB_PATH_PREFIX + TEST_PATIENT_ID + "_" + startIndex + ".xml"),
                 List.of(Parameter.param("patient", TEST_PATIENT_ID),
                         Parameter.param("count", "10"),
-                        Parameter.param("startIndex", startIndex))
+                        Parameter.param("startIndex", startIndex),
+                        Parameter.param("excludeSAMHSA", "true"))
             );
         }
     }

--- a/src/test/resources/bb-test-data/eob/20140000008325.xml
+++ b/src/test/resources/bb-test-data/eob/20140000008325.xml
@@ -7,11 +7,11 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=0"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=0&amp;excludeSAMHSA=true"/>
    </link>
    <link>
       <relation value="next"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/src/test/resources/bb-test-data/eob/20140000008325_10.xml
+++ b/src/test/resources/bb-test-data/eob/20140000008325_10.xml
@@ -7,11 +7,11 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=10&amp;excludeSAMHSA=true"/>
    </link>
    <link>
       <relation value="next"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/src/test/resources/bb-test-data/eob/20140000008325_20.xml
+++ b/src/test/resources/bb-test-data/eob/20140000008325_20.xml
@@ -7,11 +7,11 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=20&amp;excludeSAMHSA=true"/>
    </link>
    <link>
       <relation value="next"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/src/test/resources/bb-test-data/eob/20140000008325_30.xml
+++ b/src/test/resources/bb-test-data/eob/20140000008325_30.xml
@@ -7,7 +7,7 @@
    <total value="32"/>
    <link>
       <relation value="self"/>
-      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30"/>
+      <url value="http://localhost:8083/v1/fhir/ExplanationOfBenefit?patient=20140000008325&amp;count=10&amp;startIndex=30&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>

--- a/src/test/resources/bb-test-data/eob/20140000009893.xml
+++ b/src/test/resources/bb-test-data/eob/20140000009893.xml
@@ -7,7 +7,7 @@
    <total value="1"/>
    <link>
       <relation value="self"/>
-      <url value="https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/ExplanationOfBenefit?patient=20140000009893"/>
+      <url value="https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/ExplanationOfBenefit?patient=20140000009893&amp;excludeSAMHSA=true"/>
    </link>
    <entry>
       <resource>


### PR DESCRIPTION
**Why**
Data provided by DPC cannot include substance abuse and mental health claims.

**What Changed**
* Adds `excludeSAMHSA=true` on ExplanationOfBenefit requests to BFD
* `fetchBundle()` in `BlueButtonClientImpl` now accepts a `List` of criteria (`ICriterion` objects); if more than one is provided, it is added to the query with `and()`

**Tickets closed**:
[DPC-956](https://jiraent.cms.gov/browse/DPC-956)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
