### PR TITLE
DPC-2579: Adjust filter query for un-registered orgs

### DIFF
--- a/dpc-admin/app/models/organization.rb
+++ b/dpc-admin/app/models/organization.rb
@@ -37,7 +37,7 @@ class Organization < ApplicationRecord
   }
 
   scope :is_not_registered, -> {
-    where('id IN(SELECT DISTINCT(organization_id) FROM registered_organizations WHERE enabled IS NOT true)')
+    where('id IN(SELECT DISTINCT(o.id) FROM organizations as o LEFT JOIN registered_organizations as ro ON ro.organization_id = o.id WHERE ro.organization_id IS NULL or ro.enabled IS NOT true)')
   }
 
   def address_type

--- a/dpc-admin/app/models/organization.rb
+++ b/dpc-admin/app/models/organization.rb
@@ -37,7 +37,7 @@ class Organization < ApplicationRecord
   }
 
   scope :is_not_registered, -> {
-    where('id IN(SELECT DISTINCT(o.id) FROM organizations as o LEFT JOIN registered_organizations as ro ON ro.organization_id = o.id WHERE ro.organization_id IS NULL or ro.enabled IS NOT true)')
+    where('id IN(SELECT DISTINCT(o.id) FROM organizations AS o LEFT JOIN registered_organizations AS ro ON ro.organization_id = o.id WHERE ro.organization_id IS NULL OR ro.enabled IS NOT true)')
   }
 
   def address_type


### PR DESCRIPTION
This query includes un-registered orgs as well as disabled in the api orgs into the same query for the "not enabled in API" org filter. This fixes the original bug DPC-2351

## [DPC-2479](https://jira.cms.gov/browse/DPC-2579)

## Change Details

* Changed the query using a join between organizations and registered_organizations when trying to use the filter for "not enabled in API" organizations from the Web Admin Organization view. This will not include those registered orgs that have been disabled, and orgs that have not yet been registered. Previously, unregistered orgs were not showing. 

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
