### PR TITLE
DPC-250: Don't Retry BFD 404s

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
@@ -47,6 +47,7 @@ class ResourceFetcher {
         this.blueButtonClient = blueButtonClient;
         this.retryConfig = RetryConfig.custom()
                 .maxAttempts(config.getRetryCount())
+                .ignoreExceptions(ResourceNotFoundException.class)
                 .build();
         this.jobID = jobID;
         this.batchID = batchID;

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/AggregationEngineTest.java
@@ -364,9 +364,9 @@ class AggregationEngineTest {
         Mockito.verify(bbclient, atLeastOnce()).requestPatientFromServerByMbi(idCaptor.capture());
         Mockito.verify(bbclient, atLeastOnce()).requestEOBFromServer(idCaptor.capture());
         var values = idCaptor.getAllValues();
-        assertEquals(6,
+        assertEquals(2,
                 values.stream().filter(value -> value.equals("-1")).count(),
-                "Should be 6 invalid ids, 3 retries per method x 2 method calls x 1 bad-id");
+                "Should be 2 invalid ids: 0 retries per method x 2 method calls x 1 bad-id");
 
         // Look at the result. It should have one error, but be successful otherwise.
         assertTrue(queue.getJobBatches(jobID).stream().findFirst().isPresent());
@@ -411,10 +411,10 @@ class AggregationEngineTest {
         assertAll(() -> assertTrue(queue.getJobBatches(jobID).stream().findFirst().isPresent()),
                 () -> assertEquals(JobStatus.COMPLETED, queue.getJobBatches(jobID).stream().findFirst().get().getStatus()));
 
-        // Check that the bad ID was called 3 times
+        // Check that the bad ID was called 1 time (no retry)
         ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
         Mockito.verify(bbclient, atLeastOnce()).requestPatientFromServerByMbi(idCaptor.capture());
-        assertEquals(3, idCaptor.getAllValues().stream().filter(value -> value.equals("1")).count(), "Should have been called 3 times to get the patient, but with errors instead");
+        assertEquals(1, idCaptor.getAllValues().stream().filter(value -> value.equals("1")).count(), "Should have been called 1 time to get the patient, but with errors instead");
 
         // Look at the result. It should have one error, but be successful otherwise.
         assertTrue(queue.getJobBatches(jobID).stream().findFirst().isPresent());

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
@@ -146,7 +146,8 @@ public class MockBlueButtonClient implements BlueButtonClient {
      * @return the stream associated with the resource
      */
     private InputStream loadResource(String pathPrefix, String beneId) throws ResourceNotFoundException {
-        if (!MBI_BENE_ID_MAP.values().contains(beneId)) {
+        // beneId can now be null due to MBI -> beneId lookup (using the MBI_HASH_MAP)
+        if (beneId == null || !MBI_BENE_ID_MAP.values().contains(beneId)) {
             throw formNoPatientException(beneId);
         }
         final var path = pathPrefix + beneId + ".xml";


### PR DESCRIPTION
**Why**

> We currently have the BlueButtonClient set to retry all failures from BlueButton, while that's mostly ok, it's redundant when it comes to 404 errors, which will fail no matter how many times we retry it.

> We should modify the retry handler to check the exception status and fail quickly if this occurs. 

**What Changed**

* Adds `ResourceNotFoundException` to the list of exceptions to not retry.
* Updates tests to verify those exceptions are not retried.

**Choices Made**

**Tickets closed**:

DPC-250

**Future Work**

* Requires fixes @embh is looking into to have our BFD client throw the ResourceNotFoundException vs. a wrapped `JobQueueFailure exception`

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
