### PR TITLE
DPC-751 fix: update params for swagger validation

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -272,7 +272,7 @@ public class GroupResource extends AbstractGroupResource {
                            @QueryParam("_outputFormat") @NoHtml String outputFormat,
                            @ApiParam(value = "Resources will be included in the response if their state has changed after the supplied time (e.g. if Resource.meta.lastUpdated is later than the supplied _since time).")
                            @QueryParam("_since") @NoHtml String since,
-                           @HeaderParam("Prefer")  @Valid String Prefer) {
+                           @ApiParam(hidden = true) @HeaderParam("Prefer")  @Valid String Prefer) {
         logger.info("Exporting data for provider: {} _since: {}", rosterID, since);
 
         // Check the parameters

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -165,7 +165,7 @@ public class PatientResource extends AbstractPatientResource {
     @Timed
     @ExceptionMetered
     @ApiImplicitParams(
-            @ApiImplicitParam(name = "X-Provenance", required = true, paramType = "header", dataTypeClass = Provenance.class))
+            @ApiImplicitParam(name = "X-Provenance", required = true, paramType = "header", type = "string", dataTypeClass = Provenance.class))
     @ApiOperation(value = "Fetch entire Patient record", notes = "Fetch entire record for Patient with given ID synchronously. " +
             "All resources available for the Patient are included in the result Bundle.")
     @ApiResponses(value = {


### PR DESCRIPTION
### Fixes [DPC-751](https://jira.cms.gov/browse/DPC-751)

Swagger docs were not validating due to the following issues:
- Duplicate param for `Prefer` header in `GroupResource`
- `Patient/$everything` endpoint missing a type definition on the `X-Provenance` header (should be `string`)

### Proposed Changes
- Remove duplicate header in `GroupResource` using `ApiParam(hidden = true)`
- Add `type = "string"` to `X-Provenance` header

### Change Details

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

The generated `swagger.json` now validates correctly without any errors on `editor.swagger.io`

### Feedback Requested

Any
