### PR TITLE
DPC-780 Have major Snyk finding fail builds

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,131 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-LODASH-590103:
+    - newman > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-runtime > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-runtime > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-runtime > postman-sandbox > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-runtime > async > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-url-encoder > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+    - newman > postman-collection-transformer > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+    - newman > postman-runtime > postman-sandbox > uvm > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+  SNYK-JS-MARKED-584281:
+    - newman > postman-collection > marked:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-runtime > postman-collection > marked:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-runtime > postman-url-encoder > postman-collection > marked:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+  SNYK-JS-LODASH-567746:
+    - newman > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-collection-transformer > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-sandbox > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-sandbox > uvm > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > async > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-url-encoder > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+  SNYK-JS-LODASH-608086:
+    - newman > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.490Z'
+    - newman > postman-collection-transformer > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-sandbox > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-sandbox > uvm > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > async > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - newman > postman-runtime > postman-url-encoder > postman-collection > lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.491Z'
+    - lodash:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+  SNYK-JS-AJV-584908:
+    - ajv:
+        reason: No upgrade available
+        expires: '2021-01-14T20:54:26.492Z'
+    - har-validator > ajv:
+        reason: No upgrade available
+        expires: '2021-01-14T20:54:26.492Z'
+    - newman > postman-request > har-validator > ajv:
+        reason: No upgrade available
+        expires: '2021-01-14T20:54:26.492Z'
+    - newman > postman-runtime > postman-request > har-validator > ajv:
+        reason: No update available
+        expires: '2021-01-14T20:54:26.492Z'
+  SNYK-JS-SANITIZEHTML-585892:
+    - newman > postman-collection > sanitize-html:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+    - newman > postman-runtime > postman-collection > sanitize-html:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+    - newman > postman-runtime > postman-url-encoder > postman-collection > sanitize-html:
+        reason: Affects tests only
+        expires: '2021-01-14T20:54:26.492Z'
+patch: {}


### PR DESCRIPTION
### Fixes [DPC-780](https://jira.cms.gov/browse/DPC-780)
We would like to avoid pushing out software with a vulnerable dependency.  Our Snyk integration with Jenkins allows this, and a [separate ticket in the ops repo](https://github.com/CMSgov/dpc-ops/pull/279) will check the correct box (literally, _un_check the box by default, actually).  

However, we currently have a few known vulnerabilities in software that we only use in test environments, and for which we don't have a good upgrade path (we've [already upgraded to the latest available library](https://github.com/CMSgov/dpc-app/pull/1115)).  This PR gives us 30 days of silence from Snyk on those particular issues, so that we can proceed to reduce the changes of publishing new, _unknown_ issues.

### Proposed Changes
- Add a .snyk file 

### Change Details
The file was produced with the `snyk wizard` CLI tool

### Security Implications
- [ ] new software dependencies
- [x] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [ ] no PHI/PII is affected by this change

By itself, this PR does nothing.  There's no effect on CI/CD, because in Jenkins the Snyk findings are ignored by default.  When paired with the associated ops PR, it allows us to focus on new issues not limited to our testing environment.

### Acceptance Validation

#### Build job passes with .snyk file (it currently fails if SNYK_OVERRIDE is unchecked)
![Screen Shot 2020-12-15 at 4 24 15 PM](https://user-images.githubusercontent.com/2533561/102276591-03682a80-3ef5-11eb-9a3a-e944aba763fe.png)
![Screen Shot 2020-12-15 at 4 23 56 PM](https://user-images.githubusercontent.com/2533561/102276593-0400c100-3ef5-11eb-889f-7c6af7737959.png)


### Feedback Requested
- Are we ignoring too many issues?
- Is there a better way to approach this topic?