### PR TITLE
DPC-1573: Use multistage builds for V2 API and V2 Attribution

### DIFF
--- a/dpc-go/dpc-api/docker/Dockerfiles/Dockerfile.api
+++ b/dpc-go/dpc-api/docker/Dockerfiles/Dockerfile.api
@@ -1,20 +1,17 @@
-FROM golang:1.15-alpine3.12
-
+FROM golang:1.15-alpine3.12 AS builder
 RUN apk add --no-cache git
-
-# Set the Current Working Directory inside the container
 WORKDIR /app/dpc-api
-
-# We want to populate the module cache based on the go.{mod,sum} files.
 COPY src/ .
 COPY configs ../configs
 COPY swaggerui ../swaggerui
-
-# Build the Go app
 RUN go build  -o ./bin/api .
 
-# This container exposes port 8080 to the outside world
+FROM golang:1.15-alpine3.12
+RUN apk update upgrade
+RUN apk --no-cache add ca-certificates aws-cli curl
+WORKDIR /app/dpc-api
+COPY --from=builder /app/configs ../configs
+COPY --from=builder /app/swaggerui ../swaggerui
+COPY --from=builder /app/dpc-api/bin/api ./bin/api
 EXPOSE 8080
-
-# Run the binary program produced by `go install`
 CMD ["./bin/api"]

--- a/dpc-go/dpc-attribution/docker/Dockerfiles/Dockerfile.attribution
+++ b/dpc-go/dpc-attribution/docker/Dockerfiles/Dockerfile.attribution
@@ -1,19 +1,19 @@
-FROM golang:1.15-alpine3.12
-
+FROM golang:1.15-alpine3.12 AS builder
 RUN apk add --no-cache git
-
-# Set the Current Working Directory inside the container
 WORKDIR /app/dpc-attribution
-
-# We want to populate the module cache based on the go.{mod,sum} files.
 COPY src/ .
 COPY configs ../configs
-
-# Build the Go app
 RUN go build  -o ./bin/attribution .
-
-# This container exposes port 8080 to the outside world
 EXPOSE 8080
-
-# Run the binary program produced by `go install`
 CMD ["./bin/attribution"]
+
+FROM golang:1.15-alpine3.12
+RUN apk update upgrade
+RUN apk --no-cache add ca-certificates aws-cli curl
+WORKDIR /app/dpc-attribution
+COPY --from=builder /app/configs ../configs
+COPY --from=builder /app/dpc-attribution/bin/attribution ./bin/attribution
+EXPOSE 8080
+CMD ["./bin/attribution"]
+
+

--- a/dpc-go/dpc-attribution/docker/Dockerfiles/Dockerfile.attribution
+++ b/dpc-go/dpc-attribution/docker/Dockerfiles/Dockerfile.attribution
@@ -4,8 +4,6 @@ WORKDIR /app/dpc-attribution
 COPY src/ .
 COPY configs ../configs
 RUN go build  -o ./bin/attribution .
-EXPOSE 8080
-CMD ["./bin/attribution"]
 
 FROM golang:1.15-alpine3.12
 RUN apk update upgrade


### PR DESCRIPTION


### Fixes [DPC-1573](https://jira.cms.gov/browse/DPC-1573)

The V2 API and V2 Attribution Docker images currently contain all of the source code.  We should ensure that the images are lean.

### Proposed Changes

- Use multistage builds so that the final image that is used in production is lean and secure.

### Change Details

- Updated V2 API `Dockerfile` to leverage multistage builds, with a lean final image.
- Updated V2 Attribution `Dockerfile` to leverage multistage builds, with a lean final image.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

The images build successfully.  Manual inspection of the running containers was performed, and ensured that the source code has been removed.

### Feedback Requested

The scope of this modification is limited to introducing multistage builds.  However, there are a few outstanding questions which might warrant additional tickets?

(1) Is port 8080 the correct port to be exposed?  
(2) Is the CI in Github Actions building, linting, and testing these V2 containers?
(3) Should we be building Swagger documentation dynamically instead of baking it into the image from a static snapshot saved in the repo?
