### PR TITLE
DPC-3665: Update Rails portal configuration to match infrastructure setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ admin:
 
 .PHONY: portal
 portal:
-	@docker build -f dpc-portal/Dockerfile . -t dpc-portal
+	@docker build -f dpc-portal/Dockerfile . -t dpc-web-portal
 
 .PHONY: start-app
 start-app: secure-envs

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -152,4 +152,4 @@ services:
     image: dadarek/wait-for-dependencies
     depends_on:
       - dpc_portal
-    command: dpc_portal:3000
+    command: dpc_portal:3100

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -106,7 +106,7 @@ services:
       - DB_PASS=dpc-safe
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
     ports:
-      - "3100:3000"
+      - "3100:3100"
     depends_on:
       - db
       - portal_sidekiq

--- a/dpc-portal/config/initializers/health_check.rb
+++ b/dpc-portal/config/initializers/health_check.rb
@@ -1,0 +1,69 @@
+HealthCheck.setup do |config|
+
+    # uri prefix (no leading slash)
+    config.uri = 'portal/health_check'
+  
+    # Text output upon success
+    config.success = 'success'
+  
+    # Timeout in seconds used when checking smtp server
+    config.smtp_timeout = 30.0
+  
+    # http status code used when plain text error message is output
+    # Set to 200 if you want your want to distinguish between partial (text does not include success) and
+    # total failure of rails application (http status of 500 etc)
+  
+    config.http_status_for_error_text = 500
+  
+    # http status code used when an error object is output (json or xml)
+    # Set to 200 if you want your want to distinguish between partial (healthy property == false) and
+    # total failure of rails application (http status of 500 etc)
+  
+    config.http_status_for_error_object = 500
+  
+    # bucket names to test connectivity - required only if s3 check used, access permissions can be mixed
+    #config.buckets = {}
+  
+    # You can customize which checks happen on a standard health check, eg to set an explicit list use:
+    config.standard_checks = [ 'database', 'migrations', 'site' ]
+  
+    # Or to exclude one check:
+    #config.standard_checks -= [ 'emailconf' ]
+  
+    # You can set what tests are run with the 'full' or 'all' parameter
+    config.full_checks = [ 'database', 'migrations', 'site' ]
+  
+    # Add one or more custom checks that return a blank string if ok, or an error message if there is an error
+  #   config.add_custom_check do
+  #     CustomHealthCheck.perform_check # any code that returns blank on success and non blank string upon failure
+  #   end
+  
+    # Add another custom check with a name, so you can call just specific custom checks. This can also be run using
+    # the standard 'custom' check.
+    # You can define multiple tests under the same name - they will be run one after the other.
+  #   config.add_custom_check('sometest') do
+  #     CustomHealthCheck.perform_another_check # any code that returns blank on success and non blank string upon failure
+  #   end
+  
+    # max-age of response in seconds
+    # cache-control is public when max_age > 1 and basic_auth_username is not set
+    # You can force private without authentication for longer max_age by
+    # setting basic_auth_username but not basic_auth_password
+    config.max_age = 1
+  
+    # Protect health endpoints with basic auth
+    # These default to nil and the endpoint is not protected
+  #   config.basic_auth_username = 'my_username'
+  #   config.basic_auth_password = 'my_password'
+  
+    # Whitelist requesting IPs
+    # Defaults to blank and allows any IP
+  #   config.origin_ip_whitelist = %w(123.123.123.123)
+  
+    # http status code used when the ip is not allowed for the request
+  #   config.http_status_for_ip_whitelist_error = 403
+  
+    # When redis url is non-standard
+  #   config.redis_url = 'redis_url'
+  
+  end

