### PR TITLE
DPC-3740: Install lookbook in deployed environments

### DIFF
--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -29,9 +29,11 @@ gem 'health_check'
 gem 'jbuilder', '~> 2.7'
 gem 'kaminari'
 gem 'lograge'
+gem 'lookbook', '>= 2.1.1' # install lookbook so it can be deployed in lower environments.
 gem 'luhnacy', '~> 0.2.1'
 gem 'macaroons'
 gem 'newrelic_rpm', '~> 8.10'
+gem 'oauth2', '= 1.4.11'
 gem 'octokit' # can be removed once we move past github omniauth
 gem 'omniauth-github', '~> 1.4.0'
 gem 'omniauth-oktaoauth', '~> 0.1.6'
@@ -47,6 +49,8 @@ gem 'sidekiq', '~> 7.1'
 gem 'sidekiq_alive', '~> 2.1.5'
 gem 'truemail'
 gem 'uglifier', '>= 1.3.0'
+gem 'view_component', '~> 3.7'
+
 # < 1.13.2 has a vulnerability, and is required by other gems
 gem 'nokogiri', '>= 1.13.10'
 
@@ -63,9 +67,8 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'webmock'
 
-  # Lookbook
+  # Required for Lookbook live-reload
   gem 'actioncable', '~> 7.0.7.1'
-  gem 'lookbook', '>= 2.1.1'
 end
 
 group :development do
@@ -104,6 +107,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
-gem 'oauth2', '= 1.4.11'
-gem 'view_component', '~> 3.7'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3740

## 🛠 Changes

- Move lookbook dependency from :development group to :production group in Gemfile

## ℹ️ Context for reviewers

In #1979 we installed lookbook and configured it to deploy in the dev environment. However, the lookbook dependency is only installed in the :development RAILS_ENV group. It needs to be installed in the :production group, which is the RAILS_ENV used in all deployed environments.

In the future we should make sure this dependency is not installed in sandbox/prod, but until we get to production launch readiness we can keep this in the production group.

## ✅ Acceptance Validation


## 🔒 Security Implications

- [x] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

cc. @StewGoin 