### PR TITLE
DPC-1574: Add image name to V2 API and V2 Attribution

### DIFF
--- a/dpc-go/dpc-api/docker-compose.yml
+++ b/dpc-go/dpc-api/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3"
 services:
   api:
     build:
+      image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-api-go}:latest
       context: .
       dockerfile: docker/Dockerfiles/Dockerfile.api
     ports:

--- a/dpc-go/dpc-api/docker-compose.yml
+++ b/dpc-go/dpc-api/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3"
 
 services:
   api:
+    image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-api-go}:latest
     build:
-      image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-api-go}:latest
       context: .
       dockerfile: docker/Dockerfiles/Dockerfile.api
     ports:

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./dpc-go/dpc-attribution/migrator/migrations:/migrations
   attribution2:
     build:
+      image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-attribution-go}:latest
       context: dpc-go/dpc-attribution
       dockerfile: docker/Dockerfiles/Dockerfile.attribution
     depends_on:

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     volumes:
       - ./dpc-go/dpc-attribution/migrator/migrations:/migrations
   attribution2:
+    image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-attribution-go}:latest
     build:
-      image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-attribution-go}:latest
       context: dpc-go/dpc-attribution
       dockerfile: docker/Dockerfiles/Dockerfile.attribution
     depends_on:


### PR DESCRIPTION


### Partially Fixes [DPC-1574](https://jira.cms.gov/browse/DPC1574)

To ensure consistency between V1 image naming and V2 image naming, we should ensure the V2 `docker-compose` files, which are used to build the images, appropriately identify an image name for each V2 image.

### Change Details

- Added the name of the image to the V2 API and V2 Attribution `docker-compose` files.

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Local testing succeeded.

### Feedback Requested

Please review.
