### PR TITLE
Queue Health Check Fix

### DIFF
--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
@@ -15,10 +15,12 @@ public class JobQueueModule<T extends Configuration & DPCQueueConfig> extends Dr
 
     private final boolean inMemory;
     private final int batchSize;
+    private final UUID aggregatorID;
 
     public JobQueueModule() {
         this.inMemory = false;
         this.batchSize = 100;
+        this.aggregatorID = UUID.randomUUID();
     }
 
     @Override
@@ -48,6 +50,6 @@ public class JobQueueModule<T extends Configuration & DPCQueueConfig> extends Dr
     @Provides
     @AggregatorID
     UUID provideAggregatorID() {
-        return UUID.randomUUID();
+        return aggregatorID;
     }
 }

--- a/src/main/resources/server.conf
+++ b/src/main/resources/server.conf
@@ -58,6 +58,7 @@ logging {
 
   loggers {
     "liquibase" = INFO
+    "gov.cms.dpc.queue.DistributedBatchQueue" = DEBUG
   }
 }
 


### PR DESCRIPTION
**Why**

The queue health check still was not failing on a stuck job.

**What Changed**

* The `aggregatorID` was not stable between injectors. Each time the `@AggregatorID` annotation was called, a new UUID was generated, so the health check'd ID didn't match the actual queues.
* Adds additional debug statements around the health check in the event the `aggregatorID` fix still does not resolve the health check issue.

**Choices Made**


**Tickets closed**:


**Future Work**

* Remove the log level DEBUG configuration for `gov.cms.dpc.queue.DistributedBatchQueue` after we are confident the health checks are working.

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
