### PR TITLE
Ensure dpc-common entity tests are run as part of test suite

### DIFF
--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/AddressEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/AddressEntityTest.java
@@ -1,30 +1,30 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 import org.hl7.fhir.dstu3.model.Address;
 
 public class AddressEntityTest {
 	private String addressCity = "Galveston";
-    private String addressCountry = "US";
-    private String addressDistrict = "Southern";
-    private String addressZip = "77550";
-    private String addressState = "TX";
-    private String addressLine1 = "416 21st St";
-    private String addressLine2 = "N/A";
+	private String addressCountry = "US";
+	private String addressDistrict = "Southern";
+	private String addressZip = "77550";
+	private String addressState = "TX";
+	private String addressLine1 = "416 21st St";
+	private String addressLine2 = "N/A";
 
 	@Test
 	public void testGettersAndSetters() {
-		//Create an object, and set / get the objects in the Entity.
+		// Create an object, and set / get the objects in the Entity.
 		AddressEntity address = new AddressEntity();
-        address.setCity(addressCity);
-        address.setCountry(addressCountry);
-        address.setDistrict(addressDistrict);
-        address.setPostalCode(addressZip);
-        address.setState(addressState);
-        address.setUse(Address.AddressUse.WORK);
-        address.setType(Address.AddressType.BOTH);
+		address.setCity(addressCity);
+		address.setCountry(addressCountry);
+		address.setDistrict(addressDistrict);
+		address.setPostalCode(addressZip);
+		address.setState(addressState);
+		address.setUse(Address.AddressUse.WORK);
+		address.setType(Address.AddressType.BOTH);
 		address.setLine1(addressLine1);
 		address.setLine2(addressLine2);
 
@@ -39,16 +39,16 @@ public class AddressEntityTest {
 	}
 
 	@Test
-	public void testToFHIR(){
+	public void testToFHIR() {
 		AddressEntity address = new AddressEntity();
 
-        address.setCity(addressCity);
-        address.setCountry(addressCountry);
-        address.setDistrict(addressDistrict);
-        address.setPostalCode(addressZip);
-        address.setState(addressState);
-        address.setUse(Address.AddressUse.WORK);
-        address.setType(Address.AddressType.BOTH);
+		address.setCity(addressCity);
+		address.setCountry(addressCountry);
+		address.setDistrict(addressDistrict);
+		address.setPostalCode(addressZip);
+		address.setState(addressState);
+		address.setUse(Address.AddressUse.WORK);
+		address.setType(Address.AddressType.BOTH);
 		address.setLine1(addressLine1);
 		address.setLine2(addressLine2);
 
@@ -65,8 +65,6 @@ public class AddressEntityTest {
 		assertEquals(addressZip, address2.getPostalCode());
 		assertEquals(addressState, address2.getState());
 
-
 	}
-
 
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/AttributionRelationshipTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/AttributionRelationshipTest.java
@@ -1,8 +1,8 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -16,7 +16,7 @@ public class AttributionRelationshipTest {
 		AttributionRelationship r1 = new AttributionRelationship();
 		AttributionRelationship r2 = new AttributionRelationship();
 
-		//Objects should be equal at this point.
+		// Objects should be equal at this point.
 		assertEquals(r1, r2);
 		assertEquals(r1.hashCode(), r2.hashCode());
 
@@ -38,9 +38,8 @@ public class AttributionRelationshipTest {
 		r2.setPeriodBegin(periodBegin);
 		r2.setPeriodEnd(periodEnd);
 
-		assertEquals(r1,r2);
+		assertEquals(r1, r2);
 		assertEquals(r1.hashCode(), r2.hashCode());
-
 
 	}
 
@@ -53,14 +52,15 @@ public class AttributionRelationshipTest {
 		PatientEntity patient = new PatientEntity();
 		relationship.setPatient(patient);
 		relationship.setInactive(true);
-		
+
 		OffsetDateTime periodBegin = OffsetDateTime.now();
 		OffsetDateTime periodEnd = periodBegin.plusDays(30);
 
 		relationship.setPeriodBegin(periodBegin);
 		relationship.setPeriodEnd(periodEnd);
 
-		String expected = "AttributionRelationship{attributionID=1, roster=" + roster.toString() + ", patient=" + patient.toString() + ", inactive=true, begin=" + periodBegin + ", end="+ periodEnd + "}";
+		String expected = "AttributionRelationship{attributionID=1, roster=" + roster.toString() + ", patient="
+				+ patient.toString() + ", inactive=true, begin=" + periodBegin + ", end=" + periodEnd + "}";
 		assertEquals(expected, relationship.toString());
 	}
 

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/ContactEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/ContactEntityTest.java
@@ -1,16 +1,16 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.hl7.fhir.dstu3.model.Organization;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.ArrayList;
-public class ContactEntityTest {
 
+public class ContactEntityTest {
 
 	@Test
 	public void testGettersAndSetters() {
@@ -50,7 +50,7 @@ public class ContactEntityTest {
 		Organization.OrganizationContactComponent fhirContact = contact.toFHIR();
 
 		assertNotNull(fhirContact);
-		
+
 		assertEquals(name.getFamily(), fhirContact.getName().getFamily());
 		assertEquals(telecom.size(), fhirContact.getTelecom().size());
 		assertEquals(address.getType(), fhirContact.getAddress().getType());

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/ContactPointEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/ContactPointEntityTest.java
@@ -1,44 +1,42 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.hl7.fhir.dstu3.model.ContactPoint;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import java.util.UUID;
 
 public class ContactPointEntityTest {
 
-
-	@Test
-	public void testGettersAndSetters() {
-		ContactPointEntity contactPoint = new ContactPointEntity();
-		UUID id = UUID.randomUUID();
+    @Test
+    public void testGettersAndSetters() {
+        ContactPointEntity contactPoint = new ContactPointEntity();
+        UUID id = UUID.randomUUID();
         ContactEntity contact = new ContactEntity();
-		ContactPoint.ContactPointSystem system = ContactPoint.ContactPointSystem.EMAIL;
+        ContactPoint.ContactPointSystem system = ContactPoint.ContactPointSystem.EMAIL;
         ContactPoint.ContactPointUse use = ContactPoint.ContactPointUse.WORK;
         String value = "foo@bar.com";
         Integer rank = 1;
 
-		contactPoint.setId(id);
+        contactPoint.setId(id);
         contactPoint.setContactEntity(contact);
         contactPoint.setSystem(system);
         contactPoint.setUse(use);
         contactPoint.setValue(value);
         contactPoint.setRank(rank);
 
-
-		assertEquals(id, contactPoint.getId());
+        assertEquals(id, contactPoint.getId());
         assertEquals(contact, contactPoint.getContactEntity());
         assertEquals(system, contactPoint.getSystem());
         assertEquals(use, contactPoint.getUse());
         assertEquals(value, contactPoint.getValue());
         assertEquals(rank, contactPoint.getRank());
 
-	}
+    }
 
-	@Test
-	public void testToFHIR() {
+    @Test
+    public void testToFHIR() {
         ContactPointEntity contactPoint = new ContactPointEntity();
         ContactPoint.ContactPointSystem system = ContactPoint.ContactPointSystem.EMAIL;
         ContactPoint.ContactPointUse use = ContactPoint.ContactPointUse.WORK;
@@ -49,12 +47,11 @@ public class ContactPointEntityTest {
         contactPoint.setValue(value);
 
         ContactPoint fhirContactPoint = contactPoint.toFHIR();
-        
+
         assertNotNull(fhirContactPoint);
         assertEquals(system, fhirContactPoint.getSystem());
         assertEquals(use, fhirContactPoint.getUse());
         assertEquals(value, fhirContactPoint.getValue());
 
-
-	}
+    }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/EndpointEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/EndpointEntityTest.java
@@ -1,13 +1,12 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 import org.hl7.fhir.dstu3.model.Endpoint;
 import java.util.UUID;
 
 public class EndpointEntityTest {
-
 
 	@Test
 	public void testGettersAndSetters() {
@@ -65,5 +64,4 @@ public class EndpointEntityTest {
 		assertEquals(code, connectionType.getCode());
 	}
 
-	
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/NameEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/NameEntityTest.java
@@ -1,8 +1,8 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
 
 import org.hl7.fhir.dstu3.model.HumanName;
 
@@ -31,7 +31,7 @@ public class NameEntityTest {
 	}
 
 	@Test
-	public void testToFHIR(){
+	public void testToFHIR() {
 		NameEntity name = new NameEntity();
 		HumanName.NameUse use = HumanName.NameUse.OFFICIAL;
 		String given = "Australian";

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/OrganizationEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/OrganizationEntityTest.java
@@ -1,7 +1,7 @@
 
 package gov.cms.dpc.common.entities;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import org.hl7.fhir.dstu3.model.Identifier;
 
@@ -10,14 +10,14 @@ import java.util.List;
 import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 public class OrganizationEntityTest {
 
 	@Test
 	public void testGettersAndSetters() {
 		OrganizationEntity org = new OrganizationEntity();
 		UUID id = UUID.randomUUID();
-		OrganizationEntity.OrganizationID organizationID = new OrganizationEntity.OrganizationID(DPCIdentifierSystem.NPPES,"1234");
+		OrganizationEntity.OrganizationID organizationID = new OrganizationEntity.OrganizationID(
+				DPCIdentifierSystem.NPPES, "1234");
 		String orgName = "CMS";
 		AddressEntity orgAddress = new AddressEntity();
 		List<ContactEntity> contacts = new ArrayList<>();
@@ -45,7 +45,7 @@ public class OrganizationEntityTest {
 		assertEquals(providerEntities, org.getProviders());
 		assertEquals(patientEntities, org.getPatients());
 		assertEquals(rosters, org.getRosters());
-	
+
 	}
 
 	@Test
@@ -73,7 +73,8 @@ public class OrganizationEntityTest {
 
 	@Test
 	public void testOrganizationIDToFHIR() {
-		OrganizationEntity.OrganizationID orgId = new OrganizationEntity.OrganizationID(DPCIdentifierSystem.NPPES,"1234");
+		OrganizationEntity.OrganizationID orgId = new OrganizationEntity.OrganizationID(DPCIdentifierSystem.NPPES,
+				"1234");
 		Identifier fhirID = orgId.toFHIR();
 
 		assertEquals(DPCIdentifierSystem.NPPES.getSystem(), fhirID.getSystem());

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/PatientEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/PatientEntityTest.java
@@ -1,9 +1,9 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 import org.hl7.fhir.dstu3.model.Enumerations.AdministrativeGender;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -18,7 +18,7 @@ public class PatientEntityTest {
 		PatientEntity patient = new PatientEntity();
 		String beneficiaryId = "12345";
 		String mbiHash = "54321";
-		LocalDate dob = LocalDate.of(1995,1,1);
+		LocalDate dob = LocalDate.of(1995, 1, 1);
 		AdministrativeGender gender = AdministrativeGender.MALE;
 		OrganizationEntity org = new OrganizationEntity();
 		List<AttributionRelationship> attributionRelationships = new ArrayList<>();
@@ -75,12 +75,12 @@ public class PatientEntityTest {
 
 	@Test
 	public void testLocalDateFunctions() {
-		LocalDate localDate = LocalDate.of(2023,10,15);
+		LocalDate localDate = LocalDate.of(2023, 10, 15);
 		Date utilityDate = PatientEntity.fromLocalDate(localDate);
 		LocalDate convertedDate = PatientEntity.toLocalDate(utilityDate);
 
 		assertNotNull(convertedDate);
 		assertNotNull(utilityDate);
-		assertEquals(localDate,convertedDate);
+		assertEquals(localDate, convertedDate);
 	}
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/PersonEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/PersonEntityTest.java
@@ -1,23 +1,16 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public class PersonEntityTest {
-
-	private PersonEntityImpl personEntity;
-
-	@Before
-	public void setup() {
-		this.personEntity = new PersonEntityImpl();
-	}
-
 	@Test
 	public void testGettersAndSetters() {
+		PersonEntityImpl personEntity = new PersonEntityImpl();
 		String firstName = "Sydney";
 		String lastName = "Danger";
 		UUID id = UUID.randomUUID();
@@ -38,23 +31,27 @@ public class PersonEntityTest {
 
 	@Test
 	public void testSetCreation() {
+		PersonEntityImpl personEntity = new PersonEntityImpl();
 		personEntity.setCreation();
 		assertNotNull(personEntity.getCreatedAt());
 		assertNotNull(personEntity.getUpdatedAt());
 	}
+
 	@Test
 	public void testSetUpdateTime() {
+		PersonEntityImpl personEntity = new PersonEntityImpl();
 		personEntity.setUpdateTime();
 		assertNotNull(personEntity.getUpdatedAt());
 	}
 
 }
 
-class PersonEntityImpl extends PersonEntity{
-	public PersonEntityImpl(){
+class PersonEntityImpl extends PersonEntity {
+	public PersonEntityImpl() {
 		super();
 	}
-	public PersonEntityImpl(String firstName, String lastName){
+
+	public PersonEntityImpl(String firstName, String lastName) {
 		super();
 		setFirstName(firstName);
 		setLastName(lastName);

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/ProviderEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/ProviderEntityTest.java
@@ -1,8 +1,8 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,7 +28,7 @@ public class ProviderEntityTest {
 		ProviderEntity provider = new ProviderEntity();
 		PatientEntity p1 = new PatientEntity();
 		PatientEntity p2 = new PatientEntity();
-		provider.setAttributedPatients(List.of(p1,p2));
+		provider.setAttributedPatients(List.of(p1, p2));
 
 		assertEquals(2, provider.getAttributedPatients().size());
 		assertEquals(p1, provider.getAttributedPatients().get(0));
@@ -40,7 +40,7 @@ public class ProviderEntityTest {
 		ProviderEntity provider = new ProviderEntity();
 		RosterEntity r1 = new RosterEntity();
 		RosterEntity r2 = new RosterEntity();
-		provider.setAttributionRosters(List.of(r1,r2));
+		provider.setAttributionRosters(List.of(r1, r2));
 
 		assertEquals(2, provider.getAttributionRosters().size());
 		assertEquals(r1, provider.getAttributionRosters().get(0));
@@ -71,7 +71,7 @@ public class ProviderEntityTest {
 		p1.setProviderNPI("1234567890");
 
 		ProviderEntity p2 = new ProviderEntity();
-		assertNotEquals(p2.hashCode(),p1.hashCode());
+		assertNotEquals(p2.hashCode(), p1.hashCode());
 		p2.setID(id);
 		p2.setProviderNPI("1234567890");
 

--- a/dpc-common/src/test/java/gov/cms/dpc/common/entities/RosterEntityTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/entities/RosterEntityTest.java
@@ -1,8 +1,7 @@
 package gov.cms.dpc.common.entities;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 
@@ -16,14 +15,14 @@ import java.util.UUID;
 
 public class RosterEntityTest {
 
-
 	@Test
 	public void testGettersAndSetters() {
 		RosterEntity roster = new RosterEntity();
 		UUID id = UUID.randomUUID();
 		ProviderEntity provider = new ProviderEntity();
 		OrganizationEntity managingOrg = new OrganizationEntity();
-		List<AttributionRelationship> attributions = List.of(new AttributionRelationship(), new AttributionRelationship());
+		List<AttributionRelationship> attributions = List.of(new AttributionRelationship(),
+				new AttributionRelationship());
 		OffsetDateTime createdUpdatedAt = OffsetDateTime.now();
 
 		roster.setId(id);
@@ -49,22 +48,21 @@ public class RosterEntityTest {
 		coding.setSystem(DPCIdentifierSystem.DPC.getSystem());
 		coding.setCode(UUID.randomUUID().toString());
 
-
 		Meta meta = new Meta();
 		meta.addTag(coding);
 		attributionRoster.setMeta(meta);
 		attributionRoster.setId(UUID.randomUUID().toString());
-	
+
 		ProviderEntity provider = new ProviderEntity();
-		
+
 		OffsetDateTime expirationDate = OffsetDateTime.now().plusDays(30);
 
-	 	RosterEntity rosterEntity = RosterEntity.fromFHIR(attributionRoster, provider, expirationDate);
+		RosterEntity rosterEntity = RosterEntity.fromFHIR(attributionRoster, provider, expirationDate);
 		assertNotNull(rosterEntity);
 		assertNotNull(rosterEntity.getManagingOrganization());
 		assertEquals(provider, rosterEntity.getAttributedProvider());
 		assertEquals(0, rosterEntity.getAttributions().size());
-		
+
 	}
 
 	@Test


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

- Update usage of org.junit to org.junit.jupiter.api
- Update `PersonEntityTest` to create a new entity for each test
- Auto-formatting updates from the IDE (sorry 😅)

## ℹ️ Context for reviewers

Followup to #1971. @alex-dzeda noticed that the coverage didn't increase in Sonarqube after merging the PR; I tested locally with `make unit-tests` and observed that the new tests were not run as part of the test suite locally or included in local code coverage metrics.

After comparison with other, existing tests, I determined that the issue was using `org.junit.Test` and `org.junit.Asserts` instead of the jupiter equivalents.

I also needed to update `PersonEntityTest` to create a new entity for each test, since it was running into NullPointerException issues with the existing approach.

## ✅ Acceptance Validation

Verified the local code coverage reflected the new tests after running `make unit-tests`. This report is generated under:

```
dpc-common/target/site/jacoco/gov.cms.dpc.common.entities/index.html
```

<img width="1075" alt="Screen Shot 2023-11-14 at 12 29 41 AM" src="https://github.com/CMSgov/dpc-app/assets/2308368/d7559479-461f-4289-b042-ab5d6a3d689d">

