### PR TITLE
[DPC-2868] remove GitHub CI Workflows related to v2

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -31,31 +31,6 @@ jobs:
         run: |
           make smoke
 
-  build-api-v2:
-    name: "Build and Test API V2"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v2
-      - name: Run all tests
-        run: |
-          make test-docker
-        working-directory: dpc-go/dpc-api
-
-  build-attribution-v2:
-    name: "Build and Test Attribution V2"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v2
-      - name: Prepare to decrypt secrets
-        run: |
-          echo $VAULT_PW > dpc-go/dpc-attribution/.vault_password
-      - name: Run all tests
-        run: |
-          make test-docker
-        working-directory: dpc-go/dpc-attribution
-
   build-portals-v1:
     name: "Build and Test DPCv1 Web Portals"
     runs-on: ubuntu-latest
@@ -65,13 +40,3 @@ jobs:
       - name: "Web Portals v1 Build"
         run: |
           make ci-portals-v1
-
-  build-portals-v2:
-    name: "Build and Test DPCv2 Web Portals"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v1
-      - name: "Web Portals v2 Build"
-        run: |
-          make ci-portals-v2


### PR DESCRIPTION
## [DPC-2868](https://jira.cms.gov/browse/DPC-2868)

## Change Details

This PR clears out our GitHub Actions workflows, so that we stop building the V2 API and related frontends. Pull Requests will now only trigger CI for the v1 API, dpc-web, and dpc-admin.