### PR TITLE
DPC-92: Responses for create operations

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
@@ -42,7 +42,7 @@ public class EndpointResource extends AbstractEndpointResource {
     @ApiOperation(value = "Create an Endpoint", notes = "Create an Endpoint resource for an Organization")
     @ApiResponses(value = {
             @ApiResponse(code = 204, message = "Endpoint created"),
-            @ApiResponse(code = 422, message = "Endpoint could not be created")
+            @ApiResponse(code = 422, message = "Invalid Endpoint resource")
     })
     @Override
     public Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/EndpointResource.java
@@ -42,7 +42,8 @@ public class EndpointResource extends AbstractEndpointResource {
     @ApiOperation(value = "Create an Endpoint", notes = "Create an Endpoint resource for an Organization")
     @ApiResponses(value = {
             @ApiResponse(code = 204, message = "Endpoint created"),
-            @ApiResponse(code = 422, message = "Invalid Endpoint resource")
+            @ApiResponse(code = 400, message = "Bad request"),
+            @ApiResponse(code = 422, message = "Endpoint not valid")
     })
     @Override
     public Response createEndpoint(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint) {
@@ -105,7 +106,7 @@ public class EndpointResource extends AbstractEndpointResource {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Endpoint updated"),
             @ApiResponse(code = 404, message = "Endpoint not found"),
-            @ApiResponse(code = 422, message = "Endpoint is not valid")
+            @ApiResponse(code = 422, message = "Endpoint not valid")
     })
     @Override
     public Endpoint updateEndpoint(@NotNull @PathParam("endpointID") UUID endpointID, @Valid @Profiled(profile = EndpointProfile.PROFILE_URI) Endpoint endpoint) {

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
@@ -60,7 +60,7 @@ public class EndpointResourceTest extends AbstractSecureApplicationTest {
         String reqBody = "{\"test\": \"test\"}";
         conn.getOutputStream().write(reqBody.getBytes());
 
-        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, conn.getResponseCode());
+        assertEquals(HttpStatus.BAD_REQUEST_400, conn.getResponseCode());
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()))) {
             StringBuilder respBuilder = new StringBuilder();
@@ -72,6 +72,8 @@ public class EndpointResourceTest extends AbstractSecureApplicationTest {
             assertTrue(resp.contains("\"resourceType\":\"OperationOutcome\""));
             assertTrue(resp.contains("Invalid JSON content"));
         }
+
+        conn.disconnect();
     }
 
     @Test

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
@@ -14,10 +14,16 @@ import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import gov.cms.dpc.testing.OrganizationHelpers;
 import gov.cms.dpc.testing.factories.OrganizationFactory;
+import org.apache.http.HttpHeaders;
+import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
+import javax.ws.rs.HttpMethod;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.List;
 import java.util.UUID;
 
@@ -38,6 +44,34 @@ public class EndpointResourceTest extends AbstractSecureApplicationTest {
         assertEquals(endpoint.getName(), createdEndpoint.getName());
         assertEquals(endpoint.getAddress(), createdEndpoint.getAddress());
         assertEquals(APITestHelpers.ORGANIZATION_ID, FHIRExtractors.getEntityUUID(createdEndpoint.getManagingOrganization().getReference()).toString());
+    }
+
+    @Test
+    void testCreateInvalidEndpoint() throws IOException, URISyntaxException {
+        URL url = new URL(getBaseURL() + "/Endpoint");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(HttpMethod.POST);
+        conn.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/fhir+json");
+
+        APIAuthHelpers.AuthResponse auth = APIAuthHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
+        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "Bearer " + auth.accessToken);
+
+        conn.setDoOutput(true);
+        String reqBody = "{\"test\": \"test\"}";
+        conn.getOutputStream().write(reqBody.getBytes());
+
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, conn.getResponseCode());
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()))) {
+            StringBuilder respBuilder = new StringBuilder();
+            String respLine = null;
+            while ((respLine = reader.readLine()) != null) {
+                respBuilder.append(respLine.trim());
+            }
+            String resp = respBuilder.toString();
+            assertTrue(resp.contains("\"resourceType\":\"OperationOutcome\""));
+            assertTrue(resp.contains("Invalid JSON content"));
+        }
     }
 
     @Test

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/GroupResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/GroupResourceTest.java
@@ -12,17 +12,27 @@ import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import gov.cms.dpc.testing.BufferedLoggerHandler;
+import org.apache.http.HttpHeaders;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.dstu3.model.codesystems.V3RoleClass;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import javax.ws.rs.HttpMethod;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.sql.Date;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.List;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
 import static org.junit.jupiter.api.Assertions.*;
@@ -197,5 +207,41 @@ public class GroupResourceTest extends AbstractSecureApplicationTest {
                 .encodedJson()
                 .withAdditionalHeader("X-Provenance", ctx.newJsonParser().encodeResourceToString(provenance))
                 .execute());
