### PR TITLE
DPC-1946: Ignore nokogiri false positive

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -153,4 +153,8 @@ ignore:
     - '*':
         reason: see DPC-1757, used only for kicking off smoke tests
         created: 2021-11-10T15:36:14.559Z
+  SNYK-RUBY-NOKOGIRI-1726792:
+    - '*':
+        reason: false positive; alert says to upgrade to already-installed version
+        created: 2021-11-17T13:35:10.514Z
 patch: {}


### PR DESCRIPTION
### Fixes [DPC-1946](https://jira.cms.gov/browse/DPC-1946)
Snyk is reporting that we need to upgrade to the latest version of `nokogiri`. We did 😄 .

### Proposed Changes
- Ignore this alert

### Security Implications
- [ ] new software dependencies
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] requires more information or team discussion to evaluate security implications
- [x] no PHI/PII is affected by this change
This PR does not have any change to application behavior or installed software versions.

### Acceptance Validation
I have validated that we're running the version of `nokogiri` that addresses the vulnerability, and that after this change a local snyk test no longer reports it.

### Feedback Requested
Any issues?
