### PR TITLE
Get smoke test working in prod env

### DIFF
--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -41,6 +41,13 @@ public class ClientUtils {
         // Not used
     }
 
+    /* TODO When prod environment has DNS entries for prod.dpc.cms.gov, revert the workarounds in this file
+     * - revert adding the overrideURL argument to all methods that have it
+     * - remove workaround code in awaitExportResponse()
+     * - git diff f2d3abe1f23e4d1ad2f2a01 5d799c57712418de674 <<< green is good
+     * see also https://github.com/CMSgov/dpc-app/pull/849
+     */
+
     /**
      * Helper method for initiating and Export job and monitoring its success.
      * @param exportClient - {@link IGenericClient} to use for export request. Ensure this contains the necessary authentication and HttpHeaders
@@ -126,6 +133,7 @@ public class ClientUtils {
     private static JobCompletionModel awaitExportResponse(String jobLocation, String statusMessage, CloseableHttpClient client, String overrideURL) throws IOException, InterruptedException {
         // Use the traditional HTTP Client to check the job status
         JobCompletionModel jobResponse = null;
+        // TODO When DNS is set for prod, revert this workaround code; see TODO at the top of this class
         String jobLocationURL = jobLocation;
         if (jobLocation.startsWith("https://prod.dpc.cms.gov/api/v1")) {
             jobLocationURL = overrideURL.substring(0, overrideURL.indexOf("/api/v1")) + jobLocation.substring("https://prod.dpc.cms.gov".length());

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -43,17 +43,17 @@ public class ClientUtils {
 
     /**
      * Helper method for initiating and Export job and monitoring its success.
-     *
      * @param exportClient - {@link IGenericClient} to use for export request. Ensure this contains the necessary authentication and HttpHeaders
      * @param providerNPIs - {@link List} of {@link String} of provider NPIs to use for exporting
      * @param httpClient   - {@link CloseableHttpClient} to use for executing non-FHIR HTTP requests
+     * @param overrideURL  - overrides the url used for checking jobs; only useful when DNS is not active in an environment
      */
