### PR TITLE
Patient/$everything restoration (DPC-551) addendum: Adjust look back date for tests

### DIFF
--- a/dpc-aggregation/src/main/resources/local.application.conf
+++ b/dpc-aggregation/src/main/resources/local.application.conf
@@ -23,6 +23,6 @@ dpc.aggregation {
       "org.hibernate.SQL" = INFO
     }
   }
-  lookBackDate = 2000-11-01 #configures the lookback date to match what is returned from mock blue button client
+  lookBackDate = 2000-10-01 #configures the lookback date to match what is returned from mock blue button client
 
 }


### PR DESCRIPTION
In the original pull request for adding `/Patient/$everything`, the claims look back date for tests was adjusted by one month to ensure a certain number of results. This was missed when it was restored and is corrected with this PR.