### PR TITLE
FEAT: Add `make build-v2` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,12 @@ down-dpc:
 	@docker-compose -f docker-compose.yml -f docker-compose.portals.yml down
 	@docker ps
 
+.PHONY: build-v2
+build-v2:
+	@docker-compose -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build migrator
+	@docker-compose -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build attribution2
+	@docker-compose -f docker-compose.yml -f dpc-go/dpc-api/docker-compose.yml build api
+
 .PHONY: start-v2
 start-v2: secure-envs
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml up start_core_dependencies

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ down-dpc:
 build-v2:
 	@docker-compose -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build migrator
 	@docker-compose -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build attribution2
-	@docker-compose -f docker-compose.yml -f dpc-go/dpc-api/docker-compose.yml build api
+	@docker-compose -f dpc-go/dpc-api/docker-compose.yml build api
 
 .PHONY: start-v2
 start-v2: secure-envs

--- a/dpc-go/dpc-api/docker-compose.yml
+++ b/dpc-go/dpc-api/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   api:
     build:
-      context: .
+      context: dpc-go/dpc-api
       dockerfile: docker/Dockerfiles/Dockerfile.api
     ports:
       - "3000:3000"

--- a/dpc-go/dpc-api/docker-compose.yml
+++ b/dpc-go/dpc-api/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   api:
     build:
-      context: dpc-go/dpc-api
+      context: .
       dockerfile: docker/Dockerfiles/Dockerfile.api
     ports:
       - "3000:3000"

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -2,7 +2,9 @@ version: "3"
 
 services:
   migrator:
-    image: migrate/migrate
+    build:
+      context: dpc-go/dpc-attribution/migrator
+      dockerfile: Dockerfile
     depends_on:
       - db
     command: -path=/migrations/ -database postgres://postgres:dpc-safe@db:5432/dpc_attribution_v2?sslmode=disable up

--- a/dpc-go/dpc-attribution/migrator/README.md
+++ b/dpc-go/dpc-attribution/migrator/README.md
@@ -20,7 +20,7 @@ Assuming the last migration in the `/migrations` folder has an id of 41 a new mi
 
 ####Running Migrations
 1) Build the docker image (uses the `Dockerfile` found in this directory) that will be used to run the migration commands.
-`docker build -t migrator . -f docker/dockerfiles/Dockerfile.attribution`
+`docker build -t migrator .`
 
 *Note: The `Dockerfile` copies the files under /migrations to the image's own volume.*
 

--- a/dpc-go/dpc-attribution/src/repository/implementer_repository_test.go
+++ b/dpc-go/dpc-attribution/src/repository/implementer_repository_test.go
@@ -74,7 +74,6 @@ func (suite *ImplementerRepositoryTestSuite) TestInsert() {
 
 	expectedInsertQuery := "INSERT INTO implementers \\(name\\) VALUES \\(\\$1\\) returning id, name, created_at, updated_at, deleted_at"
 
-
 	rows := sqlmock.NewRows([]string{"id", "name", "created_at", "updated_at", "deleted_at"}).
 		AddRow(suite.fakeImplementer.ID, suite.fakeImplementer.Name, suite.fakeImplementer.CreatedAt, suite.fakeImplementer.UpdatedAt, nil)
 


### PR DESCRIPTION
Now that we have changed the context for the dpc-go docker-compose files, we need an easy way to rebuild all of the v2 components in order to use updated code. This includes migrator, attribution2, and api (v2).

### Proposed Changes

- add `make build-v2` target
- change context for dpc-api/docker-compose.yml build cmd
- add build cmd for migrator
- update migrator README

### Change Details


### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation
- `make build-v2` successfully rebuilds migrator, attribution2, and api (v2)
<img width="909" alt="Screen Shot 2021-06-07 at 1 24 05 PM" src="https://user-images.githubusercontent.com/12141694/121069893-a5c1e600-c793-11eb-8a79-3dec6f68a891.png">

### Feedback Requested

Any
