### PR TITLE
DPC-1283: Patient resource input validation

### DIFF
--- a/dpc-api/src/test/java/gov/cms/dpc/api/FHIRSubmissionTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/FHIRSubmissionTest.java
@@ -60,7 +60,7 @@ class FHIRSubmissionTest {
     private static final GrizzlyWebTestContainerFactory testContainer = new GrizzlyWebTestContainerFactory();
 
     // Test data
-    private static List<String> testBeneficiaries = List.of("1", "2", "3", "4");
+    private static List<String> testBeneficiaries = List.of("0Z00Z00ZZ01", "0Z00Z00ZZ02", "0Z00Z00ZZ03", "0Z00Z00ZZ04");
 
     private ResourceExtension groupResource = ResourceExtension.builder()
             .addResource(new GroupResource(queue, client, TEST_BASE_URL))

--- a/dpc-api/src/test/java/gov/cms/dpc/api/validations/ProfileTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/validations/ProfileTests.java
@@ -55,8 +55,7 @@ class ProfileTests extends AbstractSecureApplicationTest {
 
         // Try for a valid patient
         final Patient validPatient = invalidPatient.copy();
-        // TODO(nickrobison): This will need to be switched to the MBI system, once those changes are complete.
-        validPatient.addIdentifier().setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("test-mbi");
+        validPatient.addIdentifier().setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("0O00O00OO00");
         validPatient.setGender(Enumerations.AdministrativeGender.MALE);
         validPatient.setBirthDate(Date.valueOf("1990-01-01"));
         client

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
@@ -44,7 +44,7 @@ class AttributionFHIRTest {
     private static final DropwizardTestSupport<DPCAttributionConfiguration> APPLICATION = new DropwizardTestSupport<>(DPCAttributionService.class, "ci.application.conf", ConfigOverride.config("server.applicationConnectors[0].port", "3727"),
             ConfigOverride.config(KEY_PREFIX, "logging.level", "ERROR"));
     private static final FhirContext ctx = FhirContext.forDstu3();
-    private static final String CSV = "test_associations.csv";
+    private static final String CSV = "test_associations-dpr.csv";
     private static Map<String, List<Pair<String, String>>> groupedPairs = new HashMap<>();
     private static final ObjectMapper mapper = new ObjectMapper();
     private static Organization organization;
@@ -184,7 +184,7 @@ class AttributionFHIRTest {
         // Create the new patient and submit them
         final Patient patient = new Patient();
         final Identifier patientIdentifier = new Identifier();
-        patientIdentifier.setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("test-new-patient-id");
+        patientIdentifier.setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("0I00I00II00");
         patient.addIdentifier(patientIdentifier);
         patient.addName().addGiven("New Test Patient");
         patient.setBirthDate(new GregorianCalendar(2019, Calendar.MARCH, 1).getTime());

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest.java
@@ -60,8 +60,7 @@ class ExpirationJobTest {
     void test() throws InterruptedException {
 
         // Manually add a new relationship with a current creation timestamp
-        final String newPatientID = "test-new-patient-id";
-        final Bundle updateBundle = createAttributionBundle(PROVIDER_ID, newPatientID, DEFAULT_ORG_ID);
+        final Bundle updateBundle = createAttributionBundle(PROVIDER_ID, "0L00L00LL00", DEFAULT_ORG_ID);
         // Submit the attribution bundle
         ctx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
         final IGenericClient client = ctx.newRestfulGenericClient("http://localhost:" + APPLICATION.getLocalPort() + "/v1/");

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/OrganizationResourceTest.java
@@ -197,7 +197,7 @@ class OrganizationResourceTest extends AbstractAttributionTest {
     private Patient createFakePatient(Organization organization) {
         final Patient patient = new Patient();
         patient.addName().setFamily("Test").addGiven("Patient");
-        patient.addIdentifier().setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("test-fake-mbi");
+        patient.addIdentifier().setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("0ZZ0ZZ0ZZ00");
         patient.setBirthDate(Date.valueOf("1990-01-02"));
         patient.setGender(Enumerations.AdministrativeGender.MALE);
         patient.setManagingOrganization(new Reference(organization.getId()));

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/PatientResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/PatientResourceTest.java
@@ -4,6 +4,7 @@ import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.gclient.ICreateTyped;
 import ca.uhn.fhir.rest.gclient.IQuery;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import gov.cms.dpc.attribution.AbstractAttributionTest;
 import gov.cms.dpc.attribution.AttributionTestHelpers;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
@@ -27,7 +28,7 @@ class PatientResourceTest extends AbstractAttributionTest {
 
     @Test
     void testPatientReadWrite() {
-        final Patient patient = createPatientResource("1871", DEFAULT_ORG_ID);
+        final Patient patient = createPatientResource("0O00O00OO00", DEFAULT_ORG_ID);
 
         final Reference orgReference = new Reference(new IdType("Organization", DEFAULT_ORG_ID));
         patient.setManagingOrganization(orgReference);
@@ -66,6 +67,22 @@ class PatientResourceTest extends AbstractAttributionTest {
 
         final MethodOutcome execute = secondCreation.execute();
         assertNull(execute.getCreated(), "Should not be able to create again");
+    }
+
+    @Test
+    void testCreatePatientWithInvalidMbi() {
+        final Patient patient = createPatientResource("not-an-mbi", DEFAULT_ORG_ID);
+
+        final Reference orgReference = new Reference(new IdType("Organization", DEFAULT_ORG_ID));
+        patient.setManagingOrganization(orgReference);
+
+        final IGenericClient client = createFHIRClient(ctx, getServerURL());
+
+        ICreateTyped create = client
+                .create()
+                .resource(patient);
+
+        assertThrows(InvalidRequestException.class, create::execute);
     }
 
     @Test

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
@@ -21,6 +21,9 @@ import java.util.Objects;
 public class PatientEntity extends PersonEntity {
 
     public static final long serialVersionUID = 42L;
+    /* For details of the MBI format, see: https://www.cms.gov/Medicare/New-Medicare-Card/Understanding-the-MBI.pdf
+    This pattern is similar to that format, but is less restrictive to accommodate testing. Synthetic MBIs should
+    include letters and numbers not permitted in real MBIs. */
     public static final String MBI_FORMAT = "^\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z]{2}\\d{2}$";
 
     @NotEmpty

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
@@ -9,6 +9,7 @@ import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -23,6 +24,7 @@ public class PatientEntity extends PersonEntity {
 
     @NotEmpty
     @Column(name = "beneficiary_id", unique = true)
+    @Pattern(regexp = "^\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z]{2}\\d{2}$")
     private String beneficiaryID;
 
     @Column(name = "mbi_hash")

--- a/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/entities/PatientEntity.java
@@ -21,10 +21,11 @@ import java.util.Objects;
 public class PatientEntity extends PersonEntity {
 
     public static final long serialVersionUID = 42L;
+    public static final String MBI_FORMAT = "^\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z]{2}\\d{2}$";
 
     @NotEmpty
     @Column(name = "beneficiary_id", unique = true)
-    @Pattern(regexp = "^\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z]{2}\\d{2}$")
+    @Pattern(regexp = MBI_FORMAT, message = "Must be a Medicare Beneficiary Identifier (MBI)")
     private String beneficiaryID;
 
     @Column(name = "mbi_hash")

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRExtractors.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRExtractors.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.fhir;
 
+import gov.cms.dpc.common.entities.PatientEntity;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -46,7 +47,14 @@ public class FHIRExtractors {
      * @return - {@link String} patient MBI
      */
     public static String getPatientMBI(Patient patient) {
-        return findMatchingIdentifier(patient.getIdentifier(), DPCIdentifierSystem.MBI).getValue();
+        String identifier = findMatchingIdentifier(patient.getIdentifier(), DPCIdentifierSystem.MBI).getValue();
+        Pattern mbiPattern = Pattern.compile(PatientEntity.MBI_FORMAT);
+        if (mbiPattern.matcher(identifier).matches()) {
+            return identifier;
+        }
+
+        logger.error("Invalid MBI");
+        throw new IllegalArgumentException("Patient Identifier for system " + DPCIdentifierSystem.MBI.getSystem() + " must match MBI format");
     }
 
     /**

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/FHIRExtractorTests.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/FHIRExtractorTests.java
@@ -22,9 +22,9 @@ public class FHIRExtractorTests {
         final Patient patient = new Patient();
         // This double nesting verifies that the fromString method works correctly. Makes PiTest happy.
         patient.addIdentifier().setSystem(DPCIdentifierSystem.fromString(DPCIdentifierSystem.DPC.getSystem()).getSystem()).setValue("test-dpc-one");
-        patient.addIdentifier().setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("test-mbi-one");
+        patient.addIdentifier().setSystem(DPCIdentifierSystem.MBI.getSystem()).setValue("0A00A00AA01");
 
-        assertEquals("test-mbi-one", getPatientMBI(patient), "Should have MBI");
+        assertEquals("0A00A00AA01", getPatientMBI(patient), "Should have MBI");
     }
 
     @Test


### PR DESCRIPTION
**Why**

DPC needs to validate that the values provided as identifiers within the `http://hl7.org/fhir/sid/us-mbi` system match the [MBI format](https://www.cms.gov/Medicare/New-Medicare-Card/Understanding-the-MBI.pdf).

**What Changed**

Validation added to check MBI format in the `PatientEntity` and `FHIRExtractors`.

**Choices Made**

The pattern fits the MBI format for placement of letters and numbers, but in order to allow synthetic data, **does not** limit the letters or numbers that may be used.

**Future Work**

There is a lot of room for improvement in API responses across the board. Rather than spending time setting up better responses for just this ticket, we should review as part of [DPC-878](https://jiraent.cms.gov/browse/DPC-878).

**Tickets Closed**

[DPC-1283](https://jiraent.cms.gov/browse/DPC-1283)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
