### PR TITLE
DPC-1074: Password Required to Delete Account

### DIFF
--- a/dpc-web/app/controllers/users/registrations_controller.rb
+++ b/dpc-web/app/controllers/users/registrations_controller.rb
@@ -4,6 +4,22 @@ module Users
   class RegistrationsController < Devise::RegistrationsController
     include MultiModelLoginHelper
     skip_before_action :check_user, except: %i[new create]
+
+    def destroy
+      @user = User.find(current_user.id)
+      if @user.destroy_with_password(user_params[:current_password])
+          redirect_to root_url, notice: "User deleted."
+      else
+        redirect_to edit_user_registration_url
+        flash[:notice] = "Couldn't delete"
+      end
+    end
+
+    def user_params
+      params.require(:user).permit(:first_name, :last_name, :requested_organization, :requested_organization_type,
+                                    :address_1, :address_2, :city, :state, :zip, :agree_to_terms,
+                                    :email, :password, :password_confirmation, :current_password, :requested_num_providers )
+    end
     # before_action :configure_sign_up_params, only: [:create]
     # before_action :configure_account_update_params, only: [:update]
 

--- a/dpc-web/app/views/devise/registrations/edit.html.erb
+++ b/dpc-web/app/views/devise/registrations/edit.html.erb
@@ -3,6 +3,7 @@
 <div class="ds-l-row">
   <div class="ds-l-col--12 ds-l-md-col--6 ds-u-margin-bottom--1 ds-u-margin-x--auto">
     <div class="card card--border-top card--shadow">
+      <%= devise_error_messages! %>
 
       <h1>Edit your info</h1>
 

--- a/dpc-web/app/views/devise/registrations/edit.html.erb
+++ b/dpc-web/app/views/devise/registrations/edit.html.erb
@@ -132,7 +132,11 @@
   <div class="ds-l-col--12 ds-l-md-col--6 ds-u-margin-bottom--1 ds-u-margin-x--auto">
     <div class="card card--border-top--red ">
       <h2 class="ds-u-color--error-dark ds-u-margin-top--0">Delete my account</h2>
-      <p><%= button_to "Delete my account", registration_path(resource_name), data: { confirm: "Are you sure you want to delete your account?" }, method: :delete, :class => "ds-c-button ds-c-button--danger" %></p>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :delete }) do |f| %>
+        <%= f.label :password, :class => "ds-c-label" %> <i>Enter your password to delete your account.</i><br />
+        <%= f.password_field :current_password, autocomplete: "off", :class => "ds-c-field" %><br />
+        <%= f.submit "Delete my account", :class => "ds-c-button ds-c-button--danger" %>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Why**

To make the app more secure, we will require users to enter their password to delete their account.

**What Changed**

Uses devise's `delete_with_password` through the user registrations controllers to require a password to delete a user account.

**Choices Made**

![Screen Shot 2020-02-28 at 11 48 03 AM](https://user-images.githubusercontent.com/44708048/75584967-0580fb80-5a3f-11ea-8844-c96c7f54b005.png)

Also added a `devise_error_messages` to the edit page to let the user know if they enter their password incorrectly.

![Screen Shot 2020-02-28 at 3 08 51 PM](https://user-images.githubusercontent.com/44708048/75585082-4e38b480-5a3f-11ea-91e4-fe37fb2d8d12.png)

**Tickets closed**:

DPC-1074

**Future Work**

N/A

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