+    }
+
+    @Test
+    void testCreateInvalidGroup() throws IOException, URISyntaxException {
+        Provenance provenance = new Provenance();
+        provenance.setRecorded(Date.valueOf(LocalDate.now()));
+        provenance.setReason(List.of(new Coding("http://hl7.org/fhir/v3/ActReason", "TREAT", null)));
+        String provString = ctx.newJsonParser().encodeResourceToString(provenance);
+
+        URL url = new URL(getBaseURL() + "/Group");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(HttpMethod.POST);
+        conn.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/fhir+json");
+        conn.setRequestProperty("X-Provenance", provString);
+
+        APIAuthHelpers.AuthResponse auth = APIAuthHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
+        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "Bearer " + auth.accessToken);
+
+        conn.setDoOutput(true);
+        String reqBody = "{\"test\": \"test\"}";
+        conn.getOutputStream().write(reqBody.getBytes());
+
+        assertEquals(HttpStatus.BAD_REQUEST_400, conn.getResponseCode());
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()))) {
+            StringBuilder respBuilder = new StringBuilder();
+            String respLine = null;
+            while ((respLine = reader.readLine()) != null) {
+                respBuilder.append(respLine.trim());
+            }
+            String resp = respBuilder.toString();
+            assertAll(() -> assertTrue(resp.contains("\"resourceType\":\"OperationOutcome\"")),
+                    () -> assertTrue(resp.contains("Invalid JSON content")));
+        }
+
+        conn.disconnect();
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/OrganizationResourceTest.java
@@ -30,14 +30,20 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.assertj.core.util.Lists;
+import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Endpoint;
 import org.hl7.fhir.dstu3.model.Organization;
 import org.hl7.fhir.dstu3.model.Parameters;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.HttpMethod;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.util.UUID;
@@ -71,6 +77,34 @@ class OrganizationResourceTest extends AbstractSecureApplicationTest {
 
         // Now, try to create one again, but using an actual org token
         assertThrows(AuthenticationException.class, () -> OrganizationHelpers.createOrganization(ctx, APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY), UUID.randomUUID().toString(), true));
+    }
+
+    @Test
+    void testCreateInvalidOrganization() throws IOException, URISyntaxException {
+        URL url = new URL(getBaseURL() + "/Organization/$submit");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(HttpMethod.POST);
+        conn.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/fhir+json");
+        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "Bearer " + GOLDEN_MACAROON);
+
+        conn.setDoOutput(true);
+        String reqBody = "{\"test\": \"test\"}";
+        conn.getOutputStream().write(reqBody.getBytes());
+
+        assertEquals(HttpStatus.BAD_REQUEST_400, conn.getResponseCode());
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()))) {
+            StringBuilder respBuilder = new StringBuilder();
+            String respLine = null;
+            while ((respLine = reader.readLine()) != null) {
+                respBuilder.append(respLine.trim());
+            }
+            String resp = respBuilder.toString();
+            assertTrue(resp.contains("\"resourceType\":\"OperationOutcome\""));
+            assertTrue(resp.contains("Resource type must be `Parameters`"));
+        }
+
+        conn.disconnect();
     }
 
     @Test

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -13,14 +13,21 @@ import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpHeaders;
+import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Enumerations;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.HttpMethod;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.sql.Date;
@@ -205,5 +212,35 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
                 .withId(patient.getId());
 
         assertThrows(UnprocessableEntityException.class, update::execute);
+    }
+
+    @Test
+    void testCreateInvalidPatient() throws IOException, URISyntaxException {
+        URL url = new URL(getBaseURL() + "/Patient");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(HttpMethod.POST);
+        conn.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/fhir+json");
+
+        APIAuthHelpers.AuthResponse auth = APIAuthHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
+        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "Bearer " + auth.accessToken);
+
+        conn.setDoOutput(true);
+        String reqBody = "{\"test\": \"test\"}";
+        conn.getOutputStream().write(reqBody.getBytes());
+
+        assertEquals(HttpStatus.BAD_REQUEST_400, conn.getResponseCode());
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()))) {
+            StringBuilder respBuilder = new StringBuilder();
+            String respLine = null;
+            while ((respLine = reader.readLine()) != null) {
+                respBuilder.append(respLine.trim());
+            }
+            String resp = respBuilder.toString();
+            assertTrue(resp.contains("\"resourceType\":\"OperationOutcome\""));
+            assertTrue(resp.contains("Invalid JSON content"));
+        }
+
+        conn.disconnect();
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PractitionerResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PractitionerResourceTest.java
@@ -9,12 +9,19 @@ import gov.cms.dpc.api.AbstractSecureApplicationTest;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpHeaders;
+import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Practitioner;
 import org.junit.jupiter.api.Test;
 
