### PR TITLE
DPC-3643 update listen gem to avoid conflict

### DIFF
--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -78,7 +78,7 @@ end
 
 group :development do
   gem 'web-console', '>= 4.2.0'
-  gem 'listen', '>= 3.0.5', '< 3.3'
+  gem 'listen', '~> 3.5'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -214,9 +214,9 @@ GEM
       letter_opener (~> 1.7)
       railties (>= 5.2)
       rexml
-    listen (3.0.8)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
+    listen (3.8.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.12.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -478,7 +478,7 @@ DEPENDENCIES
   kramdown (~> 2.3, >= 2.3.1)
   letter_opener (>= 1.7.0)
   letter_opener_web (~> 2.0, >= 2.0.0)
-  listen (>= 3.0.5, < 3.3)
+  listen (~> 3.5)
   lograge (>= 0.12.0)
   luhnacy (~> 0.2.1)
   macaroons
@@ -515,4 +515,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.4.17
+   2.4.20


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3643

## 🛠 Changes

Version of listener gem in Gemfile updated to conflicting gem.
Gemfile.lock updated for new version of listener gem
## ℹ️ Context for reviewers

Conflict kept rails server from starting

## ✅ Acceptance Validation

Rails server now starts without error messages

## 🔒 Security Implications

None