### PR TITLE
DPC-2868 Increase logging for more clarity and visibility 

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
@@ -56,15 +56,15 @@ public abstract class DPCAuthFilter extends AuthFilter<DPCAuthCredentials, Organ
         final String macaroon = MacaroonHelpers.extractMacaroonFromRequest(requestContext, unauthorizedHandler.buildResponse(BEARER_PREFIX, realm));
 
         final DPCAuthCredentials dpcAuthCredentials = validateMacaroon(macaroon, uriInfo);
+        final String orgId = dpcAuthCredentials.getOrganization().getId();
+        final String resourceRequested = XSSSanitizerUtil.sanitize(uriInfo.getPath());
+        final String method = requestContext.getMethod();
 
         final boolean authenticated = this.authenticate(requestContext, dpcAuthCredentials, null);
         if (!authenticated) {
             throw new WebApplicationException(dpc401handler.buildResponse(BEARER_PREFIX, realm));
         }
-        logger.info("event_type=request-received, resource_requested={}, organization_id={}, method={}",
-                XSSSanitizerUtil.sanitize(uriInfo.getPath()),
-                dpcAuthCredentials.getOrganization().getId(),
-                requestContext.getMethod());
+        logger.info("event_type=request-received, resource_requested={}, organization_id={}, method={}", resourceRequested, orgId, method);
     }
 
     private DPCAuthCredentials validateMacaroon(String macaroon, UriInfo uriInfo) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
@@ -56,12 +56,15 @@ public abstract class DPCAuthFilter extends AuthFilter<DPCAuthCredentials, Organ
         final String macaroon = MacaroonHelpers.extractMacaroonFromRequest(requestContext, unauthorizedHandler.buildResponse(BEARER_PREFIX, realm));
 
         final DPCAuthCredentials dpcAuthCredentials = validateMacaroon(macaroon, uriInfo);
+        final String orgId = dpcAuthCredentials.getOrganization().getId();
+        final String resource_requested = XSSSanitizerUtil.sanitize(uriInfo.getPath());
+        final String method = requestContext.getMethod();
 
         final boolean authenticated = this.authenticate(requestContext, dpcAuthCredentials, null);
         if (!authenticated) {
             throw new WebApplicationException(dpc401handler.buildResponse(BEARER_PREFIX, realm));
         }
-        logger.info("event_type=request-received, resource_requested={}, method={}", XSSSanitizerUtil.sanitize(uriInfo.getPath()),requestContext.getMethod());
+        logger.info("event_type=request-received, resource_requested={}, organization_id={}, method={}", resource_requested, orgId, method);
     }
 
     private DPCAuthCredentials validateMacaroon(String macaroon, UriInfo uriInfo) {

--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
@@ -56,15 +56,15 @@ public abstract class DPCAuthFilter extends AuthFilter<DPCAuthCredentials, Organ
         final String macaroon = MacaroonHelpers.extractMacaroonFromRequest(requestContext, unauthorizedHandler.buildResponse(BEARER_PREFIX, realm));
 
         final DPCAuthCredentials dpcAuthCredentials = validateMacaroon(macaroon, uriInfo);
-        final String orgId = dpcAuthCredentials.getOrganization().getId();
-        final String resource_requested = XSSSanitizerUtil.sanitize(uriInfo.getPath());
-        final String method = requestContext.getMethod();
 
         final boolean authenticated = this.authenticate(requestContext, dpcAuthCredentials, null);
         if (!authenticated) {
             throw new WebApplicationException(dpc401handler.buildResponse(BEARER_PREFIX, realm));
         }
-        logger.info("event_type=request-received, resource_requested={}, organization_id={}, method={}", resource_requested, orgId, method);
+        logger.info("event_type=request-received, resource_requested={}, organization_id={}, method={}",
+                XSSSanitizerUtil.sanitize(uriInfo.getPath()),
+                dpcAuthCredentials.getOrganization().getId(),
+                requestContext.getMethod());
     }
 
     private DPCAuthCredentials validateMacaroon(String macaroon, UriInfo uriInfo) {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import javax.annotation.Priority;
+import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import java.io.IOException;
@@ -27,20 +28,18 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        String requestId = requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER);
-        String resource_requested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
-        String method = requestContext.getMethod();
-        String media_type = requestContext.getMediaType().getType();
         try {
             MDC.clear();
         } catch(Error e) {
-            logger.info("resource_requested={}, method={}, media_type={}, mdc_clear_error={}", resource_requested, method, media_type, e.getMessage());
+            logger.info("mdc_clear_error={}", e.getMessage());
+            throw new InternalServerErrorException("Something went wrong, please try again. If this continues, contact DPC admin.");
         }
