### PR TITLE
DPC-1158: As an internal user I cannot disable sandbox access for an organization

### DIFF
--- a/dpc-web/app/services/api_client.rb
+++ b/dpc-web/app/services/api_client.rb
@@ -28,7 +28,7 @@ class APIClient
   end
 
   def delete_organization(reg_org)
-    fhir_client.additional_headers = auth_header(delegated_macaroon(reg_org.api_id))
+    fhir_client.additional_headers = auth_header(golden_macaroon)
 
     response = fhir_client.destroy(FHIR::Organization, reg_org.api_id)
 


### PR DESCRIPTION
**Why**
Users could not disable sandbox access for organization (or delete orgs with sandbox access).

**What Changed**

Changed the `delegated_macaroon` to `golden_macaroon`.

**Choices Made**

Using the admin `golden_macaroon` to bypass the credential requirements of the API.

**Tickets closed**:

DPC-1158

**Future Work**


**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
