### PR TITLE
DPC-961: Change Docker default to always enable auth.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - ENV=local
       - JACOCO=${REPORT_COVERAGE}
       - exportPath=/app/data
-      - JVM_FLAGS=-Ddpc.api.authenticationDisabled=${AUTH_DISABLED:-true}
+      - JVM_FLAGS=-Ddpc.api.authenticationDisabled=${AUTH_DISABLED:-false}
     depends_on:
       - attribution
     volumes:

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -52,7 +52,7 @@ docker-compose up start_api_dependencies
 mvn test -Pintegration-tests -pl dpc-api -am
 
 # Start the API server
-docker-compose up start_api
+AUTH_DISABLED=true docker-compose up start_api
 
 # Run the Postman tests
 npm install


### PR DESCRIPTION
**Why**

Per one of our discussions with the web team, we'd like to change the defaults to always launch the application with auth enabled.

**What Changed**

Updated both the docker-compose.yml and the dpc-test.sh to ensure auth is disabled when running the postman tests.

**Choices Made**

This will make `AUTH_DISABLED` default to `false` unless otherwise specified. This should make developing against the website and using the smoke tests a lot easier.

**Tickets closed**:

DPC-961

**Future Work**

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
