### PR TITLE
Remove Snyk from Github Actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,7 +6,6 @@ env:
   VAULT_PW: ${{ secrets.VAULT_PW }}
   REPORT_COVERAGE: true
   CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-  SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
 jobs:
   build-api:
@@ -39,16 +38,3 @@ jobs:
       - name: "Website Build"
         run: |
           make ci-web
-
-  snyk:
-    name: "Run Snyk Workflows"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v2
-      - name: "Run Snyk"
-        uses: snyk/actions/maven-3-jdk-11@master
-        continue-on-error: false
-        with:
-          command: test
-          args: --severity-threshold=high --all-projects --detection-depth=2 --exclude=bbcerts,docker,ig,ops,src --skip-unresolved=true


### PR DESCRIPTION
Snyk was added to Github Actions for `dpc-app` in this PR: https://github.com/CMSgov/dpc-app/pull/1150
However, it has caused PRs to be blocked because we currently do not have a stable baseline of findings.

Until the findings can be addressed and remediated, we can rely solely on the periodic scan that happens outside of CI and can be viewed in the Snyk dashboard.


### Change Details

- Updated the Github Actions pipeline so that the Snyk scan is removed.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

CI pipeline is passing in Github Actions.

### Feedback Requested

Please review.