-    static void handleExportJob(IGenericClient exportClient, List<String> providerNPIs, CloseableHttpClient httpClient) {
+    static void handleExportJob(IGenericClient exportClient, List<String> providerNPIs, CloseableHttpClient httpClient, String overrideURL) {
         providerNPIs
                 .stream()
                 .map(npi -> exportRequestDispatcher(exportClient, npi))
                 .map(search -> (Group) search.getEntryFirstRep().getResource())
-                .map(group -> jobCompletionLambda(exportClient, httpClient, group))
+                .map(group -> jobCompletionLambda(exportClient, httpClient, group, overrideURL))
                 .peek(jobResponse -> {
                     if (jobResponse.getError().size() > 0)
                         throw new IllegalStateException("Export job completed, but with errors");
@@ -123,10 +123,15 @@ public class ClientUtils {
      * @throws IOException          - throws if the HTTP request fails
      * @throws InterruptedException - throws if the thread is interrupted
      */
-    private static JobCompletionModel awaitExportResponse(String jobLocation, String statusMessage, CloseableHttpClient client) throws IOException, InterruptedException {
+    private static JobCompletionModel awaitExportResponse(String jobLocation, String statusMessage, CloseableHttpClient client, String overrideURL) throws IOException, InterruptedException {
         // Use the traditional HTTP Client to check the job status
         JobCompletionModel jobResponse = null;
-        final HttpGet jobGet = new HttpGet(jobLocation);
+        String jobLocationURL = jobLocation;
+        if (jobLocation.startsWith("https://prod.dpc.cms.gov/api/v1")) {
+            jobLocationURL = overrideURL.substring(0, overrideURL.indexOf("/api/v1")) + jobLocation.substring("https://prod.dpc.cms.gov".length());
+            logger.info("patched job url " + jobLocationURL);
+        }
+        final HttpGet jobGet = new HttpGet(jobLocationURL);
         boolean done = false;
 
         while (!done) {
@@ -149,7 +154,6 @@ public class ClientUtils {
                         logger.error(String.format("Failed to parse job status response: %s", responseBody));
                         throw e;
                     }
-
                 }
             }
         }
@@ -190,7 +194,7 @@ public class ClientUtils {
      * @throws IOException          - throws if something bad happens
      * @throws InterruptedException - throws if someone cuts in line
      */
-    private static JobCompletionModel monitorExportRequest(IOperationUntypedWithInput<Parameters> exportOperation, CloseableHttpClient client) throws IOException, InterruptedException {
+    private static JobCompletionModel monitorExportRequest(IOperationUntypedWithInput<Parameters> exportOperation, CloseableHttpClient client, String overrideURL) throws IOException, InterruptedException {
         System.out.println("Retrying export request");
 
         // Return a MethodOutcome in order to get the response headers.
@@ -200,11 +204,10 @@ public class ClientUtils {
 
         // Get the headers and check the status
         final String exportURL = headers.get("content-location").get(0);
-        System.out.printf("Export job started. Progress URL: %s%n", exportURL);
-
+        logger.info(String.format("Export job started. Progress URL: %s%n", exportURL));
 
         // Poll the job until it's done
-        return awaitExportResponse(exportURL, "Checking job status", client);
+        return awaitExportResponse(exportURL, "Checking job status", client, overrideURL);
     }
 
     private static Bundle exportRequestDispatcher(IGenericClient exportClient, String npi) {
@@ -229,10 +232,10 @@ public class ClientUtils {
         }
     }
 
-    private static JobCompletionModel jobCompletionLambda(IGenericClient exportClient, CloseableHttpClient client, Group group) {
+    private static JobCompletionModel jobCompletionLambda(IGenericClient exportClient, CloseableHttpClient client, Group group, String overrideURL) {
         final IOperationUntypedWithInput<Parameters> exportOperation = createExportOperation(exportClient, group.getId());
         try {
-            return monitorExportRequest(exportOperation, client);
+            return monitorExportRequest(exportOperation, client, overrideURL);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(String.format("Error monitoring export groupID: %s", group.getId()), e);
         }

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -137,7 +137,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
             orgRegistrationResult.sampleStart();
             try {
                 String npi = NPIUtil.generateNPI();
-                clientToken = FHIRHelpers.registerOrganization(adminClient, ctx.newJsonParser(), organizationID, npi ,adminURL);
+                clientToken = FHIRHelpers.registerOrganization(adminClient, ctx.newJsonParser(), organizationID, npi, adminURL);
                 orgRegistrationResult.setSuccessful(true);
             } catch (Exception e) {
                 orgRegistrationResult.setSuccessful(false);
@@ -222,7 +222,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
                 .trusting()
                 .isAuthed(hostParam, clientToken, keyTuple.getKey(), keyTuple.getRight())
                 .build()) {
-            ClientUtils.handleExportJob(exportClient, providerNPIs, httpClient);
+            ClientUtils.handleExportJob(exportClient, providerNPIs, httpClient, hostParam);
             smokeTestResult.setSuccessful(true);
 
             logger.info("Test completed");

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
@@ -103,7 +103,10 @@ public class APIAuthHelpers {
     }
 
     public static AuthResponse jwtAuthFlow(String baseURL, String macaroon, UUID keyID, PrivateKey privateKey) throws IOException, URISyntaxException {
-        // TODO: Revert .signWith() to type ECC?
+        /* TODO revert this workaround to previous version of code
+         * - git diff f2d3abe1f23e4d1ad2f2a01 5d799c57712418de674 <<< green is good
+         * see also https://github.com/CMSgov/dpc-app/pull/849
+         */
         String audience = baseURL;
         if (baseURL.startsWith("http://internal-dpc-prod-")) {
             audience = "https://prod.dpc.cms.gov/api/v1";

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
@@ -104,9 +104,13 @@ public class APIAuthHelpers {
 
     public static AuthResponse jwtAuthFlow(String baseURL, String macaroon, UUID keyID, PrivateKey privateKey) throws IOException, URISyntaxException {
         // TODO: Revert .signWith() to type ECC?
+        String audience = baseURL;
+        if (baseURL.startsWith("http://internal-dpc-prod-")) {
+            audience = "https://prod.dpc.cms.gov/api/v1";
+        }
         final String jwt = Jwts.builder()
                 .setHeaderParam("kid", keyID)
-                .setAudience(String.format("%s/Token/auth", baseURL))
+                .setAudience(String.format("%s/Token/auth", audience))
                 .setIssuer(macaroon)
                 .setSubject(macaroon)
                 .setId(UUID.randomUUID().toString())


### PR DESCRIPTION
**Why**

Our smoke tests did not run in our neo prod environment because there are no DNS entries for the hosts. The smoke test code assumes that urls for posting and the domain name are the same, which is not the case in the prod environment right now.

**What Changed**

There are two operations in the code that needed attention:

1) tokens must be created using the domain name
2) the job location returned by an $export request must be converted from domain -> 

This code is a temporary bypass until we have completed our testing and are ready to make DNS changes.

**Tickets closed**:

Give a list of tickets closed in this PR.

**Future Work**

I assume we will remove these bypasses when we make the DNS changes.

**Checklist**

- [ x ] All tests are passing via `make ci-app` (app change) and `make ci-web` (website change)
- (NA) Swagger documentation has been updated
- (NA) FHIR documentation has been updated
- (NA) Any required dpc-ops changes have a PR submitted and mentioned in this ticket
- (NA) Any manual migration steps are documented, scripts written (where applicable), and tested
- (NA) Before merging, any required dpc-ops changes have been approved and merged into master of the dpc-ops repo
