### PR TITLE
Revert "Bump jackson-datatype-jsr310 from 2.10.3 to 2.11.0"

### DIFF
--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.11.0</version>
+            <version>2.10.3</version>
         </dependency>
         <dependency>
             <groupId>${hapi.fhir.groupID}</groupId>


### PR DESCRIPTION
Reverts CMSgov/dpc-app#770

Why: Smoke tests break!  (Why didn't they break in Travis?)