### PR TITLE
Add task to create local org

### DIFF
--- a/dpc-portal/lib/tasks/dpc.rake
+++ b/dpc-portal/lib/tasks/dpc.rake
@@ -13,7 +13,11 @@ namespace :dpc do
                       'uri' => 'https://dpc.cms.gov/test-endpoint' }
     client = DpcClient.new
     client.create_organization(org, fhir_endpoint: fhir_endpoint)
-    puts "http://localhost:3100/portal/organizations/#{client.response_body['id']}"
+    if client.reponse_successful?
+      puts "http://localhost:3100/portal/organizations/#{client.response_body['id']}"
+    else
+      puts "HTTP ERROR #{client.response_status} creating org"
+    end
   end
 end
 

--- a/dpc-portal/lib/tasks/dpc.rake
+++ b/dpc-portal/lib/tasks/dpc.rake
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require './vendor/api_client/app/services/dpc_client'
+require './vendor/api_client/app/serializers/organization_submit_serializer'
+namespace :dpc do
+  desc 'Create a new organization with random attributes. Prints link.'
+  task :make_org do
+    raise BadEnvironmentError, 'Only for local development' unless ENV['ENV'] == 'local'
+
+    org = MockOrg.new
+    fhir_endpoint = { 'status' => 'test',
+                      'name' => 'DPC Sandbox Test Endpoint',
+                      'uri' => 'https://dpc.cms.gov/test-endpoint' }
+    client = DpcClient.new
+    client.create_organization(org, fhir_endpoint: fhir_endpoint)
+    puts "http://localhost:3100/portal/organizations/#{client.response_body['id']}"
+  end
+end
+
+# Fakes an org necessary to work with the DpcClient
+class MockOrg
+  # rubocop:disable Naming/VariableNumber
+  attr_reader :npi, :name, :address_use, :address_type, :address_city, :address_state, :address_street,
+              :address_street_2, :address_zip
+
+  def initialize
+    randy = Random.new
+    @name = "Generated Organization #{randy.rand(1000)}"
+    @npi = Luhnacy.doctor_npi[-10..]
+    @address_use = 'work'
+    @address_type = 'both'
+    @address_street = "#{randy.rand(1000)} Elm St"
+    @address_street_2 = "Suite #{randy.rand(100)}"
+    @address_city = 'Akron'
+    @address_state = 'OH'
+    @address_zip = '22222'
+  end
+  # rubocop:enable Naming/VariableNumber
+end
+
+class BadEnvironmentError < StandardError; end

--- a/dpc-portal/spec/spec_helper.rb
+++ b/dpc-portal/spec/spec_helper.rb
@@ -16,6 +16,9 @@ SimpleCov.start 'rails' do
   # Filter out ViewComponent / Lookbook previews
   add_filter %r{app/components/.*/.*preview.rb}
 
+  # Filter out utility tasks
+  add_filter 'lib/tasks/dpc.rake'
+
   # Gems added already tested
 
   add_filter 'vendor'


### PR DESCRIPTION
## 🛠 Changes

Added rake task to create an org in DPC for use by the portal

## ℹ️ Context for reviewers

Makes testing portal UI easier

## ✅ Acceptance Validation

1. Start the dpc `make start-dpc`
2. Run the task `docker exec dpc-app-dpc_portal-1 bundle exec rails dpc:make_org`
3. Verify the printed url shows an org in the browser

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
