### PR TITLE
Hotfix: Point swagger links to sandbox (and fix typo)

### DIFF
--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -10,7 +10,7 @@ This data is made available through a set of [FHIR](http://hl7.org/fhir/STU3/) c
 
 This guide serves as a starting point for users to begin working with the API by introducing the core APIs as well as two key concepts of [Bulk Data](#bulk-data) and [Patient Attribution](#attribution).
 
-Documentation is also available in a comprehensive [OpenAPI format](/api/swagger) as well as a FHIR [implementation guide](/ig/index.html).
+Documentation is also available in a comprehensive [OpenAPI format](https://sandbox.dpc.cms.gov/api/swagger) as well as a FHIR [implementation guide](/ig/index.html).
 
 ## Bulk Data
 
@@ -1809,7 +1809,7 @@ The DPC team has created a FHIR Implementation Guide which provides detailed inf
 
 ## OpenAPI Documentation
 
-The DPC team has created comprehensive [OpenAPI](https://swagger.io/docs/specification/about/) (formerly Swagger) documentation which provides detailed information regarding public endpoints avilable for the DPC project.
+The DPC team has created comprehensive [OpenAPI](https://swagger.io/docs/specification/about/) (formerly Swagger) documentation which provides detailed information regarding public endpoints available for the DPC project.
 In addition, this documentation allows organizations to interactively explore the API, using their own access tokens and datasets.
 
-<a href="api/swagger" class="ds-c-button">View the OpenAPI Documentation</a>
+<a href="https://sandbox.dpc.cms.gov/api/swagger" class="ds-c-button">View the OpenAPI Documentation</a>


### PR DESCRIPTION
**Why**

We locked down our production API url this morning, and we have a link in our documentation that isn't pointing to sandbox.

**What Changed**

Describe the changes made to the code base including new features, refactoring of existing services and user visible API changes.

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
