### PR TITLE
Added suport for id filter in Endpoint resource search

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/macaroonauth/MacaroonsAuthenticator.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/macaroonauth/MacaroonsAuthenticator.java
@@ -61,7 +61,6 @@ public class MacaroonsAuthenticator implements Authenticator<DPCAuthCredentials,
                 .search()
                 .forResource(credentials.getPathAuthorizer().type().toString())
                 .whereMap(searchParams)
-//                .withTag("", credentials.getOrganization().getId())
                 .returnBundle(Bundle.class)
                 .encodedJson()
                 .execute();

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/EndpointResourceTest.java
@@ -6,10 +6,11 @@ import ca.uhn.fhir.rest.gclient.ICreateTyped;
 import ca.uhn.fhir.rest.gclient.IDeleteTyped;
 import ca.uhn.fhir.rest.gclient.IReadExecutable;
 import ca.uhn.fhir.rest.gclient.IUpdateExecutable;
-import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
+import gov.cms.dpc.api.TestOrganizationContext;
 import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.testing.APIAuthHelpers;
 import gov.cms.dpc.testing.OrganizationHelpers;
@@ -17,6 +18,7 @@ import gov.cms.dpc.testing.factories.OrganizationFactory;
 import org.apache.http.HttpHeaders;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.HttpMethod;
@@ -24,7 +26,11 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -117,93 +123,131 @@ public class EndpointResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    void testFetchEndpoint() {
-        Endpoint endpoint = OrganizationFactory.createValidFakeEndpoint();
-        MethodOutcome outcome = client.create().resource(endpoint).execute();
-        Endpoint createdEndpoint = (Endpoint) outcome.getResource();
+    void testFetchEndpoint() throws GeneralSecurityException, IOException, URISyntaxException {
+        final TestOrganizationContext orgAContext = registerAndSetupNewOrg();
+        final TestOrganizationContext orgBContext = registerAndSetupNewOrg();
+        final IGenericClient orgAClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgAContext.getClientToken(), UUID.fromString(orgAContext.getPublicKeyId()), orgAContext.getPrivateKey());
+        final IGenericClient orgBClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgBContext.getClientToken(), UUID.fromString(orgBContext.getPublicKeyId()), orgBContext.getPrivateKey());
 
-        Endpoint readEndpoint = client.read().resource(Endpoint.class).withId(createdEndpoint.getId()).execute();
-        assertTrue(readEndpoint.equalsDeep(createdEndpoint));
+        //Setup Org A with one single endpoint
+        MethodOutcome outcome = orgAClient.create().resource(OrganizationFactory.createValidFakeEndpoint(orgAContext.getOrgId())).execute();
+        final Endpoint orgAEndpoint = (Endpoint) outcome.getResource();
+
+        //Setup Org B with one single endpoint
+        outcome = orgBClient.create().resource(OrganizationFactory.createValidFakeEndpoint(orgBContext.getOrgId())).execute();
+        final Endpoint orgBEndpoint = (Endpoint) outcome.getResource();
+
+        //Assert Org A can get their endpoint
+        Endpoint readEndpoint = orgAClient.read().resource(Endpoint.class).withId(orgAEndpoint.getId()).execute();
+        assertTrue(readEndpoint.equalsDeep(orgAEndpoint), "Organization should have been able to retrieve their own endpoint");
+
+        //Assert Org B can get their endpoint
+        readEndpoint = orgBClient.read().resource(Endpoint.class).withId(orgBEndpoint.getId()).execute();
+        assertTrue(readEndpoint.equalsDeep(orgBEndpoint), "Organization should have been able to retrieve their own endpoint");
+
+        //Assert Org B can NOT get org A's endpoint
+        IReadExecutable<Endpoint> readExecutable = orgBClient.read().resource(Endpoint.class).withId(orgAEndpoint.getId());
+        assertThrows(AuthenticationException.class, () -> readExecutable.execute(), "Expected auth error when accessing another org's endpoint");
     }
 
     @Test
