### PR TITLE
DPC-1830: Install Postges Extensions in Container Init instead of DB Migrations

### DIFF
--- a/docker/postgres/postgres-multiple-db-init.sh
+++ b/docker/postgres/postgres-multiple-db-init.sh
@@ -13,10 +13,21 @@ function create_user_and_database() {
 EOSQL
 }
 
+function enable_extension() {
+	local database=$1
+	local extension=$2
+	echo "  Enabling extension '$extension' on database '$database'"
+	psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$database" <<-EOSQL
+	    CREATE EXTENSION IF NOT EXISTS "$extension";
+EOSQL
+}
+
 if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
 	echo "Multiple database creation requested: $POSTGRES_MULTIPLE_DATABASES"
 	for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
 		create_user_and_database $db
+		if [ $db = "dpc_attribution_v2" ]; then
+			enable_extension $db pgcyrpto
 	done
 	echo "Multiple databases created"
 fi

--- a/docker/postgres/postgres-multiple-db-init.sh
+++ b/docker/postgres/postgres-multiple-db-init.sh
@@ -27,7 +27,8 @@ if [ -n "$POSTGRES_MULTIPLE_DATABASES" ]; then
 	for db in $(echo $POSTGRES_MULTIPLE_DATABASES | tr ',' ' '); do
 		create_user_and_database $db
 		if [ $db = "dpc_attribution_v2" ]; then
-			enable_extension $db pgcyrpto
+			enable_extension $db "pgcrypto"
+		fi
 	done
 	echo "Multiple databases created"
 fi

--- a/dpc-go/dpc-attribution/migrator/migrations/1_create_org_table.up.sql
+++ b/dpc-go/dpc-attribution/migrator/migrations/1_create_org_table.up.sql
@@ -1,4 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE TABLE organization (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     version bigint DEFAULT 0,

--- a/dpc-go/dpc-attribution/migrator/migrations/2_create_group_table.up.sql
+++ b/dpc-go/dpc-attribution/migrator/migrations/2_create_group_table.up.sql
@@ -1,5 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-
 CREATE TABLE "group" (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     organization_id uuid NOT NULL,

--- a/dpc-go/dpc-attribution/migrator/migrations/3_create_implementer_table.up.sql
+++ b/dpc-go/dpc-attribution/migrator/migrations/3_create_implementer_table.up.sql
@@ -1,4 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE TABLE "implementers" (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     name varchar(200) NOT NULL,

--- a/dpc-go/dpc-attribution/migrator/migrations/4_create_implementer_org_relation_table.up.sql
+++ b/dpc-go/dpc-attribution/migrator/migrations/4_create_implementer_org_relation_table.up.sql
@@ -1,4 +1,3 @@
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
 CREATE TABLE "implementer_org_relations" (
     id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
     implementer_id uuid NOT NULL,


### PR DESCRIPTION


### Partially Fixes [DPC-1830](https://jira.cms.gov/browse/DPC-1830)

When the DB migrations are run in AWS RDS, they fail because extension installation requires superuser privileges.  Instead, th


### Change Details

- For local development/CI, the extension installation was moved to the DB container init script

### Security Implications

For local development/CI, the installation of the `pgcrypto` extension (which is required for UUID generation) was simply moved.  The end result of the local DB container is the same.

- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change


### Acceptance Validation

Tested locally:

```
$ docker logs 653b484a144e | grep extension
  Enabling extension 'pgcrypto' on database 'dpc_attribution_v2'
  ```

Tested in AWS in conjunction with [this PR](https://github.com/CMSgov/dpc-ops/pull/408).  The Jenkins deployment succeeded [here](https://management.dpc.cms.gov/job/DPC%20-%20Full%20Deploy%20and%20Release/1581/).

```
dpc_attribution_v2=> select * from pg_extension;
 extname  | extowner | extnamespace | extrelocatable | extversion | extconfig | extcondition 
----------+----------+--------------+----------------+------------+-----------+--------------
 plpgsql  |       10 |           11 | f              | 1.0        |           | 
 pgcrypto |       10 |         2200 | t              | 1.3        |           | 
(2 rows)
```

### Feedback Requested

Please review.
