### PR TITLE
fix: add `aud` to JWT and switch on env

### DIFF
--- a/dpc-web/public/jwt/jwt.html
+++ b/dpc-web/public/jwt/jwt.html
@@ -21,7 +21,7 @@
       var data = {
         "iss": clientToken,
         "sub": clientToken,
-        "aud": "https://" + env + "dpc.cms.gov/api/v1/Token/auth",
+        "aud": "https://" + env + ".dpc.cms.gov/api/v1/Token/auth",
         "exp": Math.round(new Date().getTime() / 1000) + 300,
         "iat": Math.round(Date.now()),
         "jti": uuid,
@@ -330,8 +330,8 @@
             </div>
         </div>
         <select name="env-select" id="env" style="width:800px;">
-            <option value="sandbox.">Sandbox</option>
-            <option value="">Production</option>
+            <option value="sandbox">Sandbox</option>
+            <option value="prod">Production</option>
         </select>
       </div>
 

--- a/dpc-web/public/jwt/jwt.html
+++ b/dpc-web/public/jwt/jwt.html
@@ -8,6 +8,7 @@
       var clientToken = document.getElementById("clientToken").value.trim();
       var privateKey = document.getElementById("privateKey").value.trim();
       var keyId = document.getElementById("keyId").value.trim();
+      var env = document.getElementById("env").value.trim();
 
 
       var dt = new Date().getTime();
@@ -20,6 +21,7 @@
       var data = {
         "iss": clientToken,
         "sub": clientToken,
+        "aud": "https://" + env + "dpc.cms.gov/api/v1/Token/auth",
         "exp": Math.round(new Date().getTime() / 1000) + 300,
         "iat": Math.round(Date.now()),
         "jti": uuid,
@@ -277,7 +279,7 @@
   </div>
 
   <div class="container">
-    <div id="form">  
+    <div id="form">
       <div>
         <div class="form-label">
           <div>
@@ -315,6 +317,22 @@
           </div>
         </div>
         <input type="text" id="keyId" placeholder="xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" style="width:800px;">
+      </div>
+
+      <div>
+        <div class="form-label">
+            <div>
+                Please select the Environment for this JWT:
+            </div>
+            <div class="tooltip">
+                <img class="info-logo" src="https://dpc.cms.gov/assets/information-b8baf2e245c158d1de47193512ae79db36874c8f64793d1a47d9dbef70d86699.svg">
+                <span class="tooltiptext">The JWT's environment must match the URL you will use to make requests.</span>
+            </div>
+        </div>
+        <select name="env-select" id="env" style="width:800px;">
+            <option value="sandbox.">Sandbox</option>
+            <option value="">Production</option>
+        </select>
       </div>
 
       <div>


### PR DESCRIPTION
Same change as https://github.com/CMSgov/dpc-static-site/pull/11

### Fixes [DPC-810](https://jiraent.cms.gov/browse/DPC-810)

The JWT Tool was not adding an `aud` claim to the JWT that was generated.
In addition, the `aud` claim is environment-specific, so there needed to be a way to select which environment to use when generating the JWT.

### Proposed Changes
- added a select for the environment: `Sandbox` or `Production`
- added `aud` claim to JWT generator

### Change Details
The URL in the `aud` claim includes the environment. For example, if the env is `prod-sbx` (Sandbox), the claim will have the value `https://sandbox.dpc.cms.gov/api/v1/Token/auth`. For production, the value should be `https://dpc.cms.gov/api/v1/Token/auth`

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->
No security implications.

### Acceptance Validation

Tested by using the generator to create JWTs for various environments and then validated those JWTs using Postman.

All tests were successful.

### Feedback Requested
Any, particularly if the select should be styled differently. I would also be interested in feedback on the text added to the tooltip for the environment.