-    void testUpdateEndpoint() {
-        Endpoint endpoint = OrganizationFactory.createValidFakeEndpoint();
-        MethodOutcome createOutcome = client.create().resource(endpoint).execute();
-        Endpoint createdEndpoint = (Endpoint) createOutcome.getResource();
-        createdEndpoint.setName("Test Update Endpoint");
-        // Payload type must be set because it is not in EndpointEntity and will not be returned from the create operation
+    void testUpdateEndpoint() throws GeneralSecurityException, IOException, URISyntaxException {
+        final TestOrganizationContext orgAContext = registerAndSetupNewOrg();
+        final TestOrganizationContext orgBContext = registerAndSetupNewOrg();
+        final IGenericClient orgAClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgAContext.getClientToken(), UUID.fromString(orgAContext.getPublicKeyId()), orgAContext.getPrivateKey());
+        final IGenericClient orgBClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgBContext.getClientToken(), UUID.fromString(orgBContext.getPublicKeyId()), orgBContext.getPrivateKey());
+
+        //Setup Org A with one single endpoint
+        MethodOutcome outcome = orgAClient.create().resource(OrganizationFactory.createValidFakeEndpoint(orgAContext.getOrgId())).execute();
+        final Endpoint orgAEndpoint = (Endpoint) outcome.getResource();
+
+        //Setup Org B with one single endpoint
+        outcome = orgBClient.create().resource(OrganizationFactory.createValidFakeEndpoint(orgBContext.getOrgId())).execute();
+        final Endpoint orgBEndpoint = (Endpoint) outcome.getResource();
+
+        //Assert Org A can update their own endpoint
+        orgAEndpoint.setName("Name updated by Org A");
+        orgAEndpoint.setPayloadType(List.of(createCodeableConcept()));
+        MethodOutcome updateOutcome = orgAClient.update().resource(orgAEndpoint).withId(orgAEndpoint.getId()).execute();
+        final Endpoint orgAUpdatedEndpoint = (Endpoint) updateOutcome.getResource();
+        assertEquals("Name updated by Org A", orgAEndpoint.getName(), "Org should have been able to update their own endpoint's name");
+
+        //Assert Org B can update their own endpoint
+        orgBEndpoint.setName("Name updated by Org B");
+        orgBEndpoint.setPayloadType(List.of(createCodeableConcept()));
+        updateOutcome = orgBClient.update().resource(orgBEndpoint).withId(orgBEndpoint.getId()).execute();
+        final Endpoint orgBUpdatedEndpoint = (Endpoint) updateOutcome.getResource();
+        assertEquals("Name updated by Org B", orgBUpdatedEndpoint.getName(), "Org should have been able to update their own endpoint's name");
+
+        //Assert Org B can NOT update org A's endpoint.
+        orgAEndpoint.setName("Name updated by Org A");
+        IUpdateExecutable iUpdateExecutable = orgBClient.update().resource(orgAEndpoint).withId(orgAEndpoint.getId());
+        assertThrows(AuthenticationException.class, () -> iUpdateExecutable.execute(), "Expected auth error when updating another org's endpoint.");
+
+        //Assert Org B can NOT update their endpoint to have org A's reference in managing organization
+        orgBEndpoint.setPayloadType(List.of(createCodeableConcept()));
+        orgBEndpoint.setManagingOrganization(new Reference(new IdType("Organization", orgAContext.getOrgId())));
+        final IUpdateExecutable updateExecutable = orgBClient.update().resource(orgBEndpoint).withId(orgBEndpoint.getId());
+        assertThrows(UnprocessableEntityException.class, () -> updateExecutable.execute(), "Expected 422 error when updating the endpoints org's endpoint.");
+    }
+
+    private CodeableConcept createCodeableConcept (){
         CodeableConcept payloadType = new CodeableConcept();
         payloadType.addCoding().setCode("nothing").setSystem("http://nothing.com");
-        createdEndpoint.setPayloadType(List.of(payloadType));
-
-        MethodOutcome updateOutcome = client.update().resource(createdEndpoint).withId(createdEndpoint.getId()).execute();
-
-        Endpoint updatedEndpoint = (Endpoint) updateOutcome.getResource();
-        // Same as above; not returned by update
-        updatedEndpoint.setPayloadType(List.of(payloadType));
-        assertTrue(updatedEndpoint.equalsDeep(createdEndpoint));
-    }
-
-    @Test
-    void testUpdateEndpointDifferentOrg() throws IOException {
-        final String goldenMacaroon = APIAuthHelpers.createGoldenMacaroon();
-        final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, getBaseURL(), goldenMacaroon, false);
-
-        final Organization organization1 = OrganizationHelpers.createOrganization(ctx, adminClient, "2111111110", true);
-        String endpointId = FHIRExtractors.getEntityUUID(organization1.getEndpointFirstRep().getReference()).toString();
-
-        Endpoint endpoint = client
-                .read()
-                .resource(Endpoint.class)
-                .withId(endpointId)
-                .execute();
-
-        final Organization organization2 = OrganizationHelpers.createOrganization(ctx, adminClient, "1121111110", true);
-        endpoint.setManagingOrganization(new Reference(new IdType("Organization", organization2.getId())));
-
-        IUpdateExecutable updateExec = client
-                .update()
-                .resource(endpoint)
-                .withId(endpoint.getId());
-
-        assertThrows(UnprocessableEntityException.class, updateExec::execute);
+        return payloadType;
     }
 
 
     @Test
