### PR TITLE
Dpc 1369 fix rspec error

### DIFF
--- a/dpc-web/spec/features/registration/new_user_signs_up_for_account_spec.rb
+++ b/dpc-web/spec/features/registration/new_user_signs_up_for_account_spec.rb
@@ -26,29 +26,29 @@ RSpec.feature 'new user signs up for account' do
       select 'New York', from: :user_state
       fill_in :user_zip, with: '10033'
       check :user_agree_to_terms
-  
+
       click_on('Sign up')
     end
 
     scenario 'user sent a confirmation email with confirmation token' do
       expect(:confirmation_token).to be_present
 
-      ctoken = last_email.body.match(/confirmation_token=\w*/)
+      ctoken = last_email.body.match(/confirmation_token=[^"]*/)
 
       expect(ctoken).to be_present
     end
 
     scenario 'user clicks on confirmation link to navigate to dashboard' do
-      ctoken = last_email.body.match(/confirmation_token=\w*/)
+      ctoken = last_email.body.match(/confirmation_token=[^"]*/)
 
       visit "/users/confirmation?#{ctoken}"
-  
+
       expect(page).to have_http_status(200)
       expect(page).to have_css('[data-test="my-account-menu"]')
-  
+
       find('[data-test="my-account-menu"]').click
       find('[data-test="dpc-registrations-profile-link"]', visible: false).click
-  
+
       email_field = find('#user_email')
       expect(email_field.value).to eq('clarissa@example.com')
     end
@@ -145,11 +145,11 @@ RSpec.feature 'new user signs up for account' do
       select 'New York', from: :user_state
       fill_in :user_zip, with: '10033'
       check :user_agree_to_terms
-  
+
       click_on('Sign up')
 
       visit new_user_session_path
-      
+
       last_user = User.last
 
       fill_in 'user_email', with: last_user.email

--- a/dpc-web/spec/spec_helper.rb
+++ b/dpc-web/spec/spec_helper.rb
@@ -55,7 +55,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  # config.order = :random
+  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
**Why**

There have been random rspec failures coming from the `new_user_signs_up_for_account_spec.rb` file. Particularly the `expect(page).to have_css('[data-test="my-account-menu"]')` check. This needed to be investigated so we dont experience random failures from our CI anymore.

**What Changed**

It turns out a regex wasn't accounting for certain characters and cutting off the ctoken when we try to pull it out from the email. In particular, the `-` was not being accounted for (`\w` only accounts for `[a-zA-Z0-9_]`). I've also introduced running the rspec tests in a random order.

**Choices Made**

I updated the regex to just look for the first double quote delimiter and otherwise eat all characters hungrily. This should account for any weird characters devise is using in their token.

Adding random order to our rspec tests should add another lair to our testing. This way we can hopefully uncover if some tests are being written poorly and, for example, potentially causing other tests to fail due to not breaking down test scaffolding correctly. The test run will provide the seed its being run with which can then be used to rerun the specs in the same order and, hopefully, reproduce the issues (though I should note that, in this case, it was not helpful).

**Tickets closed**:

[DPC-1369](https://jiraent.cms.gov/browse/DPC-1369)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
