### PR TITLE
DPC-1016: Data migration to populate fhir_endpoints.registered_organization_id

### DIFF
--- a/dpc-web/db/migrate/20200204135210_fhir_endpoint_data_migration.rb
+++ b/dpc-web/db/migrate/20200204135210_fhir_endpoint_data_migration.rb
@@ -1,6 +1,9 @@
 class FhirEndpointDataMigration < ActiveRecord::Migration[5.2]
   def up
     FhirEndpoint.all.each do |fhir_endpoint|
+      # Skip if this fhir endpoint has a registered organization (meaning it was created after the refactor)
+      next if fhir_endpoint.registered_organization.present?
+
       organization = Organization.find_by id: fhir_endpoint.organization_id
 
       # If organization, carry on. If not, then this is an orphaned fhir_endpoint record

--- a/dpc-web/db/migrate/20200204135210_fhir_endpoint_data_migration.rb
+++ b/dpc-web/db/migrate/20200204135210_fhir_endpoint_data_migration.rb
@@ -1,0 +1,45 @@
+class FhirEndpointDataMigration < ActiveRecord::Migration[5.2]
+  def up
+    FhirEndpoint.all.each do |fhir_endpoint|
+      organization = Organization.find_by id: fhir_endpoint.organization_id
+
+      # If organization, carry on. If not, then this is an orphaned fhir_endpoint record
+      # that should be destroyed.
+      if organization
+        # There shouldn't be more than one regsitered organization, but on the off chance there is,
+        # let's use the most recent one.
+        reg_org = organization.registered_organizations.last
+
+        # If there is a registered organization, it must be sandbox, so let's use that one. If there isn't
+        # a registered organization, then the org was never created in the API, so the endpoint shouldn't exist.
+        # So, let's destroy it.
+        if reg_org
+          # Remove organization_id value so that the end result of this migration is as close to
+          # the desired end state as possible (no organization_id column).
+          # This lets us validate in user testing that it is not needed at all.
+          fhir_endpoint.update(registered_organization_id: reg_org.id, organization_id: nil)
+        else
+          fhir_endpoint.destroy
+        end
+      else
+        fhir_endpoint.destroy
+      end
+    end
+  end
+
+  # To undo this migration:
+  def down
+    FhirEndpoint.all.each do |fhir_endpoint|
+      reg_org = fhir_endpoint.registered_organization
+
+      # If registered_organization exists, carry on. If not, then this is an orphaned fhir_endpoint record
+      # that should be destroyed.
+      if reg_org
+        # Can't reset registered_organization_id to nil because then record is invalid.
+        fhir_endpoint.update(organization_id: reg_org.organization_id)
+      else
+        fhir_endpoint.destroy
+      end
+    end
+  end
+end

--- a/dpc-web/db/schema.rb
+++ b/dpc-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_31_173905) do
+ActiveRecord::Schema.define(version: 2020_02_04_135210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
**Why**

In DPC-954 we refactored the relationships between FhirEndpoint and
Organization and RegisteredOrganization. Now, fhir_endpoints are associated with an organization's registered_organization record directly. This data migration updates
the existing data to match the new structure.

**What Changed**

Data migration that should be run once to update the data in the rails app to associate existing fhir endpoints with their organization's registered organization. This will be run automatically on deploy as part of `rails db:migrate`. Tested locally.

**Choices Made**

This is a small, low-cost, one-time data change, so we decided to do this is a migration in the rails db. There are less than 100 records that need to change.

**Tickets closed**:

DPC-1016

**Future Work**

DPC-1017

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
