### PR TITLE
Me dpc 3494 part 2 upgrade mockito

### DIFF
--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -171,12 +171,6 @@
             <artifactId>mockito-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>4.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/BaseResourceUnitTest.java
@@ -1,21 +1,26 @@
 package gov.cms.dpc.api.resources.v1;
 
 import static org.junit.jupiter.api.Assertions.*;
+
+import gov.cms.dpc.api.core.Capabilities;
+import gov.cms.dpc.common.utils.PropertiesProvider;
+import org.hl7.fhir.dstu3.model.CapabilityStatement;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 
 class BaseResourceUnitTest {
-    @Mock
-    KeyResource kr;
-    TokenResource tr;
-    GroupResource gr;
-    JobResource jr;
-    DataResource dr;
-    EndpointResource er;
-    OrganizationResource or;
-    PatientResource par;
-    PractitionerResource pr;
-    DefinitionResource sdr;
+    @Mock KeyResource kr;
+    @Mock TokenResource tr;
+    @Mock GroupResource gr;
+    @Mock JobResource jr;
+    @Mock DataResource dr;
+    @Mock EndpointResource er;
+    @Mock OrganizationResource or;
+    @Mock PatientResource par;
+    @Mock PractitionerResource pr;
+    @Mock DefinitionResource sdr;
+
+    String url = "baseURL";
 
 
     @BeforeEach
@@ -25,7 +30,7 @@ class BaseResourceUnitTest {
 
     @Test
     public void testGetterMethods() {
-        BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, "baseURL");
+        BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, url);
 
         assertEquals(kr, baseResource.keyOperations());
         assertEquals(tr, baseResource.tokenOperations());
@@ -37,5 +42,29 @@ class BaseResourceUnitTest {
         assertEquals(or, baseResource.organizationOperations());
         assertEquals(par, baseResource.patientOperations());
         assertEquals(pr, baseResource.practitionerOperations());
+    }
+
+    @Test
+    public void testMetadata() {
+        BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, url);
+        CapabilityStatement capabilityStatement = Mockito.mock(CapabilityStatement.class);
+
+        try(MockedStatic<Capabilities> capabilities = Mockito.mockStatic(Capabilities.class)) {
+            capabilities.when(() -> Capabilities.getCapabilities(url))
+                    .thenReturn(capabilityStatement);
+            assertEquals(capabilityStatement, baseResource.metadata());
+        }
+    }
+
+    @Test
+    void testVersion() {
+        try(MockedConstruction<PropertiesProvider> mock = Mockito.mockConstruction(PropertiesProvider.class)) {
+            BaseResource baseResource = new BaseResource(kr, tr, gr, jr, dr, er, or, par, pr, sdr, url);
+
+            PropertiesProvider mockedPropertiesProvider = mock.constructed().get(0);
+            Mockito.when(mockedPropertiesProvider.getBuildVersion()).thenReturn("version");
+
+            assertEquals("version", baseResource.version());
+        }
     }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/features/FHIRRequestFeatureTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/features/FHIRRequestFeatureTest.java
