### PR TITLE
Change route to redirect to docsV2

### DIFF
--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
 
   match '/home', to: redirect("#{ENV['STATIC_SITE_URL']}"), via: :get
 
-  match '/docs', to: redirect("#{ENV['STATIC_SITE_URL']}/docs"), via: :get
+  match '/docs', to: redirect("#{ENV['STATIC_SITE_URL']}/docsV2"), via: :get
 
   # downloadable files
   match '/download_snippet', to: 'public_keys#download_snippet', as: 'download_snippet', via: :post

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
 
   match '/home', to: redirect("#{ENV['STATIC_SITE_URL']}"), via: :get
 
-  match '/docs', to: redirect("#{ENV['STATIC_SITE_URL']}/docsV2"), via: :get
+  match '/docs', to: redirect("#{ENV['STATIC_SITE_URL']}/docsV1"), via: :get
 
   # downloadable files
   match '/download_snippet', to: 'public_keys#download_snippet', as: 'download_snippet', via: :post


### PR DESCRIPTION
## [DPC-2355](https://jira.cms.gov/browse/DPC-2355)

## Change Details

* The documents link has moved to /docsV1, and this change will re-route all traffic within the web applications to /docsV1.

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
