### PR TITLE
DPC-34 since support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -468,7 +468,7 @@ ij_continuation_indent_size = 2
 ij_yaml_keep_indents_on_empty_lines = false
 ij_yaml_keep_line_breaks = true
 
-[{.stylelintrc,.eslintrc,.babelrc,jest.config,*.json,*.bowerrc,*.jsb3,*.jsb2}]
+[{.stylelintrc,.eslintrc,.babelrc,jest.config,*.json,*.bowerrc,*.jsb3,*.jsb2,*.conf}]
 indent_size = 2
 ij_json_keep_blank_lines_in_code = 0
 ij_json_keep_indents_on_empty_lines = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 *.iml
 .DS_Store
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "java.configuration.updateBuildConfiguration": "automatic"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "automatic"
+}

--- a/application.local.conf.sample
+++ b/application.local.conf.sample
@@ -1,5 +1,7 @@
 dpc {
   api {
+    bbclient.keyStore.location = "bbcerts/bb.keystore"
+
     server {
       registerDefaultExceptionMappers = false
       applicationConnectors = [{

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       - ENV=local
       - JACOCO=${REPORT_COVERAGE}
       - exportPath=/app/data
+      - BFD_HASH_ITER=${BFD_HASH_ITER}
+      - BFD_HASH_PEPPER=${BFD_HASH_PEPPER}
+      - BFD_URL=${BFD_URL}
       - JVM_FLAGS=-Ddpc.api.authenticationDisabled=${AUTH_DISABLED:-false}
     depends_on:
       - attribution

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,14 +46,13 @@ services:
     ports:
       - "3002:3002"
       - "9903:9900"
+    env_file:
+      - ./ops/config/decrypted/local.env
     environment:
       - attributionURL=http://attribution:8080/v1/
       - ENV=local
       - JACOCO=${REPORT_COVERAGE}
       - exportPath=/app/data
-      - BFD_HASH_ITER=${BFD_HASH_ITER}
-      - BFD_HASH_PEPPER=${BFD_HASH_PEPPER}
-      - BFD_URL=${BFD_URL}
       - JVM_FLAGS=-Ddpc.api.authenticationDisabled=${AUTH_DISABLED:-false}
     depends_on:
       - attribution

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
@@ -232,7 +232,14 @@ public class AggregationEngine implements Runnable {
      */
     private Flowable<JobQueueBatchFile> completeResource(JobQueueBatch job, String patientID, ResourceType resourceType) {
         // Make this flow hot (ie. only called once) when multiple subscribers attach
-        final var fetcher = new ResourceFetcher(bbclient, job.getJobID(), job.getBatchID(), resourceType, operationsConfig);
+        final var fetcher = new ResourceFetcher(
+                bbclient,
+                job.getJobID(),
+                job.getBatchID(),
+                resourceType,
+                job.getSince().orElse(null),
+                job.getTransactionTime(),
+                operationsConfig);
         final Flowable<Resource> mixedFlow = fetcher.fetchResources(patientID);
         final var connectableMixedFlow = mixedFlow.publish().autoConnect(2);
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
@@ -143,7 +143,7 @@ class ResourceFetcher {
     }
 
     private Patient fetchPatient(String mbi) {
-        Bundle patients = null;
+        Bundle patients;
         try {
             patients = blueButtonClient.requestPatientFromServerByMbi(mbi);
         } catch (GeneralSecurityException e) {
@@ -243,9 +243,9 @@ class ResourceFetcher {
             logger.info("About to throw an BFD Runtime: bundle {}, job {}", bundleTransactionTime, transactionTime);
             /**
              * See BFD's RFC0004 for a discussion on why this type error may occur.
-             * Note: Retrying after a delay may fix this problem.
+             * Note: Retrying the job after a delay may fix this problem.
              */
-            throw new RuntimeException("BFD's transaction time regression");
+            throw new JobQueueFailure("BFD's transaction time regression");
         }
     }
 }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
@@ -232,19 +232,21 @@ class ResourceFetcher {
     }
 
     /**
-     * Check the transaction time of the bundle against the transaction time of the export job
+     * Check the transaction time of the BFD against the transaction time of the export job
      *
      * @param bundle to check
      */
     private void checkBundleTransactionTime(Bundle bundle) {
         if (bundle.getMeta() == null || bundle.getMeta().getLastUpdated() == null) return;
-        final var bundleTransactionTime = bundle.getMeta().getLastUpdated().toInstant().atOffset(ZoneOffset.UTC);
-        if (bundleTransactionTime.isBefore(transactionTime)) {
-            logger.info("About to throw an BFD Runtime: bundle {}, job {}", bundleTransactionTime, transactionTime);
+        final var bfdTransactionTime = bundle.getMeta().getLastUpdated().toInstant().atOffset(ZoneOffset.UTC);
+        if (bfdTransactionTime.isBefore(transactionTime)) {
             /**
              * See BFD's RFC0004 for a discussion on why this type error may occur.
              * Note: Retrying the job after a delay may fix this problem.
              */
+            logger.error("Failing the job for a BFD transaction time regression: BFD time {}, Job time {}",
+                    bfdTransactionTime,
+                    transactionTime);
             throw new JobQueueFailure("BFD's transaction time regression");
         }
     }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceWriter.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceWriter.java
@@ -44,9 +44,9 @@ class ResourceWriter {
     /**
      * Create a context for fetching FHIR resources
      * @param fhirContext - the single context for the engine
-     * @param config - config to use for the engine
      * @param job - the context for logging and reporting
      * @param resourceType - the resource type to fetch
+     * @param config - config to use for the engine
      */
     ResourceWriter(FhirContext fhirContext,
                     JobQueueBatch job,

--- a/dpc-aggregation/src/main/resources/local.application.conf
+++ b/dpc-aggregation/src/main/resources/local.application.conf
@@ -11,14 +11,21 @@ dpc.aggregation {
     password = dpc-safe
   }
 
-  bbclient.keyStore.location = "/bb.keystore"
+  bbclient {
+    keyStore {
+      type = "JKS"
+      defaultPassword = "changeit"
+      location = "/bb.keystore"
+    }
+    serverBaseUrl = "https://prod-sbx.bfdcloud.net/v1/fhir"
+  }
 
   exportPath = "/app/data"
 
   logging {
     loggers {
-      "gov.cms.dpc" = DEBUG
-      "org.hibernate.SQL" = TRACE
+      "gov.cms.dpc" = INFO
+      "org.hibernate.SQL" = INFO
     }
   }
 }

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -77,7 +77,7 @@ class AggregationEngineTest {
      */
     @Test
     void mockBlueButtonClientTest() {
-        Patient patient = bbclient.requestPatientFromServer(MockBlueButtonClient.MBI_BENE_ID_MAP.get(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)));
+        Bundle patient = bbclient.requestPatientFromServer(MockBlueButtonClient.MBI_BENE_ID_MAP.get(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)), null);
         assertNotNull(patient);
     }
 
@@ -187,7 +187,7 @@ class AggregationEngineTest {
                 Collections.singletonList(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)),
                 Collections.singletonList(ResourceType.Patient),
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch
@@ -218,7 +218,7 @@ class AggregationEngineTest {
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
                 JobQueueBatch.validResourceTypes,
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch
@@ -248,7 +248,7 @@ class AggregationEngineTest {
                 Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"),
                 JobQueueBatch.validResourceTypes,
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Assert the queue size
@@ -270,7 +270,7 @@ class AggregationEngineTest {
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
                 JobQueueBatch.validResourceTypes,
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch
@@ -308,7 +308,7 @@ class AggregationEngineTest {
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
                 Arrays.asList(ResourceType.Patient),
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch
@@ -344,7 +344,7 @@ class AggregationEngineTest {
                 List.of(),
                 Collections.singletonList(ResourceType.Patient),
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch
@@ -376,7 +376,7 @@ class AggregationEngineTest {
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
                 Collections.singletonList(ResourceType.Schedule),
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch
@@ -436,7 +436,7 @@ class AggregationEngineTest {
                 mbis,
                 List.of(ResourceType.ExplanationOfBenefit, ResourceType.Patient),
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch
@@ -544,7 +544,7 @@ class AggregationEngineTest {
                 Collections.singletonList("1"),
                 Collections.singletonList(ResourceType.Patient),
                 null,
-                OffsetDateTime.now(ZoneOffset.UTC)
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Work the batch

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -29,6 +29,8 @@ import org.mockito.Mockito;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.GeneralSecurityException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -93,7 +95,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Throw a failure on the first poll, then be successful
@@ -430,7 +434,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
-                Collections.singletonList(ResourceType.Schedule)
+                Collections.singletonList(ResourceType.Schedule),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Throw an exception when failing the batch
@@ -507,7 +513,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 mbis,
-                List.of(ResourceType.ExplanationOfBenefit, ResourceType.Patient)
+                List.of(ResourceType.ExplanationOfBenefit, ResourceType.Patient),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         queue.claimBatch(engine.getAggregatorID())
@@ -547,7 +555,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList("1"),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         AggregationEngineHealthCheck healthCheck = new AggregationEngineHealthCheck(engine);

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.aggregation.engine;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
@@ -15,7 +16,7 @@ import gov.cms.dpc.queue.exceptions.JobQueueFailure;
 import gov.cms.dpc.queue.models.JobQueueBatch;
 import gov.cms.dpc.testing.BufferedLoggerHandler;
 import io.reactivex.disposables.Disposable;
-import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
@@ -184,7 +185,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch
@@ -213,7 +216,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
-                JobQueueBatch.validResourceTypes
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch
@@ -241,7 +246,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Arrays.asList("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"),
-                JobQueueBatch.validResourceTypes
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Assert the queue size
@@ -261,7 +268,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
-                JobQueueBatch.validResourceTypes
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch
@@ -297,7 +306,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
-                Collections.singletonList(ResourceType.Patient)
+                Arrays.asList(ResourceType.Patient),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch
@@ -331,7 +342,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 List.of(),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch
@@ -361,7 +374,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 new ArrayList<>(MockBlueButtonClient.MBI_BENE_ID_MAP.keySet()),
-                Collections.singletonList(ResourceType.Schedule)
+                Collections.singletonList(ResourceType.Schedule),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch
@@ -419,7 +434,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 mbis,
-                List.of(ResourceType.ExplanationOfBenefit, ResourceType.Patient)
+                List.of(ResourceType.ExplanationOfBenefit, ResourceType.Patient),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch
@@ -432,8 +449,9 @@ class AggregationEngineTest {
 
         // Check that the bad ID was called 3 times
         ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<DateRangeParam> lastUpdatedCaptor = ArgumentCaptor.forClass(DateRangeParam.class);
         Mockito.verify(bbclient, atLeastOnce()).requestPatientFromServerByMbi(idCaptor.capture());
-        Mockito.verify(bbclient, atLeastOnce()).requestEOBFromServer(idCaptor.capture());
+        Mockito.verify(bbclient, atLeastOnce()).requestEOBFromServer(idCaptor.capture(), lastUpdatedCaptor.capture());
         var values = idCaptor.getAllValues();
         assertEquals(2,
                 values.stream().filter(value -> value.equals("-1")).count(),
@@ -515,7 +533,7 @@ class AggregationEngineTest {
     private void testWithThrowable(Throwable throwable) throws GeneralSecurityException {
         Mockito.reset(bbclient);
         // Override throwing an error on fetching a patient
-        Mockito.doThrow(throwable).when(bbclient).requestPatientFromServer(Mockito.anyString());
+        Mockito.doThrow(throwable).when(bbclient).requestPatientFromServer(Mockito.anyString(), Mockito.any(DateRangeParam.class));
 
         final var orgID = UUID.randomUUID();
 
@@ -524,7 +542,9 @@ class AggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList("1"),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Work the batch

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -2,7 +2,6 @@ package gov.cms.dpc.aggregation.engine;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.PerformanceOptionsEnum;
-import ca.uhn.fhir.rest.param.DateRangeParam;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.bluebutton.client.MockBlueButtonClient;
@@ -24,9 +23,6 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -37,9 +33,6 @@ import static org.mockito.Mockito.doReturn;
 class BatchAggregationEngineTest {
     private static final UUID aggregatorID = UUID.randomUUID();
     private static final String TEST_PROVIDER_ID = "1";
-
-    // lastUpdate date range to test
-    private static final OffsetDateTime TEST_SINCE = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(10);
 
     private IJobQueue queue;
     private AggregationEngine engine;
@@ -83,7 +76,7 @@ class BatchAggregationEngineTest {
                 TEST_PROVIDER_ID,
                 Collections.singletonList(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)),
                 Collections.singletonList(ResourceType.ExplanationOfBenefit),
-                TEST_SINCE,
+                MockBlueButtonClient.TEST_LAST_UPDATED.minusSeconds(1),
                 MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
@@ -118,7 +111,7 @@ class BatchAggregationEngineTest {
                 TEST_PROVIDER_ID,
                 MockBlueButtonClient.TEST_PATIENT_MBIS,
                 JobQueueBatch.validResourceTypes,
-                TEST_SINCE,
+                MockBlueButtonClient.TEST_LAST_UPDATED.minusSeconds(1),
                 MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
@@ -156,7 +149,7 @@ class BatchAggregationEngineTest {
                 TEST_PROVIDER_ID,
                 MockBlueButtonClient.TEST_PATIENT_WITH_BAD_IDS,
                 Collections.singletonList(ResourceType.ExplanationOfBenefit),
-                TEST_SINCE,
+                MockBlueButtonClient.TEST_LAST_UPDATED.minusSeconds(1),
                 MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -39,8 +39,7 @@ class BatchAggregationEngineTest {
     private static final String TEST_PROVIDER_ID = "1";
 
     // lastUpdate date range to test
-    private static final OffsetDateTime TEST_SINCE = OffsetDateTime.now(ZoneOffset.UTC);
-    private static final OffsetDateTime TEST_TRANSACTION_TIME = TEST_SINCE.plusSeconds(10);
+    private static final OffsetDateTime TEST_SINCE = OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(10);
 
     private IJobQueue queue;
     private AggregationEngine engine;
@@ -85,7 +84,7 @@ class BatchAggregationEngineTest {
                 Collections.singletonList(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)),
                 Collections.singletonList(ResourceType.ExplanationOfBenefit),
                 TEST_SINCE,
-                TEST_TRANSACTION_TIME
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Do the job
@@ -120,7 +119,7 @@ class BatchAggregationEngineTest {
                 MockBlueButtonClient.TEST_PATIENT_MBIS,
                 JobQueueBatch.validResourceTypes,
                 TEST_SINCE,
-                TEST_TRANSACTION_TIME
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Do the job
@@ -158,7 +157,7 @@ class BatchAggregationEngineTest {
                 MockBlueButtonClient.TEST_PATIENT_WITH_BAD_IDS,
                 Collections.singletonList(ResourceType.ExplanationOfBenefit),
                 TEST_SINCE,
-                TEST_TRANSACTION_TIME
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         // Do the job

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -23,7 +23,10 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -33,7 +36,6 @@ import static org.mockito.Mockito.doReturn;
 class BatchAggregationEngineTest {
     private static final UUID aggregatorID = UUID.randomUUID();
     private static final String TEST_PROVIDER_ID = "1";
-
     private IJobQueue queue;
     private AggregationEngine engine;
     private Disposable subscribe;

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.aggregation.engine;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.PerformanceOptionsEnum;
+import ca.uhn.fhir.rest.param.DateRangeParam;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.bluebutton.client.MockBlueButtonClient;
@@ -23,10 +24,10 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.UUID;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,6 +37,11 @@ import static org.mockito.Mockito.doReturn;
 class BatchAggregationEngineTest {
     private static final UUID aggregatorID = UUID.randomUUID();
     private static final String TEST_PROVIDER_ID = "1";
+
+    // lastUpdate date range to test
+    private static final OffsetDateTime TEST_SINCE = OffsetDateTime.now(ZoneOffset.UTC);
+    private static final OffsetDateTime TEST_TRANSACTION_TIME = TEST_SINCE.plusSeconds(10);
+
     private IJobQueue queue;
     private AggregationEngine engine;
     private Disposable subscribe;
@@ -77,7 +83,9 @@ class BatchAggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList(MockBlueButtonClient.TEST_PATIENT_MBIS.get(0)),
-                Collections.singletonList(ResourceType.ExplanationOfBenefit)
+                Collections.singletonList(ResourceType.ExplanationOfBenefit),
+                TEST_SINCE,
+                TEST_TRANSACTION_TIME
         );
 
         // Do the job
@@ -110,7 +118,9 @@ class BatchAggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 MockBlueButtonClient.TEST_PATIENT_MBIS,
-                JobQueueBatch.validResourceTypes
+                JobQueueBatch.validResourceTypes,
+                TEST_SINCE,
+                TEST_TRANSACTION_TIME
         );
 
         // Do the job
@@ -146,7 +156,9 @@ class BatchAggregationEngineTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 MockBlueButtonClient.TEST_PATIENT_WITH_BAD_IDS,
-                Collections.singletonList(ResourceType.ExplanationOfBenefit)
+                Collections.singletonList(ResourceType.ExplanationOfBenefit),
+                TEST_SINCE,
+                TEST_TRANSACTION_TIME
         );
 
         // Do the job

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/health/AggregationEngineHealthCheckTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/health/AggregationEngineHealthCheckTest.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.aggregation.health;
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.param.DateRangeParam;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.aggregation.engine.AggregationEngine;
@@ -20,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -71,7 +74,9 @@ public class AggregationEngineHealthCheckTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList("1"),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         AggregationEngineHealthCheck healthCheck = new AggregationEngineHealthCheck(engine);
@@ -88,7 +93,7 @@ public class AggregationEngineHealthCheckTest {
     @Test
     public void testHealthyEngineWhenJobBatchErrors() throws InterruptedException {
 
-        Mockito.doThrow(new RuntimeException("Error")).when(bbclient).requestPatientFromServer(Mockito.anyString());
+        Mockito.doThrow(new RuntimeException("Error")).when(bbclient).requestPatientFromServer(Mockito.anyString(), Mockito.any(DateRangeParam.class));
 
         final var orgID = UUID.randomUUID();
 
@@ -96,7 +101,9 @@ public class AggregationEngineHealthCheckTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList("1"),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         AggregationEngineHealthCheck healthCheck = new AggregationEngineHealthCheck(engine);
@@ -119,7 +126,9 @@ public class AggregationEngineHealthCheckTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList("1"),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         Mockito.doThrow(new RuntimeException("Error")).when(queue).claimBatch(Mockito.any(UUID.class));
@@ -145,7 +154,9 @@ public class AggregationEngineHealthCheckTest {
                 orgID,
                 TEST_PROVIDER_ID,
                 Collections.singletonList("1"),
-                Collections.singletonList(ResourceType.Patient)
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                MockBlueButtonClient.BFD_TRANSACTION_TIME
         );
 
         AggregationEngineHealthCheck healthCheck = new AggregationEngineHealthCheck(engine);

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -85,6 +85,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>gov.cms.dpc</groupId>
+            <artifactId>dpc-bluebutton</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>${hapi.fhir.groupID}</groupId>
             <artifactId>hapi-fhir-client</artifactId>
         </dependency>
@@ -189,12 +195,6 @@
                     <artifactId>junit</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>gov.cms.dpc</groupId>
-            <artifactId>dpc-bluebutton</artifactId>
-            <version>0.4.0-SNAPSHOT</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -190,6 +190,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>gov.cms.dpc</groupId>
+            <artifactId>dpc-bluebutton</artifactId>
+            <version>0.4.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -286,6 +286,7 @@
                     </container>
                     <extraDirectories>
                         <paths>
+                            <path>${project.basedir}/../bbcerts</path>
                             <path>${project.basedir}/target/jacoco-agent</path>
                             <path>${project.basedir}/docker</path>
                             <path>${project.basedir}/../src/main/resources/keypair</path>

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
@@ -2,6 +2,8 @@ package gov.cms.dpc.api;
 
 import ca.mestevens.java.configuration.TypesafeConfiguration;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.cms.dpc.bluebutton.config.BBClientConfiguration;
+import gov.cms.dpc.bluebutton.config.BlueButtonBundleConfiguration;
 import gov.cms.dpc.macaroons.config.TokenPolicy;
 import gov.cms.dpc.common.hibernate.auth.IDPCAuthDatabase;
 import gov.cms.dpc.common.hibernate.attribution.IDPCDatabase;
@@ -16,7 +18,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-public class DPCAPIConfiguration extends TypesafeConfiguration implements IDPCDatabase, IDPCQueueDatabase, IDPCAuthDatabase, IDPCFHIRConfiguration {
+public class DPCAPIConfiguration extends TypesafeConfiguration implements IDPCDatabase, IDPCQueueDatabase, IDPCAuthDatabase, IDPCFHIRConfiguration, BlueButtonBundleConfiguration {
 
     @NotEmpty
     private String exportPath;
@@ -39,6 +41,11 @@ public class DPCAPIConfiguration extends TypesafeConfiguration implements IDPCDa
     @NotNull
     @JsonProperty("authdb")
     private DataSourceFactory authDatabase = new DataSourceFactory();
+
+    @Valid
+    @NotNull
+    @JsonProperty("bbclient")
+    private BBClientConfiguration clientConfiguration = new BBClientConfiguration();
 
     @NotEmpty
     @NotNull
@@ -149,6 +156,11 @@ public class DPCAPIConfiguration extends TypesafeConfiguration implements IDPCDa
     @Override
     public void setFHIRConfiguration(DPCFHIRConfiguration config) {
         this.fhirConfig = config;
+    }
+
+    @Override
+    public BBClientConfiguration getBlueButtonConfiguration() {
+        return this.clientConfiguration;
     }
 
     public SwaggerBundleConfiguration getSwaggerBundleConfiguration() {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
+import com.google.inject.name.Named;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import com.typesafe.config.Config;
 import gov.cms.dpc.api.auth.jwt.IJTICache;
@@ -111,7 +112,7 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
     }
 
     @Provides
-    public OrganizationResource provideOrganizationResource(IGenericClient client, TokenDAO tokenDAO, PublicKeyDAO keyDAO) {
+    public OrganizationResource provideOrganizationResource(@Named("attribution") IGenericClient client, TokenDAO tokenDAO, PublicKeyDAO keyDAO) {
         return new UnitOfWorkAwareProxyFactory(authHibernateBundle)
                 .create(OrganizationResource.class,
                         new Class<?>[]{IGenericClient.class,
@@ -175,6 +176,7 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
 
     @Provides
     @Singleton
+    @Named("attribution")
     public IGenericClient provideFHIRClient(FhirContext ctx) {
         logger.info("Connecting to attribution server at {}.", getConfiguration().getAttributionURL());
         ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
@@ -10,6 +10,7 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.cli.keys.KeyCommand;
 import gov.cms.dpc.api.cli.organizations.OrganizationCommand;
 import gov.cms.dpc.api.cli.tokens.TokenCommand;
+import gov.cms.dpc.bluebutton.BlueButtonClientModule;
 import gov.cms.dpc.common.hibernate.attribution.DPCHibernateBundle;
 import gov.cms.dpc.common.hibernate.attribution.DPCHibernateModule;
 import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateBundle;
@@ -94,7 +95,8 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
                         new BakeryModule(),
                         new DPCAPIModule(hibernateAuthBundle),
                         new JobQueueModule<>(),
-                        new FHIRModule<>())
+                        new FHIRModule<>(),
+                        new BlueButtonClientModule<>())
                 .build();
     }
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/macaroonauth/MacaroonsAuthenticator.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/macaroonauth/MacaroonsAuthenticator.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.api.auth.macaroonauth;
 
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import com.google.inject.name.Named;
 import gov.cms.dpc.api.auth.DPCAuthCredentials;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
@@ -25,7 +26,7 @@ public class MacaroonsAuthenticator implements Authenticator<DPCAuthCredentials,
     private final IGenericClient client;
 
     @Inject
-    public MacaroonsAuthenticator(IGenericClient client) {
+    public MacaroonsAuthenticator(@Named("attribution") IGenericClient client) {
         this.client = client;
     }
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import com.google.inject.name.Named;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractEndpointResource;
@@ -30,7 +31,7 @@ public class EndpointResource extends AbstractEndpointResource {
     private final IGenericClient client;
 
     @Inject
-    EndpointResource(IGenericClient client) {
+    EndpointResource(@Named("attribution") IGenericClient client) {
         this.client = client;
     }
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import com.google.inject.name.Named;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractGroupResource;
@@ -58,7 +59,7 @@ public class GroupResource extends AbstractGroupResource {
     private final BlueButtonClient bfdClient;
 
     @Inject
-    public GroupResource(IJobQueue queue, IGenericClient client, @APIV1 String baseURL, BlueButtonClient bfdClient) {
+    public GroupResource(IJobQueue queue, @Named("attribution") IGenericClient client, @APIV1 String baseURL, BlueButtonClient bfdClient) {
         this.queue = queue;
         this.client = client;
         this.baseURL = baseURL;

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -1,5 +1,7 @@
 package gov.cms.dpc.api.resources.v1;
 
+import ca.uhn.fhir.model.primitive.DateTimeDt;
+import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.codahale.metrics.annotation.ExceptionMetered;
@@ -7,6 +9,7 @@ import com.codahale.metrics.annotation.Timed;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractGroupResource;
+import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.common.annotations.APIV1;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.FHIRExtractors;
@@ -29,6 +32,8 @@ import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -42,6 +47,7 @@ import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
 public class GroupResource extends AbstractGroupResource {
 
     private static final Logger logger = LoggerFactory.getLogger(GroupResource.class);
+    static final String SYNTHETIC_BENE_ID = "-19990000000001";
 
     // The delimiter for the '_types' list query param.
     static final String LIST_DELIMITER = ",";
@@ -49,12 +55,14 @@ public class GroupResource extends AbstractGroupResource {
     private final IJobQueue queue;
     private final IGenericClient client;
     private final String baseURL;
+    private final BlueButtonClient bfdClient;
 
     @Inject
-    public GroupResource(IJobQueue queue, IGenericClient client, @APIV1 String baseURL) {
+    public GroupResource(IJobQueue queue, IGenericClient client, @APIV1 String baseURL, BlueButtonClient bfdClient) {
         this.queue = queue;
         this.client = client;
         this.baseURL = baseURL;
+        this.bfdClient = bfdClient;
     }
 
     @POST
@@ -250,12 +258,12 @@ public class GroupResource extends AbstractGroupResource {
                            @QueryParam("_type") String resourceTypes,
                            @ApiParam(value = "Output format of requested data", allowableValues = FHIR_NDJSON, defaultValue = FHIR_NDJSON)
                            @QueryParam("_outputFormat") String outputFormat,
-                           @ApiParam(value = "Request data that has been updated after the given point. (Not implemented yet)", hidden = true)
+                           @ApiParam(value = "Request resources that have been updated after this time.")
                            @QueryParam("_since") String since) {
         logger.debug("Exporting data for provider: {}", rosterID);
 
         // Check the parameters
-        checkExportRequest(outputFormat, since);
+        checkExportRequest(outputFormat);
 
         // Get the attributed patients
         final List<String> attributedPatients = fetchPatientMBIs(rosterID);
@@ -265,7 +273,9 @@ public class GroupResource extends AbstractGroupResource {
 
         // Handle the _type query parameter
         final var resources = handleTypeQueryParam(resourceTypes);
-        final UUID jobID = this.queue.createJob(orgID, rosterID, attributedPatients, resources);
+        final var sinceDate = handleSinceQueryParam(since);
+        final var transactionTime = fetchTransactionTime();
+        final UUID jobID = this.queue.createJob(orgID, rosterID, attributedPatients, resources, sinceDate, transactionTime);
 
         return Response.status(Response.Status.ACCEPTED)
                 .contentLocation(URI.create(this.baseURL + "/Jobs/" + jobID)).build();
@@ -306,6 +316,51 @@ public class GroupResource extends AbstractGroupResource {
             resources.add(foundResourceType.get());
         }
         return resources;
+    }
+
+    /**
+     * Convert the '_since' {@link QueryParam} to a Date
+     *
+     * @param since - {@link String} a
+     * @return - A {@link OffsetDateTime} for this since.
+     */
+    private OffsetDateTime handleSinceQueryParam(String since) {
+        if (StringUtils.isEmpty(since)) {
+            return null;
+        }
+        // check that _since is a valid time
+        try {
+            var dt = new DateTimeDt();
+            dt.setValueAsString(since);
+            return dt.getValue().toInstant().atOffset(ZoneOffset.UTC);
+        } catch (DataFormatException ex) {
+            throw new BadRequestException("'_since' query parameter must be a valid date time value");
+        }
+    }
+
+    /**
+     * Fetch the BFD database last update time. Use it as the transactionTime for a job.
+     * @return transactionTime from the BFD service
+     */
+    private OffsetDateTime fetchTransactionTime() {
+        // Every bundle has transaction time after the Since RFC has beneficiary
+        final Meta meta = bfdClient.requestPatientFromServer(SYNTHETIC_BENE_ID, null).getMeta();
+        return Optional.ofNullable(meta.getLastUpdated())
+                .map(u -> u.toInstant().atOffset(ZoneOffset.UTC))
+                .orElse(OffsetDateTime.now(ZoneOffset.UTC));
+    }
+
+    /**
+     * Check the query parameters of the request. If valid, return empty. If not valid,
+     * return an error response with an {@link OperationOutcome} in the body.
+     *
+     * @param outputFormat param to check
+     */
+    private static void checkExportRequest(String outputFormat) {
+        // _outputFormat only supports FHIR_NDJSON
+        if (StringUtils.isNotEmpty(outputFormat) && !FHIR_NDJSON.equals(outputFormat)) {
+            throw new BadRequestException("'_outputFormat' query parameter must be 'application/fhir+ndjson'");
+        }
     }
 
     private List<String> fetchPatientMBIs(String groupID) {
@@ -375,25 +430,6 @@ public class GroupResource extends AbstractGroupResource {
         logger.info("Organization {} is attesting a {} purpose between provider {} and patient(s) {}{}", performer.getWhoReference().getReference(),
                 reason.getCode(),
                 performer.getOnBehalfOfReference().getReference(), attributedPatients, groupIDLog);
-    }
-
-    /**
-     * Check the query parameters of the request. If valid, return empty. If not valid,
-     * return an error response with an {@link OperationOutcome} in the body.
-     *
-     * @param outputFormat param to check
-     * @param since        param to check
-     */
-    private static void checkExportRequest(String outputFormat, String since) {
-        // _since is unsupported
-        if (StringUtils.isNotEmpty(since)) {
-            throw new BadRequestException("'_since' is not supported");
-        }
-
-        // _outputFormat only supports FHIR_NDJSON
-        if (StringUtils.isNotEmpty(outputFormat) && !FHIR_NDJSON.equals(outputFormat)) {
-            throw new BadRequestException("'_outputFormat' query parameter must be 'application/fhir+ndjson'");
-        }
     }
 
     /**

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -259,7 +259,7 @@ public class GroupResource extends AbstractGroupResource {
                            @QueryParam("_type") String resourceTypes,
                            @ApiParam(value = "Output format of requested data", allowableValues = FHIR_NDJSON, defaultValue = FHIR_NDJSON)
                            @QueryParam("_outputFormat") String outputFormat,
-                           @ApiParam(value = "Resources updated after this period will be included in the response. Must be a FHIR date-time.")
+                           @ApiParam(value = "Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).")
                            @QueryParam("_since") String since) {
         logger.debug("Exporting data for provider: {}", rosterID);
 
@@ -322,7 +322,7 @@ public class GroupResource extends AbstractGroupResource {
     /**
      * Convert the '_since' {@link QueryParam} to a Date
      *
-     * @param since - {@link String} a
+     * @param since - {@link String} an instant
      * @return - A {@link OffsetDateTime} for this since.
      */
     private OffsetDateTime handleSinceQueryParam(String since) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -259,7 +259,7 @@ public class GroupResource extends AbstractGroupResource {
                            @QueryParam("_type") String resourceTypes,
                            @ApiParam(value = "Output format of requested data", allowableValues = FHIR_NDJSON, defaultValue = FHIR_NDJSON)
                            @QueryParam("_outputFormat") String outputFormat,
-                           @ApiParam(value = "Request resources that have been updated after this time.")
+                           @ApiParam(value = "Resources updated after this period will be included in the response. Must be a FHIR date-time.")
                            @QueryParam("_since") String since) {
         logger.debug("Exporting data for provider: {}", rosterID);
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
@@ -27,6 +27,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -208,7 +209,9 @@ public class JobResource extends AbstractJobResource {
                 .map(b -> b.getCompleteTime().orElse(OffsetDateTime.MIN))
                 .max(OffsetDateTime::compareTo)
                 .orElse(OffsetDateTime.MIN);
-        if (submitTime.isEqual(OffsetDateTime.MIN) || completeTime.isEqual(OffsetDateTime.MIN)) return null;
+        if (submitTime.isEqual(OffsetDateTime.MIN) || completeTime.isEqual(OffsetDateTime.MIN)) {
+            return Collections.emptyList();
+        }
         return List.of(
                 new JobCompletionModel.FhirExtension(JobCompletionModel.SUBMIT_TIME_URL, submitTime),
                 new JobCompletionModel.FhirExtension(JobCompletionModel.COMPLETE_TIME_URL, completeTime));

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/JobResource.java
@@ -208,7 +208,7 @@ public class JobResource extends AbstractJobResource {
                 .map(b -> b.getCompleteTime().orElse(OffsetDateTime.MIN))
                 .max(OffsetDateTime::compareTo)
                 .orElse(OffsetDateTime.MIN);
-        if (submitTime == OffsetDateTime.MIN || completeTime == OffsetDateTime.MIN) return null;
+        if (submitTime.isEqual(OffsetDateTime.MIN) || completeTime.isEqual(OffsetDateTime.MIN)) return null;
         return List.of(
                 new JobCompletionModel.FhirExtension(JobCompletionModel.SUBMIT_TIME_URL, submitTime),
                 new JobCompletionModel.FhirExtension(JobCompletionModel.COMPLETE_TIME_URL, completeTime));

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import com.google.inject.name.Named;
 import gov.cms.dpc.api.auth.annotations.AdminOperation;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.jdbi.PublicKeyDAO;
@@ -35,7 +36,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     private final PublicKeyDAO keyDAO;
 
     @Inject
-    public OrganizationResource(IGenericClient client, TokenDAO tokenDAO, PublicKeyDAO keyDAO) {
+    public OrganizationResource(@Named("attribution") IGenericClient client, TokenDAO tokenDAO, PublicKeyDAO keyDAO) {
         this.client = client;
         this.tokenDAO = tokenDAO;
         this.keyDAO = keyDAO;

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.validation.ValidationOptions;
 import ca.uhn.fhir.validation.ValidationResult;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import com.google.inject.name.Named;
 import gov.cms.dpc.api.APIHelpers;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
@@ -46,7 +47,7 @@ public class PatientResource extends AbstractPatientResource {
     private final FhirValidator validator;
 
     @Inject
-    PatientResource(IGenericClient client, FhirValidator validator) {
+    PatientResource(@Named("attribution") IGenericClient client, FhirValidator validator) {
         this.client = client;
         this.validator = validator;
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PractitionerResource.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.validation.ValidationOptions;
 import ca.uhn.fhir.validation.ValidationResult;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
+import com.google.inject.name.Named;
 import gov.cms.dpc.api.APIHelpers;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
@@ -42,7 +43,7 @@ public class PractitionerResource extends AbstractPractitionerResource {
     private final FhirValidator validator;
 
     @Inject
-    PractitionerResource(IGenericClient client, FhirValidator validator) {
+    PractitionerResource(@Named("attribution") IGenericClient client, FhirValidator validator) {
         this.client = client;
         this.validator = validator;
     }

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -23,6 +23,23 @@ dpc.api {
         }
     }]
 
+    bbclient {
+        keyStore {
+            type = "JKS"
+            defaultPassword = "changeit"
+            location = "../bbcerts/bfd-client-localhost.jks"
+        }
+
+        timeouts {
+            connectionTimeout: 5000 // ms
+            socketTimeout: 5000 // ms
+            requestTimeout: 5000 // ms
+        }
+
+        serverBaseUrl = "https://localhost:7474/v1/fhir/"
+        count = 100 // Max number of resource that a request to BB will return before using another request
+    }
+
     attributionURL = "http://localhost:3500/v1/"
     exportPath = "/tmp"
 

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -23,22 +23,24 @@ dpc.api {
         }
     }]
 
-    bbclient {
-        keyStore {
-            type = "JKS"
-            defaultPassword = "changeit"
-            location = "../bbcerts/bfd-client-localhost.jks"
-        }
-
-        timeouts {
-            connectionTimeout: 5000 // ms
-            socketTimeout: 5000 // ms
-            requestTimeout: 5000 // ms
-        }
-
-        serverBaseUrl = "https://localhost:7474/v1/fhir/"
-        count = 100 // Max number of resource that a request to BB will return before using another request
+  bbclient {
+    keyStore {
+      type = "JKS"
+      defaultPassword = "changeit"
+      location = "../bbcerts/bb.keystore"
     }
+
+    timeouts {
+      connectionTimeout: 5000 // ms
+      socketTimeout: 5000 // ms
+      requestTimeout: 5000 // ms
+    }
+
+    serverBaseUrl = ${BFD_URL}
+    count = 100 // Max number of resource that a request to BB will return before using another request
+    bfdHashPepper = ${BFD_HASH_PEPPER}
+    bfdHashIter = ${BFD_HASH_ITER}
+  }
 
     attributionURL = "http://localhost:3500/v1/"
     exportPath = "/tmp"

--- a/dpc-api/src/main/resources/dev.application.conf
+++ b/dpc-api/src/main/resources/dev.application.conf
@@ -19,6 +19,15 @@ dpc.api {
         password = ${AUTH_DB_PASS}
     }
 
+    bbclient {
+        serverBaseUrl = ${BB_SERVER_BASEURL}
+
+        keyStore {
+            location = ${BB_KEYSTORE_LOCATION}
+            defaultPassword = ${BB_KEYSTORE_PASS}
+        }
+    }
+
     server {
         applicationContextPath = "/api"
     }

--- a/dpc-api/src/main/resources/dev.application.conf
+++ b/dpc-api/src/main/resources/dev.application.conf
@@ -19,15 +19,6 @@ dpc.api {
         password = ${AUTH_DB_PASS}
     }
 
-    bbclient {
-        serverBaseUrl = ${BB_SERVER_BASEURL}
-
-        keyStore {
-            location = ${BB_KEYSTORE_LOCATION}
-            defaultPassword = ${BB_KEYSTORE_PASS}
-        }
-    }
-
     server {
         applicationContextPath = "/api"
     }

--- a/dpc-api/src/main/resources/local.application.conf
+++ b/dpc-api/src/main/resources/local.application.conf
@@ -27,6 +27,15 @@ dpc.api {
         password = dpc-safe
     }
 
+    bbclient {
+        keyStore {
+            type = "JKS"
+            defaultPassword = "changeit"
+            location = "/bfd-local-client.jks"
+        }
+        serverBaseUrl = "https://host.docker.internal:7474/v1/fhir/"
+    }
+
     attributionURL = "http://attribution:8080/v1/"
     exportPath = /app/data
     authenticationDisabled = true

--- a/dpc-api/src/main/resources/local.application.conf
+++ b/dpc-api/src/main/resources/local.application.conf
@@ -31,9 +31,9 @@ dpc.api {
         keyStore {
             type = "JKS"
             defaultPassword = "changeit"
-            location = "/bfd-local-client.jks"
+            location = "/bb.keystore"
         }
-        serverBaseUrl = "https://host.docker.internal:7474/v1/fhir/"
+        serverBaseUrl = "https://prod-sbx.bfdcloud.net/v1/fhir"
     }
 
     attributionURL = "http://attribution:8080/v1/"

--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -24,6 +24,15 @@ dpc.api {
         password = ${QUEUE_DB_PASS}
     }
 
+    bbclient {
+        serverBaseUrl = ${BB_SERVER_BASEURL}
+
+        keyStore {
+            location = ${BB_KEYSTORE_LOCATION}
+            defaultPassword = ${BB_KEYSTORE_PASS}
+        }
+    }
+
     attributionURL = "http://backend.dpc-prod-sbx.local:8080/v1/"
     exportPath = "/app/data"
     keyPairLocation = ${BAKERY_KEYPAIR_LOCATION}

--- a/dpc-api/src/main/resources/prod-sbx.application.conf
+++ b/dpc-api/src/main/resources/prod-sbx.application.conf
@@ -24,15 +24,6 @@ dpc.api {
         password = ${QUEUE_DB_PASS}
     }
 
-    bbclient {
-        serverBaseUrl = ${BB_SERVER_BASEURL}
-
-        keyStore {
-            location = ${BB_KEYSTORE_LOCATION}
-            defaultPassword = ${BB_KEYSTORE_PASS}
-        }
-    }
-
     attributionURL = "http://backend.dpc-prod-sbx.local:8080/v1/"
     exportPath = "/app/data"
     keyPairLocation = ${BAKERY_KEYPAIR_LOCATION}

--- a/dpc-api/src/main/resources/test.application.conf
+++ b/dpc-api/src/main/resources/test.application.conf
@@ -25,6 +25,15 @@ dpc.api {
         password = ${AUTH_DB_PASS}
     }
 
+    bbclient {
+        serverBaseUrl = ${BB_SERVER_BASEURL}
+
+        keyStore {
+            location = ${BB_KEYSTORE_LOCATION}
+            defaultPassword = ${BB_KEYSTORE_PASS}
+        }
+    }
+
     attributionURL = "http://backend.dpc-test.local:8080/v1/"
     exportPath = "/app/data"
     keyPairLocation = ${BAKERY_KEYPAIR_LOCATION}

--- a/dpc-api/src/main/resources/test.application.conf
+++ b/dpc-api/src/main/resources/test.application.conf
@@ -25,15 +25,6 @@ dpc.api {
         password = ${AUTH_DB_PASS}
     }
 
-    bbclient {
-        serverBaseUrl = ${BB_SERVER_BASEURL}
-
-        keyStore {
-            location = ${BB_KEYSTORE_LOCATION}
-            defaultPassword = ${BB_KEYSTORE_PASS}
-        }
-    }
-
     attributionURL = "http://backend.dpc-test.local:8080/v1/"
     exportPath = "/app/data"
     keyPairLocation = ${BAKERY_KEYPAIR_LOCATION}

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/AttestationUnitTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/AttestationUnitTests.java
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
+import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.queue.IJobQueue;
 import gov.cms.dpc.testing.BufferedLoggerHandler;
@@ -44,7 +45,8 @@ public class AttestationUnitTests {
         // Do all the things
         final IJobQueue mockQueue = Mockito.mock(IJobQueue.class);
         final IGenericClient mockClient = Mockito.mock(IGenericClient.class);
-        groupResource = new GroupResource(mockQueue, mockClient, "http://local.test");
+        final BlueButtonClient mockBfdClient = Mockito.mock(BlueButtonClient.class);
+        groupResource = new GroupResource(mockQueue, mockClient, "http://local.test", mockBfdClient);
     }
 
     @BeforeEach

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/JobResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/JobResourceTest.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.ws.rs.core.Response;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -54,7 +56,12 @@ public class JobResourceTest {
         final var queue = new MemoryBatchQueue(100);
 
         // Setup a queued job
-        final var jobID = queue.createJob(orgID, TEST_PROVIDER_ID, List.of(TEST_PATIENT_ID), JobQueueBatch.validResourceTypes);
+        final var jobID = queue.createJob(orgID,
+                TEST_PROVIDER_ID,
+                List.of(TEST_PATIENT_ID),
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
 
         // Test the response
         final var resource = new JobResource(queue, TEST_BASEURL);
@@ -73,7 +80,12 @@ public class JobResourceTest {
         final var queue = new MemoryBatchQueue(100);
 
         // Setup a running job
-        final var jobID = queue.createJob(orgID, TEST_PROVIDER_ID, List.of(TEST_PATIENT_ID, TEST_PATIENT_ID), JobQueueBatch.validResourceTypes);
+        final var jobID = queue.createJob(orgID,
+                TEST_PROVIDER_ID,
+                List.of(TEST_PATIENT_ID, TEST_PATIENT_ID),
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
         final var runningJob = queue.claimBatch(AGGREGATOR_ID);
         runningJob.get().fetchNextPatient(AGGREGATOR_ID);
         queue.completePartialBatch(runningJob.get(), AGGREGATOR_ID);
@@ -95,7 +107,12 @@ public class JobResourceTest {
         final var queue = new MemoryBatchQueue(100);
 
         // Setup a completed job
-        final var jobID = queue.createJob(orgID, TEST_PROVIDER_ID, List.of(TEST_PATIENT_ID), JobQueueBatch.validResourceTypes);
+        final var jobID = queue.createJob(orgID,
+                TEST_PROVIDER_ID,
+                List.of(TEST_PATIENT_ID),
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
         queue.claimBatch(AGGREGATOR_ID);
 
         final var runningJob = queue.getJobBatches(jobID).get(0);
@@ -131,7 +148,12 @@ public class JobResourceTest {
         final var queue = new MemoryBatchQueue(100);
 
         // Setup a completed job with one error
-        final var jobID = queue.createJob(orgID, TEST_PROVIDER_ID, List.of(TEST_PATIENT_ID), JobQueueBatch.validResourceTypes);
+        final var jobID = queue.createJob(orgID,
+                TEST_PROVIDER_ID,
+                List.of(TEST_PATIENT_ID),
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
         queue.claimBatch(AGGREGATOR_ID);
 
         final var runningJob = queue.getJobBatches(jobID).get(0);
@@ -164,7 +186,12 @@ public class JobResourceTest {
         final var queue = new MemoryBatchQueue(100);
 
         // Setup a failed job
-        final var jobID = queue.createJob(orgID, TEST_PROVIDER_ID, List.of(TEST_PATIENT_ID), JobQueueBatch.validResourceTypes);
+        final var jobID = queue.createJob(orgID,
+                TEST_PROVIDER_ID,
+                List.of(TEST_PATIENT_ID),
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
         queue.claimBatch(AGGREGATOR_ID);
 
         final var runningJob = queue.getJobBatches(jobID).get(0);
@@ -188,7 +215,12 @@ public class JobResourceTest {
         final var queue = new MemoryBatchQueue(100);
 
         // Setup a completed job
-        final var jobID = queue.createJob(orgIDCorrect, TEST_PROVIDER_ID, List.of(TEST_PATIENT_ID), JobQueueBatch.validResourceTypes);
+        final var jobID = queue.createJob(orgIDCorrect,
+                TEST_PROVIDER_ID,
+                List.of(TEST_PATIENT_ID),
+                JobQueueBatch.validResourceTypes,
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
         queue.claimBatch(AGGREGATOR_ID);
 
         final var runningJob = queue.getJobBatches(jobID).get(0);

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/BlueButtonClientModule.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/BlueButtonClientModule.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
+import com.google.inject.name.Named;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.bluebutton.client.BlueButtonClientImpl;
@@ -62,11 +63,12 @@ public class BlueButtonClientModule<T extends Configuration & BlueButtonBundleCo
     }
 
     @Provides
-    public BlueButtonClient provideBlueButtonClient(IGenericClient fhirRestClient, MetricRegistry registry) {
+    public BlueButtonClient provideBlueButtonClient(@Named("bbclient") IGenericClient fhirRestClient, MetricRegistry registry) {
         return new BlueButtonClientImpl(fhirRestClient, this.bbClientConfiguration, registry);
     }
 
     @Provides
+    @Named("bbclient")
     public IGenericClient provideFhirRestClient(FhirContext fhirContext, HttpClient httpClient) {
         fhirContext.getRestfulClientFactory().setHttpClient(httpClient);
 

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClient.java
@@ -1,25 +1,25 @@
 package gov.cms.dpc.bluebutton.client;
 
 
+import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
-import org.hl7.fhir.dstu3.model.Patient;
 
 import java.security.GeneralSecurityException;
 
 
 public interface BlueButtonClient {
 
-    Patient requestPatientFromServer(String beneId) throws ResourceNotFoundException;
-
     Bundle requestPatientFromServerByMbi(String mbi) throws ResourceNotFoundException, GeneralSecurityException;
 
     Bundle requestPatientFromServerByMbiHash(String mbiHash) throws ResourceNotFoundException;
 
-    Bundle requestEOBFromServer(String beneId) throws ResourceNotFoundException;
+    Bundle requestPatientFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException;
 
-    Bundle requestCoverageFromServer(String beneId) throws ResourceNotFoundException;
+    Bundle requestEOBFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException;
+
+    Bundle requestCoverageFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException;
 
     Bundle requestNextBundleFromServer(Bundle bundle) throws ResourceNotFoundException;
 

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClientImpl.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/BlueButtonClientImpl.java
@@ -5,10 +5,14 @@ import ca.uhn.fhir.rest.gclient.ICriterion;
 import ca.uhn.fhir.rest.gclient.IParam;
 import ca.uhn.fhir.rest.gclient.IQuery;
 import ca.uhn.fhir.rest.gclient.TokenClientParam;
+import ca.uhn.fhir.rest.gclient.ReferenceClientParam;
+import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import gov.cms.dpc.bluebutton.config.BBClientConfiguration;
 import gov.cms.dpc.common.utils.MetricMaker;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
@@ -69,18 +73,16 @@ public class BlueButtonClientImpl implements BlueButtonClient {
     /**
      * Queries Blue Button server for patient data
      *
-     * @param patientID The requested patient's ID
+     * @param beneId The requested patient's ID
      * @return {@link Patient} A FHIR Patient resource
      * @throws ResourceNotFoundException when no such patient with the provided ID exists
      */
     @Override
-    public Patient requestPatientFromServer(String patientID) throws ResourceNotFoundException {
-        logger.debug("Attempting to fetch patient ID {} from baseURL: {}", patientID, client.getServerBase());
-        return instrumentCall(REQUEST_PATIENT_METRIC, () -> client
-                .read()
-                .resource(Patient.class)
-                .withId(patientID)
-                .execute());
+    public Bundle requestPatientFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException {
+        logger.debug("Attempting to fetch patient ID {} from baseURL: {}", beneId, client.getServerBase());
+        ICriterion<ReferenceClientParam> criterion = new ReferenceClientParam(Patient.SP_RES_ID).hasId(beneId);
+        return instrumentCall(REQUEST_EOB_METRIC, () ->
+                fetchBundle(Patient.class, Collections.singletonList(criterion), beneId, lastUpdated));
     }
 
     /**
@@ -125,22 +127,23 @@ public class BlueButtonClientImpl implements BlueButtonClient {
      *  returns the Bundle it received from BlueButton to the caller, and the caller is responsible for handling Bundles
      *  that contain no EoBs.
      *
-     * @param patientID The requested patient's ID
+     * @param beneId The requested patient's ID
      * @return {@link Bundle} Containing a number (possibly 0) of {@link ExplanationOfBenefit} objects
      * @throws ResourceNotFoundException when the requested patient does not exist
      */
     @Override
-    public Bundle requestEOBFromServer(String patientID) {
-        logger.debug("Attempting to fetch EOBs for patient ID {} from baseURL: {}", patientID, client.getServerBase());
+    public Bundle requestEOBFromServer(String beneId, DateRangeParam lastUpdated) {
+        logger.debug("Attempting to fetch EOBs for patient ID {} from baseURL: {}", beneId, client.getServerBase());
 
         List<ICriterion<? extends IParam>> criteria = new ArrayList<ICriterion<? extends IParam>>();
-        criteria.add(ExplanationOfBenefit.PATIENT.hasId(patientID));
+        criteria.add(ExplanationOfBenefit.PATIENT.hasId(beneId));
         criteria.add(new TokenClientParam("excludeSAMHSA").exactly().code("true"));
 
         return instrumentCall(REQUEST_EOB_METRIC, () ->
                 fetchBundle(ExplanationOfBenefit.class,
                         criteria,
-                        patientID));
+                        beneId,
+                        lastUpdated));
     }
 
     /**
@@ -156,19 +159,19 @@ public class BlueButtonClientImpl implements BlueButtonClient {
      *  returns the Bundle it received from BlueButton to the caller, and the caller is responsible for handling Bundles
      *  that contain no coverage records.
      *
-     * @param patientID The requested patient's ID
+     * @param beneId The requested patient's ID
      * @return {@link Bundle} Containing a number (possibly 0) of {@link ExplanationOfBenefit} objects
      * @throws ResourceNotFoundException when the requested patient does not exist
      */
     @Override
-    public Bundle requestCoverageFromServer(String patientID) throws ResourceNotFoundException {
-        logger.debug("Attempting to fetch Coverage for patient ID {} from baseURL: {}", patientID, client.getServerBase());
+    public Bundle requestCoverageFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException {
+        logger.debug("Attempting to fetch Coverage for patient ID {} from baseURL: {}", beneId, client.getServerBase());
 
         List<ICriterion<? extends IParam>> criteria = new ArrayList<ICriterion<? extends IParam>>();
-        criteria.add(Coverage.BENEFICIARY.hasId(formBeneficiaryID(patientID)));
+        criteria.add(Coverage.BENEFICIARY.hasId(formBeneficiaryID(beneId)));
 
         return instrumentCall(REQUEST_COVERAGE_METRIC, () ->
-                fetchBundle(Coverage.class, criteria, patientID));
+                fetchBundle(Coverage.class, criteria, beneId, lastUpdated));
     }
 
     @Override
@@ -217,11 +220,13 @@ public class BlueButtonClientImpl implements BlueButtonClient {
      * @param resourceClass - FHIR Resource class
      * @param criteria - For the resource class the correct criteria that match the patientID
      * @param patientID - id of patient
+     * @param lastUpdated - the lastUpdated date to search for
      * @return FHIR Bundle resource
      */
     private <T extends IBaseResource> Bundle fetchBundle(Class<T> resourceClass,
                                                          List<ICriterion<? extends IParam>> criteria,
-                                                         String patientID) {
+                                                         String patientID,
+                                                         DateRangeParam lastUpdated) {
         IQuery<IBaseBundle> query = client.search()
                 .forResource(resourceClass)
                 .where(criteria.remove(0));
@@ -230,12 +235,14 @@ public class BlueButtonClientImpl implements BlueButtonClient {
             query = query.and(criterion);
         }
 
-        final Bundle bundle = query.count(config.getResourcesCount())
+        final Bundle bundle = query
+                .lastUpdated(lastUpdated)
+                .count(config.getResourcesCount())
                 .returnBundle(Bundle.class)
                 .execute();
 
         // Case where patientID does not exist at all
-        if(!bundle.hasEntry()) {
+        if(!bundle.hasEntry() && lastUpdated == null) {
             throw new ResourceNotFoundException("No patient found with ID: " + patientID);
         }
         return bundle;

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
@@ -1,21 +1,19 @@
 package gov.cms.dpc.bluebutton.client;
 
-
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.PerformanceOptionsEnum;
 import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.CapabilityStatement;
-import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.security.GeneralSecurityException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -45,26 +43,15 @@ public class MockBlueButtonClient implements BlueButtonClient {
     }
 
     @Override
-    public Patient requestPatientFromServer(String beneId) throws ResourceNotFoundException {
-        return loadOne(Patient.class, SAMPLE_PATIENT_PATH_PREFIX, beneId);
+    public Bundle requestPatientFromServerByMbi(String mbi) throws ResourceNotFoundException {
+        return loadBundle(SAMPLE_PATIENT_PATH_PREFIX, MBI_BENE_ID_MAP.get(mbi));
     }
 
     @Override
-    public Bundle requestPatientFromServerByMbi(String mbi) throws ResourceNotFoundException {
-        Bundle b = new Bundle();
-        if (MULTIPLE_RESULTS_MBI.equals(mbi)) {
-            b.setTotal(2);
-            b.addEntry().setResource(new Patient());
-            b.addEntry().setResource(new Patient());
-        } else if (MBI_BENE_ID_MAP.containsKey(mbi)) {
-            Patient p = loadOne(Patient.class, SAMPLE_PATIENT_PATH_PREFIX, MBI_BENE_ID_MAP.get(mbi));
-            b.setTotal(1);
-            b.addEntry().setResource(p);
-        } else {
-            formNoPatientException(mbi);
-        }
-        return b;
+    public Bundle requestPatientFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException {
+        return loadBundle(SAMPLE_PATIENT_PATH_PREFIX, beneId);
     }
+
 
     @Override
     public Bundle requestPatientFromServerByMbiHash(String mbiHash) throws ResourceNotFoundException {
@@ -72,20 +59,16 @@ public class MockBlueButtonClient implements BlueButtonClient {
                 .filter(h -> h.equals(mbiHash))
                 .findFirst()
                 .orElse("");
-        Patient p = loadOne(Patient.class, SAMPLE_PATIENT_PATH_PREFIX, MBI_BENE_ID_MAP.get(mbi));
-        Bundle b = new Bundle();
-        b.setTotal(1);
-        b.addEntry().setResource(p);
-        return b;
+        return loadBundle(SAMPLE_PATIENT_PATH_PREFIX, MBI_BENE_ID_MAP.get(mbi));
     }
 
     @Override
-    public Bundle requestEOBFromServer(String beneId) throws ResourceNotFoundException {
+    public Bundle requestEOBFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException {
         return loadBundle(SAMPLE_EOB_PATH_PREFIX, beneId);
     }
 
     @Override
-    public Bundle requestCoverageFromServer(String beneId) throws ResourceNotFoundException {
+    public Bundle requestCoverageFromServer(String beneId, DateRangeParam lastUpdated) throws ResourceNotFoundException {
         return loadBundle(SAMPLE_COVERAGE_PATH_PREFIX, beneId);
     }
 
@@ -94,7 +77,7 @@ public class MockBlueButtonClient implements BlueButtonClient {
         // This is code is very specific to the bb-test-data directory and its contents
         final var nextLink = bundle.getLink(Bundle.LINK_NEXT).getUrl();
         final var nextUrl = URI.create(nextLink);
-        final var params = URLEncodedUtils.parse(nextUrl.getQuery(), Charset.forName("UTF-8"));
+        final var params = URLEncodedUtils.parse(nextUrl.getQuery(), StandardCharsets.UTF_8);
         final var patient = params.stream().filter(pair -> pair.getName().equals("patient")).findFirst().orElseThrow().getValue();
         final var startIndex = params.stream().filter(pair -> pair.getName().equals("startIndex")).findFirst().orElseThrow().getValue();
         var path = SAMPLE_EOB_PATH_PREFIX + patient + "_" + startIndex + ".xml";
@@ -109,7 +92,11 @@ public class MockBlueButtonClient implements BlueButtonClient {
     @Override
     public CapabilityStatement requestCapabilityStatement() throws ResourceNotFoundException {
         final var path = SAMPLE_METADATA_PATH_PREFIX + "meta.xml";
-        return loadOne(CapabilityStatement.class, path, null);
+        try(InputStream sampleData = loadResource(path, null)) {
+            return parser.parseResource(CapabilityStatement.class, sampleData);
+        } catch(IOException ex) {
+            throw formNoPatientException(null);
+        }
     }
 
     @Override
@@ -133,21 +120,6 @@ public class MockBlueButtonClient implements BlueButtonClient {
     }
 
     /**
-     * Read a FHIR Resource from the jar's resource file.
-     *
-     * @param resourceClass - FHIR Resource class
-     * @param pathPrefix - Path to the XML sample data
-     * @return FHIR Resource
-     */
-    private <T extends IBaseResource> T loadOne(Class<T> resourceClass, String pathPrefix, String patientID) {
-        try(InputStream sampleData = loadResource(pathPrefix, patientID)) {
-            return parser.parseResource(resourceClass, sampleData);
-        } catch(IOException ex) {
-            throw formNoPatientException(patientID);
-        }
-    }
-
-    /**
      * Create a stream from a resource.
      *
      * @param pathPrefix - The path to the resource file
@@ -155,7 +127,7 @@ public class MockBlueButtonClient implements BlueButtonClient {
      * @return the stream associated with the resource
      */
     private InputStream loadResource(String pathPrefix, String beneId) throws ResourceNotFoundException {
-        if (!MBI_BENE_ID_MAP.values().contains(beneId)) {
+        if (!MBI_BENE_ID_MAP.containsValue(beneId)) {
             throw formNoPatientException(beneId);
         }
         final var path = pathPrefix + beneId + ".xml";

--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
@@ -30,6 +30,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.concurrent.TimeUnit;
@@ -167,6 +168,16 @@ class BlueButtonClientTest {
     @Test
     void shouldGetFHIRFromPatientIDWithoutLastUpdated() {
         Bundle ret = bbc.requestPatientFromServer(TEST_PATIENT_ID, null);
+        // Verify that the bundle has one
+        assertNotNull(ret, "The demo Patient object returned from BlueButtonClient should not be null");
+        assertEquals(ResourceType.Bundle, ret.getResourceType());
+        assertEquals(1, ret.getEntry().size());
+        assertEquals(ResourceType.Patient, ret.getEntry().get(0).getResource().getResourceType());
+    }
+
+    @Test
+    void shouldGetFHIRFromPatientIDWithLastUpdated() {
+        Bundle ret = bbc.requestPatientFromServer(TEST_PATIENT_ID, TEST_LAST_UPDATED);
         // Verify that the bundle has one
         assertNotNull(ret, "The demo Patient object returned from BlueButtonClient should not be null");
         assertEquals(ResourceType.Bundle, ret.getResourceType());

--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/BlueButtonClientTest.java
@@ -30,7 +30,6 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.MissingResourceException;
 import java.util.concurrent.TimeUnit;

--- a/dpc-common/src/main/java/gov/cms/dpc/common/models/JobCompletionModel.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/models/JobCompletionModel.java
@@ -159,7 +159,7 @@ public class JobCompletionModel {
         this.request = request;
         this.output = output;
         this.error = error;
-        this.extension = extension;
+        this.extension = extension != null && extension.isEmpty() ? null : extension;
     }
 
     public OffsetDateTime getTransactionTime() {

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/IJobQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/IJobQueue.java
@@ -4,6 +4,7 @@ import gov.cms.dpc.queue.models.JobQueueBatch;
 import gov.cms.dpc.queue.models.JobQueueBatchFile;
 import org.hl7.fhir.dstu3.model.ResourceType;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -21,9 +22,16 @@ public interface IJobQueue {
      * @param providerID    - The provider submitting the job
      * @param mbis          - The list of MBIs of patients to fetch data for
      * @param resourceTypes - The resource types to fetch patient data for
+     * @param since         - The since parameter to use for the requests. May be null.
+     * @param transactionTime - The transactionTime of the job
      * @return The UUID of the created job
      */
-    UUID createJob(UUID orgID, String providerID, List<String> mbis, List<ResourceType> resourceTypes);
+    UUID createJob(UUID orgID,
+                   String providerID,
+                   List<String> mbis,
+                   List<ResourceType> resourceTypes,
+                   OffsetDateTime since,
+                   OffsetDateTime transactionTime);
 
     /**
      * Find a batch in the queue, regardless of job status. Does not alter the batch.

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueCommon.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueCommon.java
@@ -6,7 +6,6 @@ import io.reactivex.Observable;
 import org.hl7.fhir.dstu3.model.ResourceType;
 
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatch.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatch.java
@@ -100,6 +100,18 @@ public class JobQueueBatch implements Serializable {
     private List<ResourceType> resourceTypes;
 
     /**
+     * The since parameter from the export request
+     */
+    @Column(name = "since", nullable = true)
+    private OffsetDateTime since;
+
+    /**
+     * The transaction time parameter from the job creation
+     */
+    @Column(name = "transaction_time", nullable = true)
+    private OffsetDateTime transactionTime;
+
+    /**
      * The current aggregator processing the batch. Null indicates no aggregator is processing the batch.
      */
     @Column(name = "aggregator_id")
@@ -145,13 +157,21 @@ public class JobQueueBatch implements Serializable {
     public JobQueueBatch() {
     }
 
-    public JobQueueBatch(UUID jobID, UUID orgID, String providerID, List<String> patients, List<ResourceType> resourceTypes) {
+    public JobQueueBatch(UUID jobID,
+                         UUID orgID,
+                         String providerID,
+                         List<String> patients,
+                         List<ResourceType> resourceTypes,
+                         OffsetDateTime since,
+                         OffsetDateTime transactionTime) {
         this.batchID = UUID.randomUUID();
         this.jobID = jobID;
         this.orgID = orgID;
         this.providerID = providerID;
         this.patients = patients;
         this.resourceTypes = resourceTypes;
+        this.since = since;
+        this.transactionTime = transactionTime;
         this.status = JobStatus.QUEUED;
         this.submitTime = OffsetDateTime.now(ZoneOffset.UTC);
         this.jobQueueBatchFiles = new ArrayList<>();
@@ -210,6 +230,14 @@ public class JobQueueBatch implements Serializable {
 
     public List<ResourceType> getResourceTypes() {
         return resourceTypes;
+    }
+
+    public Optional<OffsetDateTime> getSince() {
+        return Optional.ofNullable(since);
+    }
+
+    public OffsetDateTime getTransactionTime() {
+        return transactionTime;
     }
 
     public Optional<UUID> getAggregatorID() {
@@ -417,6 +445,8 @@ public class JobQueueBatch implements Serializable {
                 .append(patients, that.patients)
                 .append(patientIndex, that.patientIndex)
                 .append(resourceTypes, that.resourceTypes)
+                .append(since, that.since)
+                .append(transactionTime, that.transactionTime)
                 .append(aggregatorID, that.aggregatorID)
                 .append(updateTime, that.updateTime)
                 .append(submitTime, that.submitTime)
@@ -438,6 +468,8 @@ public class JobQueueBatch implements Serializable {
                 .append(patients)
                 .append(patientIndex)
                 .append(resourceTypes)
+                .append(since)
+                .append(transactionTime)
                 .append(aggregatorID)
                 .append(updateTime)
                 .append(submitTime)
@@ -458,6 +490,8 @@ public class JobQueueBatch implements Serializable {
                 ", patients=" + patients +
                 ", patientIndex=" + patientIndex +
                 ", resourceTypes=" + resourceTypes +
+                ", since=" + since +
+                ", transactionTime=" + transactionTime +
                 ", aggregatorID=" + aggregatorID +
                 ", updateTime=" + updateTime +
                 ", submitTime=" + submitTime +

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -102,7 +103,12 @@ public class DistributedBatchQueueTest {
 
     private UUID buildStuckBatchScenario(UUID orgID) {
         // Add a job
-        var jobID = queue.createJob(orgID, "test-provider-1", List.of("test-patient-1", "test-patient-2"), Collections.singletonList(ResourceType.Patient));
+        var jobID = queue.createJob(orgID,
+                "test-provider-1",
+                List.of("test-patient-1", "test-patient-2"),
+                Collections.singletonList(ResourceType.Patient),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
 
         // Work the job
         Optional<JobQueueBatch> workBatch = queue.claimBatch(aggregatorID);

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
@@ -56,7 +58,8 @@ class QueueTest {
                     final DynamicTest second = DynamicTest.dynamicTest(nameGenerator.apply(queue, "Missing Job"), () -> testMissingJob(queue));
                     final DynamicTest third = DynamicTest.dynamicTest(nameGenerator.apply(queue, "EOB Submission"), () -> testPatientAndEOBSubmission(queue));
                     final DynamicTest fourth = DynamicTest.dynamicTest(nameGenerator.apply(queue, "Invalid batch on queue"), () -> testInvalidJobBatch(queue));
-                    return List.of(first, second, third, fourth);
+                    final DynamicTest fifth = DynamicTest.dynamicTest(nameGenerator.apply(queue, "since equal transaction time"), () -> testSinceEqualTransactionTime(queue));
+                    return List.of(first, second, third, fourth, fifth);
                 })
                 .flatMap(Collection::stream);
     }
@@ -86,9 +89,8 @@ class QueueTest {
         final UUID orgID = UUID.randomUUID();
 
         // Add a couple of jobs
-        var firstJobID = queue.createJob(orgID, "test-provider-1", List.of("test-patient-1", "test-patient-2"), Collections.singletonList(ResourceType.Patient));
-        var secondJobID = queue.createJob(orgID, "test-provider-1", List.of("test-patient-1", "test-patient-2"), Collections.singletonList(ResourceType.Patient));
-
+        var firstJobID = queue.createJob(orgID, "test-provider-1", List.of("test-patient-1", "test-patient-2"), Collections.singletonList(ResourceType.Patient), null, OffsetDateTime.now(ZoneOffset.UTC));
+        var secondJobID = queue.createJob(orgID, "test-provider-1", List.of("test-patient-1", "test-patient-2"), Collections.singletonList(ResourceType.Patient), null, OffsetDateTime.now(ZoneOffset.UTC));
         assertEquals(2, queue.queueSize(), "Should have 2 jobs");
 
         // Check the status of the job
@@ -158,7 +160,12 @@ class QueueTest {
     void testPatientAndEOBSubmission(JobQueueCommon queue) {
         // Add a job with a EOB resource
         final var orgID = UUID.randomUUID();
-        final var jobID = queue.createJob(orgID, "test-provider-1", List.of("test-patient-1", "test-patient-2"), Arrays.asList(ResourceType.Patient, ResourceType.ExplanationOfBenefit));
+        final var jobID = queue.createJob(orgID,
+                "test-provider-1",
+                List.of("test-patient-1", "test-patient-2"),
+                Arrays.asList(ResourceType.Patient, ResourceType.ExplanationOfBenefit),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC));
 
         // Retrieve the job with both resources
         final var workBatch = queue.claimBatch(aggregatorID).get();
@@ -192,6 +199,23 @@ class QueueTest {
         assertThrows(JobQueueFailure.class, () -> queue.completeBatch(null, aggregatorID), "Should error when completing a job which does not exist");
     }
 
+
+    void testSinceEqualTransactionTime(JobQueueCommon queue) {
+        final var transactionTime = OffsetDateTime.now(ZoneOffset.UTC);
+        final var jobId = queue.createJob(UUID.randomUUID(),
+                "test-provider-1",
+                List.of("test-patient-1", "test-patient-2"),
+                Arrays.asList(ResourceType.Patient, ResourceType.ExplanationOfBenefit),
+                transactionTime,
+                transactionTime);
+
+        // Check that the Job has a empty queue
+        final Optional<JobQueueBatch> job = queue.getJobBatches(jobId).stream().findFirst();
+        assertAll(() -> assertTrue(job.isPresent(), "Should be present in the queue."),
+                () -> assertEquals(JobStatus.QUEUED, job.get().getStatus(), "Job should be in queue"),
+                () -> assertTrue(job.get().getPatients().isEmpty()));
+    }
+
     void testInvalidJobBatch(JobQueueCommon queue) {
         final UUID orgID = UUID.randomUUID();
         final UUID jobID = UUID.randomUUID();
@@ -201,7 +225,9 @@ class QueueTest {
                 orgID,
                 "test-provider-1",
                 Collections.singletonList("test-patient-1"),
-                Collections.singletonList(ResourceType.ExplanationOfBenefit)
+                Collections.singletonList(ResourceType.ExplanationOfBenefit),
+                null,
+                OffsetDateTime.now(ZoneOffset.UTC)
         );
 
         // Set the aggregatorID to something random so it gets claimed incorrectly

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/models/JobQueueBatchTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/models/JobQueueBatchTest.java
@@ -322,7 +322,7 @@ public class JobQueueBatchTest {
     }
 
     JobQueueBatch createJobQueueBatch() {
-        return new JobQueueBatch(jobID, orgID, providerID, patientList, resourceTypes);
+        return new JobQueueBatch(jobID, orgID, providerID, patientList, resourceTypes, null, OffsetDateTime.now(ZoneOffset.UTC));
     }
 
 }

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1219,6 +1219,146 @@
 						"description": "Request a subset of the EOB data to ensure range requests work correctly."
 					},
 					"response": []
+				},
+				{
+					"name": "Try export with _since",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5497fa12-aefd-44c2-9254-2beb51c52e31",
+								"exec": [
+									"// Status should be 204",
+									"pm.test(\"Status is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"// Url for job response should be in content-location header.",
+									"pm.test(\"Content-Location header is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Location\");",
+									"});",
+									"",
+									"if (pm.response.headers.get(\"Content-Location\")) {",
+									"  pm.environment.set(\"since_content_location\", pm.response.headers.get(\"Content-Location\"));",
+									"} else {",
+									"  // Fail the test, no content location.",
+									"  postman.setNextRequest(null);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "8b8d6363-b490-428a-bfee-663b184ae05d",
+								"exec": [
+									"console.log(\"Group:\", pm.environment.get(\"attribution_group\"));",
+									"pm.environment.set(\"since_timestamp\", new Date().toISOString());"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/fhir+json"
+							},
+							{
+								"key": "Prefer",
+								"type": "text",
+								"value": "respond-async"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Group/{{attribution_group_id}}/$export?_since={{since_timestamp}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Group",
+								"{{attribution_group_id}}",
+								"$export"
+							],
+							"query": [
+								{
+									"key": "_since",
+									"value": "{{since_timestamp}}"
+								}
+							]
+						},
+						"description": "Try the export request again with the _since parameter of the current time. The resultant job should be empty. The request should succeed with a 204 status and the location for the job response in the `content-location` header."
+					},
+					"response": []
+				},
+				{
+					"name": "_since job response",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "28fe7a36-50ab-4e7d-bf21-312b5f5777f3",
+								"exec": [
+									"// Wait between pings",
+									"setTimeout(function() {}, 1000);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "70688a82-d0cf-4802-b1e5-b6ad7357c926",
+								"exec": [
+									"if (pm.response.code == 200) {",
+									"    // Response should have FHIR Content-Type",
+									"    pm.test(\"Content-type is application/json\", function() {",
+									"       pm.response.to.have.header(\"Content-Type\", \"application/json\"); ",
+									"    });",
+									"    ",
+									"    // If response code is 200, check the response and load the urls.",
+									"    pm.test(\"Empty output and no errors\", function() {",
+									"        pm.expect(pm.response.json().error).to.have.lengthOf(0);",
+									"        pm.expect(pm.response.json().output).to.have.lengthOf(0);",
+									"    });",
+									"} else {",
+									"    // If response code is not 200, it should be 202. Assert that, and retry.",
+									"    pm.test(\"Status code is 202\", function () {",
+									"        pm.response.to.have.status(202);",
+									"    });",
+									"    postman.setNextRequest(\"_since job response\");",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{since_content_location}}",
+							"host": [
+								"{{since_content_location}}"
+							]
+						},
+						"description": "While the export request is being processed, the job url will return a 202 status. When it is completed, a 200 status will be returned, along with JSON containing Job status."
+					},
+					"response": []
 				}
 			],
 			"protocolProfileBehavior": {}

--- a/src/test/resources/bb-test-data/coverage/-20140000008325.xml
+++ b/src/test/resources/bb-test-data/coverage/-20140000008325.xml
@@ -14,6 +14,9 @@
         <resource>
             <Coverage xmlns="http://hl7.org/fhir">
                 <id value="part-a-20140000008325"></id>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/ms_cd">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/ms_cd"></system>
@@ -71,6 +74,9 @@
         <resource>
             <Coverage xmlns="http://hl7.org/fhir">
                 <id value="part-b-20140000008325"></id>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/ms_cd">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/ms_cd"></system>
@@ -107,6 +113,9 @@
         <resource>
             <Coverage xmlns="http://hl7.org/fhir">
                 <id value="part-d-20140000008325"></id>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/ms_cd">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/ms_cd"></system>

--- a/src/test/resources/bb-test-data/coverage/-20140000009893.xml
+++ b/src/test/resources/bb-test-data/coverage/-20140000009893.xml
@@ -14,6 +14,9 @@
         <resource>
             <Coverage xmlns="http://hl7.org/fhir">
                 <id value="part-a-20140000009893"></id>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/ms_cd">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/ms_cd"></system>
@@ -71,6 +74,9 @@
         <resource>
             <Coverage xmlns="http://hl7.org/fhir">
                 <id value="part-b-20140000009893"></id>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/ms_cd">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/ms_cd"></system>
@@ -107,6 +113,9 @@
         <resource>
             <Coverage xmlns="http://hl7.org/fhir">
                 <id value="part-d-20140000009893"></id>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/ms_cd">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/ms_cd"></system>

--- a/src/test/resources/bb-test-data/empty.xml
+++ b/src/test/resources/bb-test-data/empty.xml
@@ -1,0 +1,12 @@
+<Bundle xmlns="http://hl7.org/fhir">
+    <id value="1de2a02c-b115-4525-9325-f6a1548f449d"></id>
+    <meta>
+        <lastUpdated value="2019-05-25T23:45:16.962-04:00"></lastUpdated>
+    </meta>
+    <type value="searchset"></type>
+    <total value="0"></total>
+    <link>
+        <relation value="self"></relation>
+        <url value="https://sandbox.bluebutton.cms.gov/v1/fhir/Coverage/?_format=application%2Fjson%2Bfhir&amp;beneficiary=Patient%2F20140000009893&amp;_count=10&amp;startIndex=0"></url>
+    </link>
+</Bundle>

--- a/src/test/resources/bb-test-data/eob/-20140000008325.xml
+++ b/src/test/resources/bb-test-data/eob/-20140000008325.xml
@@ -17,6 +17,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-20587716665"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -1741,6 +1744,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-20707791705"/>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
             <extension url="https://bluebutton.cms.gov/resources/variables/prpayamt">
                <valueMoney>
                   <value value="0.00"/>
@@ -2647,6 +2653,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-20945302182"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -3778,6 +3787,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-20956105914"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <extension url="https://bluebutton.cms.gov/resources/variables/prpayamt">
                <valueMoney>
                   <value value="0.00"/>
@@ -4684,6 +4696,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-20989445930"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -5131,6 +5146,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-21126565981"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -5585,6 +5603,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-21366012370"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -6294,6 +6315,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-21513766042"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <extension url="https://bluebutton.cms.gov/resources/variables/prpayamt">
                <valueMoney>
                   <value value="0.00"/>
@@ -6715,6 +6739,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-21856079985"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>

--- a/src/test/resources/bb-test-data/eob/-20140000008325_10.xml
+++ b/src/test/resources/bb-test-data/eob/-20140000008325_10.xml
@@ -17,6 +17,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-21870822912"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -1701,6 +1704,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-21932158205"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -2149,6 +2155,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-21957368585"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -5127,6 +5136,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22011027731"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -7286,6 +7298,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22011027732"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -9435,6 +9450,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22074654603"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -12413,6 +12431,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22100694165"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -15391,6 +15412,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22116335820"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -15839,6 +15863,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22273336765"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -18807,6 +18834,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22289703264"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>

--- a/src/test/resources/bb-test-data/eob/-20140000008325_20.xml
+++ b/src/test/resources/bb-test-data/eob/-20140000008325_20.xml
@@ -17,6 +17,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22299857407"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -980,6 +983,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22335338581"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -3381,6 +3387,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22354428064"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -3829,6 +3838,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22639159481"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -4270,6 +4282,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-22654221223"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>
@@ -4965,6 +4980,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="pde-3269834580"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <identifier>
                <system value="https://bluebutton.cms.gov/resources/variables/pde_id"/>
                <value value="3269834580"/>
@@ -5323,6 +5341,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="inpatient-4436342082"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <extension url="https://bluebutton.cms.gov/resources/variables/clm_pass_thru_per_diem_amt">
                <valueMoney>
                   <value value="0.00"/>
@@ -6469,6 +6490,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="inpatient-4512116227"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <extension url="https://bluebutton.cms.gov/resources/variables/dsh_op_clm_val_amt">
                <valueMoney>
                   <value value="350.00"/>
@@ -7800,6 +7824,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="pde-4894712975"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <identifier>
                <system value="https://bluebutton.cms.gov/resources/variables/pde_id"/>
                <value value="4894712975"/>
@@ -8176,6 +8203,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="pde-5764339373"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <identifier>
                <system value="https://bluebutton.cms.gov/resources/variables/pde_id"/>
                <value value="5764339373"/>

--- a/src/test/resources/bb-test-data/eob/-20140000008325_30.xml
+++ b/src/test/resources/bb-test-data/eob/-20140000008325_30.xml
@@ -13,6 +13,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="pde-7060841642"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <identifier>
                <system value="https://bluebutton.cms.gov/resources/variables/pde_id"/>
                <value value="7060841642"/>
@@ -402,6 +405,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="pde-930361669"/>
+            <meta>
+                <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <identifier>
                <system value="https://bluebutton.cms.gov/resources/variables/pde_id"/>
                <value value="930361669"/>

--- a/src/test/resources/bb-test-data/eob/-20140000009893.xml
+++ b/src/test/resources/bb-test-data/eob/-20140000009893.xml
@@ -13,6 +13,9 @@
       <resource>
          <ExplanationOfBenefit xmlns="http://hl7.org/fhir">
             <id value="carrier-20920812471"/>
+            <meta>
+               <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+            </meta>
             <contained>
                <ReferralRequest xmlns="http://hl7.org/fhir">
                   <id value="1"/>

--- a/src/test/resources/bb-test-data/patient/-20140000008325.xml
+++ b/src/test/resources/bb-test-data/patient/-20140000008325.xml
@@ -13,6 +13,9 @@
         <resource>
             <Patient xmlns="http://hl7.org/fhir">
                 <id value="-20140000008325"/>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/race">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/race"/>

--- a/src/test/resources/bb-test-data/patient/-20140000008325.xml
+++ b/src/test/resources/bb-test-data/patient/-20140000008325.xml
@@ -1,35 +1,47 @@
-<Patient xmlns="http://hl7.org/fhir">
-   <id value="20140000008325"/>
-   <extension url="https://bluebutton.cms.gov/resources/variables/race">
-      <valueCoding>
-         <system value="https://bluebutton.cms.gov/resources/variables/race"/>
-         <code value="1"/>
-         <display value="White"/>
-      </valueCoding>
-   </extension>
-   <identifier>
-      <system value="https://bluebutton.cms.gov/resources/variables/bene_id"/>
-      <value value="-20140000008325"/>
-   </identifier>
-   <identifier>
-      <system value="https://bluebutton.cms.gov/resources/identifier/hicn-hash"/>
-      <value value="ee78989d1d9ba0b98f3cfbd52479f10c7631679c17563186f70fbef038cc9536"/>
-   </identifier>
-   <identifier>
-      <system value="https://bluebutton.cms.gov/resources/identifier/mbi-hash"/>
-      <value value="abadf57ff8dc94610ca0d479feadb1743c9cd3c77caf1eafde5719a154379fb6"/>
-   </identifier>
-   <name>
-      <use value="usual"/>
-      <family value="Doe"/>
-      <given value="Jane"/>
-      <given value="X"/>
-   </name>
-   <gender value="unknown"/>
-   <birthDate value="2014-06-01"/>
-   <address>
-      <district value="999"/>
-      <state value="15"/>
-      <postalCode value="99999"/>
-   </address>
-</Patient>
+<Bundle xmlns="http://hl7.org/fhir">
+    <id value="eb3894fc-ca04-44d4-adab-a9fb0a6f1976"/>
+    <meta>
+        <lastUpdated value="2020-01-01T00:01:23.456-04:00"/>
+    </meta>
+    <type value="searchset"/>
+    <total value="1"/>
+    <link>
+        <relation value="self"/>
+        <url value="http://localhost:8083/v1/fhir/Patient?identifier=https://bluebutton.cms.gov/resources/identifier/mbi-hash|abadf57ff8dc94610ca0d479feadb1743c9cd3c77caf1eafde5719a154379fb6"/>
+    </link>
+    <entry>
+        <resource>
+            <Patient xmlns="http://hl7.org/fhir">
+                <id value="-20140000008325"/>
+                <extension url="https://bluebutton.cms.gov/resources/variables/race">
+                    <valueCoding>
+                        <system value="https://bluebutton.cms.gov/resources/variables/race"/>
+                        <code value="1"/>
+                        <display value="White"/>
+                    </valueCoding>
+                </extension>
+                <identifier>
+                    <system value="https://bluebutton.cms.gov/resources/variables/bene_id"/>
+                    <value value="-20140000008325"/>
+                </identifier>
+                <identifier>
+                    <system value="https://bluebutton.cms.gov/resources/identifier/mbi-hash"/>
+                    <value value="abadf57ff8dc94610ca0d479feadb1743c9cd3c77caf1eafde5719a154379fb6"/>
+                </identifier>
+                <name>
+                    <use value="usual"/>
+                    <family value="Doe"/>
+                    <given value="Jane"/>
+                    <given value="X"/>
+                </name>
+                <gender value="unknown"/>
+                <birthDate value="2014-06-01"/>
+                <address>
+                    <district value="999"/>
+                    <state value="15"/>
+                    <postalCode value="99999"/>
+                </address>
+            </Patient>
+        </resource>
+    </entry>
+</Bundle>

--- a/src/test/resources/bb-test-data/patient/-20140000009893.xml
+++ b/src/test/resources/bb-test-data/patient/-20140000009893.xml
@@ -13,6 +13,9 @@
         <resource>
             <Patient xmlns="http://hl7.org/fhir">
                 <id value="-20140000009893"/>
+                <meta>
+                    <lastUpdated value="2020-01-01T00:00:00-05:00"></lastUpdated>
+                </meta>
                 <extension url="https://bluebutton.cms.gov/resources/variables/race">
                     <valueCoding>
                         <system value="https://bluebutton.cms.gov/resources/variables/race"/>

--- a/src/test/resources/bb-test-data/patient/-20140000009893.xml
+++ b/src/test/resources/bb-test-data/patient/-20140000009893.xml
@@ -1,35 +1,48 @@
-<Patient xmlns="http://hl7.org/fhir">
-   <id value="20140000009893"/>
-   <extension url="https://bluebutton.cms.gov/resources/variables/race">
-      <valueCoding>
-         <system value="https://bluebutton.cms.gov/resources/variables/race"/>
-         <code value="1"/>
-         <display value="White"/>
-      </valueCoding>
-   </extension>
-   <identifier>
-      <system value="https://bluebutton.cms.gov/resources/variables/bene_id"/>
-      <value value="-20140000009893"/>
-   </identifier>
-   <identifier>
-      <system value="https://bluebutton.cms.gov/resources/identifier/hicn-hash"/>
-      <value value="fc463c4b2788ad575acf9194fc132c53cdad9b93d36955315d1af1ec7445d330"/>
-   </identifier>
-   <identifier>
-      <system value="https://bluebutton.cms.gov/resources/identifier/mbi-hash"/>
-      <value value="8930cab29ba5fe4311a5f5bcfd5b7384f3722b711402aacf796d2ae6fea54242"/>
-   </identifier>
-   <name>
-      <use value="usual"/>
-      <family value="Doe"/>
-      <given value="John"/>
-      <given value="X"/>
-   </name>
-   <gender value="unknown"/>
-   <birthDate value="2014-06-01"/>
-   <address>
-      <district value="999"/>
-      <state value="20"/>
-      <postalCode value="99999"/>
-   </address>
-</Patient>
+<Bundle xmlns="http://hl7.org/fhir">
+    <id value="eb3894fc-ca04-44d4-adab-a9fb0a6f1976"/>
+    <meta>
+        <lastUpdated value="2020-01-01T00:01:23.456-04:00"/>
+    </meta>
+    <type value="searchset"/>
+    <total value="1"/>
+    <link>
+        <relation value="self"/>
+        <url value="http://localhost:8083/v1/fhir/Patient?identifier=https://bluebutton.cms.gov/resources/identifier/mbi-hash|8930cab29ba5fe4311a5f5bcfd5b7384f3722b711402aacf796d2ae6fea54242"/>
+    </link>
+    <entry>
+        <resource>
+            <Patient xmlns="http://hl7.org/fhir">
+                <id value="-20140000009893"/>
+                <extension url="https://bluebutton.cms.gov/resources/variables/race">
+                    <valueCoding>
+                        <system value="https://bluebutton.cms.gov/resources/variables/race"/>
+                        <code value="1"/>
+                        <display value="White"/>
+                    </valueCoding>
+                </extension>
+                <identifier>
+                    <system value="https://bluebutton.cms.gov/resources/variables/bene_id"/>
+                    <value value="-20140000009893"/>
+                </identifier>
+                <identifier>
+                    <system value="https://bluebutton.cms.gov/resources/identifier/mbi-hash"/>
+                    <value value="8930cab29ba5fe4311a5f5bcfd5b7384f3722b711402aacf796d2ae6fea54242"/>
+                </identifier>
+                <name>
+                    <use value="usual"/>
+                    <family value="Doe"/>
+                    <given value="John"/>
+                    <given value="X"/>
+                </name>
+                <gender value="unknown"/>
+                <birthDate value="2014-06-01"/>
+                <address>
+                    <district value="999"/>
+                    <state value="20"/>
+                    <postalCode value="99999"/>
+                </address>
+            </Patient>
+        </resource>
+    </entry>
+</Bundle>
+


### PR DESCRIPTION
**Why**

Add support to the FHIR's Bulk Export _since parameter. 

**What Changed**

The export chain of components and structures had to be extended to ensure all batches use the same upper and lower bound. Consistency of these values is essential to ensure consecutive jobs do not have missing or duplicate resources. However, the overall structure of the export job has not changed. Batching and restarting a job remains the same. 

- The export API fetches the BFD's transactionTime to use as the upper bound of 
- JobBatch added since and transactionTime fields
- The AggregatorEngine and ResourceFetcher accept the new values
- The BBClient methods have a lastUpdated parameter added

One consequence of this that API now uses the BBClient module directly, whereas only the Aggregator used this module before. Again, this choice was necessary to keep transactionTime consistent between batches. About half of the file changes were made to hook this module up. 

**Choices Made**

I've added JobCompletionRecord extensions for job start and complete time. The FHIR community has encouraged experimentation with extensions. 

**Tickets closed**:

DPC-34: 

**Future Work**

CareJourney and others have pointed out that the _since parameter solves a major issue with data size, but creates a problem for new patients that are added to a roster. Future work should work on this issue. 

**Checklist**
_since has been added to our Swagger and FHIR documentation. 

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
