### PR TITLE
DPC-518 log lookback stats, add jobid, batchid and patient mbi hash to mdc

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.rest.param.DateRangeParam;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import gov.cms.dpc.bluebutton.client.BlueButtonClient;
+import gov.cms.dpc.common.MDCConstants;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.queue.exceptions.JobQueueFailure;
 import io.reactivex.Flowable;
@@ -12,6 +13,7 @@ import org.hl7.fhir.dstu3.model.*;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.security.GeneralSecurityException;
 import java.time.OffsetDateTime;
@@ -124,6 +126,11 @@ class ResourceFetcher {
      */
     private Bundle fetchFirst(String mbi) {
         Patient patient = fetchPatient(mbi);
+        patient.getIdentifier().stream()
+                .filter(i -> i.getSystem().equals(DPCIdentifierSystem.MBI_HASH.getSystem()))
+                .findFirst()
+                .ifPresent(i -> MDC.put(MDCConstants.PATIENT_ID, i.getValue()));
+
         var beneId = getBeneIdFromPatient(patient);
         final var lastUpdated = formLastUpdatedParam();
         switch (resourceType) {
@@ -143,7 +150,7 @@ class ResourceFetcher {
         try {
             patients = blueButtonClient.requestPatientFromServerByMbi(mbi);
         } catch (GeneralSecurityException e) {
-            logger.error("Job {}, batch {}: Failed to retrieve Patient", jobID, batchID, e);
+            logger.error("Failed to retrieve Patient", e);
             throw new ResourceNotFoundException("Failed to retrieve Patient");
         }
 
@@ -151,7 +158,7 @@ class ResourceFetcher {
             return (Patient) patients.getEntryFirstRep().getResource();
         }
 
-        logger.error("Job {}, batch {}: Expected 1 Patient to match MBI but found {}", jobID, batchID, patients.getTotal());
+        logger.error("Expected 1 Patient to match MBI but found {}", patients.getTotal());
         throw new ResourceNotFoundException(String.format("Expected 1 Patient to match MBI but found %d", patients.getTotal()));
     }
 
@@ -161,7 +168,7 @@ class ResourceFetcher {
                 .findFirst()
                 .map(Identifier::getValue)
                 .orElseThrow(() -> {
-                    logger.error("Job {}, batch {}: No bene_id found in Patient resource", jobID, batchID);
+                    logger.error("No bene_id found in Patient resource");
                     return new ResourceNotFoundException("No bene_id found in Patient resource");
                 });
     }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/MDCConstants.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/MDCConstants.java
@@ -1,0 +1,10 @@
+package gov.cms.dpc.common;
+
+public final class MDCConstants {
+    private MDCConstants() {}
+
+    public static final String PATIENT_ID = "patientID";
+    public static final String JOB_ID = "jobID";
+    public static final String JOB_BATCH_ID = "batchID";
+
+}


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `dpc-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [DPC-518](https://jira.cms.gov/browse/DPC-518)

<!-- Describe the problem being solved here: -->

### Proposed Changes

- Add jobID, batchID and patient MBI Hash to MDC for logs
- Log lookBack stats for each patient

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

Make sure MBI Hash is not PII

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->
```
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"Processing job, exporting to: /tmp.","mdc":{"jobID":"c925679a-ff7f-4a33-862c-14e46388b3d5","batchID":"1de6b574-5bd5-4b57-8a2f-a5a3597d1206"},"timestamp":"2020-07-09T14:44:35.087+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.service.LookBackService","thread":"RxComputationThreadPool-1","message":"LookBack stats eobWithinLookBackLimit true, eobContainsProvider true, eobRelatedToOrganization true, eobMonthsDifference 2, hasClaim true","mdc":{"batchID":"1de6b574-5bd5-4b57-8a2f-a5a3597d1206","jobID":"c925679a-ff7f-4a33-862c-14e46388b3d5","patientID":"d35350fce12f555089f938c0323a13122622123038e8af057a4191fd450c2b90"},"timestamp":"2020-07-09T14:44:35.722+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.service.LookBackService","thread":"RxComputationThreadPool-1","message":"LookBack stats eobWithinLookBackLimit true, eobContainsProvider true, eobRelatedToOrganization true, eobMonthsDifference 6, hasClaim true","mdc":{"jobID":"c925679a-ff7f-4a33-862c-14e46388b3d5","batchID":"1de6b574-5bd5-4b57-8a2f-a5a3597d1206","patientID":"41af07535e0a66226cf2f0e6c551c0a15bd49192fc055aa5cd2e63f31f90a419"},"timestamp":"2020-07-09T14:44:36.311+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.service.LookBackService","thread":"RxComputationThreadPool-1","message":"eob BillingPeriod or job providerID or job organizationID or eob OrganizationID are null","mdc":{"jobID":"c925679a-ff7f-4a33-862c-14e46388b3d5","batchID":"1de6b574-5bd5-4b57-8a2f-a5a3597d1206","patientID":"e411277fd31da392eaa9a45df53b0c429e365626182f50d9f35810d77f0e2756"},"timestamp":"2020-07-09T14:44:36.616+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.service.LookBackService","thread":"RxComputationThreadPool-1","message":"LookBack stats eobWithinLookBackLimit true, eobContainsProvider true, eobRelatedToOrganization true, eobMonthsDifference 3, hasClaim true","mdc":{"jobID":"c925679a-ff7f-4a33-862c-14e46388b3d5","batchID":"1de6b574-5bd5-4b57-8a2f-a5a3597d1206","patientID":"e411277fd31da392eaa9a45df53b0c429e365626182f50d9f35810d77f0e2756"},"timestamp":"2020-07-09T14:44:36.621+0000"}
{"exception":"java.lang.NullPointerException: null\n\tat java.base/java.util.Objects.requireNonNull(Objects.java:221)\n\tat java.base/java.util.ImmutableCollections$MapN.containsValue(ImmutableCollections.java:847)\n\tat gov.cms.dpc.bluebutton.client.MockBlueButtonClient.loadResource(MockBlueButtonClient.java:156)\n\tat gov.cms.dpc.bluebutton.client.MockBlueButtonClient.loadBundle(MockBlueButtonClient.java:139)\n\tat gov.cms.dpc.bluebutton.client.MockBlueButtonClient.requestPatientFromServerByMbi(MockBlueButtonClient.java:63)\n\tat gov.cms.dpc.aggregation.engine.ResourceFetcher.fetchPatient(ResourceFetcher.java:151)\n\tat gov.cms.dpc.aggregation.engine.ResourceFetcher.fetchFirst(ResourceFetcher.java:128)\n\tat gov.cms.dpc.aggregation.engine.ResourceFetcher.lambda$fetchResources$0(ResourceFetcher.java:72)\n\tat io.reactivex.internal.operators.flowable.FlowableFromCallable.subscribeActual(FlowableFromCallable.java:39)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableOnErrorNext.subscribeActual(FlowableOnErrorNext.java:40)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableFlatMap.subscribeActual(FlowableFlatMap.java:53)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableFilter.subscribeActual(FlowableFilter.java:37)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableAnySingle.subscribeActual(FlowableAnySingle.java:37)\n\tat io.reactivex.Single.subscribe(Single.java:3666)\n\tat io.reactivex.internal.operators.single.SingleOnErrorReturn.subscribeActual(SingleOnErrorReturn.java:38)\n\tat io.reactivex.Single.subscribe(Single.java:3666)\n\tat io.reactivex.Single.blockingGet(Single.java:2869)\n\tat gov.cms.dpc.aggregation.engine.AggregationEngine.isValidLookBack(AggregationEngine.java:208)\n\tat gov.cms.dpc.aggregation.engine.AggregationEngine.processPatient(AggregationEngine.java:189)\n\tat gov.cms.dpc.aggregation.engine.AggregationEngine.processJobBatch(AggregationEngine.java:163)\n\tat io.reactivex.internal.observers.LambdaObserver.onNext(LambdaObserver.java:63)\n\tat io.reactivex.internal.operators.observable.ObservableMap$MapObserver.onNext(ObservableMap.java:62)\n\tat io.reactivex.internal.operators.observable.ObservableFilter$FilterObserver.onNext(ObservableFilter.java:52)\n\tat io.reactivex.internal.operators.observable.ObservableRetryPredicate$RepeatObserver.onNext(ObservableRetryPredicate.java:69)\n\tat io.reactivex.internal.operators.observable.ObservableDoOnEach$DoOnEachObserver.onNext(ObservableDoOnEach.java:101)\n\tat io.reactivex.internal.operators.observable.ObservableDoOnEach$DoOnEachObserver.onNext(ObservableDoOnEach.java:101)\n\tat io.reactivex.internal.util.HalfSerializer.onNext(HalfSerializer.java:107)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver.onNext(ObservableRepeatWhen.java:100)\n\tat io.reactivex.internal.observers.DeferredScalarDisposable.complete(DeferredScalarDisposable.java:82)\n\tat io.reactivex.internal.operators.observable.ObservableFromCallable.subscribeActual(ObservableFromCallable.java:53)\n\tat io.reactivex.Observable.subscribe(Observable.java:12284)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver.subscribeNext(ObservableRepeatWhen.java:151)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver.innerNext(ObservableRepeatWhen.java:128)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver$InnerRepeatObserver.onNext(ObservableRepeatWhen.java:168)\n\tat io.reactivex.observers.SerializedObserver.onNext(SerializedObserver.java:111)\n\tat io.reactivex.internal.operators.observable.ObservableDelay$DelayObserver$OnNext.run(ObservableDelay.java:114)\n\tat io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)\n\tat io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n\tat java.base/java.lang.Thread.run(Thread.java:834)\n","level":"ERROR","logger":"gov.cms.dpc.aggregation.engine.ResourceFetcher","thread":"RxComputationThreadPool-1","message":"Turning error into OperationOutcome.","mdc":{"jobID":"c925679a-ff7f-4a33-862c-14e46388b3d5","batchID":"1de6b574-5bd5-4b57-8a2f-a5a3597d1206","patientID":"e411277fd31da392eaa9a45df53b0c429e365626182f50d9f35810d77f0e2756"},"timestamp":"2020-07-09T14:44:36.892+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"COMPLETED job","mdc":{"jobID":"c925679a-ff7f-4a33-862c-14e46388b3d5","batchID":"1de6b574-5bd5-4b57-8a2f-a5a3597d1206"},"timestamp":"2020-07-09T14:44:36.895+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"Processing job, exporting to: /tmp.","mdc":{"batchID":"1700017d-05fe-4eaf-9d1c-403feedf11e7","jobID":"f84a5c0e-587e-45fb-83d0-8529ef9bdb3d"},"timestamp":"2020-07-09T14:44:39.711+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"COMPLETED job","mdc":{"batchID":"1700017d-05fe-4eaf-9d1c-403feedf11e7","jobID":"f84a5c0e-587e-45fb-83d0-8529ef9bdb3d"},"timestamp":"2020-07-09T14:44:39.711+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"Processing job, exporting to: /tmp.","mdc":{"batchID":"4f871117-24a5-4cbb-8698-d9c5fe71ca78","jobID":"73bf6362-0925-482e-a498-c8ed73809d06"},"timestamp":"2020-07-09T14:44:42.286+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"COMPLETED job","mdc":{"batchID":"4f871117-24a5-4cbb-8698-d9c5fe71ca78","jobID":"73bf6362-0925-482e-a498-c8ed73809d06"},"timestamp":"2020-07-09T14:44:42.287+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"Processing job, exporting to: /tmp.","mdc":{"batchID":"d1d7e45a-7bee-40ae-bb29-625906acdf73","jobID":"c0439095-1ba3-4971-b074-5dc23bf491c8"},"timestamp":"2020-07-09T14:44:45.895+0000"}
{"exception":"java.lang.NullPointerException: null\n\tat java.base/java.util.Objects.requireNonNull(Objects.java:221)\n\tat java.base/java.util.ImmutableCollections$MapN.containsValue(ImmutableCollections.java:847)\n\tat gov.cms.dpc.bluebutton.client.MockBlueButtonClient.loadResource(MockBlueButtonClient.java:156)\n\tat gov.cms.dpc.bluebutton.client.MockBlueButtonClient.loadBundle(MockBlueButtonClient.java:139)\n\tat gov.cms.dpc.bluebutton.client.MockBlueButtonClient.requestPatientFromServerByMbi(MockBlueButtonClient.java:63)\n\tat gov.cms.dpc.aggregation.engine.ResourceFetcher.fetchPatient(ResourceFetcher.java:151)\n\tat gov.cms.dpc.aggregation.engine.ResourceFetcher.fetchFirst(ResourceFetcher.java:128)\n\tat gov.cms.dpc.aggregation.engine.ResourceFetcher.lambda$fetchResources$0(ResourceFetcher.java:72)\n\tat io.reactivex.internal.operators.flowable.FlowableFromCallable.subscribeActual(FlowableFromCallable.java:39)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableOnErrorNext.subscribeActual(FlowableOnErrorNext.java:40)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableFlatMap.subscribeActual(FlowableFlatMap.java:53)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableFilter.subscribeActual(FlowableFilter.java:37)\n\tat io.reactivex.Flowable.subscribe(Flowable.java:14935)\n\tat io.reactivex.internal.operators.flowable.FlowableAnySingle.subscribeActual(FlowableAnySingle.java:37)\n\tat io.reactivex.Single.subscribe(Single.java:3666)\n\tat io.reactivex.internal.operators.single.SingleOnErrorReturn.subscribeActual(SingleOnErrorReturn.java:38)\n\tat io.reactivex.Single.subscribe(Single.java:3666)\n\tat io.reactivex.Single.blockingGet(Single.java:2869)\n\tat gov.cms.dpc.aggregation.engine.AggregationEngine.isValidLookBack(AggregationEngine.java:208)\n\tat gov.cms.dpc.aggregation.engine.AggregationEngine.processPatient(AggregationEngine.java:189)\n\tat gov.cms.dpc.aggregation.engine.AggregationEngine.processJobBatch(AggregationEngine.java:163)\n\tat io.reactivex.internal.observers.LambdaObserver.onNext(LambdaObserver.java:63)\n\tat io.reactivex.internal.operators.observable.ObservableMap$MapObserver.onNext(ObservableMap.java:62)\n\tat io.reactivex.internal.operators.observable.ObservableFilter$FilterObserver.onNext(ObservableFilter.java:52)\n\tat io.reactivex.internal.operators.observable.ObservableRetryPredicate$RepeatObserver.onNext(ObservableRetryPredicate.java:69)\n\tat io.reactivex.internal.operators.observable.ObservableDoOnEach$DoOnEachObserver.onNext(ObservableDoOnEach.java:101)\n\tat io.reactivex.internal.operators.observable.ObservableDoOnEach$DoOnEachObserver.onNext(ObservableDoOnEach.java:101)\n\tat io.reactivex.internal.util.HalfSerializer.onNext(HalfSerializer.java:107)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver.onNext(ObservableRepeatWhen.java:100)\n\tat io.reactivex.internal.observers.DeferredScalarDisposable.complete(DeferredScalarDisposable.java:82)\n\tat io.reactivex.internal.operators.observable.ObservableFromCallable.subscribeActual(ObservableFromCallable.java:53)\n\tat io.reactivex.Observable.subscribe(Observable.java:12284)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver.subscribeNext(ObservableRepeatWhen.java:151)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver.innerNext(ObservableRepeatWhen.java:128)\n\tat io.reactivex.internal.operators.observable.ObservableRepeatWhen$RepeatWhenObserver$InnerRepeatObserver.onNext(ObservableRepeatWhen.java:168)\n\tat io.reactivex.observers.SerializedObserver.onNext(SerializedObserver.java:111)\n\tat io.reactivex.internal.operators.observable.ObservableDelay$DelayObserver$OnNext.run(ObservableDelay.java:114)\n\tat io.reactivex.internal.schedulers.ScheduledRunnable.run(ScheduledRunnable.java:66)\n\tat io.reactivex.internal.schedulers.ScheduledRunnable.call(ScheduledRunnable.java:57)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n\tat java.base/java.lang.Thread.run(Thread.java:834)\n","level":"ERROR","logger":"gov.cms.dpc.aggregation.engine.ResourceFetcher","thread":"RxComputationThreadPool-1","message":"Turning error into OperationOutcome.","mdc":{"batchID":"d1d7e45a-7bee-40ae-bb29-625906acdf73","jobID":"c0439095-1ba3-4971-b074-5dc23bf491c8"},"timestamp":"2020-07-09T14:44:45.904+0000"}
{"level":"INFO","logger":"gov.cms.dpc.aggregation.engine.AggregationEngine","thread":"RxComputationThreadPool-1","message":"COMPLETED job","mdc":{"batchID":"d1d7e45a-7bee-40ae-bb29-625906acdf73","jobID":"c0439095-1ba3-4971-b074-5dc23bf491c8"},"timestamp":"2020-07-09T14:44:45.904+0000"}
```

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