--- a/dpc-portal/config/initializers/sidekiq_alive.rb
+++ b/dpc-portal/config/initializers/sidekiq_alive.rb
@@ -1,0 +1,46 @@
+SidekiqAlive.setup do |config|
+  # ==> Server port
+  # Port to bind the server.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_PORT.
+  # default: 7433
+  #
+     config.port = 7435
+  # ==> Server path
+  # HTTP path to respond to.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_PATH.
+  # default: '/'
+  #
+  #   config.path = '/'
+  # ==> Liveness key
+  # Key to be stored in Redis as probe of liveness
+  # default: "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"
+  #
+  #   config.liveness_key = "SIDEKIQ::LIVENESS_PROBE_TIMESTAMP"
+  # ==> Time to live
+  # Time for the key to be kept by Redis.
+  # Here is where you can set de periodicity that the Sidekiq has to probe it is working
+  # Time unit: seconds
+  # default: 10 * 60 # 10 minutes
+  #
+  #   config.time_to_live = 10 * 60
+  # ==> Callback
+  # After the key is stored in redis you can perform anything.
+  # For example a webhook or email to notify the team
+  # default: proc {}
+  #
+  #    require 'net/http'
+  #    config.callback = proc { Net::HTTP.get("https://status.com/ping") }
+  # ==> Queue Prefix
+  # SidekiqAlive will run in a independent queue for each instance/replica
+  # This queue name will be generated with: "#{queue_prefix}-#{hostname}.
+  # You can customize the prefix here.
+  # default: :sidekiq_alive
+  #
+  #    config.queue_prefix = :other
+  # ==> Rack server
+  # Web server used to serve an HTTP response.
+  # Can also be set with the environment variable SIDEKIQ_ALIVE_SERVER.
+  # default: 'webrick'
+  #
+  #    config.server = 'puma'
+end

--- a/dpc-portal/config/puma.rb
+++ b/dpc-portal/config/puma.rb
@@ -17,7 +17,7 @@ worker_timeout 3600 if ENV.fetch('RAILS_ENV', 'development') == 'development'
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch('PORT', 3000)
+port ENV.fetch('PORT', 3100)
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Defines the root path route ("/")
-  root 'main#welcome'
+  scope 'portal' do
+    # Defines the root path route ("/")
+    root 'main#welcome'
 
-  if Rails.env.development?
-    require 'sidekiq/web'
-    mount Sidekiq::Web, at: '/sidekiq'
+    if Rails.env.development?
+      require 'sidekiq/web'
+      mount Sidekiq::Web, at: '/sidekiq'
+    end
   end
 end

--- a/dpc-portal/docker/entrypoint.sh
+++ b/dpc-portal/docker/entrypoint.sh
@@ -11,9 +11,9 @@ if [ "$1" == "portal" ]; then
   # Start the database service (and make accessible outside the Docker container)
   echo "Starting Rails server..."
   if [[ -n "$JACOCO" ]]; then
-    bundle exec rails server -b 0.0.0.0 -p 3000
+    bundle exec rails server -b 0.0.0.0 -p 3100
   else
-    bundle exec rails server -b 0.0.0.0 -p 3000 2>&1 | tee -a /var/log/dpc-portal-$(hostname).log
+    bundle exec rails server -b 0.0.0.0 -p 3100 2>&1 | tee -a /var/log/dpc-portal-$(hostname).log
   fi
 fi
 

--- a/dpcv1-portals-test.sh
+++ b/dpcv1-portals-test.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 set -e
 
-echo "┌───────────────────────┐"
-echo "│                       │"
-echo "│ Running Web & Admin   |"
-echo "|      Tests            │"
-echo "│                       │"
-echo "└───────────────────────┘"
+echo "┌────────────────────────────┐"
+echo "│                               │"
+echo "│ Running Web, Admin & Portal   |"
+echo "|            Tests              │"
+echo "│                               │"
+echo "└────────────────────────────┘"
 
 # Build the container
 make website
 make admin
+make portal
 
-# Prepare the environment 
+# Prepare the environment
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_portal
@@ -42,8 +43,8 @@ echo "└───────────────────────�
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_portal
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_portal
 