@@ -19,9 +19,6 @@ public class FHIRRequestFeatureTest {
 
     ResourceInfo info = Mockito.mock(ResourceInfo.class);
     FeatureContext context = Mockito.mock(FeatureContext.class);
-    Method method = Mockito.mock(Method.class);
-    FHIR fhirAnnotation = Mockito.mock(FHIR.class);
-    FHIRAsync asyncAnnotation = Mockito.mock(FHIRAsync.class);
     FHIRRequestFeature feature = new FHIRRequestFeature();
 
     private FHIRRequestFeatureTest() {
@@ -32,21 +29,19 @@ public class FHIRRequestFeatureTest {
     void cleanup() {
         Mockito.reset(info);
         Mockito.reset(context);
-        Mockito.reset(method);
-        Mockito.reset(fhirAnnotation);
     }
 
     @Test
-    void testFHIRResourceAnnotation() {
-        Mockito.when(method.getAnnotation(FHIR.class)).thenReturn(this.fhirAnnotation);
+    void testFHIRResourceAnnotation() throws NoSuchMethodException {
+        Method method = FHIRRequestFeatureTest.class.getMethod("testFhirAnnotationMethod");
         Mockito.when(info.getResourceMethod()).thenReturn(method);
         feature.configure(info, context);
         Mockito.verify(context, Mockito.times(1)).register(FHIRRequestFilter.class);
     }
 
     @Test
-    void testFHIRClassAnnotation() {
-        Mockito.when(method.getAnnotation(FHIR.class)).thenReturn(null);
+    void testFHIRClassAnnotation() throws NoSuchMethodException {
+        Method method = FHIRRequestFeatureTest.class.getMethod("testNoAnnotationMethod");
         Mockito.when(info.getResourceClass()).thenAnswer(answer -> FHIRResourceClass.class);
         Mockito.when(info.getResourceMethod()).thenReturn(method);
         feature.configure(info, context);
@@ -54,25 +49,27 @@ public class FHIRRequestFeatureTest {
     }
 
     @Test
-    void testAsyncFHIRResourceAnnotation() {
-        Mockito.when(info.getResourceClass()).thenAnswer(answer -> FHIRAsyncResourceClass.class);
-        Mockito.when(method.getAnnotation(FHIRAsync.class)).thenReturn(this.asyncAnnotation);
-        Mockito.when(info.getResourceMethod()).thenReturn(method);
-        feature.configure(info, context);
-        Mockito.verify(context, Mockito.times(1)).register(FHIRAsyncRequestFilter.class);
-    }
-
-    @Test
-    void testAsyncFHIRClassAnnotation() {
+    void testAsyncFHIRResourceAnnotation() throws NoSuchMethodException {
+        Method method = FHIRRequestFeatureTest.class.getMethod("testFhirAsyncAnnotatedMethod");
         Mockito.when(info.getResourceClass()).thenAnswer(answer -> FHIRAsyncResourceClass.class);
         Mockito.when(info.getResourceMethod()).thenReturn(method);
         feature.configure(info, context);
         Mockito.verify(context, Mockito.times(1)).register(FHIRAsyncRequestFilter.class);
     }
 
+    @Test
+    void testAsyncFHIRClassAnnotation() throws NoSuchMethodException {
+        Method method = FHIRRequestFeatureTest.class.getMethod("testFhirAsyncAnnotatedMethod");
+        Mockito.when(info.getResourceClass()).thenAnswer(answer -> FHIRAsyncResourceClass.class);
+        Mockito.when(info.getResourceMethod()).thenReturn(method);
+        feature.configure(info, context);
+        Mockito.verify(context, Mockito.times(1)).register(FHIRAsyncRequestFilter.class);
+    }
+
 
     @Test
-    void testNoAnnotation() {
+    void testNoAnnotation() throws NoSuchMethodException {
+        Method method = FHIRRequestFeatureTest.class.getMethod("testNoAnnotationMethod");
         Mockito.when(info.getResourceClass()).thenAnswer(answer -> NoAnnotationClass.class);
         Mockito.when(info.getResourceMethod()).thenReturn(method);
         feature.configure(info, context);
@@ -92,4 +89,10 @@ public class FHIRRequestFeatureTest {
     static class NoAnnotationClass {
 
     }
+
+    @FHIR
+    public void testFhirAnnotationMethod() {}
+    @FHIRAsync
+    public void testFhirAsyncAnnotatedMethod() {}
+    public void testNoAnnotationMethod() {}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.4.6</version>
+                <version>5.4.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3494

## 🛠 Changes

Updated Mockito from 3.4.6 to 5.4.0.
Removed mocking of Method class from FHIRRequestFeatureTest.
Updated BaseResourceUnitTest to use new MockedStatic and MockedConstruction.

## ℹ️ Context for reviewers

We were running an old version of Mockito that didn't support mocking static or final methods, or constructors, and this was preventing us from pushing code coverage as far as we otherwise could.  The new version of Mockito was also causing unit tests to fail randomly and erratically.  

The new version was causing tests to fail because an old test in `FHIRRequestFeatureTest` was mocking the `Method` class from `java.lang.reflect`.  Mockito depends on this class, along with a few others from that package, and mocking them is essentially rewriting Mockito's plumbing while it's running.  This leads to any tests running afterwards potentially failing in random ways.  See issue [here](https://github.com/mockito/mockito/issues/2026#issuecomment-741663017) for a better explanation.

## ✅ Acceptance Validation

We're running the new version of Mockito, we're using some of its new features, and all unit tests are passing.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
