### PR TITLE
DPC-1010 Vendor Id Column

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The application (along with all required dependencies) can be automatically star
 The individual services can be started (along with their dependencies) by passing the service name to the `up` command.
 
 ```bash
-docker-compose up {db,dpc-aggregation,dpc-attribution,dpc-api}
+docker-compose up {db,aggregation,attribution,api}
 ``` 
 
 By default, the Docker containers start with minimal authentication enabled, meaning that some functionality (such as extracting the organization_id from the access token) will not work as expected and always return the same value.

--- a/dpc-web-test.sh
+++ b/dpc-web-test.sh
@@ -12,7 +12,7 @@ make website
 
 # Run the tests
 docker-compose -f dpc-web/docker-compose.yml up start_core_dependencies
-docker-compose -f dpc-web/docker-compose.yml run web bundle exec rails db:create db:migrate db:seed
+docker-compose -f dpc-web/docker-compose.yml run web bundle exec rails db:create db:migrate RAILS_ENV=test
 docker-compose -f dpc-web/docker-compose.yml run web bundle exec rails spec
 
 echo "┌──────────────────────────────────┐"

--- a/dpc-web/app/models/organization.rb
+++ b/dpc-web/app/models/organization.rb
@@ -13,6 +13,7 @@ class Organization < ApplicationRecord
   validates :organization_type, inclusion: { in: ORGANIZATION_TYPES.keys }
   validates :name, uniqueness: true, presence: true
   validates :npi, uniqueness: { allow_blank: true }
+  validates :vendor_id, uniqueness: { allow_blank: true }
 
   delegate :street, :street_2, :city, :state, :zip, to: :address, allow_nil: true, prefix: true
   accepts_nested_attributes_for :address, reject_if: :all_blank

--- a/dpc-web/db/migrate/20200204190846_add_vendor_id_column_to_organizations.rb
+++ b/dpc-web/db/migrate/20200204190846_add_vendor_id_column_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddVendorIdColumnToOrganizations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :organizations, :vendor_id, :string
+  end
+end

--- a/dpc-web/db/schema.rb
+++ b/dpc-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_04_135210) do
+ActiveRecord::Schema.define(version: 2020_02_04_152555) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 2020_02_04_135210) do
     t.datetime "updated_at", null: false
     t.string "npi"
     t.string "vendor"
+    t.string "vendor_id"
   end
 
   create_table "registered_organizations", force: :cascade do |t|


### PR DESCRIPTION
**Why**

Breaking up the vendor workflow ticket into smaller, more manageable sized tickets. This was just adding a column to the `organizations` table.

I also fixed a line the DPC-APP's README.md file.

**What Changed**

Added a column for vendor ids that will be created when an external user creates a vendor account. (The next ticket will be adding the generated id number to relevant accounts.)

Corrected the app's main README file to include the correct `docker-compose up` instructions.

**Choices Made**

`venid` to keep it short but recognizable and different from `npi` and `id` columns.

**Tickets closed**:

DPC 1010

**Future Work**

Will continue with the vendor workflow ticket DPC-997.

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