-echo "┌──────────────────────────────────────────┐"
-echo "│                                          │"
-echo "│      Website & Admin Tests Complete      │"
-echo "│                                          │"
-echo "└──────────────────────────────────────────┘"
+echo "┌───────────────────────────────────────────────┐"
+echo "│                                                   │"
+echo "│      Website, Admin, & Portal Tests Complete      │"
+echo "│                                                   │"
+echo "└───────────────────────────────────────────────┘"

--- a/dpcv1-portals-test.sh
+++ b/dpcv1-portals-test.sh
@@ -12,9 +12,10 @@ echo "└───────────────────────�
 make website
 make admin
 
-# Prepare the environment
+# Prepare the environment 
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_portal
 
 # Run the tests
 echo "┌─────────────────────────┐"
@@ -32,6 +33,14 @@ echo "│                           │"
 echo "└───────────────────────────┘"
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_admin
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_admin
+
+echo "┌───────────────────────────┐"
+echo "│                           │"
+echo "│  Running DPC Portal Tests │"
+echo "│                           │"
+echo "└───────────────────────────┘"
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_portal
+docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_portal
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"

--- a/dpcv1-portals-test.sh
+++ b/dpcv1-portals-test.sh
@@ -11,7 +11,7 @@ echo "└───────────────────────�
 # Build the container
 make website
 make admin
-make portal
+# make portal
 
 # Prepare the environment
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies

--- a/dpcv1-portals-test.sh
+++ b/dpcv1-portals-test.sh
@@ -11,7 +11,7 @@ echo "└───────────────────────�
 # Build the container
 make website
 make admin
-# make portal
+make portal
 
 # Prepare the environment
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies

--- a/dpcv1-portals-test.sh
+++ b/dpcv1-portals-test.sh
@@ -12,10 +12,9 @@ echo "└───────────────────────�
 make website
 make admin
 
-# Prepare the environment 
+# Prepare the environment
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up start_core_dependencies
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
-docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_portal
 
 # Run the tests
 echo "┌─────────────────────────┐"
@@ -33,14 +32,6 @@ echo "│                           │"
 echo "└───────────────────────────┘"
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_admin
 docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_admin
-
-echo "┌───────────────────────────┐"
-echo "│                           │"
-echo "│  Running DPC Portal Tests │"
-echo "│                           │"
-echo "└───────────────────────────┘"
-docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_portal
-docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_portal
 
 echo "┌──────────────────────────────────────────┐"
 echo "│                                          │"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3665

## 🛠 Changes

- Update port from 3000 to 3100 to avoid conflict with admin portal in deployed environments
- Move all routes to be scoped under `/portal` to match routing in deployed environments
- Update sidekiq port to avoid conflict with admin sidekiq port
- Add health check endpoint to support load balancer checks

## ℹ️ Context for reviewers

We identified a couple of adjustments to the Rails application in the deployment ticket to support infra deployments.

## ✅ Acceptance Validation

Rebuilt the portal application and spun it up locally:

```
make portal
make down-portals
make start-portals
```

Was able to verify all endpoints are available:

<img width="384" alt="Screen Shot 2023-10-25 at 4 45 31 PM" src="https://github.com/CMSgov/dpc-app/assets/2308368/daca21a2-34b4-4e60-96eb-1adda648c600">

---

<img width="379" alt="Screen Shot 2023-10-25 at 4 45 39 PM" src="https://github.com/CMSgov/dpc-app/assets/2308368/9c3d618f-8b57-43d8-9551-1cc7d2bea7a7">

---

<img width="1490" alt="Screen Shot 2023-10-25 at 4 45 26 PM" src="https://github.com/CMSgov/dpc-app/assets/2308368/07f92d8f-46b9-4fbe-8777-a2522bd5a33a">

Also deployed this to dev and confirmed accessibility.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.
