### PR TITLE
DPC-551: Restore /Patient/$everything

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIModule.java
@@ -34,6 +34,7 @@ import gov.cms.dpc.macaroons.annotations.PublicURL;
 import gov.cms.dpc.macaroons.config.TokenPolicy;
 import gov.cms.dpc.macaroons.thirdparty.IThirdPartyKeyStore;
 import gov.cms.dpc.macaroons.thirdparty.MemoryThirdPartyKeyStore;
+import gov.cms.dpc.queue.service.DataService;
 import io.dropwizard.hibernate.UnitOfWorkAwareProxyFactory;
 import io.jsonwebtoken.SigningKeyResolverAdapter;
 import org.hibernate.SessionFactory;
@@ -80,6 +81,8 @@ public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
         binder.bind(FileManager.class);
         binder.bind(HttpRangeHeaderParamConverterProvider.class);
         binder.bind(ChecksumConverterProvider.class);
+
+        binder.bind(DataService.class);
 
         // Healthchecks
         // Additional health-checks can be added here

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
@@ -4,11 +4,10 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.common.annotations.NoHtml;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.annotations.Profiled;
+import gov.cms.dpc.fhir.validations.profiles.AttestationProfile;
 import gov.cms.dpc.fhir.validations.profiles.PatientProfile;
 import io.dropwizard.auth.Auth;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Parameters;
-import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 
 import javax.validation.Valid;
