### PR TITLE
DPC-916 fix: Remove requirement for Patient to be in a group for Patient/$everything

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/AggregationAppModule.java
@@ -7,6 +7,7 @@ import com.google.inject.Provides;
 import com.hubspot.dropwizard.guicier.DropwizardAwareModule;
 import com.typesafe.config.Config;
 import gov.cms.dpc.aggregation.dao.OrganizationDAO;
+import gov.cms.dpc.aggregation.dao.ProviderDAO;
 import gov.cms.dpc.aggregation.dao.RosterDAO;
 import gov.cms.dpc.aggregation.engine.AggregationEngine;
 import gov.cms.dpc.aggregation.engine.JobBatchProcessor;
@@ -35,6 +36,7 @@ public class AggregationAppModule extends DropwizardAwareModule<DPCAggregationCo
         binder.bind(AggregationEngine.class);
         binder.bind(AggregationManager.class).asEagerSingleton();
         binder.bind(JobBatchProcessor.class);
+        binder.bind(ProviderDAO.class);
         binder.bind(RosterDAO.class);
         binder.bind(OrganizationDAO.class);
 
@@ -94,13 +96,13 @@ public class AggregationAppModule extends DropwizardAwareModule<DPCAggregationCo
     }
 
     @Provides
-    LookBackService provideLookBackService(DPCManagedSessionFactory sessionFactory, RosterDAO rosterDAO, OrganizationDAO organizationDAO, OperationsConfig operationsConfig) {
+    LookBackService provideLookBackService(DPCManagedSessionFactory sessionFactory, ProviderDAO providerDAO, RosterDAO rosterDAO, OrganizationDAO organizationDAO, OperationsConfig operationsConfig) {
         //Configuring to skip look back when look back months is less than 0
         if (operationsConfig.getLookBackMonths() < 0) {
             return new EveryoneGetsDataLookBackServiceImpl();
         }
         return new UnitOfWorkAwareProxyFactory("roster", sessionFactory.getSessionFactory()).create(LookBackServiceImpl.class,
-                new Class<?>[]{RosterDAO.class, OrganizationDAO.class, OperationsConfig.class},
-                new Object[]{rosterDAO, organizationDAO, operationsConfig});
+                new Class<?>[]{ProviderDAO.class, RosterDAO.class, OrganizationDAO.class, OperationsConfig.class},
+                new Object[]{providerDAO, rosterDAO, organizationDAO, operationsConfig});
     }
 }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/dao/ProviderDAO.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/dao/ProviderDAO.java
