### PR TITLE
Sample fix for Accept header requirements

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilter.java
@@ -30,7 +30,9 @@ public class FHIRRequestFilter implements ContainerRequestFilter {
     private void checkAccepts(ContainerRequestContext requestContext) {
         final List<MediaType> contentHeader = requestContext.getAcceptableMediaTypes();
 
-        if (contentHeader == null || !shortCircuitBooleanCheck(contentHeader, FHIRMediaTypes::isFHIRContent)) {
+        if ((requestContext.getUriInfo().getPath().contains("$export") &&
+                requestContext.getHeaderString(HttpHeaders.ACCEPT) == null) ||
+                !shortCircuitBooleanCheck(contentHeader, FHIRMediaTypes::isFHIRContent)) {
             throw new WebApplicationException("`Accept:` header must specify valid FHIR content type", Response.SC_UNSUPPORTED_MEDIA_TYPE);
         }
     }


### PR DESCRIPTION
This change is incomplete and untested. It is the result of conversations with Sal and Will and me when working on DPC-554.

This is meant to be an example starting point. Also, it doesn't work because `$export` doesn't show up in the path...