### PR TITLE
DPC-1171: Queue NPE fixes

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
@@ -138,10 +138,10 @@ public class AggregationEngine implements Runnable {
      * Creates an observer to monitor the queue
      */
     private Observable<Optional<JobQueueBatch>> createQueueObserver() {
-        // Create using defer. This ensures that no events are omitted before a subscriber connects
-        return Observable.defer(() -> {
+        // Create using fromCallable. This ensures that no events are omitted before a subscriber connects
+        return Observable.fromCallable(() -> {
             logger.trace("Polling queue for job...");
-            return Observable.just(this.queue.claimBatch(this.aggregatorID));
+            return this.queue.claimBatch(this.aggregatorID);
         });
     }
 

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -60,6 +60,7 @@ class AggregationEngineTest {
         bbclient = Mockito.spy(new MockBlueButtonClient(fhirContext));
         var operationalConfig = new OperationsConfig(1000, exportPath, 500);
         engine = new AggregationEngine(aggregatorID, bbclient, queue, fhirContext, metricRegistry, operationalConfig);
+        engine.queueRunning.set(true);
         AggregationEngine.setGlobalErrorHandler();
         subscribe = Mockito.mock(Disposable.class);
         doReturn(false).when(subscribe).isDisposed();
@@ -193,11 +194,11 @@ class AggregationEngineTest {
 
         // Work the batch
         engine.stop();
-        doReturn(true).when(subscribe).isDisposed();
         queue.claimBatch(engine.getAggregatorID())
                 .ifPresent(engine::processJobBatch);
 
-        // Verify disposed call
+        // Verify the queue is stopped
+        assertFalse(engine.isRunning());
         Mockito.verify(subscribe).dispose();
 
         // Look at the result

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -95,6 +95,7 @@ class AggregationEngineTest {
         JobQueueFailure ex = new JobQueueFailure("Any failure");
 
         doReturn(Optional.empty())
+                .doThrow(ex)
                 .doReturn(Optional.empty())
                 .doReturn(Optional.empty())
                 .doThrow(ex)
@@ -116,7 +117,8 @@ class AggregationEngineTest {
             Thread.sleep(100);
         }
 
-        verify(queue, Mockito.times(9)).claimBatch(any(UUID.class));
+        // The last mock doesn't get called because the engine gets stopped during the last call
+        verify(queue, Mockito.times(10)).claimBatch(any(UUID.class));
 
         // Look at the result
         final var completeJob = queue.getJobBatches(jobID).stream().findFirst().orElseThrow();

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/BatchAggregationEngineTest.java
@@ -60,6 +60,7 @@ class BatchAggregationEngineTest {
         queue = new MemoryBatchQueue(100);
         final var bbclient = Mockito.spy(new MockBlueButtonClient(fhirContext));
         engine = new AggregationEngine(aggregatorID, bbclient, queue, fhirContext, metricRegistry, operationsConfig);
+        engine.queueRunning.set(true);
         subscribe = Mockito.mock(Disposable.class);
         doReturn(false).when(subscribe).isDisposed();
         engine.setSubscribe(subscribe);


### PR DESCRIPTION
**Why**

From the ticket:

> We've seen NPEs on the subscriber at AggregationEngine:149. We can add a null check there, but it would be even better to determine how it is ending up null in the first place.

**What Changed**

* Refactors the queue stopped check to not use the RxJava disposable as the queue stopped indicator (since it can be null in some cases), and instead use our more reliable thread-safe boolean.
* Refactors the main queue loop to address the following issues:
  * Improved logging (now includes a trace for when items are being processed, and an output message when the queue stopped entirely)
  * Sets the queue to a stopped state when it exits the processing loop for any reason
    * This should not happen once we fix the root issue, but if this does happen again, the queue will now be marked as unhealthy (due to `queueRunning=false` and ECS will launch a new instance
  * Switches from using `onErrorResumeNext` to `retry` for error-recovery
    * The `onErrorResumeNext` call was recovering the first time on an error, but it only worked once. The second or third error would not recover
* Greatly improved our error recovery unit test to not only verify errors are being handle, but multiple errors are being recovered from and processing resumes, allowing a job to complete successfully

**Choices Made**

* This so far fixes the issue from a generic perspective, and it will allow the queue to either recover from an error or get marked unhealthy. We haven't fixed the issue that lead to this yet (that seems to be db-related).

**Tickets closed**:

* Eventually DPC-1171

**Future Work**


**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
