### PR TITLE
Me 3519 remove tests from sonarqube

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This document serves as a guide for running the Data at the Point of Care (DPC) 
   * [Generating the Source Code Documentation via JavaDoc](#generating-the-source-code-documentation-via-javadoc)
   * [Building the Additional Services](#building-the-additional-services)
     * [Postman collection](#postman-collection)
+  * [Code Coverage](#code-coverage)
   * [Other Notes](#other-notes)
     * [BFD transaction time details](#bfd-transaction-time-details)
   * [Troubleshooting](#troubleshooting) 
@@ -424,6 +425,23 @@ Once the development environment is up and running, you should now be able to ru
 - Add patient to group
 - Create export data request
 
+
+## Code Coverage
+###### [`^`](#table-of-contents)
+
+- Run `make unit-tests` to use Jacoco to generate local code coverage reports.  Within each module, the human-readable report can be found at `module/target/site/jacoco/index.html`.  The machine-readable version that gets loaded to SonarQube is `jacoco.xml` in the same directory.
+- Stand up a local version of SonarQube inside a Docker container as described [here](https://docs.sonarsource.com/sonarqube/latest/try-out-sonarqube/).  Essentially, just run the following command `docker run -d --name sonarqube -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p 9000:9000 sonarqube:latest`.
+  - Login to SonarQube at http://localhost:9000 with login:pass of admin:admin.
+  - Setup a new project as described in the link above.
+- Run the following command to load your coverage data into SonarQube, inserting your project key, name and token...
+    ```
+    mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar \
+      -Dsonar.projectKey={YOUR PROJECT KEY} \
+      -Dsonar.projectName='{YOUR PROJECT NAME}' \
+      -Dsonar.host.url=http://localhost:9000 \
+      -Dsonar.token={YOUR PROJECT TOKEN}
+    ```
+- Your code coverage results should now be in your local version of SonarQube.
 
 ## Other Notes
 ###### [`^`](#table-of-contents)

--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jmeter.version>5.5</jmeter.version>
+        <sonar.skip>true</sonar.skip>
     </properties>
 
     <dependencies>

--- a/dpc-testing/pom.xml
+++ b/dpc-testing/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <jjwt.version>0.11.5</jjwt.version>
+        <sonar.skip>true</sonar.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3519

## 🛠 Changes

Removed dpc-testing and dpc-smoketest from SonarQube.
Update readme.md to show how to run SonarQube locally.

## ℹ️ Context for reviewers

dpc-smoketest and dpc-testing are modules that exist solely to test the other subprojects and don't need to be tested on their own.  They were still included in our SonarQube coverage numbers, though, and dragging them down since they're at 0%.

## ✅ Acceptance Validation

dpc-smoketest and dpc-testing are no longer included in SonarQube coverage reports.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
