### PR TITLE
DPC-264: Patient/$everything

### DIFF
--- a/dpc-aggregation/src/main/resources/local.application.conf
+++ b/dpc-aggregation/src/main/resources/local.application.conf
@@ -23,6 +23,5 @@ dpc.aggregation {
       "org.hibernate.SQL" = INFO
     }
   }
-  lookBackDate = 2000-11-01 #configures the lookback date to match what is returned from mock blue button client
-
+  lookBackDate = 2000-10-01 #configures the lookback date to match what is returned from mock blue button client
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
@@ -34,6 +34,7 @@ import gov.cms.dpc.macaroons.annotations.PublicURL;
 import gov.cms.dpc.macaroons.config.TokenPolicy;
 import gov.cms.dpc.macaroons.thirdparty.IThirdPartyKeyStore;
 import gov.cms.dpc.macaroons.thirdparty.MemoryThirdPartyKeyStore;
+import gov.cms.dpc.queue.service.DataService;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.jsonwebtoken.SigningKeyResolverAdapter;
 import org.hibernate.SessionFactory;
@@ -80,6 +81,8 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
         binder.bind(FileManager.class);
         binder.bind(HttpRangeHeaderParamConverterProvider.class);
         binder.bind(ChecksumConverterProvider.class);
+
+        binder.bind(DataService.class);
 
         // Healthchecks
         // Additional health-checks can be added here

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
@@ -4,11 +4,10 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.common.annotations.NoHtml;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.annotations.Profiled;
+import gov.cms.dpc.fhir.validations.profiles.AttestationProfile;
 import gov.cms.dpc.fhir.validations.profiles.PatientProfile;
 import io.dropwizard.auth.Auth;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Parameters;
-import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 
 import javax.validation.Valid;
