### PR TITLE
Remove redis exists warning

### DIFF
--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -412,11 +412,10 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sidekiq (6.0.7)
+    sidekiq (6.1.0)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     sidekiq_alive (2.0.2)
       sidekiq
       sinatra

--- a/dpc-web/config/initializers/redis.rb
+++ b/dpc-web/config/initializers/redis.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-# TODO: Sidekiq uses a depricated `exists` call for Redis. This config
-# option suppresses the warning. It will need to be removed once sidekiq
-# updates and conforms to the new `exists` structure.
-Redis.exists_returns_integer = false


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `dpc-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [DPC-44](https://jira.cms.gov/browse/DPC-44)

<!-- Describe the problem being solved here: -->
Due to a recent Redis update, running the sidekiq/rails server has resulted in a warning:

`Redis#exists(key)` will return an Integer by default in redis-rb 4.3. The option to explicitly disable this behaviour via `Redis.exists_returns_integer` will be removed in 5.0. You should use `exists? instead`

This is affecting our splunk forwarder and causing issues. The culprit of the warning is Sidekiq as it is, as the warning describes, using an old from of the `exists` method.

### Proposed Changes

<!-- List of changes with bullet points here: -->
Update Sidekiq to version `6.1`. The newest version has updated this functionality.

### Change Details

<!-- Add detailed discussion of changes here: -->
Simple version bump. We can also remove the `redis.rb` file since it holds no pertinent information anymore.

### Security Implications

N/A

### Acceptance Validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
Running both the sidekiq server and the rails server locally with the new sidekiq version has verified the warning is gone.
<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

N/A
