### PR TITLE
Add a make down command for start-v2-portals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ start-portals:
 down-portals:
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.portals.yml down
 
+.PHONY: down-start-v2-portals
+	@docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml
+
 .PHONY: start-dpc
 start-dpc: secure-envs
 	@docker-compose -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ down-portals:
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.portals.yml down
 
 .PHONY: down-start-v2-portals
+down-start-v2-portals:
 	@docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml down
 
 .PHONY: start-dpc

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ down-portals:
 	@docker-compose -p dpc-v2 -f docker-compose.yml -f docker-compose.portals.yml down
 
 .PHONY: down-start-v2-portals
-	@docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml
+	@docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml down
 
 .PHONY: start-dpc
 start-dpc: secure-envs

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ down-portals:
 down-start-v2-portals:
 	@docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml down
 
+.PHONY: down-start-v1-portals
+down-start-v1-portals:
+	@docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml down
+
 .PHONY: start-dpc
 start-dpc: secure-envs
 	@docker-compose -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies

--- a/dpcv1-portals-test.sh
+++ b/dpcv1-portals-test.sh
@@ -13,8 +13,8 @@ make website
 make admin
 
 # Prepare the environment 
-docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies
-docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
 
 # Run the tests
 echo "┌─────────────────────────┐"
@@ -22,16 +22,16 @@ echo "│                         │"
 echo "│  Running DPC Web Tests  │"
 echo "│                         │"
 echo "└─────────────────────────┘"
-docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "rubocop" dpc_web
-docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails spec" dpc_web
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "rubocop" dpc_web
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails spec" dpc_web
 
 echo "┌───────────────────────────┐"
 echo "│                           │"
 echo "│  Running DPC Admin Tests  │"
 echo "│                           │"
 echo "└───────────────────────────┘"
-docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "rubocop" dpc_admin
-docker-compose -p start-v2-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails spec" dpc_admin
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "rubocop" dpc_admin
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails spec" dpc_admin
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"


### PR DESCRIPTION
## Change Details

* Add a command for bringing down the resources that are created when we use make `ci-portals-v1`

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
