### PR TITLE
DPC-2004: Exclude JMeter

### DIFF
--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -65,9 +65,17 @@
                     <artifactId>xercesImpl</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.apache.jmeter</groupId>
-                    <artifactId>ApacheJMeter_core</artifactId>
-                </exclusion>	
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-1.2-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- tika parser explicit upgrade to something that doesn't break snyk -->

--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -64,6 +64,10 @@
                     <groupId>xerces</groupId>
                     <artifactId>xercesImpl</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.jmeter</groupId>
+                    <artifactId>ApacheJMeter_core</artifactId>
+                </exclusion>	
             </exclusions>
         </dependency>
         <!-- tika parser explicit upgrade to something that doesn't break snyk -->


### PR DESCRIPTION
### Fixes [DPC-2004](https://jira.cms.gov/browse/DPC-2004)
Until a release of `JMeter` is available that upgrades `log4j`, we should exclude `log4j` from the dependencies loaded by `JMeter`.

### Proposed Changes
- Explicitly exclude all `log4j` references from `JMeter` in the `dpc-smoketest`

### Security Implications
- [ ] new software dependencies
On the contrary: dependencies are dropped by this PR
- [ ] security controls or supporting software altered
- [ ] new data stored or transmitted
- [ ] security checklist is completed for this change
This and related PRs #1531 and #1532 are in response to a vulnerability in `log4j` that requires urgent response
- [ ] requires more information or team discussion to evaluate security implications
- [X] no PHI/PII is affected by this change

### Acceptance Validation
![Screen Shot 2021-12-13 at 9 27 43 PM](https://user-images.githubusercontent.com/2533561/145922295-f843661c-eed8-4a21-9382-b92c92aca5b4.png)
![Screen Shot 2021-12-13 at 9 27 14 PM](https://user-images.githubusercontent.com/2533561/145922298-138934b8-4153-43b2-b014-788a77bdb6ee.png)

### Feedback Requested
Should more be excluded? Less?