### PR TITLE
DPC-2945 Get full media type as string

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilter.java
@@ -32,7 +32,7 @@ public class GenerateRequestIdFilter implements ContainerRequestFilter {
         String method = requestContext.getMethod();
         String mediaType = requestContext.getMediaType() == null
                 ? null
-                : requestContext.getMediaType().getType();
+                : requestContext.getMediaType().toString();
         try {
             MDC.clear();
         } catch(IllegalStateException exception) {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogResponseFilter.java
@@ -26,7 +26,7 @@ public class LogResponseFilter implements ContainerResponseFilter{
         String resourceRequested = XSSSanitizerUtil.sanitize(requestContext.getUriInfo().getPath());
         String mediaType = requestContext.getMediaType() == null
                 ? null
-                : requestContext.getMediaType().getType();
+                : requestContext.getMediaType().toString();
         String method = requestContext.getMethod();
         int status = responseContext.getStatus();
 

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/GenerateRequestIdFilterUnitTest.java
@@ -36,7 +36,7 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
         MediaType mockMediaType = Mockito.mock(MediaType.class);
-        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockMediaType.toString()).thenReturn("application/json");
         Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         Logger logger = (Logger) LoggerFactory.getLogger(GenerateRequestIdFilter.class);
@@ -72,7 +72,7 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
         MediaType mockMediaType = Mockito.mock(MediaType.class);
-        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockMediaType.toString()).thenReturn("application/json");
         Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         Logger logger = (Logger) LoggerFactory.getLogger(GenerateRequestIdFilter.class);
@@ -100,7 +100,7 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
         MediaType mockMediaType = Mockito.mock(MediaType.class);
-        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockMediaType.toString()).thenReturn("application/json");
         Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         Logger logger = (Logger) LoggerFactory.getLogger(GenerateRequestIdFilter.class);
@@ -128,7 +128,7 @@ public class GenerateRequestIdFilterUnitTest {
         Mockito.when(mockContext.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockContext.getMethod()).thenReturn("GET");
         MediaType mockMediaType = Mockito.mock(MediaType.class);
-        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockMediaType.toString()).thenReturn("application/json");
         Mockito.when(mockContext.getMediaType()).thenReturn(mockMediaType);
 
         MDC.put("Some-Key", "some-value");

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogResponseFilterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogResponseFilterTest.java
@@ -47,7 +47,7 @@ public class LogResponseFilterTest {
         Mockito.when(mockRequest.getUriInfo()).thenReturn(mockUriInfo);
         Mockito.when(mockRequest.getMethod()).thenReturn("GET");
         MediaType mockMediaType = Mockito.mock(MediaType.class);
-        Mockito.when(mockMediaType.getType()).thenReturn("application/json");
+        Mockito.when(mockMediaType.toString()).thenReturn("application/json");
         Mockito.when(mockRequest.getMediaType()).thenReturn(mockMediaType);
 
 


### PR DESCRIPTION
## [DPC-2945](https://jira.cms.gov/browse/DPC-2945)

## Change Details

* Get full media type as string for logs, and fix associated tests. 

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