-    void testDeleteEndpoint() {
-        Endpoint endpoint = OrganizationFactory.createValidFakeEndpoint();
-        MethodOutcome createOutcome = client.create().resource(endpoint).execute();
-        Endpoint createdEndpoint = (Endpoint) createOutcome.getResource();
-        String endpointId = FHIRExtractors.getEntityUUID(createdEndpoint.getId()).toString();
+    void testDeleteOrgsOnlyEndpoint() throws IOException, GeneralSecurityException, URISyntaxException {
+        final TestOrganizationContext orgAContext = registerAndSetupNewOrg();
+        final IGenericClient orgAClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgAContext.getClientToken(), UUID.fromString(orgAContext.getPublicKeyId()), orgAContext.getPrivateKey());
 
-        client
-                .delete()
-                .resourceById("Endpoint", endpointId)
-                .execute();
+        //Setup Org A with 2 endpoints.
+        MethodOutcome outcome = orgAClient.create().resource(OrganizationFactory.createValidFakeEndpoint(orgAContext.getOrgId())).execute();
 
-        IReadExecutable readExec = client
-                .read()
-                .resource(Endpoint.class)
-                .withId(endpointId);
+        //Assert we have 2 resources.
+        String[] endpointIds =  getAvailableResources(orgAClient, Endpoint.class).toArray(String[]::new);
+        assertEquals(2, getAvailableResources(orgAClient, Endpoint.class).size(), "Only 2 Endpoints should exist");
 
-        assertThrows(ResourceNotFoundException.class, readExec::execute);
+        //Assert Org A CAN delete 1 of 2 endpoints.
+        orgAClient.delete().resourceById("Endpoint",new IdType(endpointIds[0]).getIdPart()).execute();
+        assertEquals(1, getAvailableResources(orgAClient, Endpoint.class).size(), "Only 1 of 2 Endpoints should exist");
+
+        //Assert Org A CAN NOT delete their last endpoint.
+        IDeleteTyped deleteExecutable = orgAClient.delete().resourceById("Endpoint",new IdType(endpointIds[1]).getIdPart());
+        assertThrows(UnprocessableEntityException.class, () -> deleteExecutable.execute(), "Expected 422 when deleting the last endpoint");
     }
 
     @Test