@@ -37,6 +36,10 @@ public abstract class AbstractPatientResource {
     @GET
     @Path("/{patientID}")
     public abstract Patient getPatient(UUID patientID);
+
+    @GET
+    @Path("/{patientID}/$everything")
+    public abstract Resource everything(OrganizationPrincipal organization, @Valid @Profiled(profile = AttestationProfile.PROFILE_URI) Provenance attestation, UUID patientId);
 
     @DELETE
     @Path("/{patientID}")

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -3,23 +3,27 @@ package gov.cms.dpc.api.resources.v1;
 import ca.uhn.fhir.parser.IParser;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.gclient.IReadExecutable;
 import ca.uhn.fhir.rest.gclient.IUpdateExecutable;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
+import gov.cms.dpc.bluebutton.client.MockBlueButtonClient;
+import gov.cms.dpc.common.utils.SeedProcessor;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
+import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpHeaders;
 import org.eclipse.jetty.http.HttpStatus;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.Enumerations;
-import org.hl7.fhir.dstu3.model.Identifier;
-import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.*;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import javax.ws.rs.HttpMethod;
 import java.io.BufferedReader;
@@ -31,19 +35,28 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.security.PrivateKey;
 import java.sql.Date;
+import java.util.List;
 import java.util.UUID;
 
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_ID;
 import static gov.cms.dpc.api.APITestHelpers.ORGANIZATION_NPI;
 import static org.junit.jupiter.api.Assertions.*;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class PatientResourceTest extends AbstractSecureApplicationTest {
+
+    public static final String PROVENANCE_FMT = "{ \"resourceType\": \"Provenance\", \"recorded\": \"" + DateTimeType.now().getValueAsString() + "\"," +
+            " \"reason\": [ { \"system\": \"http://hl7.org/fhir/v3/ActReason\", \"code\": \"TREAT\"  } ], \"agent\": [ { \"role\": " +
+            "[ { \"coding\": [ { \"system\":" + "\"http://hl7.org/fhir/v3/RoleClass\", \"code\": \"AGNT\" } ] } ], \"whoReference\": " +
+            "{ \"reference\": \"Organization/ORGANIZATION_ID\" }, \"onBehalfOfReference\": { \"reference\": " +
+            "\"Practitioner/PRACTITIONER_ID\" } } ] }";
 
     PatientResourceTest() {
         // Not used
     }
 
     @Test
+    @Order(2)
     void ensurePatientsExist() throws IOException, URISyntaxException, GeneralSecurityException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
@@ -121,6 +134,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(3)
     void testPatientRemoval() throws IOException, URISyntaxException, GeneralSecurityException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
@@ -171,6 +185,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(4)
     void testPatientUpdating() throws IOException, URISyntaxException, GeneralSecurityException {
         final IParser parser = ctx.newJsonParser();
         final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
@@ -216,6 +231,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(5)
     void testCreateInvalidPatient() throws IOException, URISyntaxException {
         URL url = new URL(getBaseURL() + "/Patient");
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
@@ -246,6 +262,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
+    @Order(1)
     public void testCreatePatientReturnsAppropriateHeaders() {
         IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
         Patient patient = APITestHelpers.createPatientResource("4S41C00AA00", APITestHelpers.ORGANIZATION_ID);
@@ -272,5 +289,101 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
                 .resource(foundPatient)
                 .encodedJson()
                 .execute();
+    }
+
+    @Test
+    @Order(6)
+    void testPatientEverything() throws IOException, URISyntaxException, GeneralSecurityException {
+        final IParser parser = ctx.newJsonParser();
+        final IGenericClient attrClient = APITestHelpers.buildAttributionClient(ctx);
+        String macaroon = FHIRHelpers.registerOrganization(attrClient, parser, ORGANIZATION_ID, ORGANIZATION_NPI, getAdminURL());
+        String keyLabel = "patient-everything-key";
+        Pair<UUID, PrivateKey> uuidPrivateKeyPair = APIAuthHelpers.generateAndUploadKey(keyLabel, ORGANIZATION_ID, GOLDEN_MACAROON, getBaseURL());
+        IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight(), false, true);
+        APITestHelpers.setupPractitionerTest(client, parser);
+
+        String mbi = MockBlueButtonClient.TEST_PATIENT_MBIS.get(2);
+        final Bundle patients = client
+                .search()
+                .forResource(Patient.class)
+                .where(Patient.IDENTIFIER.exactly().systemAndCode(DPCIdentifierSystem.MBI.getSystem(), mbi))
+                .encodedJson()
+                .returnBundle(Bundle.class)
+                .execute();
+
+        final Patient patient = (Patient) patients.getEntry().get(0).getResource();
+        final String patientId = FHIRExtractors.getEntityUUID(patient.getId()).toString();
+
+        final String practitionerNpi = "1234329724";
+        Bundle practSearch = client
+                .search()
+                .forResource(Practitioner.class)
+                .where(Practitioner.IDENTIFIER.exactly().code(practitionerNpi))
+                .returnBundle(Bundle.class)
+                .encodedJson()
+                .execute();
+        Practitioner foundPractitioner = (Practitioner) practSearch.getEntryFirstRep().getResource();
+
+        Group group = SeedProcessor.createBaseAttributionGroup(FHIRExtractors.getProviderNPI(foundPractitioner), ORGANIZATION_ID);
+        final Reference patientRef = new Reference("Patient/" + patientId);
+        group.addMember().setEntity(patientRef);
+
+        String provenance = PROVENANCE_FMT.replaceAll("ORGANIZATION_ID", ORGANIZATION_ID).replace("PRACTITIONER_ID", foundPractitioner.getId());
+        client
+                .create()
+                .resource(group)
+                .withAdditionalHeader("X-Provenance", provenance)
+                .encodedJson()
+                .execute();
+
+        Bundle result = client
+                .operation()
+                .onInstance(new IdType("Patient", patientId))
+                .named("$everything")
+                .withNoParameters(Parameters.class)
+                .returnResourceType(Bundle.class)
+                .useHttpGet()
+                .withAdditionalHeader("X-Provenance", provenance)
+                .execute();
+
+        assertEquals(64, result.getTotal(), "Should have 64 entries in Bundle");
+        for (Bundle.BundleEntryComponent bec : result.getEntry()) {
+            List<ResourceType> resourceTypes = List.of(ResourceType.Coverage, ResourceType.ExplanationOfBenefit, ResourceType.Patient);
+            assertTrue(resourceTypes.contains(bec.getResource().getResourceType()), "Resource type should be Coverage, EOB, or Patient");
+        }
+
+        // Unattributed organization (unauthorized)
+        macaroon = FHIRHelpers.registerOrganization(attrClient, parser, OTHER_ORG_ID, "1112111111", getAdminURL());
+        keyLabel = "patient-everything-key-2";
+        uuidPrivateKeyPair = APIAuthHelpers.generateAndUploadKey(keyLabel, OTHER_ORG_ID, GOLDEN_MACAROON, getBaseURL());
+        client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), macaroon, uuidPrivateKeyPair.getLeft(), uuidPrivateKeyPair.getRight());
+        APITestHelpers.setupPractitionerTest(client, parser);
+
+        Bundle practitioners = client
+                .search()
+                .forResource(Practitioner.class)
+                .returnBundle(Bundle.class)
+                .encodedJson()
+                .execute();
+        Practitioner practitioner = (Practitioner) practitioners.getEntryFirstRep().getResource();
+
+        provenance = PROVENANCE_FMT.replaceAll("ORGANIZATION_ID", OTHER_ORG_ID).replace("PRACTITIONER_ID", practitioner.getId());
+        client
+                .create()
+                .resource(group)
+                .withAdditionalHeader("X-Provenance", provenance)
+                .encodedJson()
+                .execute();
+
+        IOperationUntypedWithInput everythingOp = client
+                .operation()
+                .onInstance(new IdType("Patient", patientId))
+                .named("$everything")
+                .withNoParameters(Parameters.class)
+                .returnResourceType(Bundle.class)
+                .useHttpGet()
+                .withAdditionalHeader("X-Provenance", provenance);
+
+        assertThrows(AuthenticationException.class, everythingOp::execute);
     }
 }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
