### PR TITLE
Suppress the transfer progress logging when downloading artifacts with Maven

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ci-web:
 
 .PHONY: smoke
 smoke:
-	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am
+	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local
 smoke/local: venv smoke

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       - export-volume:/tmp
       - ./:/usr/src/mymaven
     working_dir: /usr/src/mymaven
-    command: sh -c "mvn test -Pintegration-tests -pl dpc-api -am"
+    command: sh -c "mvn test -Pintegration-tests -pl dpc-api -am -ntp"
     network_mode: host
 
 

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -41,12 +41,12 @@ fi
 
 # Build the application
 docker-compose up start_core_dependencies
-mvn clean compile -Perror-prone -B -V
-mvn package -Pci
+mvn clean compile -Perror-prone -B -V -ntp
+mvn package -Pci -ntp
 
 # Format the test results and copy to a new directory
 if [ -n "$REPORT_COVERAGE" ]; then
-    mvn jacoco:report
+    mvn jacoco:report -ntp
     mkdir -p reports
 
     for module in dpc-aggregation dpc-api dpc-attribution dpc-queue dpc-macaroons
@@ -78,7 +78,7 @@ docker-compose down -t 60
 
 # Collect the coverage reports for the Docker integration tests
 if [ -n "$REPORT_COVERAGE" ]; then
-    mvn jacoco:report-integration -Pci
+    mvn jacoco:report-integration -Pci -ntp
 
     for module in dpc-aggregation dpc-api dpc-attribution
     do

--- a/dpc-unit-test.sh
+++ b/dpc-unit-test.sh
@@ -23,7 +23,7 @@ echo "│          Running Unit Tests...           │"
 echo "│                                          │"
 echo "└──────────────────────────────────────────┘"
 
-mvn test -Punit-tests
+mvn test -Punit-tests -ntp
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"


### PR DESCRIPTION
### Fixes Excessive Logging 

Maven excessively logs transfer progress when downloading artifacts.  This makes it extremely difficult to parse logs locally and in Github Actions.  Because the transfer progress is purely informational, we can safely suppress it.

See example below of logging exceeding 50,000 lines.

<img width="619" alt="Screen Shot 2020-12-07 at 6 57 24 PM" src="https://user-images.githubusercontent.com/37818548/101419488-1e67e880-38be-11eb-9056-b34d2894d93d.png">



### Change Details

- Updated the calls to `mvn` to pass in `-ntp` to ensure the _no transfer progress_ is passed, in order to suppress transfer progress when downloading artifacts with Maven.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

In Github Actions, the `Build and Test API` step was previously logging over 50,000 lines.

Now, [with this feature branch](https://github.com/CMSgov/dpc-app/runs/1514114057?check_suite_focus=true), the logging is less than 10,000 lines.

<img width="621" alt="Screen Shot 2020-12-07 at 6 55 07 PM" src="https://user-images.githubusercontent.com/37818548/101419327-c630e680-38bd-11eb-8906-64d21d42b63c.png">


### Feedback Requested

Please review.