### PR TITLE
DPC-814 fix: Allow multiple possible values for `Accept` header

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/GroupResource.java
@@ -44,8 +44,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static gov.cms.dpc.api.APIHelpers.addOrganizationTag;
-import static gov.cms.dpc.fhir.FHIRMediaTypes.FHIR_JSON;
-import static gov.cms.dpc.fhir.FHIRMediaTypes.FHIR_NDJSON;
+import static gov.cms.dpc.fhir.FHIRMediaTypes.*;
 import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
 
 
@@ -377,7 +376,7 @@ public class GroupResource extends AbstractGroupResource {
     private static void checkRequestHeaders(List<Pair<String, String>> headers) {
         headers.stream()
                 .peek(header -> {
-                    if (header.getRight() == null) {
+                    if (header.getRight() == null || header.getRight().isBlank()) {
                         throw new BadRequestException("The " + header.getLeft() + " header is required");
                     }
                 })
@@ -385,8 +384,13 @@ public class GroupResource extends AbstractGroupResource {
                     if (pair.getLeft().equals("Prefer") && !pair.getRight().equals("respond-async")) {
                         throw new BadRequestException("The 'Prefer' header must be 'respond-async'");
                     }
-                    if (pair.getLeft().equals("Accept") && !pair.getRight().equals(FHIR_JSON)) {
-                        throw new BadRequestException("The 'Accept' header must be " + FHIR_JSON);
+                    if (pair.getLeft().equals("Accept")) {
+                        String[] values = StringUtils.split(pair.getRight(), ",");
+                        for (String value : values) {
+                            if (!ACCEPT_FHIR_JSON_VALUES.contains(value.trim())) {
+                                throw new BadRequestException("The 'Accept' header must be " + FHIR_JSON);
+                            }
+                        }
                     }
                 });
     }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/GroupResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/GroupResourceUnitTest.java
@@ -214,6 +214,36 @@ public class GroupResourceUnitTest {
             resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", FHIR_JSON);
         });
 
+        Assertions.assertDoesNotThrow(() -> {
+            resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", "application/fhir+json;q=1.0");
+        });
+
+        Assertions.assertDoesNotThrow(() -> {
+            resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", "application/json+fhir");
+        });
+
+        Assertions.assertDoesNotThrow(() -> {
+            resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", "application/json+fhir;q=0.9");
+        });
+
+        Assertions.assertDoesNotThrow(() -> {
+            resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", "application/fhir+json;q=1.0, application/json+fhir;q=0.9");
+        });
+
+        Assertions.assertDoesNotThrow(() -> {
+            resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", "application/fhir+json;q=1.0,application/json+fhir;q=0.9");
+        });
+
+
+        Assertions.assertDoesNotThrow(() -> {
+            resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", "application/json+fhir;q=0.9, application/fhir+json;q=1.0");
+        });
+
+        Assertions.assertDoesNotThrow(() -> {
+            resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", "respond-async", "application/json+fhir;q=0.9,application/fhir+json;q=1.0");
+        });
+
+
         Assertions.assertThrows(BadRequestException.class, () -> {
             resource.export(organizationPrincipal, "roster-id", "Coverage", FHIRMediaTypes.FHIR_NDJSON, "2017-01-01T00:00:00Z", null, FHIR_JSON);
         });

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRMediaTypes.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/FHIRMediaTypes.java
@@ -1,11 +1,17 @@
 package gov.cms.dpc.fhir;
 
 import javax.ws.rs.core.MediaType;
+import java.util.List;
 
 public class FHIRMediaTypes {
 
     public static final String FHIR_JSON = "application/fhir+json";
     public static final String FHIR_NDJSON = "application/fhir+ndjson";
+    public static final List<String> ACCEPT_FHIR_JSON_VALUES = List.of(
+            FHIR_JSON,
+            "application/fhir+json;q=1.0",
+            "application/json+fhir",
+            "application/json+fhir;q=0.9");
 
     private static final MediaType FHIR_JSON_MT = MediaType.valueOf(FHIR_JSON);
     private static final MediaType FHIR_NDJSON_MT = MediaType.valueOf(FHIR_NDJSON);

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/APIAuthHelpers.java
@@ -81,6 +81,7 @@ public class APIAuthHelpers {
             public void interceptRequest(IHttpRequest iHttpRequest) {
                 // Manually set these values, rather than pulling a dependency on dpc-common, where the constants are defined
                 iHttpRequest.addHeader("Prefer", "respond-async");
+                iHttpRequest.addHeader("Accept", "application/fhir+json");
             }
 
             @Override


### PR DESCRIPTION
### Fixes [DPC-814](https://jira.cms.gov/browse/DPC-814)

- After adding a method to check the value of the `Accept` header, smoke tests began failing
- In smoke tests, the `Accept` header is automatically added by the HAPI-FHIR client
- The smoke tests were failing because we were checking explicitly for the value of the header to be `application/fhir+json`, which is the current standard [as shown here](https://hl7.org/fhir/STU3/http.html#mime-type), but the client is sending `application/fhir+json;q=1.0, application/json+fhir;q=0.9`

### Proposed Changes

- add more test cases to the unit test
- create a list of possible acceptable values for the `Accept` header to make it backwards compatible as the HAPI-FHIR client does
- check the contents of the `Accept` header against this list of acceptable header values

### Change Details


### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
- Smoke tests now passing locally
<img width="681" alt="Screen Shot 2020-10-21 at 5 03 46 PM" src="https://user-images.githubusercontent.com/12141694/96792145-65a62280-13bf-11eb-9590-4fe3ab69fd1a.png">


### Feedback Requested
I don't love iterating over a String array inside of a stream. Is there a more straightforward way to do this that is more performant?