-    void testDeleteOnlyEndpoint() throws IOException {
-        final String goldenMacaroon = APIAuthHelpers.createGoldenMacaroon();
-        final IGenericClient adminClient = APIAuthHelpers.buildAdminClient(ctx, getBaseURL(), goldenMacaroon, false);
+    void testDeleteEndpoint() throws GeneralSecurityException, IOException, URISyntaxException {
+        final TestOrganizationContext orgAContext = registerAndSetupNewOrg();
+        final TestOrganizationContext orgBContext = registerAndSetupNewOrg();
+        final IGenericClient orgAClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgAContext.getClientToken(), UUID.fromString(orgAContext.getPublicKeyId()), orgAContext.getPrivateKey());
+        final IGenericClient orgBClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgBContext.getClientToken(), UUID.fromString(orgBContext.getPublicKeyId()), orgBContext.getPrivateKey());
 
-        final String newOrgNPI = "1111211110";
-        final Organization organization = OrganizationHelpers.createOrganization(ctx, adminClient, newOrgNPI, true);
-        String endpointId = FHIRExtractors.getEntityUUID(organization.getEndpointFirstRep().getReference()).toString();
+        //Setup Org A with one single endpoint
+        MethodOutcome outcome = orgAClient.create().resource(OrganizationFactory.createValidFakeEndpoint(orgAContext.getOrgId())).execute();
+        final Endpoint orgAEndpoint = (Endpoint) outcome.getResource();
 
-        IDeleteTyped delete = client
-                .delete()
-                .resourceById("Endpoint", endpointId);
+        //Setup Org B with one single endpoint
+        outcome = orgBClient.create().resource(OrganizationFactory.createValidFakeEndpoint(orgBContext.getOrgId())).execute();
+        final Endpoint orgBEndpoint = (Endpoint) outcome.getResource();
 
