### PR TITLE
DPC-1182: characteristic-value query parameter error

### DIFF
--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
@@ -392,7 +392,7 @@ class AttributionFHIRTest {
 
     private static ICriterion<TokenClientParam> buildCharacteristicSearch(String providerID) {
         return Group.CHARACTERISTIC_VALUE
-                .withLeft(Group.CHARACTERISTIC.exactly().systemAndCode("", "attributed-to"))
+                .withLeft(Group.CHARACTERISTIC.exactly().code("attributed-to"))
                 .withRight(Group.VALUE.exactly().systemAndCode(DPCIdentifierSystem.NPPES.getSystem(), providerID));
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRExtractors.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRExtractors.java
@@ -131,7 +131,7 @@ public class FHIRExtractors {
     public static Pair<String, String> parseTag(String tag) {
         final int idx = tag.indexOf('|');
         if (idx < 0) {
-            throw new IllegalArgumentException(String.format("Malformed tag: %s", tag));
+            return Pair.of("", tag);
         }
 
         return Pair.of(tag.substring(0, idx), tag.substring(idx + 1));

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/FHIRExtractorTests.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/FHIRExtractorTests.java
@@ -92,11 +92,13 @@ public class FHIRExtractorTests {
 
     @Test
     void testTagParsing() {
-        assertThrows(IllegalArgumentException.class, () -> parseTag("notATag"), "Should fail with malformed tag");
+        final Pair<String, String> codeTag = parseTag("a tag");
+        assertAll(() -> assertEquals("", codeTag.getLeft()),
+                () -> assertEquals("a tag", codeTag.getRight()));
 
-        final Pair<String, String> tag = parseTag("This|is a tag");
-        assertAll(() -> assertEquals("This", tag.getLeft()),
-                () -> assertEquals("is a tag", tag.getRight()));
+        final Pair<String, String> systemCodeTag = parseTag("This|is a tag");
+        assertAll(() -> assertEquals("This", systemCodeTag.getLeft()),
+                () -> assertEquals("is a tag", systemCodeTag.getRight()));
 
         final Pair<String, String> danglingTag = parseTag("Dangling tag|");
         assertAll(() -> assertEquals("Dangling tag", danglingTag.getLeft()),

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -212,7 +212,7 @@ public class ClientUtils {
                 .search()
                 .forResource(Group.class)
                 .where(Group.CHARACTERISTIC_VALUE
-                        .withLeft(Group.CHARACTERISTIC.exactly().systemAndCode("", "attributed-to"))
+                        .withLeft(Group.CHARACTERISTIC.exactly().code("attributed-to"))
                         .withRight(Group.VALUE.exactly().systemAndCode(DPCIdentifierSystem.NPPES.getSystem(), npi)))
                 .returnBundle(Bundle.class)
                 .encodedJson()

--- a/dpc-web/app/views/pages/reference.md
+++ b/dpc-web/app/views/pages/reference.md
@@ -1356,7 +1356,7 @@ Creating attribution groups is covered in an earlier [section](#attributing-pati
 >Searching for rosters associated to a given provider makes use of [composite search parameters](https://www.hl7.org/fhir/search.html#combining). 
 
 ~~~ sh
-GET /api/v1/Group?characteristic-value=|attributed-to$|{provider NPI}
+GET /api/v1/Group?characteristic-value=attributed-to${provider NPI}
 ~~~
 
 **cURL command**

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -561,7 +561,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://{{hostname}}:{{api_port}}/v1/Group?characteristic-value=|attributed-to$|3116145044854423862",
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Group?characteristic-value=attributed-to$3116145044854423862",
 							"protocol": "http",
 							"host": [
 								"{{hostname}}"
@@ -574,7 +574,7 @@
 							"query": [
 								{
 									"key": "characteristic-value",
-									"value": "|attributed-to$|3116145044854423862"
+									"value": "attributed-to$3116145044854423862"
 								}
 							]
 						},
@@ -1594,7 +1594,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://{{hostname}}:{{api_port}}/v1/Group?characteristic-value=|attributed-to$|3116145044854423862",
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Group?characteristic-value=attributed-to$3116145044854423862",
 							"protocol": "http",
 							"host": [
 								"{{hostname}}"
@@ -1607,7 +1607,7 @@
 							"query": [
 								{
 									"key": "characteristic-value",
-									"value": "|attributed-to$|3116145044854423862"
+									"value": "attributed-to$3116145044854423862"
 								}
 							]
 						},


### PR DESCRIPTION
**Why**
A Google Group user reported that a request for a `Group` with a `characteristic-value` parameter was returning a 500. DPC is expecting a format for that query parameter that does not match the FHIR spec. http://hl7.org/implement/standards/fhir/STU3/search.html#combining

**What Changed**
The API no longer expects a composite `characteristic-value` parameter to always include pipes (`|`) to separate system and code. For example, `|attributed-to$|12345` was the expected format when each side had only a code and no system. It is now `attributed-to$12345`.

**Tickets closed**:
[DPC-1182](https://jiraent.cms.gov/browse/DPC-1182)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
