### PR TITLE
Correct BFD server URL env var name in configuration files

### DIFF
--- a/dpc-aggregation/src/main/resources/dev.application.conf
+++ b/dpc-aggregation/src/main/resources/dev.application.conf
@@ -14,7 +14,7 @@ dpc.aggregation {
   }
 
   bbclient {
-    serverBaseUrl = ${BB_SERVER_BASEURL}
+    serverBaseUrl = ${BFD_URL}
 
     keyStore {
       location = ${BB_KEYSTORE_LOCATION}

--- a/dpc-aggregation/src/main/resources/prod-sbx.application.conf
+++ b/dpc-aggregation/src/main/resources/prod-sbx.application.conf
@@ -13,7 +13,7 @@ dpc.aggregation {
   }
 
   bbclient {
-    serverBaseUrl = ${BB_SERVER_BASEURL}
+    serverBaseUrl = ${BFD_URL}
 
     keyStore {
       location = ${BB_KEYSTORE_LOCATION}

--- a/dpc-aggregation/src/main/resources/test.application.conf
+++ b/dpc-aggregation/src/main/resources/test.application.conf
@@ -13,7 +13,7 @@ dpc.aggregation {
   }
 
   bbclient {
-    serverBaseUrl = ${BB_SERVER_BASEURL}
+    serverBaseUrl = ${BFD_URL}
 
     keyStore {
       location = ${BB_KEYSTORE_LOCATION}


### PR DESCRIPTION
This amends https://github.com/CMSgov/dpc-app/pull/640 to set `bbclient.baseServerUrl` in the aggregation dev, test, and prod-sbx configuration files to environment variable `BFD_URL`.