### PR TITLE
Fix: Stuck jobs are unable to be restarted due to SQL constraint exception

### DIFF
--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatch.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatch.java
@@ -135,7 +135,11 @@ public class JobQueueBatch implements Serializable {
      * We need to use {@link FetchType#EAGER}, otherwise the session will close before we actually read the job results and the call will fail.
      */
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "batch_id")
+    // @JoinColumn is essentially double-mapped since we don't have a @ManyToOne on the opposing side,
+    // and can't use mappedBy="". Therefore, we need to specify all the flags as false, to prevent Hibernate
+    // from running an UPDATE, setting the column to null, followed by a DELETE during a cascade
+    // https://stackoverflow.com/questions/25455280/hibernate-cascade-delete-for-one-to-many-call-sql-update-instead-of-delete
+    @JoinColumn(name = "batch_id", insertable = false, updatable = false, nullable = false)
     private List<JobQueueBatchFile> jobQueueBatchFiles;
 
     public JobQueueBatch() {

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueTest.java
@@ -1,0 +1,106 @@
+package gov.cms.dpc.queue;
+
+import com.codahale.metrics.MetricRegistry;
+import gov.cms.dpc.common.hibernate.queue.DPCQueueManagedSessionFactory;
+import gov.cms.dpc.queue.models.JobQueueBatch;
+import gov.cms.dpc.testing.BufferedLoggerHandler;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+import org.hl7.fhir.dstu3.model.ResourceType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(BufferedLoggerHandler.class)
+public class DistributedBatchQueueTest {
+
+    private final UUID aggregatorID = UUID.randomUUID();
+    private SessionFactory sessionFactory;
+    private DistributedBatchQueue queue;
+
+    @BeforeEach
+    void setUp() {
+        final Configuration conf = new Configuration();
+        sessionFactory = conf.configure().buildSessionFactory();
+        queue = new DistributedBatchQueue(new DPCQueueManagedSessionFactory(sessionFactory), 100, new MetricRegistry());
+    }
+
+    @AfterEach
+    void shutdown() {
+        try (final Session session = sessionFactory.openSession()) {
+            final Transaction tx = session.beginTransaction();
+            try {
+                session.createQuery("delete from job_queue_batch_file").executeUpdate();
+                session.createQuery("delete from job_queue_batch").executeUpdate();
+            } finally {
+                tx.commit();
+            }
+        }
+        sessionFactory.close();
+    }
+
+    @Test
+    void handleStuckBatchWithClaim() {
+        // One organization id for both jobs
+        final UUID orgID = UUID.randomUUID();
+
+        // Add a job
+        var jobID = queue.createJob(orgID, "test-provider-1", List.of("test-patient-1", "test-patient-2"), Collections.singletonList(ResourceType.Patient));
+
+        // Work the job
+        Optional<JobQueueBatch> workBatch = queue.claimBatch(aggregatorID);
+        assertTrue(workBatch.isPresent(), "Should have a job to work");
+        final UUID firstBatchID = workBatch.orElseThrow().getBatchID();
+
+        // Add a file on the batch
+        workBatch.get().addJobQueueFile(ResourceType.Patient, 0, 1);
+        queue.completePartialBatch(workBatch.get(), aggregatorID);
+
+        // Check that the persisted job is RUNNING
+        final Optional<JobQueueBatch> runningJobOptional = queue.getBatch(firstBatchID);
+        assertTrue(runningJobOptional.isPresent(), "Should have a running job");
+        runningJobOptional.ifPresent(runningJob -> {
+            assertEquals(JobStatus.RUNNING, runningJob.getStatus(), "Should be in the RUNNING state");
+            assertEquals(1, runningJob.getJobQueueBatchFiles().size(), "Should have 1 file on the running job");
+            assertTrue(runningJob.getJobQueueFile(ResourceType.Patient).isPresent(), "Should have a patient job file");
+        });
+
+        // Simulate a stuck job by modifying the update_time
+        try (final Session session = sessionFactory.openSession()) {
+            final Transaction tx = session.beginTransaction();
+            try {
+                session.createQuery("update job_queue_batch set updateTime = :updateTime where jobID = :jobID")
+                        .setParameter("jobID", jobID)
+                        .setParameter("updateTime", OffsetDateTime.now().minusMinutes(15))
+                        .executeUpdate();
+            } finally {
+                tx.commit();
+            }
+        }
+
+        // Re-claim the batch in a stuck state
+        Optional<JobQueueBatch> stuckBatch = queue.claimBatch(aggregatorID);
+        assertTrue(stuckBatch.isPresent(), "Should have a job to work");
+        final UUID stuckBatchID = stuckBatch.orElseThrow().getBatchID();
+        assertEquals(stuckBatchID, firstBatchID, "Stuck batch should be the same as the initial batch");
+
+        // Check that the stuck job is RUNNING with previous files cleared
+        final Optional<JobQueueBatch> stuckJobOptional = queue.getBatch(stuckBatchID);
+        assertTrue(stuckJobOptional.isPresent(), "Should have a job");
+        stuckJobOptional.ifPresent(stuckJob -> {
+            assertEquals(JobStatus.RUNNING, stuckJob.getStatus(), "Should be in the RUNNING state");
+            assertEquals(0, stuckJob.getJobQueueBatchFiles().size(), "Should have no files on the stuck job (they should be cleared)");
+        });
+    }
+}

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueTest.java
@@ -89,8 +89,12 @@ public class DistributedBatchQueueTest {
             }
         }
 
-        // Re-claim the batch in a stuck state
+        // Fix the stuck job during the claim process
         Optional<JobQueueBatch> stuckBatch = queue.claimBatch(aggregatorID);
+        assertFalse(stuckBatch.isPresent(), "Should have no job, but the stuck batch was released and is ready to be re-claimed");
+
+        // Re-claim the batch that was in a stuck state
+        stuckBatch = queue.claimBatch(aggregatorID);
         assertTrue(stuckBatch.isPresent(), "Should have a job to work");
         final UUID stuckBatchID = stuckBatch.orElseThrow().getBatchID();
         assertEquals(stuckBatchID, firstBatchID, "Stuck batch should be the same as the initial batch");


### PR DESCRIPTION
**Why**

Stuck jobs are failing with the exception:

```
Caused by: org.postgresql.util.PSQLException: ERROR: null value in column "batch_id" violates not-null constraint
```

**What Changed**

* Adds a unit test to reproduce this issue
* Adds additional flags on the Hibernate relationship to instruct Hibernate how to delete the object during a cascade (https://stackoverflow.com/questions/25455280/hibernate-cascade-delete-for-one-to-many-call-sql-update-instead-of-delete)

**Choices Made**

**Tickets closed**:

DPC-1171: One of many fixes related to this issue

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
