### PR TITLE
Fix dpc-go/dpc-attribution/docker-compose.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ down-dpc:
 start-v2: secure-envs
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml up start_core_dependencies
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml up start_api_dependencies
-	@docker-compose -p dpc-v2 -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml up -d attribution2
+	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml -f dpc-go/dpc-attribution/docker-compose.yml up -d attribution2
 	@docker-compose -p dpc-v2 -f dpc-go/dpc-api/docker-compose.yml up -d api
 	@docker ps
 

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -1,6 +1,9 @@
 version: "3"
 
 services:
+  db:
+    ports:
+      - "5432:5432"
   migrator:
     image: migrate/migrate
     depends_on:

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -1,9 +1,7 @@
 version: "3"
 
 services:
-  db:
-    ports:
-      - "5432:5432"
+
   migrator:
     image: migrate/migrate
     depends_on:

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -1,7 +1,6 @@
 version: "3"
 
 services:
-
   migrator:
     image: migrate/migrate
     depends_on:


### PR DESCRIPTION
Following changes made in [this PR](https://github.com/CMSgov/dpc-app/pull/1310), `make start-v2` was no longer exposing the port for the postgres container. According to the logs, the `dpc-go/dpc-attribution/docker-compose.yml` command was recreating the db since the migrator depended on it. This caused an error when trying to connect to the db via Postico or by using the `make seed-db` command:

```
could not connect to server: Connection refused
	Is the server running on host "localhost" (::1) and accepting
	TCP/IP connections on port 5432?
could not connect to server: Connection refused
	Is the server running on host "localhost" (127.0.0.1) and accepting
	TCP/IP connections on port 5432?
```

```
org.postgresql.util.PSQLException: Connection to localhost:5432 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
```

### Proposed Changes

- add back in `dpc-go/dpc-attribution/docker-compose.yml` the `db` service, specifying ports `5432:5432`

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [X] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

With this change, I was able to successfully start the application using `make start-v2` and to seed the db using `make seed-db`. I was also able to connect to the db in Postico and view and manipulate the data there.

<img width="1792" alt="Screen Shot 2021-06-04 at 3 54 17 PM" src="https://user-images.githubusercontent.com/12141694/120861657-3eb2f000-c54d-11eb-89e2-41645df311a3.png">

<img width="1133" alt="Screen Shot 2021-06-04 at 3 54 37 PM" src="https://user-images.githubusercontent.com/12141694/120861662-41154a00-c54d-11eb-9d84-b1ee2f60244d.png">

<img width="1211" alt="Screen Shot 2021-06-04 at 3 54 47 PM" src="https://user-images.githubusercontent.com/12141694/120861667-42467700-c54d-11eb-8dda-9645f5ab319d.png">

confirmed: Docker images still build successfully
<img width="1634" alt="Screen Shot 2021-06-04 at 4 24 27 PM" src="https://user-images.githubusercontent.com/12141694/120864171-660bbc00-c551-11eb-9cc2-59f61db6a3e9.png">


### Feedback Requested

Any
