### PR TITLE
DPC-902: Fix return value when adding too many providers

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/PractitionerResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/PractitionerResource.java
@@ -86,7 +86,7 @@ public class PractitionerResource extends AbstractPractitionerResource {
         final List<ProviderEntity> existingProvidersByNPI = this.dao.getProviders(null, entity.getProviderNPI(), entity.getOrganization().getId());
 
         if (providerLimit != null && providerLimit != -1 && totalExistingProviders >= providerLimit) {
-            return Response.status(422).entity(this.converter.toFHIR(Practitioner.class, existingProvidersByNPI.get(0))).build();
+            return Response.status(422).entity(this.converter.toFHIR(Practitioner.class, entity)).build();
         }
 
         if (existingProvidersByNPI.isEmpty()) {

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/PractitionerResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/PractitionerResourceTest.java
@@ -2,7 +2,6 @@ package gov.cms.dpc.attribution.resources;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.rest.gclient.ICreate;
 import ca.uhn.fhir.rest.gclient.ICreateTyped;
 import ca.uhn.fhir.rest.gclient.IDeleteTyped;
 import ca.uhn.fhir.rest.gclient.IReadExecutable;
@@ -10,8 +9,6 @@ import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import gov.cms.dpc.attribution.AbstractAttributionTest;
 import gov.cms.dpc.attribution.AttributionTestHelpers;
-import gov.cms.dpc.attribution.jdbi.ProviderDAO;
-import gov.cms.dpc.common.entities.ProviderEntity;
 import gov.cms.dpc.common.utils.NPIUtil;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.FHIRExtractors;
@@ -19,11 +16,11 @@ import gov.cms.dpc.fhir.validations.profiles.PractitionerProfile;
 import org.hl7.fhir.dstu3.model.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
 
 import java.util.*;
 
-import static gov.cms.dpc.attribution.AttributionTestHelpers.*;
+import static gov.cms.dpc.attribution.AttributionTestHelpers.DEFAULT_ORG_ID;
+import static gov.cms.dpc.attribution.AttributionTestHelpers.createFHIRClient;
 import static gov.cms.dpc.common.utils.SeedProcessor.createBaseAttributionGroup;
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
### Fixes [DPC-902](https://jira.cms.gov/browse/DPC-902)

If a new user with no existing providers tried to do a bulk upload of more providers than allowed, they would receive a 500 due to an IndexOutOfBounds error. This is because the response was trying to include the first of a list of existing providers when there were no existing providers. The test was missing this case by first successfully uploading a provider and then trying to upload the same provider again with the same NPI.

### Proposed Changes

First, change the test so that the 2nd provider uploaded has a different NPI and therefore has no existing providers to return from. Secondly, include the entity in question in the response instead of trying to find one from a list when there possibly isn't one there.

### Change Details

- create a new practitioner with a new NPI for 2nd attempt in the test
- just return the `entity` in the response instead of trying to get a provider from a list of existing ones as there may not be any in that list

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

1) Ran `make ci-app` which runs all unit and integration tests as well as the end-to-end tests
2) Ran smoke tests locally

All passed.

<img width="496" alt="Screen Shot 2020-11-23 at 4 38 17 PM" src="https://user-images.githubusercontent.com/12141694/100023360-737a0980-2daa-11eb-83e5-60e0a4b3d9f6.png">

<img width="705" alt="Screen Shot 2020-11-23 at 5 01 14 PM" src="https://user-images.githubusercontent.com/12141694/100024996-87733a80-2dad-11eb-800b-29bdf3c4bb7f.png">

### Feedback Requested

Is there a cleaner way to change than test than what I have done here?
Anything else?
