### PR TITLE
DPC-1667: Upgrade dependencies in response to Snyk alerts

### DIFF
--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -34,6 +34,16 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.17</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.24</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jmeter</groupId>
             <artifactId>ApacheJMeter_core</artifactId>
             <version>${jmeter.version}</version>


### PR DESCRIPTION
### Fixes [DPC-1667](https://jira.cms.gov/browse/DPC-1667)

Snyk has indicated that there may be vulnerabilities from `com.thoughtworks.xstream` and `org.apache.pdfbox`. Upon further inspection, these are both dependencies of org.apache.jmeter, which we only use for our smoke tests. Jmeter is using older versions of these two libraries, but their newer versions have been updated to deal with the vulnerabilities indicated by Snyk.

### Proposed Changes

override the versions of xstream and pdfbox to their newest stable versions instead of those used by jmeter

### Change Details

since we are not using these libraries directly, but instead they are used by our dependency (jmeter), we need add both of them to the pom before jmeter so that jmeter will use these versions instead of installing its own, outdated dependencies.

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [x] new software dependencies
While not completely new (these were already in use by jmeter), added newer versions of the following dependencies to override the versions installed by jmeter:
  - com.thoughtworks.xstream v 1.4.17
  - org.apache.pdfbox v 2.0.24

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [x] requires more information or team discussion to evaluate security implications
While it seems to add dependencies, we're just pinning secondary dependencies to a non-vulnerable version

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [x] no PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->

Overriding dependencies of Jmeter which we only use in Smoke tests.

### Acceptance Validation

- successful build 
- unit tests pass
- **Local Snyk scan does not include the xstream or pdfbox vulnerabilities**
- smoke tests pass
<img width="713" alt="Screen Shot 2021-08-12 at 6 26 23 PM" src="https://user-images.githubusercontent.com/12141694/129282921-fcb302c0-6dae-4184-8db4-ac415491fda3.png">

### Feedback Requested
Any