### PR TITLE
[DPC-3605] Removed port 5432 from db service in docker-compose.yml.  It was caus…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
 
   db:
     image: postgres:11
-    ports: 
-      - "5432:5432"
     command: postgres -c 'max_connections=250'
     environment:
       - POSTGRES_MULTIPLE_DATABASES=dpc_attribution,dpc_queue,dpc_auth,dpc_consent,dpc-website_development,bcda


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3605

## 🛠 Changes

Removed port 5432 from db service in docker-compose file.

## ℹ️ Context for reviewers

Jenkins deploys were failing with this error...

Creating dpc-app_db_1 ... 
Host is already in use by another container
Creating dpc-app_db_1 ... error

ERROR: for dpc-app_db_1  Cannot start service db: driver failed programming external connectivity on endpoint dpc-app_db_1 (83cff30f96d2d2723edb8887a551b8c807bbbf1444293035624484bd3a32a31e): Bind for 0.0.0.0:5432 failed: port is already allocated

This should fix it.

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