-        assertThrows(UnprocessableEntityException.class, delete::execute);
+        //Assert Org B can NOT delete org A's endpoint.
+        IDeleteTyped executableDelete = orgBClient.delete().resourceById("Endpoint",new IdType(orgAEndpoint.getId()).getIdPart());
+        assertThrows(AuthenticationException.class, () -> executableDelete.execute(), "Expected auth error when deleting another org's endpoint.");
+
+        //Assert Org B CAN delete their own endpoint
+        Set<String> availableEndpoints = getAvailableResources(orgBClient, Endpoint.class);
+        assertTrue(availableEndpoints.contains(orgBEndpoint.getId()), "Endpoint should be found in Org");
+        orgBClient.delete().resourceById("Endpoint",new IdType(orgBEndpoint.getId()).getIdPart()).execute();
+        availableEndpoints = getAvailableResources(orgBClient, Endpoint.class);
+        assertFalse(availableEndpoints.contains(orgBEndpoint.getId()), "Endpoint should not be found in Org.");
+    }
+
+    private <T extends IBaseResource> Set<String> getAvailableResources(IGenericClient client, Class<T> tClass){
+        Bundle result = client.search().forResource(tClass).returnBundle(Bundle.class).execute();
+        return result.getEntry().parallelStream().map(Bundle.BundleEntryComponent::getResource).map(Resource::getId).collect(Collectors.toSet());
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/GroupResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/GroupResourceTest.java
@@ -443,7 +443,7 @@ public class GroupResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    public void testOrgCanOnlyRetrieveTheirOwnGroup() throws GeneralSecurityException, IOException, URISyntaxException {
+    public void testOrgCanOnlyDeleteTheirOwnGroup() throws GeneralSecurityException, IOException, URISyntaxException {
         final TestOrganizationContext orgAContext = registerAndSetupNewOrg();
         final TestOrganizationContext orgBContext = registerAndSetupNewOrg();
         final IGenericClient orgAClient = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), orgAContext.getClientToken(), UUID.fromString(orgAContext.getPublicKeyId()), orgAContext.getPrivateKey());

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/EndpointDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/EndpointDAO.java
@@ -29,7 +29,7 @@ public class EndpointDAO extends AbstractDAO<EndpointEntity> {
         return Optional.ofNullable(get(endpointID));
     }
 
-    public List<EndpointEntity> search(UUID organizationID, UUID endpointId) {
+    public List<EndpointEntity> endpointSearch(UUID organizationID, UUID endpointId) {
         // Build a selection query to get records from the database
         final CriteriaBuilder builder = currentSession().getCriteriaBuilder();
         final CriteriaQuery<EndpointEntity> query = builder.createQuery(EndpointEntity.class);

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/EndpointDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/EndpointDAO.java
@@ -1,5 +1,6 @@
 package gov.cms.dpc.attribution.jdbi;
 
+import com.google.common.collect.Lists;
 import gov.cms.dpc.common.entities.EndpointEntity;
 import gov.cms.dpc.common.hibernate.attribution.DPCManagedSessionFactory;
 import io.dropwizard.hibernate.AbstractDAO;
@@ -7,6 +8,7 @@ import io.dropwizard.hibernate.AbstractDAO;
 import javax.inject.Inject;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 import java.util.List;
 import java.util.Optional;
@@ -27,15 +29,22 @@ public class EndpointDAO extends AbstractDAO<EndpointEntity> {
         return Optional.ofNullable(get(endpointID));
     }
 
-    public List<EndpointEntity> findByOrganization(UUID organizationID) {
+    public List<EndpointEntity> search(UUID organizationID, UUID endpointId) {
         // Build a selection query to get records from the database
         final CriteriaBuilder builder = currentSession().getCriteriaBuilder();
         final CriteriaQuery<EndpointEntity> query = builder.createQuery(EndpointEntity.class);
         final Root<EndpointEntity> root = query.from(EndpointEntity.class);
         query.select(root);
 
+        final List<Predicate> predicates = Lists.newArrayList();
 
-        query.where(builder.equal(root.get("organization").get("id"), organizationID));
+        if(organizationID!=null){
+            predicates.add(builder.equal(root.get("organization").get("id"), organizationID));
+        }
+        if(endpointId!=null){
+            predicates.add(builder.equal(root.get("id"), endpointId));
+        }
+        query.where(builder.and(predicates.toArray(Predicate[]::new)));
 
         return list(query);
     }

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/AbstractEndpointResource.java
@@ -19,7 +19,7 @@ public abstract class AbstractEndpointResource {
     public abstract Response createEndpoint(@NotNull Endpoint endpoint);
 
     @GET
-    public abstract List<Endpoint> searchEndpoints(@NotNull String organizationID);
+    public abstract List<Endpoint> searchEndpoints(@NotNull String organizationID, String resourceId);
 
     @GET
     @Path("/{endpointID}")

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
@@ -67,7 +67,7 @@ public class EndpointResource extends AbstractEndpointResource {
             endpointUUID = FHIRExtractors.getEntityUUID(resourceId);
         }
 
-        final List<EndpointEntity> endpointList = this.endpointDAO.search(orgUUID, endpointUUID);
+        final List<EndpointEntity> endpointList = this.endpointDAO.endpointSearch(orgUUID, endpointUUID);
 
         return endpointList
                 .stream()

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/EndpointResource.java
@@ -60,10 +60,14 @@ public class EndpointResource extends AbstractEndpointResource {
     @UnitOfWork
     @ApiOperation(value = "Search Endpoints", notes = "Search for Endpoints associated to the given Organization", response = Bundle.class)
     @Override
-    public List<Endpoint> searchEndpoints(@NotNull @QueryParam("organization") String organizationID) {
-        final UUID entityID = FHIRExtractors.getEntityUUID(organizationID);
+    public List<Endpoint> searchEndpoints(@NotNull @QueryParam("organization") String organizationID, @QueryParam("_id") String resourceId) {
+        final UUID orgUUID = FHIRExtractors.getEntityUUID(organizationID);
+        UUID endpointUUID = null;
+        if(resourceId!=null){
+            endpointUUID = FHIRExtractors.getEntityUUID(resourceId);
+        }
 
-        final List<EndpointEntity> endpointList = this.endpointDAO.findByOrganization(entityID);
+        final List<EndpointEntity> endpointList = this.endpointDAO.search(orgUUID, endpointUUID);
 
         return endpointList
                 .stream()

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/FHIRPatientBuilder.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/FHIRPatientBuilder.java
@@ -82,7 +82,7 @@ public class FHIRPatientBuilder {
 
     //add more test data if needed, this is just a start.
     public FHIRPatientBuilder withTestData(){
-        withName("Salvaorito", "Nacho");
+        withName("Salvadorito", "Nacho");
         withGender("other");
         withBirthDate("1991-12-01");
         return this;

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/OrganizationFactory.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/factories/OrganizationFactory.java
@@ -62,6 +62,7 @@ public class OrganizationFactory {
         return endpoint;
     }
 
+
     public static Endpoint createValidFakeEndpoint(String organizationId) {
         Endpoint endpoint = createValidFakeEndpoint();
         endpoint.setManagingOrganization(new Reference(new IdType("Organization", organizationId)));


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure your branch is named with this format: `user-initials/description-ABC-123`. For example, `jj/add-awesomeness-bcda-99999`
2. Update the PR title: `dpc-99999 Feature: Add Awesomeness`
3. Edit the text below - do not leave placeholders in the text.
4. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
5. Request a review from someone/multiple someones
-->

<!-- Replace xxx with the JIRA ticket number: -->

### Fixes [DPC-974](https://jira.cms.gov/browse/DPC-974)

<!-- Describe the problem being solved here: -->
During the audit/risk assessment of DPC API it was discovered that path authorization for the /Endpoint resource was not functioning correctly.

A fully authenticated client could have access to another organization's Endpoint resource and its operations (get,update,delete).

Affected endpoints:

GET /Endpoint 
PUT /Endpoint 
Delete /Endpoint

#### Cause:

MacaroonsAuthenticator was attempting to authorize requests to Endpoint resource by using DPC-attribution's Endpoint search API. The MacaroonsAuthenticator attempted to search for an EndpointResource filtering by "_id" (id of the resource specified in the path by the client) and "organization" (Extracted from authenticated principal/token).

 If the search returned a result it meant there was a resource with that specified id and belonging to the organization, so the request would pass the path filter and allow access to the resource.

Since dpc-attribution did not support the "_id" filter param the actual search was only using "organization", therefore all resources for the organization were being returned from dpc-attribution to the filter, and the request was allowed to proceed.

### Proposed Changes

- Update the Endpoint search in DPC-Attribution to support the filtering by resource id (_id query parameter).
- Write integration tests to verify that the MacaroonsAuthenticator filter is working as intended.

<!-- List of changes with bullet points here: -->

### Change Details

- Added optional _id filter parameter in EndpointResource search API
- Added integration tests and updated existing tests.

Currently if a client attempts to retrieve, modify, or delete an Endpoint resource that does not exist the client is presented with a 404 Not Found response. After this patch the client will return a 401 Not Authorized regardless due to the filter's inability to distinguish between a resource not existing with the specified UUID or the resource existing but not belonging to the organization making the request.

Returning a 401 for a resource not found is consistent with the rest of the resources using the PathAuthorizer, but we would need to discuss whether or not it's considered a breaking change.

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [X] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->
- Tested locally using integration tests
- make ci-app and smoke-tests were successful locally

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

- Mostly on the integration tests, missing any? Changes? Holes?
- Is returning a 401 instead of a 404 considered a breaking change? If so, how should we communicate this?

<!-- What type of feedback you want from your reviewers? -->
