### PR TITLE
DPC-1335: Adding New Relic integration

### DIFF
--- a/dpc-impl/Gemfile
+++ b/dpc-impl/Gemfile
@@ -13,7 +13,7 @@ gem 'webpacker', '~> 5.0'
 gem 'sidekiq', '~> 6.1'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
-
+gem 'newrelic_rpm', '~> 6.10'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
 gem 'devise_invitable', '~> 2.0.0'

--- a/dpc-impl/Gemfile.lock
+++ b/dpc-impl/Gemfile.lock
@@ -149,8 +149,9 @@ GEM
     mini_mime (1.0.3)
     minitest (5.14.4)
     msgpack (1.4.2)
+    newrelic_rpm (6.15.0)
     nio4r (2.5.7)
-    nokogiri (1.11.5-x86_64-darwin)
+    nokogiri (1.11.5-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
@@ -296,6 +297,7 @@ GEM
 PLATFORMS
   x86_64-darwin-18
   x86_64-darwin-19
+  x86_64-linux-musl
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
@@ -315,6 +317,7 @@ DEPENDENCIES
   letter_opener
   letter_opener_web (~> 1.0)
   listen (~> 3.3)
+  newrelic_rpm (~> 6.10)
   pg (~> 1.1)
   pry
   pry-nav
@@ -340,4 +343,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.4
+   2.2.19

--- a/dpc-impl/config/newrelic.yml
+++ b/dpc-impl/config/newrelic.yml
@@ -1,0 +1,15 @@
+common: &default_settings
+  log_level: info
+  log_file_name: STDOUT
+
+  distributed_tracing:
+    enabled: false
+
+test:
+  <<: *default_settings
+
+development:
+  <<: *default_settings
+
+production:
+  <<: *default_settings 


### PR DESCRIPTION
### Fixes [DPC-1335](https://jira.cms.gov/browse/DPC-1335)

This branch adds the new relic gem to dpc-impl for reporting.

### Proposed Changes

* Updating `Gemfile` with dependency
* Updating `Gemfile.lock`
* Adding config file

### Change Details

To get the updates to `Gemfile.lock`, I built the impl image with `make impl` and then ran `make start-portals`. Once it was running, I copied the file out of the running container.

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

- [ ] impl service is reporting to New Relic

### Feedback Requested

All feedback is welcome.
