### PR TITLE
DPC-1170: Pin GHA to ubuntu-18.04

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build-api:
     name: "Build and Test API"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v1
@@ -31,7 +31,7 @@ jobs:
 
   build-web:
     name: "Build and Test Website"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v1


### PR DESCRIPTION
### Fixes [DPC-1170](https://jira.cms.gov/browse/DPC-1170)
Ubuntu 20 does not currently include Ansible, which is required to set up our test environments.  For the moment, we will be pinning GitHub Actions to use Ubuntu 18.

### Proposed Changes
- Use Ubuntu 18.04 for both GHA tests

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

This is not a _change_ so much as a temporary reversion.  We expect the Ubuntu maintainers to include Ansible in a future update to version 20, and have a [ticket](https://jira.cms.gov/browse/DPC-1173) to remind us to review and revert this PR.

### Acceptance Validation
<img width="763" alt="Screen Shot 2021-03-03 at 10 34 31 PM" src="https://user-images.githubusercontent.com/2533561/109907627-ac126480-7c70-11eb-82c2-5e34b77a676e.png">

### Feedback Requested
- Do we need to pin both tests, since the web app is unaffected?
