### PR TITLE
Increase JobTimeout Threshold

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -5,6 +5,10 @@ volumes:
 
 services:
 
+  db:
+    ports:
+      - "5432:5432"
+
   redis:
     image: redis:latest
 

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -195,6 +195,7 @@ public class PatientResource extends AbstractPatientResource {
                 .execute();
 
         if (practitioner == null) {
+            // Is this the best code to be throwing here?
             throw new WebApplicationException(HttpStatus.UNAUTHORIZED_401);
         }
 
@@ -216,10 +217,13 @@ public class PatientResource extends AbstractPatientResource {
         Resource result = dataService.retrieveData(orgId, orgNPI, practitionerNPI, List.of(patientMbi), since, APIHelpers.fetchTransactionTime(bfdClient),
                 requestingIP, requestUrl, DPCResourceType.Patient, DPCResourceType.ExplanationOfBenefit, DPCResourceType.Coverage);
         if (DPCResourceType.Bundle.getPath().equals(result.getResourceType().getPath())) {
+            // A Bundle containing patient data was returned
             return (Bundle) result;
         }
         if (DPCResourceType.OperationOutcome.getPath().equals(result.getResourceType().getPath())) {
+            // An OperationOutcome (ERROR) was returned
             OperationOutcome resultOp = (OperationOutcome) result;
+            // getIssueFirstRep() grabs the first issue only - there may be others
             throw new WebApplicationException(resultOp.getIssueFirstRep().getDetails().getText());
         }
 

--- a/dpc-api/src/main/resources/application.conf
+++ b/dpc-api/src/main/resources/application.conf
@@ -3,7 +3,7 @@ dpc.api {
     include "queue.conf"
 
     jobTimeoutInSeconds = ${?JOB_TIMEOUT_IN_SECONDS}
-    jobTimeoutInSeconds = 30
+    jobTimeoutInSeconds = 60
 
     publicURL = "http://localhost:3002" # The root URL at which the application is accessible, if necssary, include the port, do not include the application version
 

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/service/DataService.java
@@ -72,7 +72,7 @@ public class DataService {
                                  OffsetDateTime transactionTime,
                                  String requestingIP, String requestUrl, DPCResourceType... resourceTypes) {
         UUID jobID = this.queue.createJob(organizationID, orgNPI, providerNPI, patientMBIs, List.of(resourceTypes), since, transactionTime, requestingIP, requestUrl, false, false);
-        LOGGER.info("Patient everything export job created with job_id={} _since={} from requestUrl{}", jobID.toString(), since, requestUrl);
+        LOGGER.info("Patient everything export job created with job_id={} _since={} from requestUrl={}", jobID.toString(), since, requestUrl);
 
         Optional<List<JobQueueBatch>> optionalBatches = waitForJobToComplete(jobID, organizationID, this.queue);
 


### PR DESCRIPTION
## [DPC-2682](https://jira.cms.gov/browse/DPC-2682)

## Change Details

*  Increase the timeout threshold for completing requests from 30 to 60
* In the case of the /Patient/$everything endpoint, this timeout is too short and results in >90% of requests to the endpoint timing out and returning 500s from the API
* Add some clarifying comments

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
