### PR TITLE
DPC-859: Changing the password should invalidate the session & force login

### DIFF
--- a/dpc-web/config/initializers/devise.rb
+++ b/dpc-web/config/initializers/devise.rb
@@ -216,7 +216,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  config.sign_in_after_reset_password = false
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
@@ -295,7 +295,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
-  # config.sign_in_after_change_password = true
+  config.sign_in_after_change_password = false
 
   # Mailer layout
   Devise::Mailer.layout "mailer"


### PR DESCRIPTION
**Why**

To improve security, have the users automatically need to sign back in when a password changed or reset.

**What Changed**

Changed devise's default to keep the session from `true` to `false`.

**Choices Made**

![Screen Shot 2020-05-01 at 10 04 52 AM](https://user-images.githubusercontent.com/44708048/80814113-4ad5bc80-8b99-11ea-9bef-3ee771fee85b.png)


**Tickets closed**:

[DPC-859](https://jiraent.cms.gov/browse/DPC-859)

**Future Work**

N/A

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
