### PR TITLE
DPC-542 Feature: Add new `make` command to simplify local manual build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ smoke.out
 .vault_password
 ops/config/decrypted/*
 !ops/config/decrypted/README.md
+.mvn/

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,9 @@ docker-base:
 secure-envs:
 	@bash ops/scripts/secrets --decrypt ops/config/encrypted/bb.keystore | tail -n +2 > bbcerts/bb.keystore
 	@bash ops/scripts/secrets --decrypt ops/config/encrypted/local.env | tail -n +2 > ops/config/decrypted/local.env
+
+.PHONY: maven-config
+maven-config:
+	@mkdir -p ./.mvn
+	@: > ./.mvn/maven.config
+	@while read line;do echo "-D$${line} " >> ./.mvn/maven.config;done < ./ops/config/decrypted/local.env

--- a/README.md
+++ b/README.md
@@ -43,21 +43,43 @@ dpc.attribution {
 This can create an issue when running tests with IntelliJ which by default sets the working directory to be the module root, which means any local overrides are ignored.
 This can be fixed by setting the working directory to the project root, but needs to done manually.
 
+Decrypting encrypted files
+---
+
+See [Secrets Management](#secrets-management) for details on how to encrypt and decrypt required secrets.
+
+Before building the app or running any tests, the decrypted secrets must be available as environment variables.
+
+In order to encrypt and decrypt configuration variables, you must create a `.vault_password` file in this repository root directory. 
+Contact another team member to gain access to the vault password.
+
+Included in the cloned project you will find a couple of encrypted files located at  `dpc-app/ops/config/encrypted` that will need to be decrypted before proceeding. 
+
+Run `make secure-envs` to decrypt the encrypted files.
+If decrypted successfully, you will see the decrypted data in new files under `/ops/config/decrypted` with the same names as the corresponding encrypted files.
+
+This command also creates a git pre-commit hook in order to avoid accidentally committing a decrypted file.
+
 Building DPC
 ---
 
-There are two ways to build DPC.
+> Note: Before building DPC, you must first ensure that [the required secrets are decrypted](#decrypting-encrypted-files). 
+
+### There are two ways to build DPC:
 
 > Note: DPC only supports Java 11 due to our use of new languages features, which prevents using older JDK versions.
 In addition, some of upstream dependencies have not been updated to support Java 12 and newer, but we plan on adding support at a later date. 
 
-### Option 1: Full Integration Test
+#### Option 1: Full Integration Test
 
 Run `make ci-app`. This will start the dependencies, build all components, run integration tests, and run a full end to end test. You will be left with compiled JARs for each component, as well as compiled Docker containers.
 
-### Option 2: Manually
+#### Option 2: Manually
 
 Run `make docker-base` to build the common, baseline Docker image (i.e., `dpc-base:latest`) used across DPC services.
+
+Next, in order to make the decrypted environment variables accessible to Maven, run `make maven-config`.
+This command will convert the contents of `ops/config/decrypted/local.env` to Maven flags which can be viewed in `.mvn/maven.config` if successful.
 
 Then, run `mvn clean install` to build and test the application. Dependencies will need to be up and running for this option to succeed.
 
@@ -213,6 +235,8 @@ Building the FHIR implementation guide is detailed [here](ig/README.md).
 
 Secrets management
 ---
+
+> Note: You can use `make secure-envs` to decrypt files and create the pre-commit hook at the same time.
 
 ### Sensitive Docker configuration files
 

--- a/application.local.conf.sample
+++ b/application.local.conf.sample
@@ -2,6 +2,16 @@ dpc {
   api {
     bbclient.keyStore.location = "bbcerts/bb.keystore"
 
+    bbclient {
+      keyStore {
+        defaultPassword = "changeit"
+        location = "path/to/decrypted/bb.keystore"
+      }
+      serverBaseUrl = "BFD_URL from decrypted local.env"
+      bfdHashPepper = "hash pepper from decrypted local.env"
+      bfdHashIter = "iter from decrytped local.env"
+    }
+
     server {
       registerDefaultExceptionMappers = false
       applicationConnectors = [{


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `dpc-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [DPC-542](https://jira.cms.gov/browse/DPC-542)
When running `mvn clean install` locally as the README indicates, the tests fail because the decrypted environment variables are not available to Maven.

### Proposed Changes

- add new `make maven-config` command in order to turn the decrypted environment variables into Maven flags stored in `.mvn/maven.config`
- add `.mvn/` to `.gitignore` to avoid tracking and committing secrets
- update README for clarity

### Change Details

The most important change here is the new `make` command which uses bash to read the `local.env` key-value pairs and convert them to `-D*` flags which are stored in a `maven.config` file and then accessible by Maven. Specifically, the command first creates a `.mvn` directory if it doesn't already exist. Then, it truncates or creates a `maven.config` file, depending on its existence. Finally, it reads the `local.env` and appends the variables to `maven.config`. The command is meant to be idempotent and to be able to run regardless the existence of `.mvn` or `.mvn/maven.config`.

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
All tests were successful when using the new command.

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

I opted for writing bash directly in the `Makefile`. Is it preferable that I turn those commands into a script that is then referenced by the `make` command? I considered doing that but decided against it because it is only 3 lines.

