### PR TITLE
[DPC-3599] Opt-out Import Database Migrations

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
@@ -95,7 +95,7 @@ public class ConsentEntity implements Serializable {
     private String sourceCode;
 
     @ManyToOne()
-    @JoinColumn(name = "opt_out_id")
+    @JoinColumn(name = "opt_out_file_id")
     private OptOutFileEntity optOutFile;
 
     public UUID getId() {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
@@ -94,6 +94,10 @@ public class ConsentEntity implements Serializable {
     @Column(name = "source_code")
     private String sourceCode;
 
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "opt_out_id", nullable = false)
+    private OptOutFileEntity optOutFile;
+
     public UUID getId() {
         return id;
     }
@@ -182,6 +186,9 @@ public class ConsentEntity implements Serializable {
 
     public void setSourceCode(String sourceCode) { this.sourceCode = sourceCode; }
 
+    public OptOutFileEntity getOptOutFile() { return optOutFile; }
+
+    public void setOptOutFile(OptOutFileEntity optOutFile) { this.optOutFile = optOutFile; }
 
     public static ConsentEntity defaultConsentEntity(Optional<UUID> id, Optional<String> hicn, Optional<String> mbi) {
         ConsentEntity ce = new ConsentEntity();

--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/ConsentEntity.java
@@ -94,8 +94,8 @@ public class ConsentEntity implements Serializable {
     @Column(name = "source_code")
     private String sourceCode;
 
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "opt_out_id", nullable = false)
+    @ManyToOne()
+    @JoinColumn(name = "opt_out_id")
     private OptOutFileEntity optOutFile;
 
     public UUID getId() {

--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/OptOutFileEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/OptOutFileEntity.java
@@ -6,6 +6,8 @@ import javax.persistence.*;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
 import java.util.UUID;
 
 @Entity(name = "opt_out_file")
@@ -13,6 +15,8 @@ public class OptOutFileEntity implements Serializable {
     public static final String IMPORT_STATUS_IN_PROGRESS = "In-Progress";
     public static final String IMPORT_STATUS_COMPLETED = "Completed";
     public static final String IMPORT_STATUS_FAILED = "Failed";
+
+    public OptOutFileEntity() {}
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
@@ -63,4 +67,22 @@ public class OptOutFileEntity implements Serializable {
     public OffsetDateTime getUpdatedAt() { return updatedAt; }
 
     public void setUpdatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; }
+
+    public static OptOutFileEntity defaultOptOutEntity(Optional<UUID> id, Optional<String> name) {
+        OptOutFileEntity optOut = new OptOutFileEntity();
+
+        optOut.setId(UUID.randomUUID());
+        id.ifPresent(optOut::setId);
+
+        optOut.setName("TestOptOutFile");
+        name.ifPresent(optOut::setName);
+
+        optOut.setImportStatus(IMPORT_STATUS_COMPLETED);
+
+        optOut.setTimestamp(LocalDate.now(ZoneId.of("UTC")));
+        optOut.setCreatedAt(OffsetDateTime.now(ZoneId.of("UTC")));
+        optOut.setUpdatedAt(OffsetDateTime.now(ZoneId.of("UTC")));
+
+        return optOut;
+    }
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/OptOutFileEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/OptOutFileEntity.java
@@ -1,0 +1,67 @@
+package gov.cms.dpc.common.consent.entities;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity(name = "opt_out_file")
+public class OptOutFileEntity implements Serializable {
+    public static final String IMPORT_STATUS_IN_PROGRESS = "In-Progress";
+    public static final String IMPORT_STATUS_COMPLETED = "Completed";
+    public static final String IMPORT_STATUS_FAILED = "Failed";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "id", updatable = false, nullable = false, columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "timestamp", nullable = false)
+    private LocalDate timestamp;
+
+    @Column(name = "import_status")
+    private String importStatus;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    @CreationTimestamp
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP WITH TIME ZONE")
+    @UpdateTimestamp
+    private OffsetDateTime updatedAt;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() { return name; }
+
+    public void setName(String name) { this.name = name; }
+
+    public LocalDate getTimestamp() { return timestamp; }
+
+    public void setTimestamp(LocalDate timestamp) { this.timestamp = timestamp; }
+
+    public String getImportStatus() { return importStatus; }
+
+    public void setImportStatus(String importStatus) { this.importStatus = importStatus; }
+
+    public OffsetDateTime getCreatedAt() { return createdAt; }
+
+    public void setCreatedAt(OffsetDateTime createdAt) { this.createdAt = createdAt; }
+
+    public OffsetDateTime getUpdatedAt() { return updatedAt; }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/OptOutFileEntity.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/consent/entities/OptOutFileEntity.java
@@ -3,7 +3,6 @@ package gov.cms.dpc.common.consent.entities;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import javax.persistence.*;
-import javax.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;

--- a/dpc-consent/src/main/resources/consent.migrations.xml
+++ b/dpc-consent/src/main/resources/consent.migrations.xml
@@ -74,7 +74,7 @@
             <column name="updated_at" type="TIMESTAMP WITH TIME ZONE" />
         </createTable>
         <addColumn tableName="CONSENT">
-            <column name="opt_out_file_id" type="UUID"></column>
+            <column name="opt_out_file_id" type="UUID" />
         </addColumn>
         <addForeignKeyConstraint
                 baseTableName="CONSENT"

--- a/dpc-consent/src/main/resources/consent.migrations.xml
+++ b/dpc-consent/src/main/resources/consent.migrations.xml
@@ -58,4 +58,30 @@
             <column name="source_code" type="VARCHAR"/>
         </addColumn>
     </changeSet>
+    <changeSet id="add-opt-out-file" author="rswv">
+        <createTable tableName="OPT_OUT_FILE">
+            <column name="id" type="UUID">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR">
+                <constraints nullable="false"/>
+            </column>
+            <column name="timestamp" type="DATE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="import_status" type="VARCHAR" />
+            <column name="created_at" type="TIMESTAMP WITH TIME ZONE" />
+            <column name="updated_at" type="TIMESTAMP WITH TIME ZONE" />
+        </createTable>
+        <addColumn tableName="CONSENT">
+            <column name="opt_out_file_id" type="UUID"></column>
+        </addColumn>
+        <addForeignKeyConstraint
+                baseTableName="CONSENT"
+                baseColumnNames="opt_out_file_id"
+                constraintName="fk_consent_opt_out_file"
+                referencedTableName="OPT_OUT_FILE"
+                referencedColumnNames="id"
+        />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3599

## 🛠 Changes

This PR does the following:
1. A database migration for `dpc_consent` db. It creates a table called `opt_out_file`, consisting of metadata for each opt out file we import, as well as a foreign key `opt_out_file_id` on the `consent` table. For every beneficiary who chooses to opt out, we'll be storing a record in the `consent` table. The Many-to-One relationship here allows us to tie each record to an opt out file and timestamp, for visibility/transparency.
2. Creates an `OptOutFileEntity` for the ORM, so that our Java code can interact with it.
3. Updates the `ConsentEntity` to reflect the Many-to-One relationship.

## ✅ Acceptance Validation

- Successfully ran the migration on my local environment without any issues.
- Successfully compiled `dpc-common` and `dpc-consent`.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
