### PR TITLE
Jstewart/dpc 2660 check org id before create token

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
 
   db:
     image: postgres:11
-    ports:
-      - "5432:5432"
     command: postgres -c 'max_connections=250'
     environment:
       - POSTGRES_MULTIPLE_DATABASES=dpc_attribution,dpc_queue,dpc_auth,dpc_consent,dpc-website_development,dpc-impl_development,dpc_attribution_v2,bcda

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
   db:
     image: postgres:11
+    ports:
+      - "5432:5432"
     command: postgres -c 'max_connections=250'
     environment:
       - POSTGRES_MULTIPLE_DATABASES=dpc_attribution,dpc_queue,dpc_auth,dpc_consent,dpc-website_development,dpc-impl_development,dpc_attribution_v2,bcda

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -59,15 +59,14 @@ public class GenerateClientTokens extends Task {
             final Organization organization = new Organization();
             organization.setId(organizationId);
 
-            // `checkOrg` parameter is meant to be optional, if not present, default `canCreateToken` to true.
-            // When `checkOrg` is provided, ensure the submitted orgId matches an org in the db before creating token.
-            Boolean canCreateToken = true;
+            /*
+             * `checkOrg` parameter is meant to be optional, if provided and "true" ensure the submitted orgId
+             * matches an org in the db before creating token. `checkOrg` Not present, just create the token.
+             */
             final Boolean needOrgValidation = !needCheckOrgCollection.isEmpty()
                     && !StringUtils.isBlank(needCheckOrgCollection.asList().get(0))
                     && needCheckOrgCollection.asList().get(0) == "true";
-            if(needOrgValidation) {
-                canCreateToken = validateOrgExists(organization);
-            }
+            Boolean canCreateToken = needOrgValidation ? validateOrgExists(organization) : true;
 
             if(canCreateToken) {
                 createTokan(output, labelCollection, expirationCollection, organization);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -59,17 +59,17 @@ public class GenerateClientTokens extends Task {
             final Organization organization = new Organization();
             organization.setId(organizationId);
 
-            // default `orgExist` to true, the `checkOrg` option is meant to be optional
-            // when present, ensure the submitted orgId matches an org in the db.
-            Boolean orgExists = true;
+            // `checkOrg` parameter is meant to be optional, if not present, default `canCreateToken` to true.
+            // When `checkOrg` is provided, ensure the submitted orgId matches an org in the db before creating token.
+            Boolean canCreateToken = true;
             final Boolean needOrgValidation = !needCheckOrgCollection.isEmpty()
                     && !StringUtils.isBlank(needCheckOrgCollection.asList().get(0))
                     && needCheckOrgCollection.asList().get(0) == "true";
             if(needOrgValidation) {
-                orgExists = validateOrgExists(organization);
+                canCreateToken = validateOrgExists(organization);
             }
 
-            if(orgExists) {
+            if(canCreateToken) {
                 createTokan(output, labelCollection, expirationCollection, organization);
             } else {
                 logger.warn("ATTEMPT TO CREATE ORPHAN MACAROON.");

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -63,10 +63,10 @@ public class GenerateClientTokens extends Task {
              * `checkOrg` parameter is meant to be optional, if provided and "true" ensure the submitted orgId
              * matches an org in the db before creating token. `checkOrg` Not present, just create the token.
              */
-            final Boolean needOrgValidation = !needCheckOrgCollection.isEmpty()
+            final boolean needOrgValidation = !needCheckOrgCollection.isEmpty()
                     && !StringUtils.isBlank(needCheckOrgCollection.asList().get(0))
                     && needCheckOrgCollection.asList().get(0) == "true";
-            Boolean canCreateToken = needOrgValidation ? validateOrgExists(organization) : true;
+            boolean canCreateToken = needOrgValidation ? validateOrgExists(organization) : true;
 
             if(canCreateToken) {
                 createTokan(output, labelCollection, expirationCollection, organization);
@@ -93,7 +93,7 @@ public class GenerateClientTokens extends Task {
         final String tokenLabel = labelCollection.isEmpty() ? null : labelCollection.asList().get(0);
         // Use Expiration Date if provided, otherwise use `empty` value, and will default to 1-year
         Optional<OffsetDateTimeParam> expiration = Optional.empty();
-        final Boolean hasExpiration = !expirationCollection.isEmpty() && !StringUtils.isBlank(expirationCollection.asList().get(0));
+        final boolean hasExpiration = !expirationCollection.isEmpty() && !StringUtils.isBlank(expirationCollection.asList().get(0));
         if(hasExpiration){
             expiration = Optional.of(new OffsetDateTimeParam(expirationCollection.asList().get(0)));
         }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -58,10 +58,10 @@ public class GenerateClientTokens extends Task {
             orgResource.setId(organizationId);
 
             final OrganizationPrincipal orgPrincipal = new OrganizationPrincipal(orgResource);
-            final var existingOrg = resourceOrganization.orgSearch(orgPrincipal);
+            final var existingOrg = this.resourceOrganization.orgSearch(orgPrincipal);
+            String existingId = existingOrg == null ? "-1" : existingOrg.getEntryFirstRep().getResource().getId();
 
-            String existingId = existingOrg == null ? "-1" : existingOrg.getId();
-            if(existingId == organizationId) {
+            if(organizationId.equals(existingId)) {
                 final String tokenLabel = labelCollection.isEmpty() ? null : labelCollection.asList().get(0);
                 Optional<OffsetDateTimeParam> expiration = Optional.empty();
                 if(!expirationCollection.isEmpty() && !StringUtils.isBlank(expirationCollection.asList().get(0))){

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -34,15 +34,15 @@ public class GenerateClientTokens extends Task {
     private static final Logger logger = LoggerFactory.getLogger(GenerateClientTokens.class);
 
     private final MacaroonBakery bakery;
-    private final TokenResource resourceToken;
-    private final OrganizationResource resourceOrganization;
+    private final TokenResource tokenResource;
+    private final OrganizationResource orgResource;
 
     @Inject
-    public GenerateClientTokens(MacaroonBakery bakery, TokenResource resourceToken, OrganizationResource resourceOrganization) {
+    public GenerateClientTokens(MacaroonBakery bakery, TokenResource tokenResource, OrganizationResource orgResource) {
         super("generate-token");
         this.bakery = bakery;
-        this.resourceToken = resourceToken;
-        this.resourceOrganization = resourceOrganization;
+        this.tokenResource = tokenResource;
+        this.orgResource = orgResource;
     }
 
     @Override
@@ -56,11 +56,11 @@ public class GenerateClientTokens extends Task {
             output.write(macaroon.serialize(MacaroonVersion.SerializationVersion.V1_BINARY));
         } else {
             final String organizationId = organizationCollection.asList().get(0);
-            final Organization orgResource = new Organization();
-            orgResource.setId(organizationId);
+            final Organization organization = new Organization();
+            organization.setId(organizationId);
 
-            final OrganizationPrincipal orgPrincipal = new OrganizationPrincipal(orgResource);
-            final var existingOrg = this.resourceOrganization.orgSearch(orgPrincipal);
+            final OrganizationPrincipal orgPrincipal = new OrganizationPrincipal(organization);
+            final var existingOrg = this.orgResource.orgSearch(orgPrincipal);
             String existingId = existingOrg == null ? "-1" : existingOrg.getEntryFirstRep().getResource().getId();
 
             if(organizationId.equals(existingId)) {
@@ -69,9 +69,9 @@ public class GenerateClientTokens extends Task {
                 if(!expirationCollection.isEmpty() && !StringUtils.isBlank(expirationCollection.asList().get(0))){
                     expiration = Optional.of(new OffsetDateTimeParam(expirationCollection.asList().get(0)));
                 }
-                final TokenEntity tokenResponse = this.resourceToken
+                final TokenEntity tokenResponse = this.tokenResource
                         .createOrganizationToken(
-                                new OrganizationPrincipal(orgResource), null,
+                                new OrganizationPrincipal(organization), null,
                                 tokenLabel,
                                 expiration);
     

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -36,7 +36,7 @@ public class GenerateClientTokens extends Task {
     private final OrganizationResource resourceOrganization;
 
     @Inject
-    public GenerateClientTokens(MacaroonBakery bakery, TokenResource resourceToken, OrganizationResource  resourceOrganization) {
+    public GenerateClientTokens(MacaroonBakery bakery, TokenResource resourceToken, OrganizationResource resourceOrganization) {
         super("generate-token");
         this.bakery = bakery;
         this.resourceToken = resourceToken;

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -18,6 +18,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import java.io.PrintWriter;
 import java.util.Collections;
 import java.util.Optional;
@@ -76,7 +78,7 @@ public class GenerateClientTokens extends Task {
                 output.write(tokenResponse.getToken());
             } else {
                 logger.warn("ATTEMPT TO CREATE ORPHAN MACAROON.");
-                throw new Error("ERROR: No Organization found with this ID (`" + organizationId + "`). Please double check your data and try again.");
+                throw new WebApplicationException(String.format("ERROR: Organization not found with ID: \"%s\". Please double check your data and try again.", organizationId), Response.Status.BAD_REQUEST);
             }
         }
     }

--- a/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/tasks/tokens/GenerateClientTokens.java
@@ -96,7 +96,6 @@ public class GenerateClientTokens extends Task {
     private Boolean checkOrgExists(Organization organization) {
         final OrganizationPrincipal orgPrincipal = new OrganizationPrincipal(organization);
         final var existingOrg = this.orgResource.orgSearch(orgPrincipal);
-//        String existingId = existingOrg == null ? "-1" : existingOrg.getEntryFirstRep().getResource().getId();
         return existingOrg == null ? false : true;
     }
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
@@ -141,13 +141,10 @@ public class GenerateClientTokenTests {
 
         final ImmutableMultimap<String, String> map = ImmutableMultimap.of("organization", id.toString());
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            gct.execute(map, new PrintWriter(new OutputStreamWriter(bos)));
-            final WebApplicationException ex = assertThrows(WebApplicationException.class, () -> lct.execute(map, new PrintWriter(new OutputStreamWriter(bos))));
-//            assertEquals(HttpStatus.BAD_REQUEST_400
-//                    , ex.getResponse().getStatus()
-//                    , String.format("ERROR: Organization not found with ID: \"%s\". Please double check your data and try again.", id.toString()));
-            assertEquals(String.format("ERROR: Organization not found with ID: \"%s\". Please double check your data and try again.", id.toString())
-                    , ex.getMessage());
+            final WebApplicationException ex = assertThrows(WebApplicationException.class, () -> gct.execute(map, new PrintWriter(new OutputStreamWriter(bos))));
+            assertEquals(HttpStatus.BAD_REQUEST_400
+                    , ex.getResponse().getStatus()
+                    , String.format("ERROR: Organization not found with ID: \"%s\". Please double check your data and try again.", id.toString()));
         }
     }
 

--- a/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
@@ -150,7 +150,7 @@ public class GenerateClientTokenTests {
         final Organization org = new Organization();
         org.setId(id.toString());
 
-        Mockito.when(orgResource.orgSearch(Mockito.any())).thenReturn(null);
+        Mockito.when(orgResource.orgSearch(Mockito.any())).thenReturn(new Bundle());
 
         final ImmutableMultimap<String, String> map = ImmutableMultimap.of("organization", id.toString(), "checkOrg", "true");
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {

--- a/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
@@ -13,11 +13,9 @@ import gov.cms.dpc.api.resources.v1.TokenResource;
 import gov.cms.dpc.api.tasks.tokens.DeleteToken;
 import gov.cms.dpc.api.tasks.tokens.GenerateClientTokens;
 import gov.cms.dpc.api.tasks.tokens.ListClientTokens;
-import gov.cms.dpc.common.entities.OrganizationEntity;
 import gov.cms.dpc.macaroons.MacaroonBakery;
 import gov.cms.dpc.testing.BufferedLoggerHandler;
 import io.dropwizard.jersey.jsr310.OffsetDateTimeParam;
-
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Organization;

--- a/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
@@ -3,18 +3,7 @@ package gov.cms.dpc.api.tasks;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.nitram509.jmacaroons.MacaroonsBuilder;
 import com.google.common.collect.ImmutableMultimap;
-
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.parser.IParser;
-import ca.uhn.fhir.rest.api.MethodOutcome;
-import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
-import ca.uhn.fhir.rest.gclient.IReadExecutable;
-import ca.uhn.fhir.rest.gclient.IUpdateTyped;
-import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
-import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import edu.emory.mathcs.backport.java.util.Collections;
-import gov.cms.dpc.api.AbstractSecureApplicationTest;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.entities.PublicKeyEntity;
 import gov.cms.dpc.api.entities.TokenEntity;
@@ -26,7 +15,6 @@ import gov.cms.dpc.api.tasks.tokens.GenerateClientTokens;
 import gov.cms.dpc.api.tasks.tokens.ListClientTokens;
 import gov.cms.dpc.common.entities.OrganizationEntity;
 import gov.cms.dpc.macaroons.MacaroonBakery;
-import gov.cms.dpc.testing.APIAuthHelpers;
 import gov.cms.dpc.testing.BufferedLoggerHandler;
 import io.dropwizard.jersey.jsr310.OffsetDateTimeParam;
 
@@ -54,7 +42,7 @@ import static org.mockito.Mockito.times;
 
 @SuppressWarnings("unchecked")
 @ExtendWith(BufferedLoggerHandler.class)
-public class GenerateClientTokenTests extends AbstractSecureApplicationTest {
+public class GenerateClientTokenTests {
 
     private TokenResource tokenResource = Mockito.mock(TokenResource.class);
     private OrganizationResource orgResource = Mockito.mock(OrganizationResource.class);
@@ -93,25 +81,17 @@ public class GenerateClientTokenTests extends AbstractSecureApplicationTest {
 
     @Test
     void testTokenCreation() throws IOException {
-
         final TokenEntity response = Mockito.mock(TokenEntity.class);
-        final OrganizationPrincipal orgPrincipal = Mockito.mock(OrganizationPrincipal.class);
         Mockito.when(response.getToken()).thenReturn("test token");
         Mockito.when(tokenResource.createOrganizationToken(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(response);
-
-        final IGenericClient client = APIAuthHelpers.buildAuthenticatedClient(ctx, getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY);
-        final Bundle organizationBundle = client
-                .search()
-                .forResource(Organization.class)
-                .returnBundle(Bundle.class)
-                .encodedJson()
-                .execute();
-
-        Mockito.when(orgResource.orgSearch(orgPrincipal)).thenReturn(organizationBundle);
 
         final UUID id = UUID.randomUUID();
         final Organization org = new Organization();
         org.setId(id.toString());
+
+        final Bundle orgBundle = new Bundle();
+        orgBundle.addEntry().setResource(org);
+        Mockito.when(orgResource.orgSearch(Mockito.any())).thenReturn(orgBundle);
 
         final ImmutableMultimap<String, String> map = ImmutableMultimap.of("organization", id.toString());
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
@@ -134,6 +114,10 @@ public class GenerateClientTokenTests extends AbstractSecureApplicationTest {
         final Organization org = new Organization();
         org.setId(id.toString());
 
+        final Bundle orgBundle = new Bundle();
+        orgBundle.addEntry().setResource(org);
+        Mockito.when(orgResource.orgSearch(Mockito.any())).thenReturn(orgBundle);
+
         final ImmutableMultimap<String, String> map = ImmutableMultimap.of("organization", id.toString(), "label", tokenLabel);
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
             gct.execute(map, new PrintWriter(new OutputStreamWriter(bos)));
@@ -152,6 +136,10 @@ public class GenerateClientTokenTests extends AbstractSecureApplicationTest {
         final UUID id = UUID.randomUUID();
         final Organization org = new Organization();
         org.setId(id.toString());
+
+        final Bundle orgBundle = new Bundle();
+        orgBundle.addEntry().setResource(org);
+        Mockito.when(orgResource.orgSearch(Mockito.any())).thenReturn(orgBundle);
 
         final ImmutableMultimap<String, String> map = ImmutableMultimap.of("organization", id.toString(), "expiration", "");
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
@@ -172,6 +160,10 @@ public class GenerateClientTokenTests extends AbstractSecureApplicationTest {
         final UUID id = UUID.randomUUID();
         final Organization org = new Organization();
         org.setId(id.toString());
+
+        final Bundle orgBundle = new Bundle();
+        orgBundle.addEntry().setResource(org);
+        Mockito.when(orgResource.orgSearch(Mockito.any())).thenReturn(orgBundle);
 
         final ImmutableMultimap<String, String> map = ImmutableMultimap.of("organization", id.toString(), "expiration", expires);
         try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {


### PR DESCRIPTION
## [DPC-2660](https://jira.cms.gov/browse/DPC-2660)

## Change Details

* Added the OrganizationResource into the GenerateClientTokens class in order to call `orgSearch` to ensure we are only creating tokens for current existing orgs. The system currently allows orphans tokens that can unnecessarily add data to the db. 

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
