### PR TITLE
Ensure smoke test dependencies exclude Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ venv: venv/bin/activate
 
 venv/bin/activate: requirements.txt
 	test -d venv || virtualenv venv
-	. venv/bin/activate; pip install -Ur requirements.txt
+	. venv/bin/activate; CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip install -Ur requirements.txt
 	touch venv/bin/activate
 
 


### PR DESCRIPTION
The `cryptography` library was [updated](https://cryptography.io/en/latest/changelog.html) on 2/7/2021 and it introduced a dependency on `Rust`.  This dependency requirement causes our usage of the library to fail.  

To aid users in building the library without `Rust`, the `cryptography` build process now outputs:
```
=============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation.html for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq.html
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation.html#rust
      5) If you are experiencing issues with Rust for *this release only* you may
         set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
      =============================DEBUG ASSISTANCE=============================
```

We should temporarily implement the workaround so that the smoke tests will execute without fail, and additionally plan a future modification to the smoke test to eliminate the dependency altogether.

### Change Details

-  Set the recommended env var (`CRYPTOGRAPHY_DONT_BUILD_RUST`) so that the `cryptography` library builds without Rust

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

The smoke test is passing [here](https://management.dpc.cms.gov/job/DPC%20-%20Smoke%20Test/1976/console), when executed from this feature branch.

### Feedback Requested

Please review.
