### PR TITLE
DPC-1875: Implementer portal email server configuration

### DIFF
--- a/dpc-adminv2/config/environments/production.rb
+++ b/dpc-adminv2/config/environments/production.rb
@@ -119,4 +119,19 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
+  config.action_mailer.default_url_options = { host: ENV['HOST_NAME'], port: ENV['PORT'] }
+  config.action_mailer.asset_host = "https://#{ENV['HOST_NAME']}:#{ENV['PORT']}"
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              ENV['SMTP_ADDRESS'],
+    port:                 ENV['SMTP_PORT'],
+    domain:               ENV['SMTP_DOMAIN'],
+    user_name:            ENV['SMTP_USER_NAME'],
+    password:             ENV['SMTP_PASSWORD'],
+    authentication:       ENV['SMTP_AUTH'],
+    openssl_verify_mode:  ENV['SMTP_SSL_VERIFY'],
+    enable_starttls_auto: true
+  }
 end

--- a/dpc-impl/config/environments/production.rb
+++ b/dpc-impl/config/environments/production.rb
@@ -140,4 +140,16 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: ENV['HOST_NAME'], port: ENV['PORT'] }
   config.action_mailer.asset_host = "https://#{ENV['HOST_NAME']}:#{ENV['PORT']}"
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              ENV['SMTP_ADDRESS'],
+    port:                 ENV['SMTP_PORT'],
+    domain:               ENV['SMTP_DOMAIN'],
+    user_name:            ENV['SMTP_USER_NAME'],
+    password:             ENV['SMTP_PASSWORD'],
+    authentication:       ENV['SMTP_AUTH'],
+    openssl_verify_mode:  ENV['SMTP_SSL_VERIFY'],
+    enable_starttls_auto: true
+  }
 end


### PR DESCRIPTION
### Fixes [DPC-1875](https://jira.cms.gov/browse/DPC-1875)
In the implementer portal the `production` configuration did not read the email server configuration from the environment. This PR reads these values, including email server URL, port, etc.

### Proposed Changes
- Read email server configuration values from environment variables (implementer portal)
- Copy the same configuration code to the v2 admin portal 

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
This is a bug fix for work in previous sprints with SIA and security checklists
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change

### Acceptance Validation
#### Emails are now being sent
<img width="795" alt="Screen Shot 2021-10-01 at 12 23 53 PM" src="https://user-images.githubusercontent.com/2533561/135655150-2723e7c1-b43a-4877-867c-afd6dd174627.png">

### Feedback Requested
Any changes needed?