### PR TITLE
Me dpc 3437 baseresource code coverage update

### DIFF
--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -168,7 +168,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -168,7 +168,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
+            <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
@@ -1,0 +1,68 @@
+package gov.cms.dpc.api.resources.v1;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import gov.cms.dpc.api.core.Capabilities;
+import gov.cms.dpc.common.utils.PropertiesProvider;
+import org.hl7.fhir.dstu3.model.CapabilityStatement;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+
+class BaseResourceUnitTest {
+    @Mock
+    KeyResource kr;
+    TokenResource tr;
+    GroupResource gr;
+    JobResource jr;
+    DataResource dr;
+    EndpointResource er;
+    OrganizationResource or;
+    PatientResource par;
+    PractitionerResource pr;
+    DefinitionResource sdr;
+
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetterMethods() {
+        BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, "baseURL");
+
+        assertEquals(kr, baseResource.keyOperations());
+        assertEquals(tr, baseResource.tokenOperations());
+        assertEquals(gr, baseResource.groupOperations());
+        assertEquals(jr, baseResource.jobOperations());
+        assertEquals(sdr, baseResource.definitionResourceOperations());
+        assertEquals(dr, baseResource.dataOperations());
+        assertEquals(er, baseResource.endpointOperations());
+        assertEquals(or, baseResource.organizationOperations());
+        assertEquals(par, baseResource.patientOperations());
+        assertEquals(pr, baseResource.practitionerOperations());
+    }
+
+    @Test
+    public void testCapabilitiesStatement() {
+        String baseURL = "baseURL";
+        BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, baseURL);
+        CapabilityStatement capStatement = new CapabilityStatement();
+
+        try(MockedStatic<Capabilities> capabilities = Mockito.mockStatic(Capabilities.class) ) {
+            capabilities.when(() -> Capabilities.getCapabilities(baseURL)).thenReturn(capStatement);
+            assertEquals(capStatement, baseResource.metadata());
+        }
+    }
+
+    @Test
+    public void testVersion() {
+        String version = "version";
+
+        try(MockedConstruction<PropertiesProvider> ignored = mockConstruction(PropertiesProvider.class, (mock, context) ->
+                when(mock.getBuildVersion()).thenReturn(version))) {
+            BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, "baseURL");
+            assertEquals(version, baseResource.version());
+        }
+    }
+}

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
@@ -1,10 +1,6 @@
 package gov.cms.dpc.api.resources.v1;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import gov.cms.dpc.api.core.Capabilities;
-import gov.cms.dpc.common.utils.PropertiesProvider;
-import org.hl7.fhir.dstu3.model.CapabilityStatement;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
@@ -42,27 +42,4 @@ class BaseResourceUnitTest {
         assertEquals(par, baseResource.patientOperations());
         assertEquals(pr, baseResource.practitionerOperations());
     }
-
-    @Test
-    public void testCapabilitiesStatement() {
-        String baseURL = "baseURL";
-        BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, baseURL);
-        CapabilityStatement capStatement = new CapabilityStatement();
-
-        try(MockedStatic<Capabilities> capabilities = Mockito.mockStatic(Capabilities.class) ) {
-            capabilities.when(() -> Capabilities.getCapabilities(baseURL)).thenReturn(capStatement);
-            assertEquals(capStatement, baseResource.metadata());
-        }
-    }
-
-    @Test
-    public void testVersion() {
-        String version = "version";
-
-        try(MockedConstruction<PropertiesProvider> ignored = mockConstruction(PropertiesProvider.class, (mock, context) ->
-                when(mock.getBuildVersion()).thenReturn(version))) {
-            BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, "baseURL");
-            assertEquals(version, baseResource.version());
-        }
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
+                <artifactId>mockito-inline</artifactId>
                 <version>3.4.6</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-inline</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>3.4.6</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -674,7 +674,7 @@
                     </execution>
                     <execution>
                         <id>report</id>
-                        <phase>prepare-package</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3474

## 🛠 Changes

Updated Jacoco settings to get it to generate a coverage report when unit tests are run locally.
Added unit tests for BaseResource.

## ℹ️ Context for reviewers

This was done as part of [DPC-3381](https://jira.cms.gov/browse/DPC-3381), which is an attempt to increase coverage in the Resources folder.

Also, I temporarily updated to the newest version of Mockito, which let me push code coverage to 100%.  Unfortunately, even though everything ran fine locally tests started failing when they were run on the DPC CI Workflow (See [example](https://github.com/CMSgov/dpc-app/actions/runs/5326360468/jobs/9648950731)), so I reverted it back.  We should probably look into upgrading at some point in the future, or just refactoring our code to be more easily testable.

## ✅ Acceptance Validation

New code coverage report ran.  Coverage for BaseResource now at 89%.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.

