### PR TITLE
dpc-1899 Feature: Puma dependency update

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -6,7 +6,7 @@ ruby '2.7.2'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.1.3', '>= 6.1.3.2'
 gem 'dotenv-rails', groups: [:development, :test]
-gem 'puma', '~> 4.3.8'
+gem 'puma', '~> 4.3.9'
 gem 'redis', '~> 4.0'
 gem 'luhnacy', '~> 0.2.1'
 gem 'omniauth-rails_csrf_protection', '~> 0.1'

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -284,7 +284,7 @@ GEM
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
     public_suffix (4.0.6)
-    puma (4.3.8)
+    puma (4.3.10)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -496,7 +496,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   pry-nav
-  puma (~> 4.3.8)
+  puma (~> 4.3.9)
   rails (~> 6.1.3, >= 6.1.3.2)
   rails-controller-testing
   rbnacl

--- a/dpc-adminv2/Gemfile
+++ b/dpc-adminv2/Gemfile
@@ -7,7 +7,7 @@ ruby '2.7.2'
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 gem 'pg', '~> 1.1'
 # Use Puma as the app server
-gem 'puma', '~> 5.0'
+gem 'puma', '>= 5.5.1'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6.0.0'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/dpc-adminv2/Gemfile.lock
+++ b/dpc-adminv2/Gemfile.lock
@@ -215,7 +215,7 @@ GEM
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
     public_suffix (4.0.6)
-    puma (5.4.0)
+    puma (5.5.2)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -394,7 +394,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry
   pry-nav
-  puma (~> 5.0)
+  puma (>= 5.5.1)
   rails (~> 6.1.4, >= 6.1.4.1)
   rails-controller-testing (>= 1.0.5)
   redis (~> 4.0)

--- a/dpc-impl/Gemfile
+++ b/dpc-impl/Gemfile
@@ -5,7 +5,7 @@ ruby '2.7.2'
 
 gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 gem 'pg', '~> 1.1'
-gem 'puma', '>= 5.3.1'
+gem 'puma', '>= 5.5.1'
 gem 'redis', '~> 4.0'
 gem 'sass-rails', '>= 6.0.0'
 gem 'webpacker', '~> 5.4', '>= 5.4.0'

--- a/dpc-impl/Gemfile.lock
+++ b/dpc-impl/Gemfile.lock
@@ -194,9 +194,9 @@ GEM
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
     public_suffix (4.0.6)
-    puma (5.4.0)
+    puma (5.5.2)
       nio4r (~> 2.0)
-    puma (5.4.0-java)
+    puma (5.5.2-java)
       nio4r (~> 2.0)
     racc (1.5.2)
     racc (1.5.2-java)
@@ -388,7 +388,7 @@ DEPENDENCIES
   pg (~> 1.1)
   pry
   pry-nav
-  puma (>= 5.3.1)
+  puma (>= 5.5.1)
   rails (~> 6.1.4, >= 6.1.4.1)
   rails-controller-testing (>= 1.0.5)
   redis (~> 4.0)

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -7,7 +7,7 @@ ruby '2.7.2'
 
 # Anchored versions, do not bump without testing
 gem 'rails', '~> 6.1.3', '>= 6.1.3.2'
-gem 'puma', '>= 5.3.1'
+gem 'puma', '>= 5.5.1'
 gem 'redis', '~> 4.0'
 gem 'coffee-rails', '~> 5.0', '>= 5.0.0'
 gem 'kramdown', '~> 2.3', '>= 2.3.1'

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -317,9 +317,9 @@ GEM
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
     public_suffix (4.0.6)
-    puma (5.4.0)
+    puma (5.5.2)
       nio4r (~> 2.0)
-    puma (5.4.0-java)
+    puma (5.5.2-java)
       nio4r (~> 2.0)
     racc (1.5.2)
     racc (1.5.2-java)
@@ -557,7 +557,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   pry-nav
-  puma (>= 5.3.1)
+  puma (>= 5.5.1)
   rails (~> 6.1.3, >= 6.1.3.2)
   rails-controller-testing (>= 1.0.5)
   redis (~> 4.0)


### PR DESCRIPTION
### Fixes [DPC-1899](https://jira.cms.gov/browse/DPC-1899)

The `bundle audit` command has found a vulnerability of the `puma` package used within our various rails projects. For more details, see the [CVE page](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41136)

### Proposed Changes

Bump the version(s) of `puma` to the up-to-date and current minor version.

### Change Details

- Bump `dpc-web` puma package to `5.5.2`
- Bump `dpc-impl` puma package to `5.5.2`
- Bump `dpc-adminv2` puma package to `5.5.2`
- Bump `dpc-admin` puma package to `4.3.9`

### Security Implications

- [ ] new software dependencies

- [ ] security controls or supporting software altered

- [ ] new data stored or transmitted

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications

- [x] no PHI/PII is affected by this change

### Acceptance Validation

`puma` package has been bumped to the newest minor version that has no possible security vulnerabilities and passes the bundle audit.

### Feedback Requested

General feedback always appreciated.