### PR TITLE
Fix broken token creation in sandbox

### DIFF
--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -1,6 +1,6 @@
 dpc.api {
 
-    publicURL = "https://dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
+    publicURL = "https://sandbox.dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
     server {
         applicationContextPath = "/api"


### PR DESCRIPTION
**Why**

The sandbox API is currently configured to use the production API URL. This is causing a number of problems with token creation.

**What Changed**

The configuration URL of the sandbox API has been changed from `https://dpc.cms.gov/api` to `https://sandbox.dpc.cms.gov/api`.

**Choices Made**

This change will break token creation for users who were using the incorrect URL, but working URL. [In our documentation](https://dpc.cms.gov/docs#authentication-and-authorization) we say to use `https://sandbox.dpc.cms.gov/api/v1/Token/auth` for the aud claim, but this was never actually working in sandbox. Users had to use `https://dpc.cms.gov/api/v1/Token/auth` as the aud claim for token authentication to work.

**This is a change we will need to communicate to our Google Group.** It's going to fix it for some users, as it matches what's in our documentation, but it's going to break it for others who were using the incorrect URL.

We need to make this change, because we have locked down the `https://dpc.cms.gov/api/` domain in preparation for actually launching production. We can no longer have users make API requests to sandbox through the production URL.

**Tickets closed**:


**Future Work**

* Communicate this on the Google Group.
* Verify the website is not also using the incorrect value for token creation in sandbox. @switzersc-usds @Sun-Mountain 

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
