### PR TITLE
Remove delve dependency from SSAS image

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -5,7 +5,6 @@ package main
 import (
 	// bcda/worker/ssas dependencies
 	_ "github.com/BurntSushi/toml"
-	_ "github.com/go-delve/delve/cmd/dlv"
 	_ "github.com/howeyc/fsnotify"
 	_ "github.com/mattn/go-colorable"
 )


### PR DESCRIPTION
This change stems from https://github.com/CMSgov/bcda-app/pull/731

DPC is not using `delve` in the DPC-specific SSAS image; it should be removed.

### Change Details

- Removed the `delve` dependency from the DPC-specific SSAS image.

NOTE: This is simply a workaround to get the team moving after incompatible delve changes were [released today](https://github.com/go-delve/delve/pull/2606).  In the future, the SSAS image should either be taken directly from ECR or pulled directly from `bcda-ssas-app` (in order to eliminate cross-project dependencies)

### Security Implications

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation

Docker Build passing.

### Feedback Requested

Please review.
