### PR TITLE
DPC-3735: Enqueue admin and portal jobs in unique sidekiq queues

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -80,7 +80,7 @@ services:
     build:
       context: .
       dockerfile: dpc-admin/Dockerfile
-    command: sidekiq -q admin
+    command: sidekiq
     image: dpc-admin-sidekiq:latest
     environment:
       - REDIS_URL=redis://redis
@@ -118,7 +118,7 @@ services:
     build:
       context: .
       dockerfile: dpc-portal/Dockerfile
-    command: sidekiq -q portal
+    command: sidekiq
     image: dpc-portal-sidekiq:latest
     environment:
       - REDIS_URL=redis://redis

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -3,6 +3,7 @@ version: '3'
 volumes:
   coverage:
 
+
 services:
 
   redis:
@@ -79,7 +80,7 @@ services:
     build:
       context: .
       dockerfile: dpc-admin/Dockerfile
-    command: sidekiq
+    command: sidekiq -q admin
     image: dpc-admin-sidekiq:latest
     environment:
       - REDIS_URL=redis://redis
@@ -117,7 +118,7 @@ services:
     build:
       context: .
       dockerfile: dpc-portal/Dockerfile
-    command: sidekiq
+    command: sidekiq -q portal
     image: dpc-portal-sidekiq:latest
     environment:
       - REDIS_URL=redis://redis

--- a/dpc-admin/app/jobs/application_job.rb
+++ b/dpc-admin/app/jobs/application_job.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  # Ensure jobs get sent to a specialized admin queue. Our web applications share
+  # a single Redis instance and process jobs based on their queue name.
+  queue_as :admin
+
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 

--- a/dpc-admin/config/application.rb
+++ b/dpc-admin/config/application.rb
@@ -28,6 +28,10 @@ module Admin
     # Sending mail with`DeliveryJob` has been deprecated. Work has been moved to `MailDeliveryJob`
     config.action_mailer.delivery_job = 'ActionMailer::MailDeliveryJob'
 
+    # Ensure mailer jobs get sent to a specialized admin queue. Our web applications share
+    # a single Redis instance and process jobs based on their queue name.
+    config.action_mailer.deliver_later_queue_name = "admin"
+
     config.to_prepare { Devise::Mailer.layout 'mailer' }
 
     # Mail throttling

--- a/dpc-admin/docker/entrypoint.sh
+++ b/dpc-admin/docker/entrypoint.sh
@@ -20,8 +20,8 @@ fi
 if [ "$1" == "sidekiq" ]; then
   # Start Sidekiq job processing
   if [[ -n "$JACOCO" ]]; then
-    bundle exec sidekiq -q default -q mailers
+    bundle exec sidekiq -q admin
   else
-    bundle exec sidekiq -q default -q mailers 2>&1 | tee -a /var/log/dpc-admin-$(hostname)-sidekiq.log
+    bundle exec sidekiq -q admin 2>&1 | tee -a /var/log/dpc-admin-$(hostname)-sidekiq.log
   fi
 fi

--- a/dpc-portal/app/jobs/application_job.rb
+++ b/dpc-portal/app/jobs/application_job.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationJob < ActiveJob::Base
+  # Ensure jobs get sent to a specialized admin queue. Our web applications share
+  # a single Redis instance and process jobs based on their queue name.
+  queue_as :portal
+  
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked
 

--- a/dpc-portal/config/application.rb
+++ b/dpc-portal/config/application.rb
@@ -22,5 +22,9 @@ module DpcPortal
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.active_job.queue_adapter = :sidekiq
+    
+    # Ensure mailer jobs get sent to a specialized admin queue. Our web applications share
+    # a single Redis instance and process jobs based on their queue name.
+    config.action_mailer.deliver_later_queue_name = "portal"
   end
 end

--- a/dpc-portal/docker/entrypoint.sh
+++ b/dpc-portal/docker/entrypoint.sh
@@ -20,8 +20,8 @@ fi
 if [ "$1" == "sidekiq" ]; then
   # Start Sidekiq job processing
   if [[ -n "$JACOCO" ]]; then
