### PR TITLE
DPC-732: Basic performance test suite for /Token endpoints

### DIFF
--- a/dpc-testing/performance/key.go
+++ b/dpc-testing/performance/key.go
@@ -10,6 +10,7 @@ import (
 func testKeyEndpoints(accessToken string) {
 
 	resps := runTestWithTargeter(fmt.Sprintf("POST %s/Key", apiURL), newPOSTKeyTargeter(accessToken), 5, 5)
+	var keyIDs []string
 	for _, resp := range resps {
 		var result Resource
 		json.Unmarshal(resp, &result)

--- a/dpc-testing/performance/key.go
+++ b/dpc-testing/performance/key.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	vegeta "github.com/tsenart/vegeta/lib"
+)
+
+func testKeyEndpoints(accessToken string) {
+
+	resps := runTestWithTargeter(fmt.Sprintf("POST %s/Key", apiURL), newPOSTKeyTargeter(accessToken), 5, 5)
+	for _, resp := range resps {
+		var result Resource
+		json.Unmarshal(resp, &result)
+		keyIDs = append(keyIDs, result.ID)
+	}
+
+	getKeysTarget := vegeta.Target{
+		Method: "GET",
+		URL:    fmt.Sprintf("%s%s", apiURL, "/Key"),
+		Header: map[string][]string{
+			"Accept":        {"application/json"},
+			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
+		},
+	}
+	runTest(getKeysTarget, 5, 5)
+
+	getKeyTarget := vegeta.Target{
+		Method: "GET",
+		URL:    fmt.Sprintf("%s%s%s", apiURL, "/Key/", keyIDs[0]),
+		Header: map[string][]string{
+			"Accept":        {"application/json"},
+			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
+		},
+	}
+	runTest(getKeyTarget, 5, 5)
+
+	deleteKeyTargeter := newDELETEKeyTargeter(accessToken, func() string {
+		keyID := keyIDs[0]
+		keyIDs = keyIDs[1:]
+		return keyID
+	})
+	runTestWithTargeter(fmt.Sprintf("DELETE %s/Key/{id}", apiURL), deleteKeyTargeter, 5, 5)
+}
+
+func newPOSTKeyTargeter(accessToken string) vegeta.Targeter {
+	return func(t *vegeta.Target) error {
+		t.Method = "POST"
+		t.URL = fmt.Sprintf("%s/Key", apiURL)
+		t.Header = map[string][]string{
+			"Content-Type":  {"application/json"},
+			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
+		}
+
+		pubKeyStr, _, signature := generateKeyPairAndSignature()
+		body := fmt.Sprintf("{ \"key\": \"%s\", \"signature\": \"%s\"}", pubKeyStr, signature)
+		t.Body = []byte(body)
+
+		return nil
+	}
+}
+
+func newDELETEKeyTargeter(accessToken string, nextKeyID func() string) vegeta.Targeter {
+	return func(t *vegeta.Target) error {
+		t.Method = "DELETE"
+		t.URL = fmt.Sprintf("%s/Key/%s", apiURL, nextKeyID())
+		t.Header = map[string][]string{
+			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
+		}
+		return nil
+	}
+}

--- a/dpc-testing/performance/main.go
+++ b/dpc-testing/performance/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/rsa"
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -15,6 +14,7 @@ var (
 	apiURL, adminURL string
 	goldenMacaroon   []byte
 	keyIDs           []string
+	clientTokenResps []ClientTokenResp
 )
 
 func init() {
@@ -34,6 +34,9 @@ func main() {
 	accessToken := refreshAccessToken(privateKey, keyID, clientToken)
 	testKeyEndpoints(accessToken)
 
+	accessToken = refreshAccessToken(privateKey, keyID, clientToken)
+	testTokenEndpoints(accessToken, privateKey, keyID, clientToken)
+
 	cleanUp(orgID)
 }
 
@@ -47,71 +50,6 @@ func testMetadata() {
 	}
 
 	runTest(getMetadataTarget, 5, 5)
-}
-
-func testKeyEndpoints(accessToken string) {
-
-	resps := runTestWithTargeter(fmt.Sprintf("POST %s/Key", apiURL), newPOSTKeyTargeter(accessToken), 5, 5)
-	for _, resp := range resps {
-		var result Resource
-		json.Unmarshal(resp, &result)
-		keyIDs = append(keyIDs, result.ID)
-	}
-
-	getKeysTarget := vegeta.Target{
-		Method: "GET",
-		URL:    fmt.Sprintf("%s%s", apiURL, "/Key"),
-		Header: map[string][]string{
-			"Accept":        {"application/json"},
-			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
-		},
-	}
-	runTest(getKeysTarget, 5, 5)
-
-	getKeyTarget := vegeta.Target{
-		Method: "GET",
-		URL:    fmt.Sprintf("%s%s%s", apiURL, "/Key/", keyIDs[0]),
-		Header: map[string][]string{
-			"Accept":        {"application/json"},
-			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
-		},
-	}
-	runTest(getKeyTarget, 5, 5)
-
-	deleteKeyTargeter := newDELETEKeyTargeter(accessToken, func() string {
-		keyID := keyIDs[0]
-		keyIDs = keyIDs[1:]
-		return keyID
-	})
-	runTestWithTargeter(fmt.Sprintf("DELETE %s/Key/{id}", apiURL), deleteKeyTargeter, 5, 5)
-}
-
-func newPOSTKeyTargeter(accessToken string) vegeta.Targeter {
-	return func(t *vegeta.Target) error {
-		t.Method = "POST"
-		t.URL = fmt.Sprintf("%s/Key", apiURL)
-		t.Header = map[string][]string{
-			"Content-Type":  {"application/json"},
-			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
-		}
-
-		pubKeyStr, _, signature := generateKeyPairAndSignature()
-		body := fmt.Sprintf("{ \"key\": \"%s\", \"signature\": \"%s\"}", pubKeyStr, signature)
-		t.Body = []byte(body)
-
-		return nil
-	}
-}
-
-func newDELETEKeyTargeter(accessToken string, nextKeyID func() string) vegeta.Targeter {
-	return func(t *vegeta.Target) error {
-		t.Method = "DELETE"
-		t.URL = fmt.Sprintf("%s/Key/%s", apiURL, nextKeyID())
-		t.Header = map[string][]string{
-			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
-		}
-		return nil
-	}
 }
 
 func refreshAccessToken(privateKey *rsa.PrivateKey, keyID string, clientToken []byte) string {

--- a/dpc-testing/performance/main.go
+++ b/dpc-testing/performance/main.go
@@ -13,8 +13,6 @@ import (
 var (
 	apiURL, adminURL string
 	goldenMacaroon   []byte
-	keyIDs           []string
-	clientTokenResps []ClientTokenResp
 )
 
 func init() {

--- a/dpc-testing/performance/token.go
+++ b/dpc-testing/performance/token.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	dpcclient "github.com/CMSgov/dpc-app/dpcclient/lib"
+	vegeta "github.com/tsenart/vegeta/lib"
+)
+
+type ClientTokenResp struct {
+	Resource
+	ClientToken []byte `json:"token"`
+}
+
+type AccessTokenResp struct {
+	Resource
+	AccessToken string `json:"access_token"`
+}
+
+func testTokenEndpoints(accessToken string, privateKey *rsa.PrivateKey, keyID string, clientToken []byte) {
+	postTokenTarget := vegeta.Target{
+		Method: "POST",
+		URL:    fmt.Sprintf("%s%s", apiURL, "/Token"),
+		Header: map[string][]string{
+			"Content-Type":  {"application/json"},
+			"Authorization": {fmt.Sprintf("Bearer %s", accessToken)},
+		},
+	}
+	resps := runTest(postTokenTarget, 5, 5)
+	for _, resp := range resps {
+		var result ClientTokenResp
+		json.Unmarshal(resp, &result)
+		clientTokenResps = append(clientTokenResps, result)
+	}
+
+	postTokenAuthTargeter := newPOSTTokenAuthTargeter(func() string {
+		authToken, err := dpcclient.GenerateAuthToken(privateKey, keyID, clientTokenResps[0].ClientToken, apiURL)
+		if err != nil {
+			cleanAndPanic(err)
+		}
+		return string(authToken)
+	})
+	resps = runTestWithTargeter(fmt.Sprintf("%s/Token/auth", apiURL), postTokenAuthTargeter, 5, 5)
+	var accessTokens []string
+	for _, resp := range resps {
+		var result AccessTokenResp
+		json.Unmarshal(resp, &result)
+		accessTokens = append(accessTokens, result.AccessToken)
+	}
+
+	getTokensTarget := vegeta.Target{
+		Method: "GET",
+		URL:    fmt.Sprintf("%s%s", apiURL, "/Token"),
+		Header: map[string][]string{
+			"Accept":        {"application/json"},
+			"Authorization": {fmt.Sprintf("Bearer %s", accessTokens[0])},
+		},
+	}
+
+	runTest(getTokensTarget, 5, 5)
+}
+
+func newPOSTTokenAuthTargeter(nextAuthToken func() string) vegeta.Targeter {
+	return func(t *vegeta.Target) error {
+		t.Method = "POST"
+		t.URL = fmt.Sprintf("%s/Token/auth", apiURL)
+		t.Header = map[string][]string{
+			"Content-Type": {"application/x-www-form-urlencoded"},
+		}
+
+		v := url.Values{
+			"scope":                 {"system/*.*"},
+			"grant_type":            {"client_credentials"},
+			"client_assertion_type": {"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"},
+			"client_assertion":      {nextAuthToken()},
+		}
+		t.Body = []byte(v.Encode())
+
+		return nil
+	}
+}


### PR DESCRIPTION
### Fixes [DPC-732](https://jira.cms.gov/browse/DPC-732)

DPC is setting up a basic performance test suite for attribution endpoints.

### Proposed Changes

This pull request adds performance tests for the /Token endpoints.

### Change Details

Tests include:
* POST /Token
* POST /Token/validate
* POST /Token/auth
* GET /Token
* GET /Token/{id}
* DELETE /Token/{id}

The new tests are in token.go, and the existing /Key endpoint tests have been moved into key.go.

### Security Implications

This contains tests only. No security impacts.

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

<img width="1295" alt="Screen Shot 2020-09-24 at 5 18 38 PM" src="https://user-images.githubusercontent.com/1923441/94201445-002b4880-fe8a-11ea-83f0-78595d9eb17c.png">

### Feedback Requested

Any
