### PR TITLE
DPC-3312 - Fix sidekiq config code to match updated version

### DIFF
--- a/dpc-admin/config/initializers/sidekiq.rb
+++ b/dpc-admin/config/initializers/sidekiq.rb
@@ -12,11 +12,11 @@ Sidekiq.configure_server do |config|
     end
   end
 
-  config.log_formatter = DPCJSON.new
+  config.logger.formatter = DPCJSON.new
 
-  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1", namespace: 'sidekiq-admin-app' }
+  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1" }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1", namespace: 'sidekiq-admin-app' }
+  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1" }
 end

--- a/dpc-adminv2/config/initializers/sidekiq.rb
+++ b/dpc-adminv2/config/initializers/sidekiq.rb
@@ -12,11 +12,11 @@ Sidekiq.configure_server do |config|
     end
   end
 
-  config.log_formatter = DPCJSON.new
+  config.logger.formatter = DPCJSON.new
 
-  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1", namespace: 'sidekiq-adminv2-app' }
+  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1" }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1", namespace: 'sidekiq-adminv2-app' }
+  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1" }
 end

--- a/dpc-impl/config/initializers/sidekiq.rb
+++ b/dpc-impl/config/initializers/sidekiq.rb
@@ -12,11 +12,11 @@ Sidekiq.configure_server do |config|
     end
   end
 
-  config.log_formatter = DPCJSON.new
+  config.logger.formatter = DPCJSON.new
 
-  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1", namespace: 'sidekiq-impl-app' }
+  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1" }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1", namespace: 'sidekiq-impl-app' }
+  config.redis = { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1" }
 end


### PR DESCRIPTION
## [DPC-3312](https://jira.cms.gov/browse/DPC-3312)

## Change Details

This updates the Sidekiq configurations in dpc-admin, dpc-adminv2, and dpc-impl, to match the change made [here](https://github.com/CMSgov/dpc-app/pull/1860/files#diff-3928310c948a0787c751598050c359efc90035cbe50db5a960f8695c089e2ad6) in dpc-web.

Though these three passed our GitHub Actions, it's possible that this is what's causing our ECS container checks to fail during the dev deployment (error messages in our AWS logs seem to hint that this is the case). If that's true, then this PR should fix our dev deployments.
