### PR TITLE
[DPC-2297] Update gson Maven dependency to 2.9.0

### DIFF
--- a/dpc-aggregation/pom.xml
+++ b/dpc-aggregation/pom.xml
@@ -138,7 +138,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.9.0</version>
         </dependency>
     </dependencies>
 

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -200,7 +200,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.9.0</version>
         </dependency>
     </dependencies>
 

--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.9.0</version>
         </dependency>
 
         <!--Test resources-->

--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>2.9.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Fixes [DPC-2297](https://jira.cms.gov/browse/DPC-2297)

### Change Details

Update gson Maven dependency 2.8.9 -> 2.9.0 to keep dependencies up to date

### Security Implications

- [x] new software dependencies

