### PR TITLE
Disabled lookback for smoketest orgs

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
@@ -82,7 +82,8 @@ public class AggregationAppModule extends DropwizardAwareModule<DPCAggregationCo
                 config.getRetryCount(),
                 config.getPollingFrequency(),
                 config.getLookBackMonths(),
-                config.getLookBackDate()
+                config.getLookBackDate(),
+                config.getLookBackExemptOrgs()
         );
     }
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationConfiguration.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationConfiguration.java
@@ -15,6 +15,7 @@ import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import java.util.Date;
+import java.util.List;
 
 public class DPCAggregationConfiguration extends TypesafeConfiguration implements BlueButtonBundleConfiguration, IDPCDatabase, IDPCQueueDatabase, DPCQueueConfig {
 
@@ -56,6 +57,8 @@ public class DPCAggregationConfiguration extends TypesafeConfiguration implement
 
     @Min(-1)
     private int lookBackMonths;
+
+    private List<String> lookBackExemptOrgs;
 
     @NotNull
     private Date lookBackDate = new Date();
@@ -112,5 +115,11 @@ public class DPCAggregationConfiguration extends TypesafeConfiguration implement
         return lookBackDate;
     }
 
+    public List<String> getLookBackExemptOrgs() {
+        return lookBackExemptOrgs;
+    }
 
+    public void setLookBackExemptOrgs(List<String> lookBackExemptOrgs) {
+        this.lookBackExemptOrgs = lookBackExemptOrgs;
+    }
 }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/OperationsConfig.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/OperationsConfig.java
@@ -1,6 +1,7 @@
 package gov.cms.dpc.aggregation.engine;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  * Holds configuration information for the operations of {@link gov.cms.dpc.aggregation.engine.AggregationEngine}.