+        String requestId = requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER);
         if(requestId!=null && useProvidedRequestId) {
             MDC.put(MDCConstants.DPC_REQUEST_ID, requestId);
         }else{
             MDC.put(MDCConstants.DPC_REQUEST_ID, UUID.randomUUID().toString());
         }
-        logger.info("resource_requested={}, method={}, media_type={}, use_provided_request_id={}", resource_requested, method, media_type, useProvidedRequestId );
+        logger.info("resource_requested={}, method={}", XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath()),requestContext.getMethod());
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -30,8 +30,8 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) throws IOException {
         try {
             MDC.clear();
-        } catch(Error e) {
-            logger.info("mdc_clear_error={}", e.getMessage());
+        } catch(IllegalStateException exception) {
+            logger.info("mdc_clear_error={}", exception.getMessage());
             throw new InternalServerErrorException("Something went wrong, please try again. If this continues, contact DPC admin.");
         }
         String requestId = requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER);

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -40,6 +40,10 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
         }else{
             MDC.put(MDCConstants.DPC_REQUEST_ID, UUID.randomUUID().toString());
         }
-        logger.info("resource_requested={}, method={}", XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath()),requestContext.getMethod());
+        logger.info("resource_requested={}, method={}, media_type={}, use_provided_request_id={}",
+                XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath()),
+                requestContext.getMethod(),
+                requestContext.getMediaType().getType(),
+                useProvidedRequestId);
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -37,12 +37,10 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
             logger.info("mdc_clear_error={}, resource_requested={}, method={}, media_type={}, use_provided_request_id={}", exception.getMessage(), resourceRequested, method, mediaType, useProvidedRequestId);
             throw new WebApplicationException("Something went wrong, please try again. If this continues, contact DPC admin.");
         }