@@ -9,10 +9,7 @@ import gov.cms.dpc.queue.exceptions.DataRetrievalException;
 import gov.cms.dpc.queue.exceptions.DataRetrievalRetryException;
 import gov.cms.dpc.queue.models.JobQueueBatch;
 import gov.cms.dpc.queue.models.JobQueueBatchFile;
-import org.hl7.fhir.dstu3.model.Bundle;
-import org.hl7.fhir.dstu3.model.OperationOutcome;
-import org.hl7.fhir.dstu3.model.Resource;
-import org.hl7.fhir.dstu3.model.ResourceType;
+import org.hl7.fhir.dstu3.model.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +42,10 @@ public class DataService {
         this.jobTimeoutInSeconds = jobTimeoutInSeconds;
     }
 
+    public Resource retrieveData(UUID organizationId, UUID providerId, List<String> patientIds, ResourceType... resourceTypes) {
+        return retrieveData(organizationId, providerId, patientIds, OffsetDateTime.now(ZoneOffset.UTC), resourceTypes);
+    }
+
     /**
      * Retrieves data from BFD
      * @param organizationID UUID of organization
@@ -56,8 +57,9 @@ public class DataService {
     public Resource retrieveData(UUID organizationID,
                                  UUID providerID,
                                  List<String> patientIDs,
+                                 OffsetDateTime transactionTime,
                                  ResourceType... resourceTypes) {
-        UUID jobID = this.queue.createJob(organizationID, providerID.toString(), patientIDs, List.of(resourceTypes), null, OffsetDateTime.now(ZoneOffset.UTC));
+        UUID jobID = this.queue.createJob(organizationID, providerID.toString(), patientIDs, List.of(resourceTypes), null, transactionTime);
         Optional<List<JobQueueBatch>> optionalBatches = waitForJobToComplete(jobID, organizationID, this.queue);
 
         if (optionalBatches.isPresent()) {
@@ -134,13 +136,27 @@ public class DataService {
                 .filter(bf -> resourceTypes.contains(bf.getResourceType()))
                 .forEach(batchFile -> {
                     Path path = Paths.get(String.format("%s/%s.ndjson", exportPath, batchFile.getFileName()));
-                    addResourceEntries(Resource.class, path, bundle);
+                    Class<? extends Resource> typeClass = getClassForResourceType(batchFile.getResourceType());
+                    addResourceEntries(typeClass, path, bundle);
                 });
 
 
         // set a bundle id here? anything else?
         bundle.setId(UUID.randomUUID().toString());
         return bundle.setTotal(bundle.getEntry().size());
+    }
+
+    private Class<? extends Resource> getClassForResourceType(ResourceType resourceType) {
+        switch(resourceType) {
+            case Coverage:
+                return Coverage.class;
+            case ExplanationOfBenefit:
+                return ExplanationOfBenefit.class;
+            case Patient:
+                return Patient.class;
+            default:
+                throw new DataRetrievalException("Unexpected resource type: " + resourceType);
+        }
     }
 
     private void addResourceEntries(Class<? extends Resource> clazz, Path path, Bundle bundle) {

--- a/ig/ig.json
+++ b/ig/ig.json
@@ -171,6 +171,11 @@
       "defns": "OperationDefinition-dpc-operation-patient-validate-definition.html",
       "source": "dpc-patient-validate.json"
     },
+    "OperationDefinition/dpc-operation-patient-everything": {
+      "base": "OperationDefinition-dpc-operation-patient-everything.html",
+      "defns": "OperationDefinition-dpc-operation-patient-everything-definition.html",
+      "source": "dpc-patient-everything.json"
+    },
     "OperationDefinition/dpc-operation-group-add": {
       "base": "OperationDefinition-dpc-operation-group-add.html",
       "defns": "OperationDefinition-dpc-operation-group-add-definition.html",

--- a/ig/source/resources/implementationguide/cms-dpc-ig.xml
+++ b/ig/source/resources/implementationguide/cms-dpc-ig.xml
@@ -116,6 +116,13 @@
         <resource>
             <example value="false"/>
             <sourceReference>
+                <reference value="OperationDefinition/dpc-patient-everything"/>
+                <display value="dpc-patient-everything.json"/>
+            </sourceReference>
+        </resource>
+        <resource>
+            <example value="false"/>
+            <sourceReference>
                 <reference value="OperationDefinition/dpc-group-add"/>
                 <display value="dpc-group-add.json"/>
             </sourceReference>

--- a/ig/source/resources/implementationguide/ig-new.json
+++ b/ig/source/resources/implementationguide/ig-new.json
@@ -154,6 +154,14 @@
     },
     {
       "reference" : {
+        "reference" : "OperationDefinition/dpc-patient-everything",
+        "display" : "dpc-patient-everything.json"
+      },
+      "exampleBoolean" : false,
+      "groupingId" : "p1"
+    },
+    {
+      "reference" : {
         "reference" : "OperationDefinition/dpc-group-add",
         "display" : "dpc-group-add.json"
       },

--- a/ig/source/resources/implementationguide/ig-new.xml
+++ b/ig/source/resources/implementationguide/ig-new.xml
@@ -148,6 +148,14 @@
       <groupingId value="p1"/>
     </resource>
     <resource>
+        <reference>
+            <reference value="OperationDefinition/dpc-patient-everything"/>
+            <display value="dpc-patient-everything.json"/>
+        </reference>
+        <exampleBoolean value="false"/>
+        <groupingId value="p1"/>
+    </resource>
+    <resource>
       <reference>
         <reference value="OperationDefinition/dpc-group-add"/>
         <display value="dpc-group-add.json"/>

--- a/ig/source/resources/operationdefinition/dpc-patient-everything.json
+++ b/ig/source/resources/operationdefinition/dpc-patient-everything.json
@@ -1,0 +1,37 @@
+{
+  "resourceType": "OperationDefinition",
+  "id": "dpc-operation-patient-everything",
+  "url": "https://dpc.cms.gov/api/v1/OperationDefinition/dpc-operation-patient-everything",
+  "name": "Patient Everything",
+  "title": "Retrieve all resources for a Patient",
+  "publisher": "The DPC Team",
+  "status": "draft",
+  "version": "0.0.1",
+  "kind": "operation",
+  "code": "everything",
+  "description": "Synchronously retrieve all Coverage, ExplanationOfBenefit, and Patient resources for a Patient.",
+  "resource": [
+    "Patient"
+  ],
+  "system": false,
+  "type": true,
+  "instance": false,
+  "parameter": [
+    {
+      "name": "attestation",
+      "use": "in",
+      "min": 1,
+      "max": "1",
+      "documentation": "Provenance resource representing attestation",
+      "type": "Provenance"
+    },
+    {
+      "name": "return",
+      "use": "out",
+      "min": 1,
+      "max": "1",
+      "documentation": "Bundle containing Coverage, ExplanationOfBenefit, and Patient resources",
+      "type": "Bundle"
+    }
+  ]
+}

--- a/src/main/resources/bb-test-data/eob/-19990000002208_40.xml
+++ b/src/main/resources/bb-test-data/eob/-19990000002208_40.xml
@@ -6192,7 +6192,7 @@
         <organization>
           <identifier>
             <system value='http://hl7.org/fhir/sid/us-npi'/>
-            <value value='9999999999'/>
+            <value value='1111111112'/>
           </identifier>
         </organization>
         <facility>
@@ -6246,7 +6246,7 @@
           <provider>
             <identifier>
               <system value='http://hl7.org/fhir/sid/us-npi'/>
-              <value value='9999999999'/>
+              <value value='1234329724'/>
             </identifier>
           </provider>
           <role>

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "81baa1d6-f0aa-427a-b719-d025233e2fb4",
+		"_postman_id": "df021205-c00a-43c1-b327-553ff95a0fe1",
 		"name": "EndToEndRequestTest",
 		"description": "This test is an example of an end to end set of API requests to submit a roster and export patient data. Each element in the 'item' list is a single request.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -15,7 +15,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "14881883-87a4-4f64-a8ec-9b2091733b71",
+								"id": "d20f48b5-e251-47e2-8807-03bc9edf21d7",
 								"exec": [
 									"// Status should be 201",
 									"pm.test(\"Status is 201\", function () {",
@@ -81,7 +81,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "bb4c1214-5029-407a-bfd2-9dcb91fbd51c",
+								"id": "84e24f62-ac2f-4895-806d-90b32fd24c9e",
 								"exec": [
 									"pm.test(\"Status is 201 Created\", function () {",
 									"    pm.expect(pm.response.code).equals(201);",
@@ -128,7 +128,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4178bf7f-d8eb-432a-b404-197df2db37be",
+								"id": "524f7746-8121-4563-a134-1e062e14ae4d",
 								"exec": [
 									"pm.test(\"Status is OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -172,7 +172,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "869cb09c-2ddb-4a75-870a-871e71fa2fc3",
+								"id": "e608aed2-c479-41fa-865b-1c66edd63aa3",
 								"exec": [
 									"pm.test(\"Status is 201\", function () {",
 									"    pm.response.to.have.status(201);",
@@ -241,7 +241,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b8346df1-12f3-40b8-a9bd-4d126dd96bfd",
+								"id": "8064037b-3c73-4019-bdf3-0f665c0dcdf1",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -308,7 +308,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4c3e0cdd-b9ae-4ea3-beb9-6770d0814289",
+								"id": "48795c9c-7ee1-4ba8-8512-6e37a7ee7a49",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -377,7 +377,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "235efb91-1c7a-4b36-ba33-cdb9a29df81f",
+								"id": "5a45e0b9-af07-4c64-9fd3-16f4877f9b89",
 								"exec": [
 									"// Status should be 201",
 									"pm.test(\"Status is 201\", function () {",
@@ -412,7 +412,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "0e9ff3ce-5d8e-4590-8614-7d3848f03855",
+								"id": "1af7fc14-0bdd-478a-bfd7-a6e0cead266d",
 								"exec": [
 									"var group = {",
 									"  \"resourceType\": \"Group\",",
@@ -535,7 +535,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "30646b7a-8144-4881-a4a0-e256101bfbd2",
+								"id": "3d67a3c8-d3c5-4ca5-850b-5d7a48ee396e",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -592,7 +592,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "f5939ea3-a787-4e6e-98be-9607686e70b7",
+								"id": "4ab264d5-ed98-47dd-9f78-c0e63feb133b",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -651,7 +651,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "9fad24a8-6929-47d2-9e1b-e557a3aceb92",
+								"id": "c0e1b44e-9099-4083-ac5e-06aba318543f",
 								"exec": [
 									"var group = JSON.parse(pm.globals.get(\"attribution_group\"));",
 									"var patientID = pm.globals.get(\"single_patient_id\");",
@@ -674,7 +674,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "2ac6cce0-a76f-4b75-bcaa-40c610115983",
+								"id": "2c2d4869-aafa-4e5f-80ac-b6f8a8318dc0",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -741,7 +741,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "bf098707-01e6-46f5-8473-9077a1c2825f",
+								"id": "9facf58c-0dcd-4c73-a3ad-0fa80048a851",
 								"exec": [
 									"// Build the attestation header",
 									"var attestation = {",
@@ -782,7 +782,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "4888ad03-35f6-47fb-a73b-136985a2093c",
+								"id": "94547b23-330a-4b46-a1d5-bd4f4c4e7164",
 								"exec": [
 									"// Status should be 400",
 									"pm.test(\"Status is 400\", function () {",
@@ -859,7 +859,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "fbd50044-5b1a-4ae2-91a4-352bb914aeb2",
+								"id": "d05846e2-02ec-464c-ad71-65ea76894679",
 								"exec": [
 									"// Status should be 202",
 									"pm.test(\"Status is 202\", function () {",
@@ -884,7 +884,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "745e975b-8a1f-4b4e-90fd-657f4aa3c069",
+								"id": "c717d23c-2870-4a91-8135-35ce86c2b482",
 								"exec": [
 									"console.log(\"Group:\", pm.environment.get(\"attribution_group\"));"
 								],
@@ -930,7 +930,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "5e12c595-6254-4072-8d57-2e092ba84cf1",
+								"id": "7a2207f3-efe4-4fb1-8184-e9317476095b",
 								"exec": [
 									"// Wait between pings",
 									"setTimeout(function() {}, 1000);"
@@ -941,7 +941,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "76f18c5a-c24f-4a74-8512-2e119ce6c83b",
+								"id": "5a165b1c-6876-44a5-8453-a4c9b5840c9a",
 								"exec": [
 									"if (pm.response.code == 200) {",
 									"    // Response should have FHIR Content-Type",
@@ -1026,7 +1026,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "64832ee4-d74e-4aae-be17-4f9fba9bd1d6",
+								"id": "1a72410f-a0e0-414c-a922-6afc137ca145",
 								"exec": [
 									"require('crypto-js')",
 									"",
@@ -1063,7 +1063,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "b87bbee1-30b2-4d6a-9957-592821ea2f0e",
+								"id": "befdd9de-99be-488f-87b0-31fb3b1f818f",
 								"exec": [
 									"pm.environment.set(\"patient_url\", pm.environment.get(\"patient\").url)"
 								],
@@ -1090,7 +1090,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "8e3fbab9-368a-4e1a-b718-95a76b2fc917",
+								"id": "3f8626e1-827f-4738-80eb-480674a06618",
 								"exec": [
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
@@ -1115,7 +1115,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "f0cdf32d-fa0b-4321-a543-b22c05d02211",
+								"id": "0b36739e-fd94-43d6-b585-b47d14436d3d",
 								"exec": [
 									"pm.environment.set(\"eob_url\", pm.environment.get(\"eob\").url)"
 								],
@@ -1142,7 +1142,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0c10eb44-fac2-4202-ab9e-c42572105f8c",
+								"id": "2ad8997c-8da4-41ef-ad55-c25e1a649a94",
 								"exec": [
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
@@ -1176,7 +1176,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "bc414e46-aa06-4960-951b-7011d0429883",
+								"id": "0f77a7bd-fd9f-4cca-9ea4-02974fb84720",
 								"exec": [
 									"pm.environment.set(\"coverage_url\", pm.environment.get(\"coverage\").url)"
 								],
@@ -1203,7 +1203,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0881d3d0-12ef-4e2d-ad48-2afe4184f8a1",
+								"id": "0147765a-3211-4300-88a0-873ddb2a382b",
 								"exec": [
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
@@ -1248,7 +1248,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "5dd6d38b-9c83-45b4-a67b-9abd872f1802",
+								"id": "36a4c38c-a2ff-4436-bd3a-991f9d87f122",
 								"exec": [
 									"// Response should be 304",
 									"pm.test('Response should be not-modified', function() {",
@@ -1291,7 +1291,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "be799143-2978-4d51-a7d9-c3e4476cbfe5",
+								"id": "4f4ecdc1-0b54-498b-af77-514fabcaf34e",
 								"exec": [
 									"// Status should be 202",
 									"pm.test(\"Status is 202\", function () {",
@@ -1316,7 +1316,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "db9b8ff9-ec24-4256-a099-72e519779700",
+								"id": "a89b4b2e-979e-4a7e-b84f-bb4a13f206a1",
 								"exec": [
 									"console.log(\"Group:\", pm.environment.get(\"attribution_group\"));",
 									"pm.environment.set(\"since_timestamp\", new Date().toISOString());"
@@ -1376,7 +1376,7 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"id": "3122fbaf-e53b-46b4-84e9-cf49c6cc2e7c",
+								"id": "a1aaa954-4935-4a45-a922-001e3e5d8603",
 								"exec": [
 									"// Wait between pings",
 									"setTimeout(function() {}, 1000);"
@@ -1387,7 +1387,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "7a5298b2-29b5-4c7e-a634-eab3ee1e7daa",
+								"id": "fb5a1ec8-d19f-4e7d-8208-34ba4bef55e7",
 								"exec": [
 									"if (pm.response.code == 200) {",
 									"    // Response should have FHIR Content-Type",
@@ -1424,6 +1424,64 @@
 						"description": "While the export request is being processed, the job url will return a 202 status. When it is completed, a 200 status will be returned, along with JSON containing Job status."
 					},
 					"response": []
+				},
+				{
+					"name": "All data about a patient ($everything)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "933dff96-fdef-4d05-8e23-315dadc37ac2",
+								"exec": [
+									"pm.test(\"Status code should be 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response should be a Bundle\", function() {",
+									"    var response = pm.response.json();",
+									"    pm.expect(response.resourceType).to.equal(\"Bundle\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"id": "4447fb96-7a76-4a71-b5a7-3fa66016a6eb",
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "X-Provenance",
+								"value": "{{attestationHeader}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "http://{{hostname}}:{{api_port}}/v1/Patient/728b270d-d7de-4143-82fe-d3ccd92cebe4/$everything",
+							"protocol": "http",
+							"host": [
+								"{{hostname}}"
+							],
+							"port": "{{api_port}}",
+							"path": [
+								"v1",
+								"Patient",
+								"728b270d-d7de-4143-82fe-d3ccd92cebe4",
+								"$everything"
+							]
+						},
+						"description": "The patient data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one patient."
+					},
+					"response": []
 				}
 			],
 			"protocolProfileBehavior": {}
@@ -1437,7 +1495,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1ed75b11-be56-4dc5-9a4e-421fc11f01dd",
+								"id": "5a719af5-c2ea-4924-88d7-f905523fa99a",
 								"exec": [
 									"pm.test(\"Status is 415\", function () {",
 									"    pm.response.to.have.status(415);",
@@ -1490,7 +1548,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "1cd811d5-77a6-432f-bd10-63119d15699d",
+								"id": "806f5f1d-bf0b-43ee-9bc8-4cadf281f454",
 								"exec": [
 									"pm.test(\"Status is OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -1547,7 +1605,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c0a991a3-8d67-41a8-9de8-3dca0d0066c9",
+								"id": "0ed8b9a3-bec2-4eb6-98b2-c24b9d19bbf5",
 								"exec": [
 									"pm.test(\"Status is OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -1602,7 +1660,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "deb736b1-c4db-4ff3-94c3-edb0fe08db53",
+								"id": "07b38e0b-ad22-4ed1-ac8f-dd56d66e36c8",
 								"exec": [
 									"pm.test(\"Status is 422\", function () {",
 									"    pm.response.to.have.status(422);",
@@ -1653,7 +1711,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "e5f1714d-9ddd-44f1-8946-2d69295a620a",
+								"id": "ab5d2c53-cc43-46ad-94d2-13724b7c7bca",
 								"exec": [
 									"pm.test(\"Status is 200\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -1721,7 +1779,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "b6ba2911-9e73-446d-9bcc-f2b96c53ab04",
+								"id": "547377c7-b14a-49fa-87b2-f4b3e77605a5",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -1798,7 +1856,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "260d61c5-7a8b-491a-a81a-b2f5983b3ae9",
+								"id": "74e7e7d8-96f5-4637-88e5-083a4901ad60",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -1858,7 +1916,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "c4dabb3d-6a19-49c3-a726-9e4ab1815564",
+								"id": "6f850276-d46b-4ffd-af9e-c505012b7203",
 								"exec": [
 									"// Status should be 200",
 									"pm.test(\"Status is 200\", function () {",
@@ -1894,7 +1952,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "0231d556-9cae-408f-b2ee-5ffdd147a145",
+								"id": "ad6f283f-bb9b-4432-b8aa-96d1264cdf38",
 								"exec": [
 									"pm.test(\"Bundle should be empty\", function() {",
 									"    var response = pm.response.json();",
@@ -1939,7 +1997,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"id": "32200755-0de7-4b04-b567-85f00a064df2",
+								"id": "af991418-08c6-49f5-806f-4088c3218449",
 								"exec": [
 									"pm.test(\"Status is OK\", function () {",
 									"    pm.response.to.be.ok;",
@@ -1984,7 +2042,7 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "068d4433-4362-4491-8328-d074d4f9ac15",
+				"id": "51b7df23-3d6f-4405-b324-5407416bdc39",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -1994,7 +2052,7 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "ba0de053-6083-4779-b6a3-302ad1989263",
+				"id": "f88b6af6-58b9-4d0f-b4be-229ac01afcc4",
 				"type": "text/javascript",
 				"exec": [
 					""

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1479,7 +1479,7 @@
 								"$everything"
 							]
 						},
-						"description": "The patient data url comes from the response to the job in the previous request. It is in ndjson, which is a set of JSON responses, one per line. Each line contains the JSON data for one patient."
+						"description": "Synchronously retrieves all Coverage, EoB, and Patient resources for the requested patient."
 					},
 					"response": []
 				}


### PR DESCRIPTION
### Fixes [DPC-551](https://jira.cms.gov/browse/DPC-551)

This restores the `/Patient/$everything` endpoint that was previously added in PR #894 and reverted in #901 .

### Security Implications

No security implications. All data transmitted was already provided by DPC through other endpoints.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

Integration tests are included, in PatientResourceTest and the Postman EndToEndRequestTest collection.

A deployment of this branch to dev can be found in Jenkins, `Full Deploy and Release` job 676. The test errors we saw last time are no longer occurring.

### Feedback Requested

Any
