### PR TITLE
Update Makefile to Ensure V2 Images are Built Appropriately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,17 +76,17 @@ down-dpc:
 
 .PHONY: build-v2
 build-v2:
-	@docker-compose -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build migrator
-	@docker-compose -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build attribution2
-	@docker-compose -f dpc-go/dpc-api/docker-compose.yml build api
-	@docker-compose -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml -f docker-compose.v2.yml build ssas
+	@docker-compose -p dpc-v2 -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build migrator
+	@docker-compose -p dpc-v2 -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build attribution2
+	@docker-compose -p dpc-v2 -f dpc-go/dpc-api/docker-compose.yml build api
+	@docker-compose -p dpc-v2 -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml -f docker-compose.v2.yml build ssas
 
 .PHONY: start-v2
 start-v2: secure-envs
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml up start_core_dependencies
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml up start_api_dependencies
-	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml -f dpc-go/dpc-attribution/docker-compose.yml up -d attribution2
-	@docker-compose -p dpc-v2 -f dpc-go/dpc-api/docker-compose.yml up -d api
+	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml -f dpc-go/dpc-attribution/docker-compose.yml up -d --build attribution2
+	@docker-compose -p dpc-v2 -f dpc-go/dpc-api/docker-compose.yml up -d --build api
 	@docker ps
 
 .PHONY: down-v2


### PR DESCRIPTION
Issues in our `Makefile` were identified:
- `start-v2` uses images in the `dpc-v2` project, and does not build new images when executed (potentially resulting in new containers containing stale code)
- `build-v2` builds new images in the default project instead of the `dpc-v2` project


### Change Details

- Updated the `build-v2` target to ensure the images are built in the `dpc-v2` project (via `-p`).  This is necessary since all the images that are run as part of `start-v2`, are specified to run in `dpc-v2` project.
- Updated the `start-v2` target to ensure stale images are rebuilt.  This is necessary in situations when `build-v2` is not used, allowing users to run containers with latest/greatest code that is built into newly built images when this target is run.

### Security Implications


- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Tested locally with successful results.

### Feedback Requested

Please review.
