### PR TITLE
DPC-970: Update Docker entrypoints to limit NewRelic use

### DIFF
--- a/dpc-aggregation/docker/entrypoint.sh
+++ b/dpc-aggregation/docker/entrypoint.sh
@@ -21,18 +21,23 @@ if [ -n "$BOOTSTRAP" ]; then
   bootstrap_config
 fi
 
+JAVA_CLASSES="-cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.aggregation.DPCAggregationService"
+
 if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
-    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.aggregation.DPCAggregationService"
+    NR_AGENT="-javaagent:/newrelic/newrelic.jar"
 else
-    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.aggregation.DPCAggregationService"
+    NR_AGENT=""
 fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"
-  eval ${CMDLINE} db migrate
+  eval java ${JVM_FLAGS} ${JAVA_CLASSES} db migrate
 fi
 
+CMDLINE="java ${JVM_FLAGS} ${JACOCO} ${NR_AGENT} ${JAVA_CLASSES}"
+
 echo "Running server via entrypoint!"
+
 if [ -n "$JACOCO" ]; then
   exec ${CMDLINE} "$@"
 else

--- a/dpc-api/docker/entrypoint.sh
+++ b/dpc-api/docker/entrypoint.sh
@@ -21,16 +21,21 @@ if [ -n "$BOOTSTRAP" ]; then
   bootstrap_config
 fi
 
+JAVA_CLASSES="-cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.api.DPCAPIService"
+
+# If we have NewRelic license, enable the java agent.
 if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
-    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.api.DPCAPIService"
+    NR_AGENT="-javaagent:/newrelic/newrelic.jar"
 else
-    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.api.DPCAPIService"
+    NR_AGENT=""
 fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"
-  eval ${CMDLINE} db migrate
+  eval "java ${JVM_FLAGS} ${JAVA_CLASSES} db migrate"
 fi
+
+CMDLINE="java ${JVM_FLAGS} ${JACOCO} ${NR_AGENT} ${JAVA_CLASSES}"
 
 echo "Running server via entrypoint!"
 

--- a/dpc-attribution/docker/entrypoint.sh
+++ b/dpc-attribution/docker/entrypoint.sh
@@ -8,23 +8,27 @@ else
   JACOCO=""
 fi
 
+JAVA_CLASSES="-cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.attribution.DPCAttributionService"
+
 if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
-    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.attribution.DPCAttributionService"
+    NR_AGENT="-javaagent:/newrelic/newrelic.jar"
 else
-    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.attribution.DPCAttributionService"
+    NR_AGENT=""
 fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"
-  eval ${CMDLINE} db migrate
+  eval java ${JVM_FLAGS} ${JAVA_CLASSES} db migrate
 fi
+
+CMDLINE="java ${JVM_FLAGS} ${JACOCO} ${NR_AGENT} ${JAVA_CLASSES}"
 
 if [ -n "$SEED" ]; then
     echo "Loading seeds"
-    eval ${CMDLINE} seed
+    eval java ${JVM_FLAGS} ${JAVA_CLASSES} seed
 fi
 
-echo "Running server"
+echo "Running server via entrypoint!"
 
 if [ -n "$JACOCO" ]; then
   exec ${CMDLINE} "$@"

--- a/dpc-consent/docker/entrypoint.sh
+++ b/dpc-consent/docker/entrypoint.sh
@@ -8,18 +8,22 @@ else
   JACOCO=""
 fi
 
+JAVA_CLASSES="-cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.consent.DPCConsentService"
+
 if [ -n "$NEW_RELIC_LICENSE_KEY" ]; then
-    CMDLINE="java -javaagent:/newrelic/newrelic.jar $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.consent.DPCConsentService"
+    NR_AGENT="-javaagent:/newrelic/newrelic.jar"
 else
-    CMDLINE="java $JVM_FLAGS ${JACOCO} -cp /app/resources:/app/classes:/app/libs/* gov.cms.dpc.consent.DPCConsentService"
+    NR_AGENT=""
 fi
 
 if [ $DB_MIGRATION -eq 1 ]; then
   echo "Migrating the database"
-  eval ${CMDLINE} db migrate
+  eval java ${JVM_FLAGS} ${JAVA_CLASSES} db migrate
 fi
 
-echo "Running server"
+CMDLINE="java ${JVM_FLAGS} ${JACOCO} ${NR_AGENT} ${JAVA_CLASSES}"
+
+echo "Running server via entrypoint!"
 
 if [ -n "$JACOCO" ]; then
   exec ${CMDLINE} "$@"


### PR DESCRIPTION
**Why**

We don't want NewRelic running when we do our migration and seed commands, as it slows everything down with its reporting and instrumentation.

**What Changed**

Updated the Docker entrypoints to make the CMDLINE variable more flexible and only add in JACOCO and NR_AGENT when necessary.

**Choices Made**

**Tickets closed**:

DPC-970

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
