### PR TITLE
Revert #1531

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,17 +310,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.15.0</version>
-        </dependency>
-
         <!--Test resources-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
PR #1531 causes the local build to fail. The maven dependency tree does not add a `log4j` reference when it is reverted; it is an unnecessary step in `log4shell` remediation.