### PR TITLE
Use quotes around database password

### DIFF
--- a/dpc-web/config/database.yml
+++ b/dpc-web/config/database.yml
@@ -23,7 +23,7 @@ default: &default
 
   url: <%= ENV['DATABASE_URL'] %>
   username: <%= ENV['DB_USER'] %>
-  password: <%= ENV['DB_PASS'] %>
+  password: "<%= ENV['DB_PASS'] %>"
 
 
 development: &development

--- a/dpc-web/config/database.yml
+++ b/dpc-web/config/database.yml
@@ -23,7 +23,7 @@ default: &default
 
   url: <%= ENV['DATABASE_URL'] %>
   username: <%= ENV['DB_USER'] %>
-  password: "<%= ENV['DB_PASS'] %>"
+  password: '<%= ENV['DB_PASS'] %>'
 
 
 development: &development


### PR DESCRIPTION
**Why**

When trying to deploy `dpc-web`, we saw this error:
```
YAML syntax error occurred while parsing /dpc-web/config/database.yml. Please note that YAML must be consistently indented using spaces. Tabs are not allowed. Error: (<unknown>): did not find expected comment or line break while scanning a block scalar at line 26 column 13
```

This YAML syntax error is referring to the line that contains a password, which can contain any of these special characters: `!#$%&*()-_=+[]{}<>:?`

In YAML, the `>` character is a [reserved indicator](https://yaml.org/spec/1.2/spec.html#id2774228) and cannot start a string.

In this case, the current database password starts with `>`. This branch puts the ERB interpolation inside double quotes so that the YAML is valid after interpolation.

According to [this stackoverflow answer](https://stackoverflow.com/a/22235064/148017):
>Seems to me that the best approach would be to not use quotes unless you have to, and then to use single quotes unless you specifically want to process escape codes.

**What Changed**

* Single quotes around the ERB tag

**Choices Made**

* Using single quotes instead of double for extra robustness.

**Tickets closed**:

N/A

**Future Work**

N/A

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
