### PR TITLE
DPC-1575: Move attribution v2 migrator to Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,6 @@ down-dpc:
 
 .PHONY: build-v2
 build-v2:
-	@docker-compose -p dpc-v2 -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build migrator
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f dpc-go/dpc-attribution/docker-compose.yml build attribution2
 	@docker-compose -p dpc-v2 -f dpc-go/dpc-api/docker-compose.yml build api
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.v2.yml build --no-cache ssas-migrate

--- a/dpc-go/dpc-attribution/docker-compose.yml
+++ b/dpc-go/dpc-attribution/docker-compose.yml
@@ -1,22 +1,11 @@
 version: "3"
 
 services:
-  migrator:
-    build:
-      context: dpc-go/dpc-attribution/migrator
-      dockerfile: Dockerfile
-    depends_on:
-      - db
-    command: -path=/migrations/ -database postgres://postgres:dpc-safe@db:5432/dpc_attribution_v2?sslmode=disable up
-    volumes:
-      - ./dpc-go/dpc-attribution/migrator/migrations:/migrations
   attribution2:
     image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-attribution-go}:latest
     build:
       context: dpc-go/dpc-attribution
       dockerfile: docker/Dockerfiles/Dockerfile.attribution
-    depends_on:
-      - migrator
     ports:
       - "3001:3001"
     environment:

--- a/dpc-go/dpc-attribution/docker/Dockerfiles/Dockerfile.attribution
+++ b/dpc-go/dpc-attribution/docker/Dockerfiles/Dockerfile.attribution
@@ -5,12 +5,17 @@ COPY src/ .
 COPY configs ../configs
 RUN go build  -o ./bin/attribution .
 
+FROM migrate/migrate AS migrator
+WORKDIR /usr/local/bin
+
 FROM golang:1.15-alpine3.12
 RUN apk update upgrade
 RUN apk --no-cache add ca-certificates aws-cli curl
 WORKDIR /app/dpc-attribution
 COPY --from=builder /app/configs ../configs
 COPY --from=builder /app/dpc-attribution/bin/attribution ./bin/attribution
-CMD ["./bin/attribution"]
+COPY docker/Dockerfiles/entrypoint.sh entrypoint.sh
+COPY --from=migrator migrate migrate
+COPY migrator/migrations migrations
 
-
+CMD ["./entrypoint.sh"]

--- a/dpc-go/dpc-attribution/docker/Dockerfiles/entrypoint.sh
+++ b/dpc-go/dpc-attribution/docker/Dockerfiles/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+set -ex
+
+./migrate -path=./migrations/ -database "${DPC_DB_URL}?sslmode=disable" up
+
+./bin/attribution

--- a/dpc-go/dpc-attribution/migrator/README.md
+++ b/dpc-go/dpc-attribution/migrator/README.md
@@ -33,4 +33,4 @@ Assuming the last migration in the `/migrations` folder has an id of 41 a new mi
     * *You may roll back a specific migration by specifying the id*
   
 ####Checking Schema Version
-The table `shema_migrations` contains the most recent migration and its status.
+The table `schema_migrations` contains the most recent migration and its status.


### PR DESCRIPTION
### Fixes [DPC-1575](https://jira.cms.gov/browse/DPC-1575)

This PR is part of the work needed to complete DPC-1575.
SRE team requires the migrator to be run as part of running attribution v2

### Proposed Changes

- include the migrator image in the attribution v2 Dockerfile
- add entrypoint script to run the migrations
- update docker-compose for attribution and Makefile make build-v2 target to drop separate migrator build
- fix typo in migrator README

### Change Details


### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

### Acceptance Validation

- Running `make start-v2` successfully starts up attribution v2 (and other services) normally and also automatically migrates attribution v2

<img width="688" alt="Screen Shot 2021-08-11 at 10 35 11 AM" src="https://user-images.githubusercontent.com/12141694/129059259-96f31e8a-868f-4b87-a91c-ea4913182766.png">

### Feedback Requested

Does the migrator README need to be changed more or dropped entirely? I think the manual instructions could still be helpful when not using docker, but am open to other thoughts.