-        String requestId = requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER);
-        if(requestId!=null && useProvidedRequestId) {
-            MDC.put(MDCConstants.DPC_REQUEST_ID, requestId);
-        }else{
-            MDC.put(MDCConstants.DPC_REQUEST_ID, UUID.randomUUID().toString());
-        }
+        String requestId = requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER) != null && useProvidedRequestId
+                ? requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER)
+                : UUID.randomUUID().toString();
+        MDC.put(MDCConstants.DPC_REQUEST_ID, requestId);
         logger.info("resource_requested={}, method={}, media_type={}, request_id={}, use_provided_request_id={}", resourceRequested, method, mediaType, requestId, useProvidedRequestId);
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -30,7 +30,9 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
     public void filter(ContainerRequestContext requestContext) throws IOException {
         String resourceRequested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
         String method = requestContext.getMethod();
-        String mediaType = requestContext.getMediaType().getType();
+        String mediaType = requestContext.getMediaType() == null
+                ? null
+                : requestContext.getMediaType().getType();
         try {
             MDC.clear();
         } catch(IllegalStateException exception) {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -27,13 +27,20 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        MDC.clear();
         String requestId = requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER);
+        String resource_requested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
+        String method = requestContext.getMethod();
+        String media_type = requestContext.getMediaType().getType();
+        try {
+            MDC.clear();
+        } catch(Error e) {
+            logger.info("resource_requested={}, method={}, media_type={}, mdc_clear_error={}", resource_requested, method, media_type, e.getMessage());
+        }
         if(requestId!=null && useProvidedRequestId) {
             MDC.put(MDCConstants.DPC_REQUEST_ID, requestId);
         }else{
             MDC.put(MDCConstants.DPC_REQUEST_ID, UUID.randomUUID().toString());
         }
-        logger.info("resource_requested={}, method={}", XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath()),requestContext.getMethod());
+        logger.info("resource_requested={}, method={}, media_type={}, use_provided_request_id={}", resource_requested, method, media_type, useProvidedRequestId );
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -34,7 +34,7 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
         try {
             MDC.clear();
         } catch(IllegalStateException exception) {
-            logger.info("mdc_clear_error={}", exception.getMessage());
+            logger.info("mdc_clear_error={}, resource_requested={}, method={}, media_type={}, use_provided_request_id={}", exception.getMessage(), resourceRequested, method, mediaType, useProvidedRequestId);
             throw new WebApplicationException("Something went wrong, please try again. If this continues, contact DPC admin.");
         }
         String requestId = requestContext.getHeaderString(Constants.DPC_REQUEST_ID_HEADER);

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
@@ -23,14 +23,14 @@ public class LogResponseFilter implements ContainerResponseFilter{
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext){
         String requestId = MDC.get(MDCConstants.DPC_REQUEST_ID);
-        String resource_requested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
-        String media_type = requestContext.getMediaType().getType();
-        String method = requestContext.getMethod();
-        int status = responseContext.getStatus();
 
         if(requestId!=null){
             responseContext.getHeaders().add(Constants.DPC_REQUEST_ID_HEADER, requestId);
         }
-        logger.info("resource_requested={}, media_type={}, method={}, status={}", resource_requested, media_type, method, status);
+        logger.info("resource_requested={}, media_type={}, method={}, status={}",
+                XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath()),
+                requestContext.getMediaType().getType(),
+                requestContext.getMethod(),
+                responseContext.getStatus());
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
@@ -23,14 +23,14 @@ public class LogResponseFilter implements ContainerResponseFilter{
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext){
         String requestId = MDC.get(MDCConstants.DPC_REQUEST_ID);
+        String resourceRequested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
+        String mediaType = requestContext.getMediaType().getType();
+        String method = requestContext.getMethod();
+        int status = responseContext.getStatus();
 
         if(requestId!=null){
             responseContext.getHeaders().add(Constants.DPC_REQUEST_ID_HEADER, requestId);
         }
-        logger.info("resource_requested={}, media_type={}, method={}, status={}",
-                XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath()),
-                requestContext.getMediaType().getType(),
-                requestContext.getMethod(),
-                responseContext.getStatus());
+        logger.info("resource_requested={}, media_type={}, method={}, status={}", resourceRequested, mediaType, method, status);
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
@@ -31,6 +31,6 @@ public class LogResponseFilter implements ContainerResponseFilter{
         if(requestId!=null){
             responseContext.getHeaders().add(Constants.DPC_REQUEST_ID_HEADER, requestId);
         }
-        logger.info("resource_requested={}, method={}, status={}", XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath()),requestContext.getMethod(),responseContext.getStatus());
+        logger.info("resource_requested={}, media_type={}, method={}, status={}", resource_requested, media_type, method, status);
     }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