-    bundle exec sidekiq -q default -q mailers
+    bundle exec sidekiq -q portal
   else
-    bundle exec sidekiq -q default -q mailers 2>&1 | tee -a /var/log/dpc-portal-$(hostname)-sidekiq.log
+    bundle exec sidekiq -q portal 2>&1 | tee -a /var/log/dpc-portal-$(hostname)-sidekiq.log
   fi
 fi

--- a/dpc-web/app/jobs/application_job.rb
+++ b/dpc-web/app/jobs/application_job.rb
@@ -1,2 +1,5 @@
 class ApplicationJob < ActiveJob::Base
+  # Ensure jobs get sent to a specialized web queue. Our web applications share
+  # a single Redis instance and process jobs based on their queue name.
+  queue_as :web
 end

--- a/dpc-web/config/application.rb
+++ b/dpc-web/config/application.rb
@@ -59,7 +59,11 @@ module DpcWebsite
 
     # Sending mail with`DeliveryJob` has been deprecated. Work has been moved to `MailDeliveryJob`
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
-
+    
+    # Ensure mailer jobs get sent to a specialized web queue. Our web applications share
+    # a single Redis instance and process jobs based on their queue name.
+    config.action_mailer.deliver_later_queue_name = "admin"
+    
     config.to_prepare { Devise::Mailer.layout "mailer" }
 
     # Mail throttling

--- a/dpc-web/config/application.rb
+++ b/dpc-web/config/application.rb
@@ -62,7 +62,7 @@ module DpcWebsite
     
     # Ensure mailer jobs get sent to a specialized web queue. Our web applications share
     # a single Redis instance and process jobs based on their queue name.
-    config.action_mailer.deliver_later_queue_name = "admin"
+    config.action_mailer.deliver_later_queue_name = "web"
     
     config.to_prepare { Devise::Mailer.layout "mailer" }
 

--- a/dpc-web/docker/entrypoint.sh
+++ b/dpc-web/docker/entrypoint.sh
@@ -27,8 +27,8 @@ fi
 if [ "$1" == "sidekiq" ]; then
   # Start Sidekiq job processing
   if [[ -n "$JACOCO" ]]; then
-    bundle exec sidekiq -q default -q mailers
+    bundle exec sidekiq -q web
   else
-    bundle exec sidekiq -q default -q mailers 2>&1 | tee -a /var/log/dpc-web-$(hostname)-sidekiq.log
+    bundle exec sidekiq -q web 2>&1 | tee -a /var/log/dpc-web-$(hostname)-sidekiq.log
   fi
 fi


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3735

## 🛠 Changes

- Update actionmailer configuration to add jobs in specific queues (this setting is used by Devise)
- Update base ApplicationJob to add jobs in specific queues
- Update sidekiq commands in entrypoints to process specific queues

## ℹ️ Context for reviewers

We are currently experiencing inconsistent issues with emails being sent out from the sandbox portal.

Emails are queued as sidekiq jobs within Redis and then processed by sidekiq workers. However, the dpc-web, dpc-admin, and dpc-portal sidekiq applications are all configured to enqueue and process jobs from the same Redis instance and the same default queue, which means that a job meant for the dpc-web application may be processed by the -admin or -portal worker. This ends in failure.

This PR configures sidekiq and actionmailer to use `admin` and `portal` queues for managing jobs from those applications. 

You can read more about using different queues here: https://github.com/sidekiq/sidekiq/wiki/Advanced-Options and also here specifically for Rails / ActiveJob: https://github.com/sidekiq/sidekiq/wiki/Active-Job#queues

This will allow the following:

- Sign up confirmation and password reset emails should be sent out successfully by dpc-web
- Organization assignment emails should be sent out successfully by dpc-admin
- No jobs should be processed by the dpc-portal application (yet)

## ✅ Acceptance Validation

Tested with current master branch in dev and did not receive password or confirmation codes most of the time.

After deploying, was able to consistently receive password and confirmation codes:

<img width="969" alt="CleanShot 2023-11-29 at 13 25 36@2x" src="https://github.com/CMSgov/dpc-app/assets/2308368/76347f8a-44c6-4def-abae-15c07e24f772">


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.