### PR TITLE
Feature: Add Prod Conf File

### DIFF
--- a/dpc-api/src/main/resources/prod.application.conf
+++ b/dpc-api/src/main/resources/prod.application.conf
@@ -1,4 +1,5 @@
 dpc.api {
+    
     publicURL = "https://prod.dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
      server {

--- a/dpc-api/src/main/resources/prod.application.conf
+++ b/dpc-api/src/main/resources/prod.application.conf
@@ -1,26 +1,35 @@
 dpc.api {
     publicURL = "https://prod.dpc.cms.gov/api" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 
-    database = {
+     server {
+        applicationContextPath = "/api"
+    }
+
+    database {
         url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_attribution"
         user = ${ATTRIBUTION_DB_USER}
         password = ${ATTRIBUTION_DB_PASS}
     }
 
-    queuedb = {
-        url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_queue"
-        user = ${QUEUE_DB_USER}
-        password = ${QUEUE_DB_PASS}
-    }
-
-    authdb = {
+    authdb {
         url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_auth"
         user = ${AUTH_DB_USER}
         password = ${AUTH_DB_PASS}
     }
 
-    server {
-        applicationContextPath = "/api"
+    queuedb {
+        url = "jdbc:postgresql://db.dpc-prod.local:5432/dpc_queue"
+        user = ${QUEUE_DB_USER}
+        password = ${QUEUE_DB_PASS}
+    }
+
+    bbclient {
+        serverBaseUrl = ${BFD_URL}
+
+        keyStore {
+            location = ${BB_KEYSTORE_LOCATION}
+            defaultPassword = ${BB_KEYSTORE_PASS}
+        }
     }
 
     attributionURL = "http://backend.dpc-prod.local:8080/v1/"


### PR DESCRIPTION
**Why**

Prod was missing a .conf file for deployment.

**What Changed**

Add a prod .conf file

**Future Work**

- We should look into separating the .conf files away from `dpc-app` into `dpc-ops`.

**Checklist**

- [ ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- [ ] Swagger documentation has been updated
- [ ] FHIR documentation has been updated
- [ ] Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- [ ] Any manual migration steps are documented, scripts written (where applicable), and tested
- [ ] Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
