### PR TITLE
DPC 1329 Fix: Pin Postgres image version to 11

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -9,7 +9,7 @@ services:
     image: redis:latest
 
   db:
-    image: postgres
+    image: postgres:11
     environment:
       - POSTGRES_DB=dpc-website_development
       - POSTGRES_PASSWORD=dpc-safe

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   db:
-    image: postgres
+    image: postgres:11
     command: postgres -c 'max_connections=250'
     environment:
       - POSTGRES_MULTIPLE_DATABASES=dpc_attribution,dpc_queue,dpc_auth,dpc_consent,dpc-website_development

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   db:
-    image: postgres
+    image: postgres:11
     command: postgres
     environment:
       - POSTGRES_MULTIPLE_DATABASES=dpc_attribution_v2


### PR DESCRIPTION
### Fixes [DPC-1329](https://jira.cms.gov/browse/DPC-1329)

The current deployed major version of Postgres in AWS for DPC is Postgres 11.  However, in the docker-compose stacks for dpc-app, we are pulling from postgres:latest (see here for example).

We need to ensure all references to pulling Postgres images from Dockerhub in dpc-app align with the version of Postgres that we are using in AWS.  This should be `postgres:11` image in Dockerhub.


### Proposed Changes

- Pin Postgres version to 11

### Change Details

<!-- Add detailed discussion of changes here: -->

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

<!-- Were you able to fully test the acceptance criteria on the related ticket? if not, why not? -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
