### PR TITLE
DPC-1073: Fixing docker build job

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -60,7 +60,7 @@ services:
     build:
       context: .
       dockerfile: dpc-admin/Dockerfile
-    image: dpc-admin:latest
+    image: dpc-web-admin:latest
     volumes:
       - "./dpc-admin/coverage:/dpc-admin/coverage"
       - ./tmp/letter_opener/admin:/dpc-admin/tmp/letter_opener


### PR DESCRIPTION
### Related to [DPC-1073](https://jira.cms.gov/browse/DPC-1073)

This branch fixes the broken docker image build job on jenkins: https://management.dpc.cms.gov/job/DPC%20-%20Docker%20Build/

### Proposed Changes

* changing admin app image from `dpc-admin` to `dpc-web-admin`

### Change Details

The jenkins job was failing because the docker-compose specified the wrong image for the `dpc-admin` service. That meant that rubocop was being ran on an older image that had been cached on jenkins.

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

- [x] docker build job [ran successfully](https://management.dpc.cms.gov/job/DPC%20-%20Docker%20Build/1574/)

### Feedback Requested

All feedback welcome.