@@ -13,6 +14,7 @@ public class OperationsConfig {
     private int pollingFrequency;
     private int lookBackMonths;
     private Date lookBackDate;
+    private List<String> lookBackExemptOrgs;
 
     public OperationsConfig(
             int resourcesPerFileCount,
@@ -20,7 +22,8 @@ public class OperationsConfig {
             int retryCount,
             int pollingFrequency,
             int lookBackMonths,
-            Date lookBackDate
+            Date lookBackDate,
+            List<String> lookBackExemptOrgs
     ) {
         this.retryCount = retryCount;
         this.resourcesPerFileCount = resourcesPerFileCount;
@@ -28,6 +31,7 @@ public class OperationsConfig {
         this.pollingFrequency = pollingFrequency;
         this.lookBackMonths = lookBackMonths;
         this.lookBackDate = lookBackDate;
+        this.lookBackExemptOrgs = lookBackExemptOrgs;
     }
 
     public OperationsConfig(
@@ -66,4 +70,6 @@ public class OperationsConfig {
     public Date getLookBackDate() {
         return lookBackDate;
     }
+
+    public List<String> getLookBackExemptOrgs() { return lookBackExemptOrgs; }
 }

--- a/dpc-aggregation/src/main/resources/application.conf
+++ b/dpc-aggregation/src/main/resources/application.conf
@@ -29,6 +29,8 @@ dpc.aggregation {
   # The number of months to look back for a claim
   lookBackMonths = 18
   lookBackMonths = ${?LOOK_BACK_MONTHS}
+  lookBackExemptOrgs = ["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145"]
+  lookbackExemptOrgs = ${?LOOK_BACK_EXEMPT_ORGS}
 
   # The date to start looking back from
   lookBackDate = ${?LOOK_BACK_DATE}

--- a/dpc-aggregation/src/main/resources/local.application.conf
+++ b/dpc-aggregation/src/main/resources/local.application.conf
@@ -12,7 +12,7 @@ dpc.aggregation {
     keyStore {
       location = "/bb.keystore"
     }
-    useBfdMock=true
+    useBfdMock=false
   }
 
   exportPath = "/app/data"

--- a/dpc-aggregation/src/main/resources/local.application.conf
+++ b/dpc-aggregation/src/main/resources/local.application.conf
@@ -12,7 +12,7 @@ dpc.aggregation {
     keyStore {
       location = "/bb.keystore"
     }
-    useBfdMock=false
+    useBfdMock=true
   }
 
   exportPath = "/app/data"

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -61,11 +61,10 @@ public class ClientUtils {
                 .map(npi -> exportRequestDispatcher(exportClient, npi))
                 .map(search -> (Group) search.getEntryFirstRep().getResource())
                 .map(group -> jobCompletionLambda(exportClient, httpClient, group, overrideURL))
-                //TODO: ignore until we can skip lookback per request and switch over to use real bfd client
-//                .peek(jobResponse -> {
-//                    if (jobResponse.getError().size() > 0)
-//                        throw new IllegalStateException("Export job completed, but with errors");
-//                })
+                .peek(jobResponse -> {
+                    if (jobResponse.getError().size() > 0)
+                        throw new IllegalStateException("Export job completed, but with errors");
+                })
                 .forEach(jobResponse -> jobResponse.getOutput().forEach(entry -> {
                     jobResponseHandler(httpClient, entry);
                 }));

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.testing.smoketests;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import com.google.common.base.Splitter;
 import gov.cms.dpc.common.utils.NPIUtil;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.fhir.helpers.FHIRHelpers;
@@ -14,9 +15,6 @@ import org.apache.jmeter.protocol.java.sampler.JavaSamplerContext;
 import org.apache.jmeter.samplers.SampleResult;
 import org.apache.jmeter.threads.JMeterContextService;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMKeyPair;
-import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Practitioner;
@@ -26,12 +24,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.GeneralSecurityException;
-import java.security.KeyPair;
+import java.security.GeneralSecurityException;;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.util.List;
@@ -61,10 +54,7 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         arguments.addArgument("seed-file", "src/main/resources/test_associations-dpr.csv");
         arguments.addArgument("provider-bundle", "provider_bundle.json");
         arguments.addArgument("patient-bundle", "patient_bundle-dpr.json");
-        arguments.addArgument("organization-id", "");
-        arguments.addArgument("client-token", "");
-        arguments.addArgument("private-key", "");
-        arguments.addArgument("key-id", "");
+        arguments.addArgument("organization-ids", "");
 
         return arguments;
     }
@@ -102,85 +92,76 @@ public class SmokeTest extends AbstractJavaSamplerClient {
 
     @Override
     public SampleResult runTest(JavaSamplerContext javaSamplerContext) {
-        // Create things
-        final String hostParam = javaSamplerContext.getParameter("host");
+        final String apiURL = javaSamplerContext.getParameter("host");
         final String adminURL = javaSamplerContext.getParameter("admin-url");
-        logger.info("Running against {}", hostParam);
+        logger.info("Running against {}", apiURL);
         logger.info("Admin URL: {}", adminURL);
         logger.info("Running with {} threads", JMeterContextService.getNumberOfThreads());
 
-        this.organizationID = javaSamplerContext.getParameter("organization-id");
-        String clientToken = javaSamplerContext.getParameter("client-token");
-        String privateKeyPath = javaSamplerContext.getParameter("private-key");
-        final String keyID = javaSamplerContext.getParameter("key-id");
+        this.organizationID = getTestOrganizationId(javaSamplerContext);
 
         final SampleResult smokeTestResult = new SampleResult();
         smokeTestResult.setSampleLabel("Smoke Test");
-        // False, unless proven otherwise
         smokeTestResult.setSuccessful(false);
         smokeTestResult.sampleStart();
 
         // Disable validation against Attribution service
         this.ctx = FhirContext.forDstu3();
 
-        // If we're not supplied all the init parameters, create a new org
-        Pair<UUID, PrivateKey> keyTuple;
-        if (organizationID.equals("") || clientToken.equals("") || privateKeyPath.equals("") || keyID.equals("")) {
-            this.organizationID = UUID.randomUUID().toString();
-
-            logger.info(String.format("Creating organization %s", organizationID));
-
-            try {
-                this.goldenMacaroon = APIAuthHelpers.createGoldenMacaroon(adminURL);
-            } catch (Exception e) {
-                throw new IllegalStateException("Failed creating Macaroon", e);
-            }
-            // Create admin client for registering organization
-            final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, hostParam, goldenMacaroon, true, true);
-
-            final SampleResult orgRegistrationResult = new SampleResult();
-            smokeTestResult.addSubResult(orgRegistrationResult);
-
-            orgRegistrationResult.sampleStart();
-            try {
-                String npi = NPIUtil.generateNPI();
-                clientToken = FHIRHelpers.registerOrganization(adminClient, ctx.newJsonParser(), organizationID, npi, adminURL);
-                orgRegistrationResult.setSuccessful(true);
-            } catch (Exception e) {
-                orgRegistrationResult.setSuccessful(false);
-                throw new IllegalStateException("Cannot register org", e);
-            } finally {
-                orgRegistrationResult.sampleEnd();
-            }
-
-            // Create a new public key
-            try {
-                keyTuple = APIAuthHelpers.generateAndUploadKey(KEY_ID, organizationID, goldenMacaroon, hostParam);
-            } catch (IOException | URISyntaxException | GeneralSecurityException e) {
-                throw new IllegalStateException("Failed uploading public key", e);
-            }
-        } else {
-            // Parse the private key and create a new ID/PrivateKey tuple
-            final Path path = Paths.get(privateKeyPath);
-            try (final PEMParser pemParser = new PEMParser(Files.newBufferedReader(path, StandardCharsets.UTF_8))) {
-                JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
-                Object object = pemParser.readObject();
-                KeyPair kp = converter.getKeyPair((PEMKeyPair) object);
-                PrivateKey privateKey = kp.getPrivate();
-                if (privateKey == null) {
-                    throw new IllegalStateException("Key cannot be null");
-                }
-                keyTuple = Pair.of(UUID.fromString(keyID), privateKey);
-            } catch (IOException e) {
-                throw new IllegalArgumentException(String.format("Cannot read private key from: %s", privateKeyPath));
-            }
+        try {
+            this.goldenMacaroon = APIAuthHelpers.createGoldenMacaroon(adminURL);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed creating Macaroon", e);
         }
+
+        final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, apiURL, goldenMacaroon, true, true);
+
+        String clientToken = createOrganization(smokeTestResult, adminClient, adminURL);
+
+        Pair<UUID, PrivateKey> keyTuple = createPublicKey(apiURL);
+
         // Create an authenticated and async client (the async part is ignored by other endpoints)
-        final IGenericClient exportClient;
+        final IGenericClient exportClient = APIAuthHelpers.buildAuthenticatedClient(ctx, apiURL, clientToken, keyTuple.getLeft(), keyTuple.getRight(), true, true);
 
-        exportClient = APIAuthHelpers.buildAuthenticatedClient(ctx, hostParam, clientToken, keyTuple.getLeft(), keyTuple.getRight(), true, true);
+        Pair<Bundle, List<String>> practSubmitResults = submitPractitioners(javaSamplerContext, smokeTestResult, exportClient);
 
-        // Upload a batch of patients and a batch of providers
+        final Map<String, Reference> patientReferences = submitPatients(javaSamplerContext, smokeTestResult, exportClient);
+
+        uploadRosterBundle(javaSamplerContext, practSubmitResults.getLeft(), exportClient, patientReferences);
+
+        runAndMonitorExportJob(smokeTestResult, apiURL, clientToken, keyTuple, exportClient, practSubmitResults.getRight());
+
+        return smokeTestResult;
+    }
+
+    private Pair<UUID, PrivateKey> createPublicKey(String hostParam){
+        try {
+           return APIAuthHelpers.generateAndUploadKey(KEY_ID, organizationID, goldenMacaroon, hostParam);
+        } catch (IOException | URISyntaxException | GeneralSecurityException e) {
+            throw new IllegalStateException("Failed uploading public key", e);
+        }
+    }
+
+    private String createOrganization(SampleResult smokeTestResult, IGenericClient adminClient, String adminURL){
+        logger.info(String.format("Creating organization %s", organizationID));
+        final SampleResult orgRegistrationResult = new SampleResult();
+        smokeTestResult.addSubResult(orgRegistrationResult);
+        orgRegistrationResult.sampleStart();
+        String clientToken;
+        try {
+            String npi = NPIUtil.generateNPI();
+            clientToken = FHIRHelpers.registerOrganization(adminClient, ctx.newJsonParser(), organizationID, npi, adminURL);
+            orgRegistrationResult.setSuccessful(true);
+        } catch (Exception e) {
+            orgRegistrationResult.setSuccessful(false);
+            throw new IllegalStateException("Cannot register org", e);
+        } finally {
+            orgRegistrationResult.sampleEnd();
+        }
+        return clientToken;
+    }
+
+    private Pair<Bundle, List<String>> submitPractitioners(JavaSamplerContext javaSamplerContext, SampleResult smokeTestResult, IGenericClient exportClient){
         logger.debug("Submitting practitioners");
         final SampleResult practitionerSample = new SampleResult();
         practitionerSample.setSampleLabel("Practitioner submission");
@@ -203,14 +184,16 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         } finally {
             practitionerSample.sampleEnd();
         }
-
         smokeTestResult.addSubResult(practitionerSample);
+        return Pair.of(providerBundle, providerNPIs);
+    }
 
+    private Map<String, Reference> submitPatients(JavaSamplerContext javaSamplerContext,SampleResult smokeTestResult, IGenericClient exportClient){
         logger.debug("Submitting patients");
         final SampleResult patientSample = new SampleResult();
         patientSample.setSampleLabel("Patient submission");
         patientSample.sampleStart();
-        final Map<String, Reference> patientReferences;
+        Map<String, Reference> patientReferences;
         try {
             patientReferences = ClientUtils.submitPatients(javaSamplerContext.getParameter("patient-bundle"), this.getClass(), ctx, exportClient);
             patientSample.setSuccessful(true);
@@ -221,18 +204,20 @@ public class SmokeTest extends AbstractJavaSamplerClient {
             patientSample.sampleEnd();
             smokeTestResult.addSubResult(patientSample);
         }
+        return patientReferences;
+    }
 
 
-        // Upload the roster bundle
+    private void uploadRosterBundle(JavaSamplerContext samplerContext, Bundle providerBundle, IGenericClient exportClient, Map<String,Reference> patientReferences){
         logger.debug("Uploading roster");
         try {
-            ClientUtils.createAndUploadRosters(javaSamplerContext.getParameter("seed-file"), providerBundle, exportClient, UUID.fromString(organizationID), patientReferences);
+            ClientUtils.createAndUploadRosters(samplerContext.getParameter("seed-file"), providerBundle, exportClient, UUID.fromString(organizationID), patientReferences);
         } catch (Exception e) {
             throw new IllegalStateException("Cannot upload roster", e);
         }
+    }
 
-        // Run the job
-        // Create a custom http client to use for monitoring the non-FHIR export request
+    private void runAndMonitorExportJob(SampleResult smokeTestResult, String hostParam, String clientToken, Pair<UUID, PrivateKey> keyTuple, IGenericClient exportClient, List<String> providerNPIs){
         try (CloseableHttpClient httpClient = APIAuthHelpers.createCustomHttpClient()
                 .trusting()
                 .isAuthed(hostParam, clientToken, keyTuple.getKey(), keyTuple.getRight())
@@ -241,9 +226,22 @@ public class SmokeTest extends AbstractJavaSamplerClient {
             smokeTestResult.setSuccessful(true);
 
             logger.info("Test completed");
-            return smokeTestResult;
+
         } catch (IOException e) {
             throw new IllegalStateException("Somehow, could not monitor export response", e);
         }
+    }
+
+    private  String getTestOrganizationId(JavaSamplerContext javaSamplerContext){
+        String orgIdsString = javaSamplerContext.getParameter("organization-ids");
+        if(orgIdsString == null){
+            throw new IllegalArgumentException("Missing organization-ids argument.");
+        }
+        List<String> orgIds = Splitter.on(',').splitToList(orgIdsString);
+        int currThreadNum = javaSamplerContext.getJMeterContext().getThreadNum();
+        if(currThreadNum+1 > orgIds.size()){
+            throw new IllegalArgumentException("Not enough test org ids provided. The number of threads must be less than or equal to the number of test org ids.");
+        }
+        return orgIds.get(currThreadNum);
     }
 }

--- a/src/main/resources/SmokeTest.jmx
+++ b/src/main/resources/SmokeTest.jmx
@@ -58,24 +58,9 @@
                 <stringProp name="Argument.value">${__P(admin-url,)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
-              <elementProp name="organization-id" elementType="Argument">
-                <stringProp name="Argument.name">organization-id</stringProp>
-                <stringProp name="Argument.value">${__P(organization-id,)}</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="client-token" elementType="Argument">
-                <stringProp name="Argument.name">client-token</stringProp>
-                <stringProp name="Argument.value">${__P(client-token,)}</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="private-key" elementType="Argument">
-                <stringProp name="Argument.name">private-key</stringProp>
-                <stringProp name="Argument.value">${__P(private-key,)}</stringProp>
-                <stringProp name="Argument.metadata">=</stringProp>
-              </elementProp>
-              <elementProp name="key-id" elementType="Argument">
-                <stringProp name="Argument.name">key-id</stringProp>
-                <stringProp name="Argument.value">${__P(key-id,)}</stringProp>
+              <elementProp name="organization-ids" elementType="Argument">
+                <stringProp name="Argument.name">organization-ids</stringProp>
+                <stringProp name="Argument.value">${__P(organization-ids,)}</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>
             </collectionProp>

--- a/src/main/resources/patient_bundle-dpr.json
+++ b/src/main/resources/patient_bundle-dpr.json
@@ -6555,7 +6555,7 @@
                 },
                 {
                   "system": "http://hl7.org/fhir/sid/us-mbi",
-                  "value": "3SS0C00AA00"
+                  "value": "3ST0C00AA00"
                 },
                 {
                   "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
@@ -6778,7 +6778,7 @@
                 },
                 {
                   "system": "http://hl7.org/fhir/sid/us-mbi",
-                  "value": "2SS0C00AA00"
+                  "value": "2ST0C00AA00"
                 },
                 {
                   "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
@@ -7227,7 +7227,7 @@
                 },
                 {
                   "system": "http://hl7.org/fhir/sid/us-mbi",
-                  "value": "1SS0C00AA00"
+                  "value": "1ST0C00AA00"
                 },
                 {
                   "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
@@ -10920,7 +10920,7 @@
                 },
                 {
                   "system": "http://hl7.org/fhir/sid/us-mbi",
-                  "value": "3SS3F00AA00"
+                  "value": "3ST3F00AA00"
                 },
                 {
                   "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
@@ -11590,7 +11590,7 @@
                 },
                 {
                   "system": "http://hl7.org/fhir/sid/us-mbi",
-                  "value": "1SS3F00AA00"
+                  "value": "1ST3F00AA00"
                 },
                 {
                   "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
@@ -11823,7 +11823,7 @@
                 },
                 {
                   "system": "http://hl7.org/fhir/sid/us-mbi",
-                  "value": "2SS3F00AA00"
+                  "value": "2ST3F00AA00"
                 },
                 {
                   "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",

--- a/src/test/smoke_test.yml
+++ b/src/test/smoke_test.yml
@@ -15,10 +15,7 @@ scenarios:
       seed-file: ${SEED_FILE}
       provider-bundle: ${PROVIDER_BUNDLE}
       patient-bundle: ${PATIENT_BUNDLE}
-      organization-id: ""
-      client-token: ""
-      private-key: ""
-      key-id: ""
+      organization-ids: "0ab352f1-2bf1-44c4-aa7a-3004a1ffef12,69c0d4d4-9c07-4fa8-9053-e10fb1608b48,c7f5247b-4c41-478c-84eb-a6e801bdb145"
     script: src/main/resources/SmokeTest.jmx
 
 reporting:


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `dpc-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [DPC-725](https://jira.cms.gov/browse/DPC-725)

<!-- Describe the problem being solved here: -->
Facts

- Currently in DEV, TEST, and SBX we have lookback disabled for all organizations (lookbackMonths = -1) and are able to retrieve data for our smoke test patients.
- Currently in PROD we have lookback enabled for all organizations(lookbackMonths = 18) and this caused smoke tests to fail since there are lookback failures and operationOutcome files are generated.

Original Solution:
The original intention behind DPC-725 and related tickets was to allow organizations with administrative privileges to disable lookback at a request level. Orgs with administrative privileges would pass a custom header (flag) that would be forwarded to aggregation and lookback would be disabled .

Issues encountered during implementation:
DPC-API does not send an export request directly to Aggregation, instead a job is added to the queu and picked up by aggregation. This would have required us to keep track of skipLookback flag for each job (new col in JOB_BATCH, or new table)


### Proposed Changes
Instead of passing flags around and adding flags to orgs we decided to simply disable lookback for pre-determined organizations.

Aggregation will have a list of lookback exempt organizations and would skip lookback completely during an export or patientEverything request.

### Change Details

<!-- Add detailed discussion of changes here: -->

-  Introduced new config for aggregation (3 orgs that can skip lookback)

`lookBackExemptOrgs = ["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145"]
  
lookbackExemptOrgs = ${?LOOK_BACK_EXEMPT_ORGS}`

-  Updated JobBatchProcessor to skip lookback for exempt orgs

- Smoke tests now use predefined orgs ids instead of creating random ones.
- Smoke tests now check for errors during export.
- Refactored smoke tests
- Removed the ability to specify 

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [X] requires more information or team discussion to evaluate security implications

The UUIDS were randomly generated, during a smoke test orgs are created using supplied org ids and orgs are deleted after tests are completed.

The odds of a real org having the same UUID as the ones generated for test purposes are extremely low, however I would like some input and thoughts on this. 

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
-No acceptance criteria changed, need to test on dev.

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

See security implications section.
<!-- What type of feedback you want from your reviewers? -->
