### PR TITLE
Persist data in the local database across containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,11 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=dpc-safe
     volumes:
+      # Mount database startup script, which automatically creates new databases
+      # based on the POSTGRES_MULTIPLE_DATABASES variable above.
       - ./docker/postgres:/docker-entrypoint-initdb.d
+      # Mount persistent volume to ensure data is not erased across containers.
+      - pgdata:/var/lib/postgresql/data
 
   aggregation:
     image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-aggregation}:latest
@@ -115,6 +119,7 @@ services:
     network_mode: host
 
 volumes:
+  pgdata:
   export-volume:
     driver: local
     driver_opts:

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -63,6 +63,7 @@ docker-compose up start_api_dependencies
 docker-compose up --exit-code-from tests tests
 
 docker-compose down
+docker volume rm dpc-app_pgdata
 docker-compose up start_core_dependencies
 docker-compose up start_api_dependencies
 


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

- Add persistent volume to store local DB data
- Explicitly wipe database before running postman tests, since it seems to be required.

## ℹ️ Context for reviewers

Our local database gets wiped automatically whenever we restart the container. This data should persist to simplify development.

## ✅ Acceptance Validation

Stopped and recreated the database container, didn't have any issues.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