@@ -1,0 +1,24 @@
+package gov.cms.dpc.aggregation.dao;
+
+import gov.cms.dpc.common.entities.ProviderEntity;
+import gov.cms.dpc.common.hibernate.attribution.DPCManagedSessionFactory;
+import io.dropwizard.hibernate.AbstractDAO;
+
+import javax.inject.Inject;
+import java.util.Optional;
+import java.util.UUID;
+
+public class ProviderDAO extends AbstractDAO<ProviderEntity> {
+
+    @Inject
+    ProviderDAO(DPCManagedSessionFactory factory) {
+        super(factory.getSessionFactory());
+    }
+
+
+    public Optional<String> fetchProviderNPI(UUID providerID, UUID orgID) {
+        return Optional.ofNullable(get(providerID))
+                .filter(provider -> provider.getOrganization().getId().equals(orgID))
+                .map(ProviderEntity::getProviderNPI);
+    }
+}

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/dao/RosterDAO.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/dao/RosterDAO.java
@@ -22,9 +22,9 @@ public class RosterDAO extends AbstractDAO<RosterEntity> {
 
     /**
      * Retrieves the ProviderID from the roster by orgID, patientMBI and either rosterID or providerID
-     * @param organizationID        The organizationID
-     * @param providerOrRosterID    Either a rosterID or the providerID
-     * @param patientMBI            The patient MBI
+     * @param organizationID     The organizationID
+     * @param providerOrRosterID Either a rosterID or the providerID
+     * @param patientMBI         The patient MBI
      * @return the provider ID for that roster
      */
     public Optional<String> retrieveProviderNPIFromRoster(UUID organizationID, UUID providerOrRosterID, String patientMBI) {
@@ -48,7 +48,7 @@ public class RosterDAO extends AbstractDAO<RosterEntity> {
         Query<String> q = currentSession().createQuery(query);
         try {
             return Optional.ofNullable(q.getSingleResult());
-        } catch(NoResultException e) {
+        } catch (NoResultException e) {
             return Optional.empty();
         }
     }
@@ -60,10 +60,7 @@ public class RosterDAO extends AbstractDAO<RosterEntity> {
 
     private Predicate providerOrRosterIDPredicate(CriteriaBuilder builder, Root<RosterEntity> root, UUID providerOrRosterID) {
         //Group Export passes in the rosterID as the jobBatch providerID
-        final Predicate rosterIDPredicate = builder.equal(root.get(RosterEntity_.ID), providerOrRosterID);
-        //DataService passes in the providerID as the jobBatch providerID
-        final Predicate providerIDPredicate = builder.equal(root.get(RosterEntity_.ATTRIBUTED_PROVIDER).get(ProviderEntity_.ID), providerOrRosterID);
-        return builder.or(rosterIDPredicate, providerIDPredicate);
+        return builder.equal(root.get(RosterEntity_.ID), providerOrRosterID);
     }
 
     private Predicate mbiPredicate(CriteriaBuilder builder, Root<RosterEntity> root, String patientMBI) {

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/health/AggregationEngineHealthCheckTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/health/AggregationEngineHealthCheckTest.java
@@ -5,6 +5,7 @@ import ca.uhn.fhir.rest.param.DateRangeParam;
 import com.codahale.metrics.MetricRegistry;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.aggregation.dao.OrganizationDAO;
+import gov.cms.dpc.aggregation.dao.ProviderDAO;
 import gov.cms.dpc.aggregation.dao.RosterDAO;
 import gov.cms.dpc.aggregation.engine.AggregationEngine;
 import gov.cms.dpc.aggregation.engine.JobBatchProcessor;
@@ -66,8 +67,8 @@ public class AggregationEngineHealthCheckTest {
     void setupEach() throws ParseException {
         queue = Mockito.spy(new MemoryBatchQueue(10));
         bbclient = Mockito.spy(new MockBlueButtonClient(fhirContext));
-        var operationalConfig = new OperationsConfig(1000, exportPath, 500,new SimpleDateFormat("dd/MM/yyyy").parse("03/01/2015"));
-        lookBackService = Mockito.spy(new LookBackServiceImpl(Mockito.mock(RosterDAO.class), Mockito.mock(OrganizationDAO.class), operationalConfig));
+        var operationalConfig = new OperationsConfig(1000, exportPath, 500, new SimpleDateFormat("dd/MM/yyyy").parse("03/01/2015"));
+        lookBackService = Mockito.spy(new LookBackServiceImpl(Mockito.mock(ProviderDAO.class), Mockito.mock(RosterDAO.class), Mockito.mock(OrganizationDAO.class), operationalConfig));
         jobBatchProcessor = Mockito.spy(new JobBatchProcessor(bbclient, fhirContext, metricRegistry, operationalConfig, lookBackService));
         engine = Mockito.spy(new AggregationEngine(aggregatorID, queue, operationalConfig, jobBatchProcessor));
         AggregationEngine.setGlobalErrorHandler();

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/service/LookBackServiceImplTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/service/LookBackServiceImplTest.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.aggregation.service;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import gov.cms.dpc.aggregation.dao.OrganizationDAO;
+import gov.cms.dpc.aggregation.dao.ProviderDAO;
 import gov.cms.dpc.aggregation.dao.RosterDAO;
 import gov.cms.dpc.aggregation.engine.OperationsConfig;
 import gov.cms.dpc.common.utils.NPIUtil;
@@ -38,6 +39,9 @@ public class LookBackServiceImplTest {
     private ExplanationOfBenefit eob;
 
     @Mock
+    private ProviderDAO providerDAO;
+
+    @Mock
     private RosterDAO rosterDAO;
 
     @Mock
@@ -49,7 +53,7 @@ public class LookBackServiceImplTest {
         Config config = ConfigFactory.load("testing.conf").getConfig("dpc.aggregation");
         String exportPath = config.getString("exportPath");
         OperationsConfig operationsConfig = new OperationsConfig(10, exportPath, 3, new Date());
-        lookBackService = new LookBackServiceImpl(rosterDAO, organizationDAO, operationsConfig);
+        lookBackService = new LookBackServiceImpl(providerDAO, rosterDAO, organizationDAO, operationsConfig);
         eob = new ExplanationOfBenefit();
         eob.setBillablePeriod(new Period());
         eob.setProvider(new Reference());

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -205,7 +205,7 @@ public class PatientResource extends AbstractPatientResource {
         }
         if (ResourceType.OperationOutcome.equals(result.getResourceType())) {
             OperationOutcome resultOp = (OperationOutcome) result;
-            throw new NotAuthorizedException(resultOp.getIssueFirstRep().getDetails().getText());
+            throw new WebApplicationException(resultOp.getIssueFirstRep().getDetails().getText());
         }
 
         throw new WebApplicationException(HttpStatus.INTERNAL_SERVER_ERROR_500);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static gov.cms.dpc.api.APIHelpers.bulkResourceClient;
 import static gov.cms.dpc.fhir.helpers.FHIRHelpers.handleMethodOutcome;
@@ -198,15 +197,15 @@ public class PatientResource extends AbstractPatientResource {
         final String patientMbi = FHIRExtractors.getPatientMBI(patient);
         final UUID orgId = organization.getID();
 
-        if (!isPatientInRoster(patientId, FHIRExtractors.getProviderNPI(practitioner), orgId)) {
-            throw new WebApplicationException(HttpStatus.UNAUTHORIZED_401);
-        }
-
         final String requestingIP = APIHelpers.fetchRequestingIP(request);
         Resource result = dataService.retrieveData(orgId, practitionerId, List.of(patientMbi), APIHelpers.fetchTransactionTime(bfdClient),
                 requestingIP, ResourceType.Patient, ResourceType.ExplanationOfBenefit, ResourceType.Coverage);
         if (ResourceType.Bundle.equals(result.getResourceType())) {
             return (Bundle) result;
+        }
+        if (ResourceType.OperationOutcome.equals(result.getResourceType())) {
+            OperationOutcome resultOp = (OperationOutcome) result;
+            throw new NotAuthorizedException(resultOp.getIssueFirstRep().getDetails().getText());
         }
 
         throw new WebApplicationException(HttpStatus.INTERNAL_SERVER_ERROR_500);
@@ -281,31 +280,5 @@ public class PatientResource extends AbstractPatientResource {
                 throw new WebApplicationException(APIHelpers.formatValidationMessages(result.getMessages()), HttpStatus.UNPROCESSABLE_ENTITY_422);
             }
         }
-    }
-
-    private boolean isPatientInRoster(UUID patientId, String providerNpi, UUID organizationId) {
-        Bundle providerRosters = client.search()
-                .forResource(Group.class)
-                .where(Group.CHARACTERISTIC_VALUE
-                        .withLeft(Group.CHARACTERISTIC.exactly().code("attributed-to"))
-                        .withRight(Group.VALUE.exactly().systemAndCode(DPCIdentifierSystem.NPPES.getSystem(), providerNpi)))
-                .withTag("", organizationId.toString())
-                .returnBundle(Bundle.class)
-                .encodedJson()
-                .execute();
-
-        for (Bundle.BundleEntryComponent bec : providerRosters.getEntry()) {
-            Group roster = (Group) bec.getResource();
-            List<Group.GroupMemberComponent> members = roster.getMember();
-            List<UUID> rosterPatientIds = members.stream()
-                    .map(Group.GroupMemberComponent::getEntity)
-                    .map(ref -> FHIRExtractors.getEntityUUID(ref.getReference()))
-                    .collect(Collectors.toList());
-            if (rosterPatientIds.contains(patientId)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -7,6 +7,7 @@ import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.gclient.IReadExecutable;
 import ca.uhn.fhir.rest.gclient.IUpdateExecutable;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
@@ -296,7 +297,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
                 .useHttpGet()
                 .withAdditionalHeader("X-Provenance", provenance);
 
-        assertThrows(AuthenticationException.class, everythingOp::execute);
+        assertThrows(InternalErrorException.class, everythingOp::execute);
     }
 
     @Test
@@ -363,7 +364,7 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
                 .useHttpGet()
                 .withAdditionalHeader("X-Provenance", provenance);
 
-        assertThrows(AuthenticationException.class, everythingOp::execute);
+        assertThrows(InternalErrorException.class, everythingOp::execute);
     }
 
     private IGenericClient generateClient(String orgID, String orgNPI, String keyLabel) throws IOException, URISyntaxException, GeneralSecurityException {

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
@@ -53,17 +53,17 @@ public class DataService {
      * Retrieves data from BFD
      * @param organizationID UUID of organization
      * @param providerID UUID of provider
-     * @param patientIDs List of patient String UUIDs
+     * @param patientMBIs List of patient String UUIDs
      * @param requestingIP
      * @param resourceTypes List of ResourceType data to retrieve
      * @return Resource
      */
     public Resource retrieveData(UUID organizationID,
                                  UUID providerID,
-                                 List<String> patientIDs,
+                                 List<String> patientMBIs,
                                  OffsetDateTime transactionTime,
                                  String requestingIP, ResourceType... resourceTypes) {
-        UUID jobID = this.queue.createJob(organizationID, providerID.toString(), patientIDs, List.of(resourceTypes), null, transactionTime, requestingIP);
+        UUID jobID = this.queue.createJob(organizationID, providerID.toString(), patientMBIs, List.of(resourceTypes), null, transactionTime, requestingIP);
         Optional<List<JobQueueBatch>> optionalBatches = waitForJobToComplete(jobID, organizationID, this.queue);
 
         if (optionalBatches.isPresent()) {

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
@@ -53,7 +53,7 @@ public class DataService {
      * Retrieves data from BFD
      * @param organizationID UUID of organization
      * @param providerID UUID of provider
-     * @param patientMBIs List of patient String UUIDs
+     * @param patientMBIs List of patient String MBIs
      * @param requestingIP
      * @param resourceTypes List of ResourceType data to retrieve
      * @return Resource


### PR DESCRIPTION
### Fixes [DPC-916](https://jira.cms.gov/browse/DPC-916)

The Patient/$everything endpoint was unnecessarily requiring both a Provenance header (attesting to the provider/patient relationship) and a Roster for the given patient and provider. This was redundant and confusing for users.

### Proposed Changes

It was decided to remove the requirement for a Roster when using `Patient/$everything`
- Remove Roster check from the `PatientResource`
- Update tests for this change

### Change Details

- The `PatientResourceTest` is relying heavily on existing test data and the tests are dependent on one another. As part of this PR, I refactored some of this in order to aid in readability and adjust for the change to the `PatientResource`
- Since there was no longer a Roster, `LookBackServiceImpl. getPractitionerNPIFromRoster` was failing to return a Practitioner NPI. To fix this, I added a `ProviderDAO` and fallback to checking for the provider when there is not a Roster found.
- We no longer need to limit the RosterDAO search by the provider now that we are checking for it in the `LookBackServiceImpl`

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

LookBackService continues to check for Practitioner NPIs and Organization NPIs on the EoBs as before.

### Acceptance Validation

- all tests pass when running `make ci-app` locally
- smoke tests pass locally

<img width="684" alt="Screen Shot 2020-12-09 at 4 50 43 PM" src="https://user-images.githubusercontent.com/12141694/101702373-5863f680-3a46-11eb-9195-dcb73892eb10.png">


### Feedback Requested

Any