@@ -23,6 +23,11 @@ public class LogResponseFilter implements ContainerResponseFilter{
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext){
         String requestId = MDC.get(MDCConstants.DPC_REQUEST_ID);
+        String resource_requested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
+        String media_type = requestContext.getMediaType().getType();
+        String method = requestContext.getMethod();
+        int status = responseContext.getStatus();
+
         if(requestId!=null){
             responseContext.getHeaders().add(Constants.DPC_REQUEST_ID_HEADER, requestId);
         }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
@@ -24,7 +24,9 @@ public class LogResponseFilter implements ContainerResponseFilter{
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext){
         String requestId = MDC.get(MDCConstants.DPC_REQUEST_ID);
         String resourceRequested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
-        String mediaType = requestContext.getMediaType().getType();
+        String mediaType = requestContext.getMediaType() == null
+                ? null
+                : requestContext.getMediaType().getType();
         String method = requestContext.getMethod();
         int status = responseContext.getStatus();
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/XSSSanitizerUtil.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/XSSSanitizerUtil.java
@@ -2,7 +2,7 @@ package gov.cms.dpc.common.utils;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 
 public final class XSSSanitizerUtil {
 
@@ -12,6 +12,6 @@ public final class XSSSanitizerUtil {
 
     public static String sanitize(String unsanitized) {
         String s1 = unsanitized.replaceAll("(\\s&\\s)", "   ");
-        return Jsoup.clean(s1, "", Whitelist.none(), new Document.OutputSettings().prettyPrint(false));
+        return Jsoup.clean(s1, "", Safelist.none(), new Document.OutputSettings().prettyPrint(false));
     }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
@@ -50,7 +50,7 @@ public class GenerateRequestIdFilterUnitTest {
             Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(null);
             filter = new GenerateRequestIdFilter(true);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + null + ", use_provided_request_id=false", listAppender.list.get(0).getFormattedMessage());
             assertNotNull(MDC.get(MDCConstants.DPC_REQUEST_ID));
             UUID.fromString(MDC.get(MDCConstants.DPC_REQUEST_ID));
 
@@ -58,7 +58,7 @@ public class GenerateRequestIdFilterUnitTest {
             Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(null);
             filter = new GenerateRequestIdFilter(false);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=false", listAppender.list.get(1).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + requestId + ", use_provided_request_id=false", listAppender.list.get(1).getFormattedMessage());
             assertNotNull(MDC.get(MDCConstants.DPC_REQUEST_ID));
             UUID.fromString(MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
@@ -87,7 +87,7 @@ public class GenerateRequestIdFilterUnitTest {
             //With request-id in header and use header value Disabled
             filter = new GenerateRequestIdFilter(false);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + requestId + ", use_provided_request_id=false", listAppender.list.get(0).getFormattedMessage());
             assertNotEquals(requestId, MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
             listAppender.stop();
@@ -115,7 +115,7 @@ public class GenerateRequestIdFilterUnitTest {
             //With request-id in header and use header value enabled
             filter = new GenerateRequestIdFilter(true);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + requestId + ", use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
             assertEquals(requestId, MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
             listAppender.stop();

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
@@ -139,27 +139,4 @@ public class GenerateRequestIdFilterUnitTest {
         filter.filter(mockContext);
         assertNull(MDC.get("Some-Key"));
     }
-
-    @Test
-    public void TestMdcClearFailTo500() throws IOException {
-        String requestId = UUID.randomUUID().toString();
-        Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(requestId);
-        UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
-        Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
-        Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
-        Mockito.when(mockContext.getMethod()).thenReturn("GET");
-        MediaType mockMediaType = Mockito.mock(MediaType.class);
-        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
-        Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
-//        MDC mockMDC = Mockito.mock(MDC.class);
-//        mockMDC.put("Some-Key", "some-value");
-//        mockMDC.clear();
-//        Mockito.when(mockMDC.clear()).thenThrow()
-
-//        MDC.put("Some-Key", "some-value");
-        filter = new GenerateRequestIdFilter(true);
-        filter.filter(mockContext);
-        assertEquals(requestId, "12");
-        //assertThrows(WebApplicationException.class, MDC.clear(), "Something went wrong, please try again. If this continues, contact DPC admin.");
-    }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
@@ -12,6 +12,8 @@ import org.mockito.*;
 import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Logger;
 import org.slf4j.MDC;
+
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
@@ -30,8 +32,7 @@ public class GenerateRequestIdFilterUnitTest {
 
     @Test
     public void testRequestIdIsGeneratedWhenMissingInHeader() throws IOException {
-        String requestId = UUID.randomUUID().toString();
-        Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(requestId);
+        Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(null);
         UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
         Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
@@ -47,18 +48,16 @@ public class GenerateRequestIdFilterUnitTest {
             logger.addAppender(listAppender);
 
             //Without request-id in header and extraction enabled
-            Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(null);
             filter = new GenerateRequestIdFilter(true);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + null + ", use_provided_request_id=false", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + MDC.get(MDCConstants.DPC_REQUEST_ID) + ", use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
             assertNotNull(MDC.get(MDCConstants.DPC_REQUEST_ID));
             UUID.fromString(MDC.get(MDCConstants.DPC_REQUEST_ID));
 
             //Without request-id in header and extraction disabled
-            Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(null);
             filter = new GenerateRequestIdFilter(false);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + requestId + ", use_provided_request_id=false", listAppender.list.get(1).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + MDC.get(MDCConstants.DPC_REQUEST_ID) + ", use_provided_request_id=false", listAppender.list.get(1).getFormattedMessage());
             assertNotNull(MDC.get(MDCConstants.DPC_REQUEST_ID));
             UUID.fromString(MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
@@ -87,7 +86,7 @@ public class GenerateRequestIdFilterUnitTest {
             //With request-id in header and use header value Disabled
             filter = new GenerateRequestIdFilter(false);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + requestId + ", use_provided_request_id=false", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, request_id=" + MDC.get(MDCConstants.DPC_REQUEST_ID) + ", use_provided_request_id=false", listAppender.list.get(0).getFormattedMessage());
             assertNotEquals(requestId, MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
             listAppender.stop();
@@ -139,5 +138,28 @@ public class GenerateRequestIdFilterUnitTest {
         filter = new GenerateRequestIdFilter(true);
         filter.filter(mockContext);
         assertNull(MDC.get("Some-Key"));
+    }
+
+    @Test
+    public void TestMdcClearFailTo500() throws IOException {
+        String requestId = UUID.randomUUID().toString();
+        Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(requestId);
+        UriInfo mockUriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
+        Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
+        Mockito.when(mockContext.getMethod()).thenReturn("GET");
+        MediaType mockMediaType = Mockito.mock(MediaType.class);
+        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
+//        MDC mockMDC = Mockito.mock(MDC.class);
+//        mockMDC.put("Some-Key", "some-value");
+//        mockMDC.clear();
+//        Mockito.when(mockMDC.clear()).thenThrow()
+
+//        MDC.put("Some-Key", "some-value");
+        filter = new GenerateRequestIdFilter(true);
+        filter.filter(mockContext);
+        assertEquals(requestId, "12");
+        //assertThrows(WebApplicationException.class, MDC.clear(), "Something went wrong, please try again. If this continues, contact DPC admin.");
     }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
@@ -12,8 +12,6 @@ import org.mockito.*;
 import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Logger;
 import org.slf4j.MDC;
-
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Logger;
 import org.slf4j.MDC;
 import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,6 +36,9 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
+        MediaType mockMediaType = Mockito.mock(MediaType.class);
+        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         Logger logger = (Logger) LoggerFactory.getLogger(GenerateRequestIdFilter.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
@@ -46,7 +50,7 @@ public class GenerateRequestIdFilterUnitTest {
             Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(null);
             filter = new GenerateRequestIdFilter(true);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
             assertNotNull(MDC.get(MDCConstants.DPC_REQUEST_ID));
             UUID.fromString(MDC.get(MDCConstants.DPC_REQUEST_ID));
 
@@ -54,7 +58,7 @@ public class GenerateRequestIdFilterUnitTest {
             Mockito.when(mockContext.getHeaderString(ArgumentMatchers.eq(Constants.DPC_REQUEST_ID_HEADER))).thenReturn(null);
             filter = new GenerateRequestIdFilter(false);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=false", listAppender.list.get(1).getFormattedMessage());
             assertNotNull(MDC.get(MDCConstants.DPC_REQUEST_ID));
             UUID.fromString(MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
@@ -70,6 +74,9 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
+        MediaType mockMediaType = Mockito.mock(MediaType.class);
+        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         Logger logger = (Logger) LoggerFactory.getLogger(GenerateRequestIdFilter.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
@@ -80,7 +87,7 @@ public class GenerateRequestIdFilterUnitTest {
             //With request-id in header and use header value Disabled
             filter = new GenerateRequestIdFilter(false);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
             assertNotEquals(requestId, MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
             listAppender.stop();
@@ -95,6 +102,9 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
+        MediaType mockMediaType = Mockito.mock(MediaType.class);
+        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         Logger logger = (Logger) LoggerFactory.getLogger(GenerateRequestIdFilter.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
@@ -105,7 +115,7 @@ public class GenerateRequestIdFilterUnitTest {
             //With request-id in header and use header value enabled
             filter = new GenerateRequestIdFilter(true);
             filter.filter(mockContext);
-            assertEquals("resource_requested=v1/Patients, method=GET", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, method=GET, media_type=application/json, use_provided_request_id=true", listAppender.list.get(0).getFormattedMessage());
             assertEquals(requestId, MDC.get(MDCConstants.DPC_REQUEST_ID));
         } finally {
             listAppender.stop();
@@ -120,6 +130,9 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
+        MediaType mockMediaType = Mockito.mock(MediaType.class);
+        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         MDC.put("Some-Key", "some-value");
         assertNotNull(MDC.get("Some-Key"));

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogResponseFilterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogResponseFilterTest.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
@@ -45,6 +46,9 @@ public class LogResponseFilterTest {
         Mockito.when(mockUriInfo.getPath()).thenReturn("v1/Patients");
         Mockito.when(mockRequest.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockRequest.getMethod()).thenReturn("GET");
+        MediaType mockMediaType = Mockito.mock(MediaType.class);
+        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockRequest.getMediaType()).thenReturn(mockMediaType);
 
 
         Logger logger = (Logger) LoggerFactory.getLogger(LogResponseFilter.class);
@@ -59,7 +63,7 @@ public class LogResponseFilterTest {
             MDC.put(MDCConstants.DPC_REQUEST_ID, requestId);
             Mockito.when(mockResponse.getStatus()).thenReturn(200);
             filter.filter(mockRequest,mockResponse);
-            assertEquals("resource_requested=v1/Patients, method=GET, status=200", listAppender.list.get(0).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, media_type=application/json, method=GET, status=200", listAppender.list.get(0).getFormattedMessage());
             assertEquals(1,headers.get(Constants.DPC_REQUEST_ID_HEADER).size());
             assertEquals(requestId,headers.get(Constants.DPC_REQUEST_ID_HEADER).get(0));
 
@@ -67,7 +71,7 @@ public class LogResponseFilterTest {
             MDC.clear();
             Mockito.when(mockResponse.getStatus()).thenReturn(202);
             filter.filter(mockRequest, mockResponse);
-            assertEquals("resource_requested=v1/Patients, method=GET, status=202", listAppender.list.get(1).getFormattedMessage());
+            assertEquals("resource_requested=v1/Patients, media_type=application/json, method=GET, status=202", listAppender.list.get(1).getFormattedMessage());
             assertFalse(headers.containsKey(MDCConstants.DPC_REQUEST_ID));
 
         } finally {


### PR DESCRIPTION
Also updated XSSSanitizer from using a deprecated properties

## [DPC-2868](https://jira.cms.gov/browse/DPC-2868)

## Change Details

* Added properties to logging we didn't have before
* Added try/catch around MDC.clear() as we think there could be an error in that function we're not capturing causing MDC to persist from one call to the next across organizations. 

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
