### PR TITLE
Remove DB port exposure from base docker-compose file so it can be overridden

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+
+  db:
+    ports:
+      - "5432:5432"
+

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -8,6 +8,10 @@ services:
   redis:
     image: redis:latest
 
+  db:
+    ports:
+      - "5434:5432"
+
   dpc_web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@ services:
       - POSTGRES_MULTIPLE_DATABASES=dpc_attribution,dpc_queue,dpc_auth,dpc_consent,dpc-website_development,dpc-impl_development,dpc_attribution_v2
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=dpc-safe
-    ports:
-      - "5432:5432"
     volumes:
       - ./docker/postgres:/docker-entrypoint-initdb.d
 


### PR DESCRIPTION

### Fixes [DPC-1422](https://jira.cms.gov/browse/DPC-1422)

Recent changes to the CI for the `portals` docker-compose stack has caused a port clashing in Jenkins, because the Application CI and the Portals CI is run in parallel (and the DB exposes port 5432 to host in both CI executions that run in parallel).


### Change Details

- Removed the DB port mapping in `docker-compose.yml` so that it can be overridden by overriding docker-compose stacks.
- Added a `docker-compose.override.yml` file, which is [used by default](https://docs.docker.com/compose/extends/#understanding-multiple-compose-files), to perform the default DB port mapping
- Added an overridding DB port mapping in `docker-compose.portals.yml` so that there is no clash in Jenkins when `make ci-app` and `make ci-portals` are run in parallel

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

The [Jenkins Docker Build job](https://management.dpc.cms.gov/job/DPC%20-%20Docker%20Build/1659/) passes from this feature branch without port clashing.

### Feedback Requested

Please review.
