### PR TITLE
Disable New Relic distributed tracing

### DIFF
--- a/dpc-web/config/newrelic.yml
+++ b/dpc-web/config/newrelic.yml
@@ -3,4 +3,4 @@ common: &default_settings
   log_file_name: STDOUT
 
   distributed_tracing:
-    enabled: true
+    enabled: false

--- a/src/main/resources/newrelic.yml
+++ b/src/main/resources/newrelic.yml
@@ -45,7 +45,7 @@ common: &default_settings
     max_samples_stored: 2000
 
   distributed_tracing:
-    enabled: true
+    enabled: false
 
   cross_application_tracer:
     enabled: false


### PR DESCRIPTION
**Why**

In order to get under the account CU limit, we need to disable our distributed tracing support.

**What Changed**

Disabled the `distributed_tracing` flag for all services.

**Choices Made**

This is the simplest way to remove the feature, in the future, we could add a JVM flag in prod-sbx and prod to re-enable.

**Tickets closed**:

**Future Work**

DPC-1088: Enable distributed tracing in higher environments.

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
