### PR TITLE
Create prod.application.conf file

### DIFF
--- a/dpc-aggregation/src/main/resources/prod.application.conf
+++ b/dpc-aggregation/src/main/resources/prod.application.conf
@@ -1,0 +1,26 @@
+# Override the keystore location to point to correct location when run within docker environment
+dpc.aggregation {
+  database {
+    driverClass = org.postgresql.Driver
+    url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_attribution"
+    user = ${ATTRIBUTION_DB_USER}
+    password = ${ATTRIBUTION_DB_PASS}
+  }
+
+  queuedb {
+    url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_queue"
+    user = ${QUEUE_DB_USER}
+    password = ${QUEUE_DB_PASS}
+  }
+
+  bbclient {
+    serverBaseUrl = ${BFD_URL}
+
+    keyStore {
+      location = ${BB_KEYSTORE_LOCATION}
+      defaultPassword = ${BB_KEYSTORE_PASS}
+    }
+  }
+
+  exportPath = "/app/data"
+}

--- a/dpc-api/src/main/resources/prod.application.conf
+++ b/dpc-api/src/main/resources/prod.application.conf
@@ -1,0 +1,29 @@
+dpc.api {
+    publicURL = "https://prod.dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
+
+    database = {
+        url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_attribution"
+        user = ${ATTRIBUTION_DB_USER}
+        password = ${ATTRIBUTION_DB_PASS}
+    }
+
+    queuedb = {
+        url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_queue"
+        user = ${QUEUE_DB_USER}
+        password = ${QUEUE_DB_PASS}
+    }
+
+    authdb = {
+        url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_auth"
+        user = ${AUTH_DB_USER}
+        password = ${AUTH_DB_PASS}
+    }
+
+    server {
+        applicationContextPath = "/api"
+    }
+
+    attributionURL = "http://backend.dpc-prod.local:8080/v1/"
+    exportPath = "/app/data"
+    keyPairLocation = ${BAKERY_KEYPAIR_LOCATION}
+}

--- a/dpc-attribution/src/main/resources/prod.application.conf
+++ b/dpc-attribution/src/main/resources/prod.application.conf
@@ -1,0 +1,15 @@
+dpc.attribution {
+  database = {
+    driverClass = org.postgresql.Driver
+    url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_attribution"
+    user = ${ATTRIBUTION_DB_USER}
+    password = ${ATTRIBUTION_DB_PASS}
+  }
+
+  server {
+    applicationConnectors = [{
+      type = http
+      port = 8080
+    }]
+  }
+}

--- a/dpc-consent/src/main/resources/prod.application.conf
+++ b/dpc-consent/src/main/resources/prod.application.conf
@@ -1,0 +1,21 @@
+dpc.consent {
+
+    consentdb = {
+        driverClass = org.postgresql.Driver
+        url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_consent"
+        user = ${CONSENT_DB_USER}
+        password = ${CONSENT_DB_PASS}
+    }
+
+    server {
+        applicationConnectors = [{
+            type = http
+            port = 3600
+        }]
+    }
+
+  // base URL for FHIR references to DPC resources (Patients, Organizations, etc) embedded in a Consent resource
+  fhirReferenceURL = "https://prod.dpc.cms.gov/api/v1"
+
+  consentOrganizationURL = "https://prod.dpc.cms.gov"
+}


### PR DESCRIPTION
**Why**

We are attempting to bootstrap `prod`.

**What Changed**

Need the appropriate `application.conf` files for `prod`.

**Choices Made**

It is unclear why these env vars can't be defined as part of `dpc-ops` (i.e., SSM).  To expedite the bootstrap process, a choice was made to align these files with the way the existing environments are configured.  

**Tickets closed**:

N/A

**Future Work**

In the future, I'd image it would be best to deprecate these files and control variables via SSM.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
