### PR TITLE
DPC-1662: Change V2 API Routes to `/api/v2`

### DIFF
--- a/dpc-go/dpc-api/src/client/ssas_client.go
+++ b/dpc-go/dpc-api/src/client/ssas_client.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/CMSgov/dpc/api/logger"
 	"github.com/CMSgov/dpc/api/model"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	"io/ioutil"
-	"net/http"
 )
 
 // SsasHTTPClientConfig is a struct to hold configuration info for retryable http client
@@ -28,7 +29,8 @@ const (
 	PostV2SystemEndpoint    string = "v2/system"
 	PostV2GroupEndpoint     string = "v2/group"
 	PostV2AuthenticateToken string = "v2/token"
-	TokenInfoEndpoint       string = "v2/token_info"
+	/* #nosec */
+	TokenInfoEndpoint string = "v2/token_info"
 )
 
 // SsasClient interface for testing purposes

--- a/dpc-go/dpc-api/src/service/admin/router.go
+++ b/dpc-go/dpc-api/src/service/admin/router.go
@@ -18,7 +18,7 @@ func buildAdminRoutes(c controllers) http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware2.Logging())
 	r.Use(middleware2.RequestIPCtx)
-	r.With(middleware2.Sanitize).Route("/v2", func(r chi.Router) {
+	r.With(middleware2.Sanitize).Route("/api/v2", func(r chi.Router) {
 		r.Use(middleware.SetHeader("Content-Type", "application/fhir+json; charset=UTF-8"))
 		r.Get("/_health", func(w http.ResponseWriter, r *http.Request) {
 			m := make(map[string]string)

--- a/dpc-go/dpc-api/src/service/admin/router_test.go
+++ b/dpc-go/dpc-api/src/service/admin/router_test.go
@@ -3,12 +3,13 @@ package admin
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/CMSgov/dpc/api/constants"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/CMSgov/dpc/api/constants"
 
 	"github.com/go-chi/chi/middleware"
 	"github.com/kinbiko/jsonassert"
@@ -114,7 +115,7 @@ func (suite *RouterTestSuite) TestHealthRoute() {
 
 	ts := httptest.NewServer(suite.router)
 
-	res, _ := http.Get(fmt.Sprintf("%s/%s", ts.URL, "v2/_health"))
+	res, _ := http.Get(fmt.Sprintf("%s/%s", ts.URL, "api/v2/_health"))
 
 	assert.Equal(suite.T(), "application/fhir+json; charset=UTF-8", res.Header.Get("Content-Type"))
 	assert.Equal(suite.T(), http.StatusOK, res.StatusCode)
@@ -130,7 +131,7 @@ func (suite *RouterTestSuite) TestErrorHandling() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/%s", ts.URL, "v2/Organization/12345"), nil)
+	req, _ := http.NewRequest(http.MethodDelete, fmt.Sprintf("%s/%s", ts.URL, "api/v2/Organization/12345"), nil)
 	req.Header.Set(middleware.RequestIDHeader, "54321")
 	res, _ := http.DefaultClient.Do(req)
 
@@ -167,7 +168,7 @@ func (suite *RouterTestSuite) TestOrganizationPostRoute() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s", ts.URL, "v2/Organization"), strings.NewReader(apitest.Orgjson))
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/%s", ts.URL, "api/v2/Organization"), strings.NewReader(apitest.Orgjson))
 	req.Header.Set("Content-Type", "application/fhir+json")
 	req.Header.Set(middleware.RequestIDHeader, "54321")
 	res, _ := http.DefaultClient.Do(req)
@@ -196,7 +197,7 @@ func (suite *RouterTestSuite) TestOrganizationDeleteRoutes() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/%s", ts.URL, "v2/Organization/12345"), nil)
+	req, _ := http.NewRequest("DELETE", fmt.Sprintf("%s/%s", ts.URL, "api/v2/Organization/12345"), nil)
 	req.Header.Set(middleware.RequestIDHeader, "54321")
 	res, _ := http.DefaultClient.Do(req)
 
@@ -221,7 +222,7 @@ func (suite *RouterTestSuite) TestOrganizationPutRoutes() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/%s", ts.URL, "v2/Organization/12345"), strings.NewReader(apitest.Orgjson))
+	req, _ := http.NewRequest(http.MethodPut, fmt.Sprintf("%s/%s", ts.URL, "api/v2/Organization/12345"), strings.NewReader(apitest.Orgjson))
 	req.Header.Set(middleware.RequestIDHeader, "54321")
 	res, _ := http.DefaultClient.Do(req)
 
@@ -246,7 +247,7 @@ func (suite *RouterTestSuite) TestPostSystemProxyRoute() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/%s", ts.URL, "v2/Implementer/12345/Org/123/system"), strings.NewReader("{}"))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/%s", ts.URL, "api/v2/Implementer/12345/Org/123/system"), strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	fmt.Println(err)
@@ -264,7 +265,7 @@ func (suite *RouterTestSuite) TestOrganizationGetRoutes() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", ts.URL, "v2/Organization/12345"), nil)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", ts.URL, "api/v2/Organization/12345"), nil)
 	req.Header.Set(middleware.RequestIDHeader, "54321")
 	res, _ := http.DefaultClient.Do(req)
 

--- a/dpc-go/dpc-api/src/service/public/router.go
+++ b/dpc-go/dpc-api/src/service/public/router.go
@@ -18,8 +18,8 @@ func buildPublicRoutes(cont controllers, ssasClient client.SsasClient) http.Hand
 	r := chi.NewRouter()
 	r.Use(middleware2.Logging())
 	r.Use(middleware2.RequestIPCtx)
-	fileServer(r, "/v2/swagger", http.Dir("../swaggerui"))
-	r.With(middleware2.Sanitize).Route("/v2", func(r chi.Router) {
+	fileServer(r, "/api/v2/swagger", http.Dir("../swaggerui"))
+	r.With(middleware2.Sanitize).Route("/api/v2", func(r chi.Router) {
 		r.Use(middleware.SetHeader("Content-Type", "application/fhir+json; charset=UTF-8"))
 		r.Get("/metadata", cont.Metadata.Read)
 		r.Get("/_health", func(w http.ResponseWriter, r *http.Request) {

--- a/dpc-go/dpc-api/src/service/public/router_test.go
+++ b/dpc-go/dpc-api/src/service/public/router_test.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/CMSgov/dpc/api/client"
-	"github.com/CMSgov/dpc/api/constants"
-	"github.com/CMSgov/dpc/api/model"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/CMSgov/dpc/api/client"
+	"github.com/CMSgov/dpc/api/constants"
+	"github.com/CMSgov/dpc/api/model"
 
 	"github.com/CMSgov/dpc/api/apitest"
 	"github.com/go-chi/chi/middleware"
@@ -186,7 +187,7 @@ func (suite *RouterTestSuite) TestMetadataRoute() {
 
 	ts := httptest.NewServer(suite.router)
 
-	res, _ := http.Get(fmt.Sprintf("%s/%s", ts.URL, "v2/metadata"))
+	res, _ := http.Get(fmt.Sprintf("%s/%s", ts.URL, "api/v2/metadata"))
 
 	assert.Equal(suite.T(), "application/fhir+json; charset=UTF-8", res.Header.Get("Content-Type"))
 	assert.Equal(suite.T(), http.StatusOK, res.StatusCode)
@@ -197,7 +198,7 @@ func (suite *RouterTestSuite) TestHealthRoute() {
 
 	ts := httptest.NewServer(suite.router)
 
-	res, _ := http.Get(fmt.Sprintf("%s/%s", ts.URL, "v2/_health"))
+	res, _ := http.Get(fmt.Sprintf("%s/%s", ts.URL, "api/v2/_health"))
 
 	assert.Equal(suite.T(), "application/fhir+json; charset=UTF-8", res.Header.Get("Content-Type"))
 	assert.Equal(suite.T(), http.StatusOK, res.StatusCode)
@@ -216,7 +217,7 @@ func (suite *RouterTestSuite) TestGroupExportRoute() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", ts.URL, "v2/Group/9876/$export"), nil)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", ts.URL, "api/v2/Group/9876/$export"), nil)
 	req.Header.Add("Authorization", "Bearer hello")
 
 	req.Header.Set("Content-Type", "application/fhir+json")
@@ -249,7 +250,7 @@ func (suite *RouterTestSuite) TestOrganizationGetRoutes() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", ts.URL, "v2/Organization/12345"), nil)
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", ts.URL, "api/v2/Organization/12345"), nil)
 	req.Header.Add("Authorization", "Bearer hello")
 
 	req.Header.Set(middleware.RequestIDHeader, "54321")
@@ -276,7 +277,7 @@ func (suite *RouterTestSuite) TestGetAuthTokenProxyRoute() {
 
 	ts := httptest.NewServer(suite.router)
 
-	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/%s", ts.URL, "v2/Token/auth"), strings.NewReader("{}"))
+	req, _ := http.NewRequest("POST", fmt.Sprintf("%s/%s", ts.URL, "api/v2/Token/auth"), strings.NewReader("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	fmt.Println(err)

--- a/dpc-go/dpc-attribution/src/repository/organization_repository_test.go
+++ b/dpc-go/dpc-attribution/src/repository/organization_repository_test.go
@@ -118,7 +118,7 @@ func (suite *OrganizationRepositoryTestSuite) TestInsertErrorInRepo() {
 
 	expectedInsertQuery := `INSERT INTO organizations \(info\) VALUES \(\$1\) returning id, version, created_at, updated_at, info`
 
-	rows = sqlmock.NewRows([]string{"id", "version", "created_at", "updated_at", "info"})
+	_ = sqlmock.NewRows([]string{"id", "version", "created_at", "updated_at", "info"})
 
 	mock.ExpectQuery(expectedInsertQuery).WithArgs(suite.fakeOrg.Info).WillReturnError(errors.New("error"))
 

--- a/dpc-go/postman/developer-edition/DPC V2 - Developer's Edition.postman_collection.json
+++ b/dpc-go/postman/developer-edition/DPC V2 - Developer's Edition.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "9b6f3285-3168-4a0b-bf8a-7fba1f12d4c6",
+		"_postman_id": "fd2454f3-c671-40b9-b710-b2d4e16aaff6",
 		"name": "DPC V2 - Developer's Edition",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -67,11 +67,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{api_public_base}}/v2/Group",
+							"raw": "{{api_public_base}}/api/v2/Group",
 							"host": [
 								"{{api_public_base}}"
 							],
 							"path": [
+								"api",
 								"v2",
 								"Group"
 							]
@@ -113,11 +114,12 @@
 							}
 						],
 						"url": {
-							"raw": "{{api_public_base}}/v2/Group/{{group_id}}/$export?_outputFormat=ndjson",
+							"raw": "{{api_public_base}}/api/v2/Group/{{group_id}}/$export?_outputFormat=ndjson",
 							"host": [
 								"{{api_public_base}}"
 							],
 							"path": [
+								"api",
 								"v2",
 								"Group",
 								"{{group_id}}",
@@ -173,11 +175,12 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api_public_base}}/v2/Data/",
+							"raw": "{{api_public_base}}/api/v2/Data/",
 							"host": [
 								"{{api_public_base}}"
 							],
 							"path": [
+								"api",
 								"v2",
 								"Data",
 								""
@@ -207,11 +210,12 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{api_public_base}}/v2/Organization/{{organization_id}}",
+							"raw": "{{api_public_base}}/api/v2/Organization/{{organization_id}}",
 							"host": [
 								"{{api_public_base}}"
 							],
 							"path": [
+								"api",
 								"v2",
 								"Organization",
 								"{{organization_id}}"

--- a/dpc-go/postman/functional-tests/DPC_V2_Functional_Tests.postman_collection.json
+++ b/dpc-go/postman/functional-tests/DPC_V2_Functional_Tests.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "d313d3bd-04e6-4d4b-9a03-437f3bce76fc",
+		"_postman_id": "f8738712-b93b-48b4-811f-ab8323268e4e",
 		"name": "DPC V2 Functional Tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -51,13 +51,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Organization/",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Organization/",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Organization",
 										""
@@ -105,13 +106,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Organization/",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Organization/",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Organization",
 										""
@@ -150,13 +152,14 @@
 									}
 								],
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Organization/{{organization_id}}",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Organization/{{organization_id}}",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Organization",
 										"{{organization_id}}"
@@ -195,13 +198,14 @@
 									}
 								],
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Organization/00000000-5671-473f-b3fe-ed5a0551a2d7",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Organization/00000000-5671-473f-b3fe-ed5a0551a2d7",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Organization",
 										"00000000-5671-473f-b3fe-ed5a0551a2d7"
@@ -235,13 +239,14 @@
 									}
 								],
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Organization/{{organization_id}}",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Organization/{{organization_id}}",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Organization",
 										"{{organization_id}}"
@@ -280,13 +285,14 @@
 									}
 								],
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Organization/{{organization_id}}",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Organization/{{organization_id}}",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Organization",
 										"{{organization_id}}"
@@ -348,13 +354,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer"
 									]
@@ -399,13 +406,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/org",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/org",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -480,13 +488,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/org",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/org",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -531,13 +540,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/org",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/org",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -612,13 +622,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/org",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/org",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -678,13 +689,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer"
 									]
@@ -758,13 +770,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/org",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/org",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -834,13 +847,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/Org/{{organization_id}}/system",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/Org/{{organization_id}}/system",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -919,13 +933,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/Org/{{organization_id}}/system",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/Org/{{organization_id}}/system",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -976,13 +991,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/Org/123456-fake-1234/system",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/Org/123456-fake-1234/system",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -1028,13 +1044,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/Org/0fe60651-1634-4d43-9f39-b4d34651f21d/system",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/Org/0fe60651-1634-4d43-9f39-b4d34651f21d/system",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -1085,13 +1102,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Implementer/{{implementer_id}}/Org/0fe60651-1634-4d43-9f39-b4d34651f21d/system",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Implementer/{{implementer_id}}/Org/0fe60651-1634-4d43-9f39-b4d34651f21d/system",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Implementer",
 										"{{implementer_id}}",
@@ -1147,13 +1165,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/v2/Organization/",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_admin_port}}/api/v2/Organization/",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_admin_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Organization",
 										""
@@ -1202,13 +1221,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/v2/Group/",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/api/v2/Group/",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_public_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Group",
 										""
@@ -1276,13 +1296,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/v2/Group/{{group_id}}/$export?_outputFormat=application/ndjson",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/api/v2/Group/{{group_id}}/$export?_outputFormat=application/ndjson",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_public_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Group",
 										"{{group_id}}",
@@ -1354,13 +1375,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/v2/Jobs/{{job-id}}",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/api/v2/Jobs/{{job-id}}",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_public_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Jobs",
 										"{{job-id}}"
@@ -1405,13 +1427,14 @@
 									}
 								],
 								"url": {
-									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/v2/Data/{{ndjson_file}}",
+									"raw": "{{api_admin_protocol}}://{{api_admin_host}}:{{api_public_port}}/api/v2/Data/{{ndjson_file}}",
 									"protocol": "{{api_admin_protocol}}",
 									"host": [
 										"{{api_admin_host}}"
 									],
 									"port": "{{api_public_port}}",
 									"path": [
+										"api",
 										"v2",
 										"Data",
 										"{{ndjson_file}}"


### PR DESCRIPTION
### Fixes [DPC-1662](https://jira.cms.gov/browse/DPC-1662)

The SRE team has requested that all public and admin api routes be based off of `/api/v2` instead of `/v2`

### Proposed Changes

- update public and admin routes to be based off of `/api/v2`
- update unit tests
- update postman tests

### Change Details
### Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

- Unit tests for API all pass
- Postman requests do not return 404s when using `/api/v2`

<img width="770" alt="Screen Shot 2021-08-10 at 3 08 38 PM" src="https://user-images.githubusercontent.com/12141694/128930250-5d1f3dd4-897a-410a-9758-09aa635e4db2.png">


### Feedback Requested

Any