### PR TITLE
[DPC-2297] Upgrade hibernate-core to lastest version

### DIFF
--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.5.7.Final</version>
+            <version>5.6.5.Final</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
             <dependency>
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-core</artifactId>
-                <version>5.5.7.Final</version>
+                <version>5.6.5.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.postgresql</groupId>


### PR DESCRIPTION
### Fixes [DPC-2297](https://jira.cms.gov/browse/DPC-2297)

### Change Details

* Update hibernate-core 5.5.7 -> 5.6.5

### Security Implications

- [x] new software dependencies