@@ -37,6 +36,10 @@ public abstract class AbstractPatientResource {
     @GET
     @Path("/{patientID}")
     public abstract Patient getPatient(UUID patientID);
+
+    @GET
+    @Path("/{patientID}/$everything")
+    public abstract Resource everything(OrganizationPrincipal organization, @Valid @Profiled(profile = AttestationProfile.PROFILE_URI) Provenance attestation, UUID patientId);
 
     @DELETE
     @Path("/{patientID}")

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.rest.client.api.IGenericClient;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Timed;
 import com.google.inject.name.Named;
+import gov.cms.dpc.api.APIHelpers;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractGroupResource;
@@ -49,7 +50,6 @@ import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
 public class GroupResource extends AbstractGroupResource {
 
     private static final Logger logger = LoggerFactory.getLogger(GroupResource.class);
-    static final String SYNTHETIC_BENE_ID = "-19990000000001";
 
     // The delimiter for the '_types' list query param.
     static final String LIST_DELIMITER = ",";
@@ -279,7 +279,7 @@ public class GroupResource extends AbstractGroupResource {
         // Handle the _type query parameter
         final var resources = handleTypeQueryParam(resourceTypes);
         final var sinceDate = handleSinceQueryParam(since);
-        final var transactionTime = fetchTransactionTime();
+        final var transactionTime = APIHelpers.fetchTransactionTime(bfdClient);
         final UUID jobID = this.queue.createJob(orgID, rosterID, attributedPatients, resources, sinceDate, transactionTime);
 
         return Response.status(Response.Status.ACCEPTED)
@@ -341,18 +341,6 @@ public class GroupResource extends AbstractGroupResource {
         } catch (DataFormatException ex) {
             throw new BadRequestException("'_since' query parameter must be a valid date time value");
         }
-    }
-
-    /**
-     * Fetch the BFD database last update time. Use it as the transactionTime for a job.
-     * @return transactionTime from the BFD service
-     */
-    private OffsetDateTime fetchTransactionTime() {
-        // Every bundle has transaction time after the Since RFC has beneficiary
-        final Meta meta = bfdClient.requestPatientFromServer(SYNTHETIC_BENE_ID, null).getMeta();
-        return Optional.ofNullable(meta.getLastUpdated())
-                .map(u -> u.toInstant().atOffset(ZoneOffset.UTC))
-                .orElse(OffsetDateTime.now(ZoneOffset.UTC));
     }
 
     /**

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -14,6 +14,7 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractPatientResource;
 import gov.cms.dpc.common.annotations.NoHtml;
+import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.annotations.FHIR;
@@ -53,12 +54,14 @@ public class PatientResource extends AbstractPatientResource {
     private final IGenericClient client;
     private final FhirValidator validator;
     private final DataService dataService;
+    private final BlueButtonClient bfdClient;
 
     @Inject
-    public PatientResource(@Named("attribution") IGenericClient client, FhirValidator validator, DataService dataService) {
+    public PatientResource(@Named("attribution") IGenericClient client, FhirValidator validator, DataService dataService, BlueButtonClient bfdClient) {
         this.client = client;
         this.validator = validator;
         this.dataService = dataService;
+        this.bfdClient = bfdClient;
     }
 
     @GET
@@ -190,13 +193,13 @@ public class PatientResource extends AbstractPatientResource {
 
         final Patient patient = getPatient(patientId);
         final String patientMbi = FHIRExtractors.getPatientMBI(patient);
+        final UUID orgId = organization.getID();
 
-        if (!isPatientInRoster(patientId, FHIRExtractors.getProviderNPI(provider), organization.getID())) {
+        if (!isPatientInRoster(patientId, FHIRExtractors.getProviderNPI(provider), orgId)) {
             throw new WebApplicationException(HttpStatus.UNAUTHORIZED_401);
         }
 
-        final UUID orgId = organization.getID();
-        Resource result = dataService.retrieveData(orgId, providerId, List.of(patientMbi),
+        Resource result = dataService.retrieveData(orgId, providerId, List.of(patientMbi), APIHelpers.fetchTransactionTime(bfdClient),
                 ResourceType.Patient, ResourceType.ExplanationOfBenefit, ResourceType.Coverage);
         if (ResourceType.Bundle.equals(result.getResourceType())) {
             return (Bundle) result;

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -15,10 +15,14 @@ import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractPatientResource;
 import gov.cms.dpc.common.annotations.NoHtml;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
+import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.annotations.Profiled;
+import gov.cms.dpc.fhir.annotations.ProvenanceHeader;
 import gov.cms.dpc.fhir.validations.ValidationHelpers;
+import gov.cms.dpc.fhir.validations.profiles.AttestationProfile;
 import gov.cms.dpc.fhir.validations.profiles.PatientProfile;
+import gov.cms.dpc.queue.service.DataService;
 import io.dropwizard.auth.Auth;
 import io.swagger.annotations.*;
 import org.eclipse.jetty.http.HttpStatus;
@@ -29,9 +33,11 @@ import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static gov.cms.dpc.api.APIHelpers.bulkResourceClient;
 import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
@@ -46,11 +52,13 @@ public class PatientResource extends AbstractPatientResource {
 
     private final IGenericClient client;
     private final FhirValidator validator;
+    private final DataService dataService;
 
     @Inject
-    PatientResource(@Named("attribution") IGenericClient client, FhirValidator validator) {
+    public PatientResource(@Named("attribution") IGenericClient client, FhirValidator validator, DataService dataService) {
         this.client = client;
         this.validator = validator;
+        this.dataService = dataService;
     }
 
     @GET
@@ -147,6 +155,56 @@ public class PatientResource extends AbstractPatientResource {
                 .execute();
     }
 
+    @GET
+    @FHIR
+    @Path("/{patientID}/$everything")
+    @PathAuthorizer(type = ResourceType.Patient, pathParam = "patientID")
+    @Timed
+    @ExceptionMetered
+    @ApiImplicitParams(
+            @ApiImplicitParam(name = "X-Provenance", required = true, paramType = "header", dataTypeClass = Provenance.class))
+    @ApiOperation(value = "Fetch entire Patient record", notes = "Fetch entire record for Patient with given ID synchronously. " +
+            "All resources available for the Patient are included in the result Bundle.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Cannot find Patient record with given ID"),
+            @ApiResponse(code = 504, message = "", response = OperationOutcome.class),
+            @ApiResponse(code = 500, message = "A system error occurred", response = OperationOutcome.class)
+    })
+    @Override
+    public Bundle everything(@ApiParam(hidden = true) @Auth OrganizationPrincipal organization,
+                               @Valid @Profiled(profile = AttestationProfile.PROFILE_URI) @ProvenanceHeader Provenance provenance,
+                               @ApiParam(value = "Patient resource ID", required = true) @PathParam("patientID") UUID patientId) {
+
+        final Provenance.ProvenanceAgentComponent performer = FHIRExtractors.getProvenancePerformer(provenance);
+        final UUID providerId = FHIRExtractors.getEntityUUID(performer.getOnBehalfOfReference().getReference());
+        Practitioner provider = this.client
+                .read()
+                .resource(Practitioner.class)
+                .withId(providerId.toString())
+                .encodedJson()
+                .execute();
+
+        if (provider == null) {
+            throw new WebApplicationException(HttpStatus.UNAUTHORIZED_401);
+        }
+
+        final Patient patient = getPatient(patientId);
+        final String patientMbi = FHIRExtractors.getPatientMBI(patient);
+
+        if (!isPatientInRoster(patientId, FHIRExtractors.getProviderNPI(provider), organization.getID())) {
+            throw new WebApplicationException(HttpStatus.UNAUTHORIZED_401);
+        }
+
+        final UUID orgId = organization.getID();
+        Resource result = dataService.retrieveData(orgId, providerId, List.of(patientMbi),
+                ResourceType.Patient, ResourceType.ExplanationOfBenefit, ResourceType.Coverage);
+        if (ResourceType.Bundle.equals(result.getResourceType())) {
+            return (Bundle) result;
+        }
+
+        throw new WebApplicationException(HttpStatus.INTERNAL_SERVER_ERROR_500);
+    }
+
     @DELETE
     @FHIR
     @Path("/{patientID}")
@@ -173,7 +231,7 @@ public class PatientResource extends AbstractPatientResource {
     @Timed
     @ExceptionMetered
     @ApiOperation(value = "Update Patient record", notes = "Update specific Patient record." +
-            "<p>Currently, this method only allows for updating of the Patient first/last name, and BirthDate.")
+            "<p>Currently, this method allows for updating of only the Patient first name, last name, and birthdate.")
     @ApiResponses(value = {
             @ApiResponse(code = 404, message = "Unable to find Patient to update"),
             @ApiResponse(code = 422, message = "Patient does not satisfy the required FHIR profile")
@@ -200,7 +258,7 @@ public class PatientResource extends AbstractPatientResource {
     @Timed
     @ExceptionMetered
     @ApiOperation(value = "Validate Patient resource", notes = "Validates the given resource against the " + PatientProfile.PROFILE_URI + " profile." +
-            "<p>This method always returns a 200 status, even in respond to a non-conformant resource.")
+            "<p>This method always returns a 200 status, even in response to a non-conformant resource.")
     @Override
     public IBaseOperationOutcome validatePatient(@Auth @ApiParam(hidden = true) OrganizationPrincipal organization, @ApiParam Parameters parameters) {
         return ValidationHelpers.validateAgainstProfile(this.validator, parameters, PatientProfile.PROFILE_URI);
@@ -218,5 +276,31 @@ public class PatientResource extends AbstractPatientResource {
                 }
             }
         }
+    }
+
+    private boolean isPatientInRoster(UUID patientId, String providerNpi, UUID organizationId) {
+        Bundle providerRosters = client.search()
+                .forResource(Group.class)
+                .where(Group.CHARACTERISTIC_VALUE
+                        .withLeft(Group.CHARACTERISTIC.exactly().code("attributed-to"))
+                        .withRight(Group.VALUE.exactly().systemAndCode(DPCIdentifierSystem.NPPES.getSystem(), providerNpi)))
+                .withTag("", organizationId.toString())
+                .returnBundle(Bundle.class)
+                .encodedJson()
+                .execute();
+
+        for (Bundle.BundleEntryComponent bec : providerRosters.getEntry()) {
+            Group roster = (Group) bec.getResource();
+            List<Group.GroupMemberComponent> members = roster.getMember();
+            List<UUID> rosterPatientIds = members.stream()
+                    .map(Group.GroupMemberComponent::getEntity)
+                    .map(ref -> FHIRExtractors.getEntityUUID(ref.getReference()))
+                    .collect(Collectors.toList());
+            if (rosterPatientIds.contains(patientId)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -179,15 +179,15 @@ public class PatientResource extends AbstractPatientResource {
                                @ApiParam(value = "Patient resource ID", required = true) @PathParam("patientID") UUID patientId) {
 
         final Provenance.ProvenanceAgentComponent performer = FHIRExtractors.getProvenancePerformer(provenance);
-        final UUID providerId = FHIRExtractors.getEntityUUID(performer.getOnBehalfOfReference().getReference());
-        Practitioner provider = this.client
+        final UUID practitionerId = FHIRExtractors.getEntityUUID(performer.getOnBehalfOfReference().getReference());
+        Practitioner practitioner = this.client
                 .read()
                 .resource(Practitioner.class)
-                .withId(providerId.toString())
+                .withId(practitionerId.toString())
                 .encodedJson()
                 .execute();
 
-        if (provider == null) {
+        if (practitioner == null) {
             throw new WebApplicationException(HttpStatus.UNAUTHORIZED_401);
         }
 
@@ -195,11 +195,11 @@ public class PatientResource extends AbstractPatientResource {
         final String patientMbi = FHIRExtractors.getPatientMBI(patient);
         final UUID orgId = organization.getID();
 
-        if (!isPatientInRoster(patientId, FHIRExtractors.getProviderNPI(provider), orgId)) {
+        if (!isPatientInRoster(patientId, FHIRExtractors.getProviderNPI(practitioner), orgId)) {
             throw new WebApplicationException(HttpStatus.UNAUTHORIZED_401);
         }
 
-        Resource result = dataService.retrieveData(orgId, providerId, List.of(patientMbi), APIHelpers.fetchTransactionTime(bfdClient),
+        Resource result = dataService.retrieveData(orgId, practitionerId, List.of(patientMbi), APIHelpers.fetchTransactionTime(bfdClient),
                 ResourceType.Patient, ResourceType.ExplanationOfBenefit, ResourceType.Coverage);
         if (ResourceType.Bundle.equals(result.getResourceType())) {
             return (Bundle) result;

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -3,13 +3,16 @@ package gov.cms.dpc.api.resources.v1;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.gclient.IReadExecutable;
 import ca.uhn.fhir.rest.gclient.IUpdateExecutable;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
+import gov.cms.dpc.common.utils.SeedProcessor;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
+import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import org.apache.commons.lang3.tuple.Pair;
@@ -18,8 +21,13 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.hl7.fhir.dstu3.model.Identifier;
+import org.hl7.fhir.dstu3.model.Parameters;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.*;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import javax.ws.rs.HttpMethod;
 import java.io.BufferedReader;
@@ -31,20 +39,29 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.sql.Date;
+import java.util.List;
 import java.util.UUID;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_NPI;
 import static org.junit.jupiter.api.Assertions.*;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class PatientResourceTest extends AbstractSecureApplicationTest {
+
+    public static final String PROVENANCE_FMT = "{ \"resourceType\": \"Provenance\", \"recorded\": \"" + DateTimeType.now().getValueAsString() + "\"," +
+            " \"reason\": [ { \"system\": \"http://hl7.org/fhir/v3/ActReason\", \"code\": \"TREAT\"  } ], \"agent\": [ { \"role\": " +
+            "[ { \"coding\": [ { \"system\":" + "\"http://hl7.org/fhir/v3/RoleClass\", \"code\": \"AGNT\" } ] } ], \"whoReference\": " +
+            "{ \"reference\": \"Organization/ORGANIZATION_ID\" }, \"onBehalfOfReference\": { \"reference\": " +
+            "\"Practitioner/PRACTITIONER_ID\" } } ] }";
 
     PatientResourceTest() {
         // Not used
     }
 
     @Test
-    void ensurePatientsExist() throws IOException, URISyntaxException, GeneralSecurityException {
+    @Order(1)
+        void ensurePatientsExist() throws IOException, URISyntaxException, GeneralSecurityException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
         IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
@@ -121,6 +138,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(2)
     void testPatientRemoval() throws IOException, URISyntaxException, GeneralSecurityException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
@@ -171,6 +189,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(3)
     void testPatientUpdating() throws IOException, URISyntaxException, GeneralSecurityException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
@@ -216,6 +235,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(4)
     void testCreateInvalidPatient() throws IOException, URISyntaxException {
         URL url = new URL(getBaseURL() + "/Patient");
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -246,6 +266,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(5)
     public void testCreatePatientReturnsAppropriateHeaders() {
         IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
         Patient patient = APITestHelpers.createPatientResource("4S41C00AA00", APITestHelpers.ORGANIZATION_ID);
@@ -272,5 +293,102 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
                 .resource(foundPatient)
                 .encodedJson()
                 .execute();
+    }
+
+    @Test
+    @Order(6)
+    void testPatientEverything() throws IOException, URISyntaxException, GeneralSecurityException {
+        final IParser parser = ctx.newJsonParser();
+        final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
+        String macaroon = FHIRHelpers.registerOrganization(attrClient, parser, ORGANIZATION_ID, ORGANIZATION_NPI, getAdminURL());
+        String keyLabel = "patient-everything-key";
+        Pair<UUID, PrivateKey> uuidPrivateKeyPair = APIAuthHelpers.generateAndUploadKey(keyLabel, ORGANIZATION_ID, GOLDEN_MACAROON, getBaseURL());
+        IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight(), false, true);
+        APITestHelpers.setupPractitionerTest(client, parser);
+
+        final Bundle patients = client
+                .search()
+                .forResource(Patient.class)
+                .encodedJson()
+                .returnBundle(Bundle.class)
+                .execute();
+        final Patient patient = (Patient) patients.getEntry().get(patients.getTotal() - 17).getResource();
+        final String patientId = FHIRExtractors.getEntityUUID(patient.getId()).toString();
+
+        Bundle practSearch = client
+                .search()
+                .forResource(Practitioner.class)
+                .where(Practitioner.IDENTIFIER.exactly().code("8075963174210588464"))
+                .returnBundle(Bundle.class)
+                .encodedJson()
+                .execute();
+        Practitioner foundProvider = (Practitioner) practSearch.getEntryFirstRep().getResource();
+
+        Group group = SeedProcessor.createBaseAttributionGroup(FHIRExtractors.getProviderNPI(foundProvider), ORGANIZATION_ID);
+        final Reference patientRef = new Reference("Patient/" + patientId);
+        group.addMember().setEntity(patientRef);
+
+        String provenance = PROVENANCE_FMT.replaceAll("ORGANIZATION_ID", ORGANIZATION_ID).replace("PRACTITIONER_ID", foundProvider.getId());
+        client
+                .create()
+                .resource(group)
+                .withAdditionalHeader("X-Provenance", provenance)
+                .encodedJson()
+                .execute();
+
+        Bundle result = client
+                .operation()
+                .onInstance(new IdType("Patient", patientId))
+                .named("$everything")
+                .withNoParameters(Parameters.class)
+                .returnResourceType(Bundle.class)
+                .useHttpGet()
+                .withAdditionalHeader("X-Provenance", provenance)
+                .execute();
+
+        assertEquals(31, result.getTotal(), "Should have 31 entries in Bundle");
+        for (Bundle.BundleEntryComponent bec : result.getEntry()) {
+            List<ResourceType> resourceTypes = List.of(ResourceType.Coverage, ResourceType.ExplanationOfBenefit, ResourceType.Patient);
+            assertTrue(resourceTypes.contains(bec.getResource().getResourceType()), "Resource type should be Coverage, EOB, or Patient");
+        }
+
+        // With unattributed provider in X-Provenance
+        macaroon = FHIRHelpers.registerOrganization(attrClient, parser, OTHER_ORG_ID, ORGANIZATION_NPI, getAdminURL());
+        keyLabel = "patient-everything-key-2";
+        uuidPrivateKeyPair = APIAuthHelpers.generateAndUploadKey(keyLabel, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight());
+        APITestHelpers.setupPractitionerTest(client, parser);
+
+        Bundle practitioners = client
+                .search()
+                .forResource(Practitioner.class)
+                .where(Practitioner.IDENTIFIER.exactly().code("164333597980511237"))
+                .returnBundle(Bundle.class)
+                .encodedJson()
+                .execute();
+        Practitioner provider = (Practitioner) practitioners.getEntryFirstRep().getResource();
+
+        group = SeedProcessor.createBaseAttributionGroup(FHIRExtractors.getProviderNPI(provider), OTHER_ORG_ID);
+        final Patient otherPatient = (Patient) patients.getEntry().get(patients.getTotal() - 18).getResource();
+        Reference otherPatientRef = new Reference("Patient/" + otherPatient.getId());
+        group.addMember().setEntity(otherPatientRef);
+        provenance = PROVENANCE_FMT.replaceAll("ORGANIZATION_ID", OTHER_ORG_ID).replace("PRACTITIONER_ID", provider.getId());
+        client
+                .create()
+                .resource(group)
+                .withAdditionalHeader("X-Provenance", provenance)
+                .encodedJson()
+                .execute();
+
+        IOperationUntypedWithInput everythingOp = client
+                .operation()
+                .onInstance(new IdType("Patient", patientId))
+                .named("$everything")
+                .withNoParameters(Parameters.class)
+                .returnResourceType(Bundle.class)
+                .useHttpGet()
+                .withAdditionalHeader("X-Provenance", provenance);
+
+        assertThrows(AuthenticationException.class, everythingOp::execute);
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -318,7 +318,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
         Bundle practSearch = client
                 .search()
                 .forResource(Practitioner.class)
-                .where(Practitioner.IDENTIFIER.exactly().code("8075963174210588464"))
+                .where(Practitioner.IDENTIFIER.exactly().code("1232125215"))
                 .returnBundle(Bundle.class)
                 .encodedJson()
                 .execute();

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
@@ -37,9 +37,6 @@ public class MockBlueButtonClient implements BlueButtonClient {
             TEST_PATIENT_MBIS.get(2), "-19990000002208",
             TEST_PATIENT_MBIS.get(3), "-19990000002209",
             TEST_PATIENT_MBIS.get(4), "-19990000002210"
-
-
-
     );
     public static final Map<String, String> MBI_HASH_MAP = Map.of(
             TEST_PATIENT_MBIS.get(0), "abadf57ff8dc94610ca0d479feadb1743c9cd3c77caf1eafde5719a154379fb6",
@@ -47,8 +44,7 @@ public class MockBlueButtonClient implements BlueButtonClient {
             TEST_PATIENT_MBIS.get(2), "e411277fd31da392eaa9a45df53b0c429e365626182f50d9f35810d77f0e2756",
             TEST_PATIENT_MBIS.get(3), "41af07535e0a66226cf2f0e6c551c0a15bd49192fc055aa5cd2e63f31f90a419",
             TEST_PATIENT_MBIS.get(4), "d35350fce12f555089f938c0323a13122622123038e8af057a4191fd450c2b90"
-
-            );
+    );
     public static final List<String> TEST_PATIENT_WITH_BAD_IDS = List.of("-1", "-2", TEST_PATIENT_MBIS.get(0), TEST_PATIENT_MBIS.get(1), "-3");
     public static final String MULTIPLE_RESULTS_MBI = "0SW4N00AA00";
     public static final OffsetDateTime BFD_TRANSACTION_TIME = OffsetDateTime.ofInstant(Instant.now().truncatedTo(ChronoUnit.MILLIS), ZoneOffset.UTC);

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
@@ -42,6 +42,10 @@ public class DataService {
         this.jobTimeoutInSeconds = jobTimeoutInSeconds;
     }
 
+    public Resource retrieveData(UUID organizationId, UUID providerId, List<String> patientIds, ResourceType... resourceTypes) {
+        return retrieveData(organizationId, providerId, patientIds, OffsetDateTime.now(ZoneOffset.UTC), resourceTypes);
+    }
+
     /**
      * Retrieves data from BFD
      * @param organizationID UUID of organization
@@ -53,8 +57,9 @@ public class DataService {
     public Resource retrieveData(UUID organizationID,
                                  UUID providerID,
                                  List<String> patientIDs,
+                                 OffsetDateTime transactionTime,
                                  ResourceType... resourceTypes) {
-        UUID jobID = this.queue.createJob(organizationID, providerID.toString(), patientIDs, List.of(resourceTypes), null, OffsetDateTime.now(ZoneOffset.UTC));
+        UUID jobID = this.queue.createJob(organizationID, providerID.toString(), patientIDs, List.of(resourceTypes), null, transactionTime);
         Optional<List<JobQueueBatch>> optionalBatches = waitForJobToComplete(jobID, organizationID, this.queue);
 
         if (optionalBatches.isPresent()) {

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
@@ -35,7 +35,7 @@ public class DataService {
     private int jobTimeoutInSeconds;
 
     @Inject
-    public DataService(IJobQueue queue, FhirContext fhirContext, @ExportPath String exportPath, @JobTimeout  int jobTimeoutInSeconds) {
+    public DataService(IJobQueue queue, FhirContext fhirContext, @ExportPath String exportPath, @JobTimeout int jobTimeoutInSeconds) {
         this.queue = queue;
         this.fhirContext = fhirContext;
         this.exportPath = exportPath;

--- a/ig/ig.json
+++ b/ig/ig.json
@@ -171,6 +171,11 @@
       "defns": "OperationDefinition-dpc-operation-patient-validate-definition.html",
       "source": "dpc-patient-validate.json"
     },
+    "OperationDefinition/dpc-operation-patient-everything": {
+      "base": "OperationDefinition-dpc-operation-patient-everything.html",
+      "defns": "OperationDefinition-dpc-operation-patient-everything-definition.html",
+      "source": "dpc-patient-everything.json"
+    },
     "OperationDefinition/dpc-operation-group-add": {
       "base": "OperationDefinition-dpc-operation-group-add.html",
       "defns": "OperationDefinition-dpc-operation-group-add-definition.html",

--- a/ig/source/resources/implementationguide/cms-dpc-ig.xml
+++ b/ig/source/resources/implementationguide/cms-dpc-ig.xml
@@ -116,6 +116,13 @@
         <resource>
             <example value="false"/>
             <sourceReference>
+                <reference value="OperationDefinition/dpc-patient-everything"/>
+                <display value="dpc-patient-everything.json"/>
+            </sourceReference>
+        </resource>
+        <resource>
+            <example value="false"/>
+            <sourceReference>
                 <reference value="OperationDefinition/dpc-group-add"/>
                 <display value="dpc-group-add.json"/>
             </sourceReference>

--- a/ig/source/resources/implementationguide/ig-new.json
+++ b/ig/source/resources/implementationguide/ig-new.json
@@ -154,6 +154,14 @@
     },
     {
       "reference" : {
+        "reference" : "OperationDefinition/dpc-patient-everything",
+        "display" : "dpc-patient-everything.json"
+      },
+      "exampleBoolean" : false,
+      "groupingId" : "p1"
+    },
+    {
+      "reference" : {
         "reference" : "OperationDefinition/dpc-group-add",
         "display" : "dpc-group-add.json"
       },

--- a/ig/source/resources/implementationguide/ig-new.xml
+++ b/ig/source/resources/implementationguide/ig-new.xml
@@ -149,6 +149,14 @@
     </resource>
     <resource>
       <reference>
+        <reference value="OperationDefinition/dpc-patient-everything"/>
+        <display value="dpc-patient-everything.json"/>
+      </reference>
+      <exampleBoolean value="false"/>
+      <groupingId value="p1"/>
+    </resource>
+    <resource>
+      <reference>
         <reference value="OperationDefinition/dpc-group-add"/>
         <display value="dpc-group-add.json"/>
       </reference>

--- a/ig/source/resources/operationdefinition/dpc-patient-everything.json
+++ b/ig/source/resources/operationdefinition/dpc-patient-everything.json
@@ -1,0 +1,37 @@
+{
+  "resourceType": "OperationDefinition",
+  "id": "dpc-operation-patient-everything",
+  "url": "https://dpc.cms.gov/api/v1/OperationDefinition/dpc-operation-patient-everything",
+  "name": "Patient Everything",
+  "title": "Retrieve all resources for a Patient",
+  "publisher": "The DPC Team",
+  "status": "draft",
+  "version": "0.0.1",
+  "kind": "operation",
+  "code": "everything",
+  "description": "Synchronously retrieve all Coverage, ExplanationOfBenefit, and Patient resources for a Patient.",
+  "resource": [
+    "Patient"
+  ],
+  "system": false,
+  "type": true,
+  "instance": false,
+  "parameter": [
+    {
+      "name": "attestation",
+      "use": "in",
+      "min": 1,
+      "max": "1",
+      "documentation": "Provenance resource representing attestation",
+      "type": "Provenance"
+    },
+    {
+      "name": "return",
+      "use": "out",
+      "min": 1,
+      "max": "1",
+      "documentation": "Bundle containing Coverage, ExplanationOfBenefit, and Patient resources",
+      "type": "Bundle"
+    }
+  ]
+}

--- a/src/main/resources/bb-test-data/eob/-19990000002208_40.xml
+++ b/src/main/resources/bb-test-data/eob/-19990000002208_40.xml
@@ -6192,7 +6192,7 @@
         <organization>
           <identifier>
             <system value='http://hl7.org/fhir/sid/us-npi'/>
-            <value value='9999999999'/>
+            <value value='1111111112'/>
           </identifier>
         </organization>
         <facility>
@@ -6246,7 +6246,7 @@
           <provider>
             <identifier>
               <system value='http://hl7.org/fhir/sid/us-npi'/>
-              <value value='9999999999'/>
+              <value value='1234329724'/>
             </identifier>
           </provider>
           <role>

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ef19bc1b-2082-4b65-b702-79c557084bc2",
+		"_postman_id": "a78786d4-5857-4424-b0cc-3dc336c4128f",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -1423,6 +1423,457 @@
                     },
                     "description": "While the export request is being processed, the job url will return a 202 status. When it is completed, a 200 status will be returned, along with JSON containing Job status."
                   },
+					"response": []
+				},
+				{
+					"name": "Patient data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "3e50ce2a-4322-4723-981b-31251393b449",
+								"exec": [
+									"require('crypto-js')",
+									"",
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"});",
+									"",
+									"// There should be 2 patients.",
+									"pm.test(\"Patient data correct\", function() {",
+									"    var responseOutput = pm.response.text();",
+									"    var responseLines = responseOutput.trim().split('\\n');",
+									"    pm.expect(responseLines).to.have.lengthOf(3);",
+									"    for (var line of responseLines) {",
+									"        var lineData = JSON.parse(line);",
+									"        pm.expect(lineData.resourceType).to.equal(\"Patient\");",
+									"    }",
+									"});",
+									"",
+									"// Verify sha256 checksums",
+									"pm.test(\"Checksums should match\", function() {",
+									"    var output = pm.environment.get(\"patient\")",
+									"    var responseOutput = pm.response.text();",
+									"    ",
+									"    var checksum  = CryptoJS.SHA256(responseOutput);",
+									"    pm.expect(\"sha256:\" + checksum).to.equal(output.extension[0].valueString)",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "b848c339-0867-41c0-81e8-326e6da9e6d6",
+								"exec": [
+									"pm.environment.set(\"patient_url\", pm.environment.get(\"patient\").url)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{patient_url}}",
+							"host": [
+								"{{patient_url}}"
+							]
+						},
+						"description": "The patient data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one patient."
+					},
+					"response": []
+				},
+				{
+					"name": "Explanation of Benefit data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "64383543-afd0-4aed-8e62-533892909b98",
+								"exec": [
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"   pm.environment.set(\"file_timestamp\", pm.response.headers.get(\"Last-Modified\"))",
+									"});",
+									"",
+									"// There should be 86 Explanations of Benefits.",
+									"pm.test(\"Explanation of Benefits data correct\", function() {",
+									"    var responseOutput = pm.response.text();",
+									"    var responseLines = responseOutput.trim().split('\\n');",
+									"    pm.expect(responseLines.length).to.be.above(100);",
+									"    for (var line of responseLines) {",
+									"        var lineData = JSON.parse(line);",
+									"        pm.expect(lineData.resourceType).to.equal(\"ExplanationOfBenefit\");",
+									"    }",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "61e1278d-0e11-4a4b-97b3-6118ac20a20f",
+								"exec": [
+									"pm.environment.set(\"eob_url\", pm.environment.get(\"eob\").url)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{eob_url}}",
+							"host": [
+								"{{eob_url}}"
+							]
+						},
+						"description": "The explanation of benefits data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one explanation of benefits."
+					},
+					"response": []
+				},
+				{
+					"name": "Coverage data",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "756f4c51-bce2-4a77-b3b9-bd7e96d844e5",
+								"exec": [
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"});",
+									"",
+									"// There should be 8 coverage.",
+									"pm.test(\"Coverage data correct\", function() {",
+									"    var responseOutput = pm.response.text();",
+									"    var responseLines = responseOutput.trim().split('\\n');",
+									"    pm.expect(responseLines).to.have.lengthOf(12);",
+									"    for (var line of responseLines) {",
+									"        var lineData = JSON.parse(line);",
+									"        pm.expect(lineData.resourceType).to.equal(\"Coverage\");",
+									"    }",
+									"});",
+									"",
+									"// Verify sha256 checksum",
+									"pm.test(\"Checksum should match\", function() {",
+									"    var output = pm.environment.get(\"coverage\")",
+									"    var responseOutput = pm.response.text();",
+									"    ",
+									"    var checksum  = CryptoJS.SHA256(responseOutput);",
+									"    pm.expect(\"sha256:\" + checksum).to.equal(output.extension[0].valueString)",
+									"    ",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "f30dd4c7-de1c-4d75-8119-24935c3e4959",
+								"exec": [
+									"pm.environment.set(\"coverage_url\", pm.environment.get(\"coverage\").url)"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{coverage_url}}",
+							"host": [
+								"{{coverage_url}}"
+							]
+						},
+						"description": "The coverage data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one coverage."
+					},
+					"response": []
+				},
+				{
+					"name": "Request Partial Range",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9c3140af-4f5d-493a-85b7-ec73dec7b750",
+								"exec": [
+									"// Response should have FHIR Content-Type",
+									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"   pm.response.to.have.header(\"Content-Range\");",
+									"});",
+									"",
+									"// Should be 10kb total",
+									"pm.test('Should have 10kb of data', function() {",
+									"    pm.expect(pm.response.text().length).to.be.above(10000);",
+									"})",
+									"",
+									"pm.test('Content should be gzipped', function() {",
+									"    pm.response.to.have.header(\"Content-Encoding\", \"gzip\");",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Range",
+								"value": "bytes=0-10240",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{eob_url}}",
+							"host": [
+								"{{eob_url}}"
+							]
+						},
+						"description": "Request a subset of the EOB data to ensure range requests work correctly."
+					},
+					"response": []
+				},
+				{
+					"name": "Request Modified Since",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "9c3140af-4f5d-493a-85b7-ec73dec7b750",
+								"exec": [
+									"// Response should be 304",
+									"pm.test('Response should be not-modified', function() {",
+									"    pm.response.to.have.status(304);",
+									"})"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "If-Modified-Since",
+								"type": "text",
+								"value": "{{file_timestamp}}"
+							}
+						],
+						"url": {
+							"raw": "{{eob_url}}",
+							"host": [
+								"{{eob_url}}"
+							],
+							"query": [
+								{
+									"key": "",
+									"value": "",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Request a subset of the EOB data to ensure range requests work correctly."
+					},
+					"response": []
+				},
+				{
+					"name": "Try export with _since",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "5497fa12-aefd-44c2-9254-2beb51c52e31",
+								"exec": [
+									"// Status should be 202",
+									"pm.test(\"Status is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									"",
+									"// Url for job response should be in content-location header.",
+									"pm.test(\"Content-Location header is present\", function () {",
+									"    pm.response.to.have.header(\"Content-Location\");",
+									"});",
+									"",
+									"if (pm.response.headers.get(\"Content-Location\")) {",
+									"  pm.environment.set(\"since_content_location\", pm.response.headers.get(\"Content-Location\"));",
+									"} else {",
+									"  // Fail the test, no content location.",
+									"  postman.setNextRequest(null);",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "8b8d6363-b490-428a-bfee-663b184ae05d",
+								"exec": [
+									"console.log(\"Group:\", pm.environment.get(\"attribution_group\"));",
+									"pm.environment.set(\"since_timestamp\", new Date().toISOString());"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/fhir+json"
+							},
+							{
+								"key": "Prefer",
+								"type": "text",
+								"value": "respond-async"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Group/{{attribution_group_id}}/$export?_since={{since_timestamp}}",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Group",
+								"{{attribution_group_id}}",
+								"$export"
+							],
+							"query": [
+								{
+									"key": "_since",
+									"value": "{{since_timestamp}}"
+								}
+							]
+						},
+						"description": "Try the export request again with the _since parameter of the current time. The resultant job should be empty. The request should succeed with a 202 status and the location for the job response in the `content-location` header."
+					},
+					"response": []
+				},
+				{
+					"name": "_since job response",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "28fe7a36-50ab-4e7d-bf21-312b5f5777f3",
+								"exec": [
+									"// Wait between pings",
+									"setTimeout(function() {}, 1000);"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"id": "70688a82-d0cf-4802-b1e5-b6ad7357c926",
+								"exec": [
+									"if (pm.response.code == 200) {",
+									"    // Response should have FHIR Content-Type",
+									"    pm.test(\"Content-type is application/json\", function() {",
+									"       pm.response.to.have.header(\"Content-Type\", \"application/json\"); ",
+									"    });",
+									"    ",
+									"    // If response code is 200, check the response and load the urls.",
+									"    pm.test(\"Empty output and no errors\", function() {",
+									"        pm.expect(pm.response.json().error).to.have.lengthOf(0);",
+									"        pm.expect(pm.response.json().output).to.have.lengthOf(0);",
+									"    });",
+									"} else {",
+									"    // If response code is not 200, it should be 202. Assert that, and retry.",
+									"    pm.test(\"Status code is 202\", function () {",
+									"        pm.response.to.have.status(202);",
+									"    });",
+									"    postman.setNextRequest(\"_since job response\");",
+									"}"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{since_content_location}}",
+							"host": [
+								"{{since_content_location}}"
+							]
+						},
+						"description": "While the export request is being processed, the job url will return a 202 status. When it is completed, a 200 status will be returned, along with JSON containing Job status."
+					},
+					"response": []
+				},
+				{
+					"name": "All data for a patient",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e0daa691-6ba0-4eb8-a86f-d27b006f4749",
+								"exec": [
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response should be a Bundle\", function() {",
+									"    var response = pm.response.json();",
+									"    pm.expect(response.resourceType).to.equal(\"Bundle\")",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Provenance",
+								"value": "{{attestationHeader}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Patient/728b270d-d7de-4143-82fe-d3ccd92cebe4/$everything",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Patient",
+								"728b270d-d7de-4143-82fe-d3ccd92cebe4",
+								"$everything"
+							]
+						}
+					},
 					"response": []
 				}
 			],


### PR DESCRIPTION
**Why**

Vendors need a way to synchronously retrieve all data about a patient.

**What Changed**

New `/Patient/{patient ID}/$everything` endpoint returns all `Coverage`, `ExplanationOfBenefit`, and `Patient` resources for a given patient.

**Tickets closed**:

[DPC-264](https://jiraent.cms.gov/browse/DPC-264)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
