### PR TITLE
Adding quotes around all password interpolations

### DIFF
--- a/dpc-web/config/database.yml
+++ b/dpc-web/config/database.yml
@@ -36,7 +36,7 @@ development: &development
   username: <%= ENV.fetch("DB_USER", nil) %>
 
   # The password associated with the postgres role (username).
-  password: <%= ENV.fetch("DB_PASS", nil) %>
+  password: '<%= ENV.fetch("DB_PASS", nil) %>'
 
   url: <%= ENV.fetch("DATABASE_URL", "postgresql://localhost/dpc-website_development") %>
 
@@ -62,7 +62,7 @@ test:
   username: <%= ENV.fetch("DB_USER", nil) %>
 
   # The password associated with the postgres role (username).
-  password: <%= ENV.fetch("DB_PASS", nil) %>
+  password: '<%= ENV.fetch("DB_PASS", nil) %>'
 
   url: <%= ENV.fetch("TEST_DATABASE_URL", "postgresql://localhost/dpc-website_test") %>
 


### PR DESCRIPTION
**Why**

This branch is a follow up from #740 which fixed the problem for only one line in `database.yml`. We now need to use single quotes around all other lines that interpolate `DB_PASS` so that the file is valid YAML.

**What Changed**

* Adding single quotes around all interpolated passwords.

**Choices Made**

* The choice was made to put single quotes around anywhere a password is interpolated so that the file is valid YAML.

**Tickets closed**:

N/A

**Future Work**

N/A

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
