### PR TITLE
Revert "DPC-1225 remove unchecked exception for bfd time regression"

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceFetcher.java
@@ -243,12 +243,12 @@ class ResourceFetcher {
         if (bundle.getMeta() == null || bundle.getMeta().getLastUpdated() == null) return;
         final var bfdTransactionTime = bundle.getMeta().getLastUpdated().toInstant().atOffset(ZoneOffset.UTC);
         if (bfdTransactionTime.isBefore(transactionTime)) {
-            // See BFD's RFC0004 for a discussion on why this type error may occur.
-            // Note: Retrying the job after a delay may fix this problem.
-            // monthly jira ticket reminder to check the progress of BFD time regression
-            logger.error("BFD transaction time regression found: BFD time {}, Job time {}",
+           // See BFD's RFC0004 for a discussion on why this type error may occur.
+           // Note: Retrying the job after a delay may fix this problem.
+            logger.error("Failing the job for a BFD transaction time regression: BFD time {}, Job time {}",
                     bfdTransactionTime,
                     transactionTime);
+            throw new JobQueueFailure("BFD's transaction time regression");
         }
     }
 }


### PR DESCRIPTION
Reverts CMSgov/dpc-app#1251

Because [BFD fixed the underlying issue](https://github.com/CMSgov/beneficiary-fhir-data/pull/516) that caused our outage, we would like to return to our position of strict enforcement of `_since` timing.