### PR TITLE
Fix stuck batch health check not marking the instance as unhealthy

### DIFF
--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
@@ -322,9 +322,12 @@ public class DistributedBatchQueue extends JobQueueCommon {
     public void assertHealthy(UUID aggregatorID) {
         try (final Session session = this.factory.openSession()) {
             try {
-                @SuppressWarnings("rawtypes") final Query healthCheck = session.createSQLQuery("select count(*) from job_queue_batch where aggregatorID = '" + aggregatorID.toString() + "' and job_status == 1 and update_time < current_timestamp - interval '3 minutes'"); // lgtm [java/concatenated-sql-query] These values are sanitized and not susceptible to user tainting.
-                int stuckBatches = healthCheck.getFirstResult();
-                if (stuckBatches > 0) {
+                Long stuckBatchCount = (Long) session
+                        .createQuery("select count(*) from job_queue_batch where aggregatorID = :aggregatorID and status = 1 and updateTime < :updateTime")
+                        .setParameter("aggregatorID", aggregatorID)
+                        .setParameter("updateTime", OffsetDateTime.now().minusMinutes(3))
+                        .uniqueResult();
+                if (stuckBatchCount > 0) {
                     throw new JobQueueUnhealthy(JOB_UNHEALTHY);
                 }
             } catch (JobQueueUnhealthy e) {

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
@@ -22,6 +22,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
@@ -325,7 +326,7 @@ public class DistributedBatchQueue extends JobQueueCommon {
                 Long stuckBatchCount = (Long) session
                         .createQuery("select count(*) from job_queue_batch where aggregatorID = :aggregatorID and status = 1 and updateTime < :updateTime")
                         .setParameter("aggregatorID", aggregatorID)
-                        .setParameter("updateTime", OffsetDateTime.now().minusMinutes(3))
+                        .setParameter("updateTime", OffsetDateTime.now(ZoneId.systemDefault()).minusMinutes(3))
                         .uniqueResult();
                 if (stuckBatchCount > 0) {
                     throw new JobQueueUnhealthy(JOB_UNHEALTHY);

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueHealthTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueHealthTest.java
@@ -35,14 +35,17 @@ public class QueueHealthTest {
         when(factory.openSession())
                 .thenReturn(session);
 
-        when(session.createSQLQuery(Mockito.anyString()))
+        when(session.createQuery(Mockito.anyString()))
+                .thenReturn(query);
+
+        when(query.setParameter(Mockito.anyString(), Mockito.any()))
                 .thenReturn(query);
     }
 
     @Test
     void testHealthyQueue() {
-        when(query.getFirstResult())
-                .thenReturn(0);
+        when(query.uniqueResult())
+                .thenReturn(0L);
 
         final DistributedBatchQueue queue = new DistributedBatchQueue(managedSessionFactory, 100, metrics);
         assertDoesNotThrow(() -> queue.assertHealthy(UUID.randomUUID()), "Queue should be healthy");
@@ -54,8 +57,8 @@ public class QueueHealthTest {
 
     @Test
     void testUnhealthyQueue() {
-        when(query.getFirstResult())
-                .thenReturn(2);
+        when(query.uniqueResult())
+                .thenReturn(2L);
 
         final DistributedBatchQueue queue = new DistributedBatchQueue(managedSessionFactory, 100, metrics);
         assertThrows(JobQueueUnhealthy.class, () -> queue.assertHealthy(UUID.randomUUID()), "Queue should be unhealthy");


### PR DESCRIPTION
**Why**

Our existing health check that markes instances as unhealthy when the aggregator is not making progress on the job was not working. The query was a mix of native SQL and JQL, and didn't return what were testing for.

**What Changed**

* Re-wrote the query using JQL
* Added unit tests testing the query both in health and unhealthy scenarios, in addition to our previous tests that asserted using mocks on the query

**Choices Made**

**Tickets closed**:

**Future Work**

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