+import javax.ws.rs.HttpMethod;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.util.UUID;
@@ -110,5 +117,35 @@ class PractitionerResourceTest extends AbstractSecureApplicationTest {
         assertEquals(0, otherSpecificSearch.getTotal(), "Should not have a specific provider");
 
         // Try to search for our fund provider
+    }
+
+    @Test
+    void testCreateInvalidPractitioner() throws IOException, URISyntaxException {
+        URL url = new URL(getBaseURL() + "/Practitioner");
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod(HttpMethod.POST);
+        conn.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/fhir+json");
+
+        APIAuthHelpers.AuthResponse auth = APIAuthHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
+        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "Bearer " + auth.accessToken);
+
+        conn.setDoOutput(true);
+        String reqBody = "{\"test\": \"test\"}";
+        conn.getOutputStream().write(reqBody.getBytes());
+
+        assertEquals(HttpStatus.BAD_REQUEST_400, conn.getResponseCode());
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getErrorStream()))) {
+            StringBuilder respBuilder = new StringBuilder();
+            String respLine = null;
+            while ((respLine = reader.readLine()) != null) {
+                respBuilder.append(respLine.trim());
+            }
+            String resp = respBuilder.toString();
+            assertTrue(resp.contains("\"resourceType\":\"OperationOutcome\""));
+            assertTrue(resp.contains("Invalid JSON content"));
+        }
+
+        conn.disconnect();
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/FHIRHandler.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/FHIRHandler.java
@@ -48,7 +48,9 @@ public class FHIRHandler implements MessageBodyReader<BaseResource>, MessageBody
             // We need to manually handle the DataFormatException because our custom exception handlers aren't loaded yet.
         } catch (DataFormatException e) {
             String message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
-            throw new WebApplicationException(message, HttpStatus.UNPROCESSABLE_ENTITY_422);
+            // Bad request if not parsable; unprocessable if parsable but in violation of profile or business rules
+            int status = message.contains("Invalid attribute value") ? HttpStatus.UNPROCESSABLE_ENTITY_422 : HttpStatus.BAD_REQUEST_400;
+            throw new WebApplicationException(message, status);
         }
     }
 

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/ProfileValidator.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/ProfileValidator.java
@@ -35,6 +35,12 @@ public class ProfileValidator implements ConstraintValidator<Profiled, BaseResou
         // Disable default error messages, as we want to generate our own
         context.disableDefaultConstraintViolation();
 
+        if (value == null || !value.isResource()) {
+            context.buildConstraintViolationWithTemplate("No resource provided")
+                    .addConstraintViolation();
+            return false;
+        }
+
         // Create a validation option object which forces validation against the given profile.
         final ValidationOptions options = new ValidationOptions();
         options.addProfile(profileURI);

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/handlers/FHIRHandlerTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/handlers/FHIRHandlerTest.java
@@ -57,7 +57,7 @@ public class FHIRHandlerTest {
         void testNonFHIRRead() {
             final InputStream is = IOUtils.toInputStream("this is not fhir", StandardCharsets.UTF_8);
             final WebApplicationException exception = assertThrows(WebApplicationException.class, () -> handler.readFrom(BaseResource.class, null, null, MediaType.TEXT_HTML_TYPE, null, is), "Should throw exception");
-            assertAll(() -> assertEquals(HttpStatus.UNPROCESSABLE_ENTITY_422, exception.getResponse().getStatus(), "Should have correct error status"),
+            assertAll(() -> assertEquals(HttpStatus.BAD_REQUEST_400, exception.getResponse().getStatus(), "Should have correct error status"),
                     () -> assertEquals("Content does not appear to be FHIR JSON, first non-whitespace character was: 't' (must be '{')", exception.getMessage(), "Should have correct message"));
         }
     }


### PR DESCRIPTION
**Why**

Ensure and demonstrate that DPC API's create operations return appropriate error responses.

**What Changed**

Tests were added to show that appropriate error responses are returned from API create operations for Endpoint, Group, Organization, Patient, and Practitioner resources. Some logic was updated accordingly.

Information about create operation error status codes may be found at https://www.hl7.org/fhir/http.html#create.

> Common HTTP Status codes returned on FHIR-related errors (in addition to normal HTTP errors related to security, header and content type negotiation issues):
> 
>     400 Bad Request - resource could not be parsed or failed basic FHIR validation rules
>     404 Not Found - resource type not supported, or not a FHIR end-point
>     422 Unprocessable Entity - the proposed resource violated applicable FHIR profiles or server business rules. This should be accompanied by an OperationOutcome resource providing additional detail

Examples of how this PR interprets it:
* POST with body that isn't JSON: 400
* POST with body that is JSON but doesn't look like a supported FHIR resource: 400 
* POST with body that includes `"resourceType": "Patient"` but is missing a field required by the Patient profile: 422 (DPC understands the request, but it violates rules)

**Tickets closed**:

[DPC-92](https://jira.cms.gov/browse/DPC-92)

**Checklist**

- [x] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [x] Swagger documentation has been updated
- [x] FHIR documentation has been updated
- [x] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [x] Any manual migration steps are documented, scripts written (where applicable), and tested
- [x] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
