### PR TITLE
Revert "Bump jackson-datatype-jsr310 from 2.10.3 to 2.11.2 (#945)"

### DIFF
--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.11.2</version>
+            <version>2.10.3</version>
         </dependency>
         <dependency>
             <groupId>${hapi.fhir.groupID}</groupId>


### PR DESCRIPTION
This reverts commit 7a304d5229447375e22ed07b6d7eccb42e84329b, which breaks the smoke tests.  Ticket [DPC-607](https://jira.cms.gov/browse/DPC-607) has been created to make code changes necessary for this upgrade.

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

This is a reversion to a known good state of the code.

### Acceptance Validation
#### Before and after views of this branch
![Screen Shot 2020-08-14 at 6 54 47 PM](https://user-images.githubusercontent.com/2533561/90298283-adf51180-de5f-11ea-9aee-9e955a78f202.png)

### Feedback Requested
Any concerns?