### PR TITLE
DPC-565 Data Headers

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
@@ -43,6 +43,7 @@ import static gov.cms.dpc.fhir.dropwizard.filters.StreamingContentSizeFilter.X_C
  */
 @Api(tags = {"Bulk Data", "Data"}, authorizations = @Authorization(value = "access_token"))
 @Path("/v1/Data")
+@Produces("application/ndjson")
 public class DataResource extends AbstractDataResource {
 
     private static final Logger logger = LoggerFactory.getLogger(DataResource.class);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
@@ -43,7 +43,7 @@ import static gov.cms.dpc.fhir.dropwizard.filters.StreamingContentSizeFilter.X_C
  */
 @Api(tags = {"Bulk Data", "Data"}, authorizations = @Authorization(value = "access_token"))
 @Path("/v1/Data")
-@Produces("application/ndjson")
+@Consumes("application/ndjson")
 public class DataResource extends AbstractDataResource {
 
     private static final Logger logger = LoggerFactory.getLogger(DataResource.class);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/DataResource.java
@@ -43,7 +43,7 @@ import static gov.cms.dpc.fhir.dropwizard.filters.StreamingContentSizeFilter.X_C
  */
 @Api(tags = {"Bulk Data", "Data"}, authorizations = @Authorization(value = "access_token"))
 @Path("/v1/Data")
-@Consumes("application/ndjson")
+@Produces("application/ndjson")
 public class DataResource extends AbstractDataResource {
 
     private static final Logger logger = LoggerFactory.getLogger(DataResource.class);

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/DataResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/DataResourceTest.java
@@ -76,6 +76,7 @@ class DataResourceTest {
 
         final Response response = RESOURCE.target("/v1/Data/test.ndjson")
                 .request()
+                .header(org.apache.http.HttpHeaders.ACCEPT, "application/ndjson")
                 .get();
 
         final InputStream output = response.readEntity(InputStream.class);
@@ -125,6 +126,7 @@ class DataResourceTest {
         Response response = RESOURCE.target("/v1/Data/test.ndjson")
                 .request()
                 .header(org.apache.http.HttpHeaders.RANGE, "bytes=0-1")
+                .header(org.apache.http.HttpHeaders.ACCEPT, "application/ndjson")
                 .get();
 
         InputStream is = response.readEntity(InputStream.class);
@@ -193,6 +195,7 @@ class DataResourceTest {
         // Request file with an invalid range
         response = RESOURCE.target("/v1/Data/test.ndjson")
                 .request()
+                .header(org.apache.http.HttpHeaders.ACCEPT, "application/ndjson")
                 .header(org.apache.http.HttpHeaders.RANGE, "bytes=50-0")
                 .get();
 
@@ -211,6 +214,7 @@ class DataResourceTest {
 
         final Response response = RESOURCE.target("/v1/Data/test.ndjson")
                 .request()
+                .header(org.apache.http.HttpHeaders.ACCEPT, "application/ndjson")
                 .header(org.apache.http.HttpHeaders.RANGE, "frames=0-1")
                 .get();
 
@@ -249,6 +253,7 @@ class DataResourceTest {
         void testMismatchingETagHeader(String method) {
             final Invocation.Builder builder = RESOURCE.target("/v1/Data/test.ndjson")
                     .request()
+                    .header(org.apache.http.HttpHeaders.ACCEPT, "application/ndjson")
                     .header(HttpHeaders.IF_NONE_MATCH, "Not a real value");
 
             final Response response = createHTTPMethodCall(method, builder);
@@ -271,6 +276,7 @@ class DataResourceTest {
         void testWeakETagHeader(String method) {
             final Invocation.Builder builder = RESOURCE.target("/v1/Data/test.ndjson")
                     .request()
+                    .header(org.apache.http.HttpHeaders.ACCEPT, "application/ndjson")
                     .header(HttpHeaders.IF_NONE_MATCH, "This should match--gzip");
 
             final Response response = createHTTPMethodCall(method, builder);
@@ -283,6 +289,7 @@ class DataResourceTest {
 
             final Invocation.Builder builder = RESOURCE.target("/v1/Data/test.ndjson")
                     .request()
+                    .header(org.apache.http.HttpHeaders.ACCEPT, "application/ndjson")
                     .header(HttpHeaders.IF_MODIFIED_SINCE, modifiedDate.toInstant().toEpochMilli());
 
             final Response response = createHTTPMethodCall(method, builder);

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1054,7 +1054,7 @@
 									"",
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
-									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"});",
 									"",
 									"// There should be 2 patients.",
@@ -1116,7 +1116,7 @@
 								"exec": [
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
-									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"   pm.environment.set(\"file_timestamp\", pm.response.headers.get(\"Last-Modified\"))",
 									"});",
 									"",
@@ -1168,7 +1168,7 @@
 								"exec": [
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
-									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"});",
 									"",
 									"// There should be 8 coverage.",
@@ -1229,7 +1229,7 @@
 								"exec": [
 									"// Response should have FHIR Content-Type",
 									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
-									"   pm.response.to.have.header(\"Content-Type\", \"application/fhir+ndjson\"); ",
+									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"});",
 									"",
 									"// There should be 1 operation outcome.",

--- a/src/test/EndToEndRequestTest.postman_collection.json
+++ b/src/test/EndToEndRequestTest.postman_collection.json
@@ -1053,7 +1053,7 @@
 									"require('crypto-js')",
 									"",
 									"// Response should have FHIR Content-Type",
-									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"pm.test(\"Content-type is application/ndjson\", function() {",
 									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"});",
 									"",
@@ -1115,7 +1115,7 @@
 								"id": "1ff19a39-1917-4d23-9fc0-1e80b624a267",
 								"exec": [
 									"// Response should have FHIR Content-Type",
-									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"pm.test(\"Content-type is application/ndjson\", function() {",
 									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"   pm.environment.set(\"file_timestamp\", pm.response.headers.get(\"Last-Modified\"))",
 									"});",
@@ -1167,7 +1167,7 @@
 								"id": "7a7b2436-1612-405a-98ba-592d6c125da6",
 								"exec": [
 									"// Response should have FHIR Content-Type",
-									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"pm.test(\"Content-type is application/ndjson\", function() {",
 									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"});",
 									"",
@@ -1228,7 +1228,7 @@
 								"id": "25ec9c81-b59c-4524-adb0-05c5633b2033",
 								"exec": [
 									"// Response should have FHIR Content-Type",
-									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"pm.test(\"Content-type is application/ndjson\", function() {",
 									"   pm.response.to.have.header(\"Content-Type\", \"application/ndjson\"); ",
 									"});",
 									"",
@@ -1291,7 +1291,7 @@
 								"id": "b66bb3d3-b465-40f1-a0fa-507816ff7619",
 								"exec": [
 									"// Response should have FHIR Content-Type",
-									"pm.test(\"Content-type is application/fhir+ndjson\", function() {",
+									"pm.test(\"Content-type is application/ndjson\", function() {",
 									"   pm.response.to.have.header(\"Content-Range\");",
 									"});",
 									"",


### PR DESCRIPTION
## [DPC-565](https://jira.cms.gov/browse/DPC-565)

## Change Details
Making the `/Data` endpoint `@Produce` application/ndjson instead of producing an aplication/fhir+json

Needed to update the tests as well to contain the `Accepts application/ndjson` header
* 

## Security Implications

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] security controls or supporting software altered

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications

<!-- Use this to indicate you're unsure how this change may impact system security
and would like to solicit the team's feedback. Optionally, provide background
information regarding your questions and concerns. -->

- [ ] PHI/PII is affected by this change

<!-- If yes, provide what PHI/PII is affected by this change -->
