### PR TITLE
Automatically generate golden macaroon on local dev startup

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -52,31 +52,6 @@ Set authentication_disabled for JVM set to **[true]** in the `api` service in th
 By default, the Docker containers start with minimal authentication enabled, meaning that some functionality (such as extracting the organization_id from the access token) will not work as expected and always return the same value.
 This can be overridden during startup by setting the `AUTH_DISABLED=false` environment variable.
 
-
-
-### Generate a Golden Macaroon
-You will need a macaroon for the Docker configuration. Run this command to generate one.
-`curl -X POST http://localhost:9903/tasks/generate-token`
-
-You will then need to add the **`API_METADATA URL`** variable and the **`GOLDEN_MACAROON`** variable to the `dpc_web` and `dpc_admin` services in the docker-compose.portal.yml file.
-```yaml
-dpc-web: 
-   
-  environment: 
-    ... 
-    - GOLDEN_MACAROON=newly-generated-macaroon  
-    - API_METADATA_URL=http://host.docker.internal:3002/v1
-    .. 
-  dpc_admin: 
-    ...
-    - API_METADATA_URL=${API_METADATA URL}
-    - GOLDEN_MACAROON=${ ...
-```
-
-
-
-
-
 RUN
 ====
 

--- a/README.md
+++ b/README.md
@@ -265,24 +265,9 @@ db:
 ```
 ### Generating a golden macaroon
 
-You will need a macaroon for the Docker configuration. Run the command below to generate one:
-`curl -X POST http://localhost:9903/tasks/generate-token`
+Golden macaroons are automatically generated and configured upon startup for the frontend applications. To generate your own for use, run the command below:
 
-
-Also, the docker-compose.portal.yml file requires adding the **`API_METADATA URL`** variable and the **`GOLDEN_MACAROON`** variable.
-```yaml
-dpc-web: 
-  ... 
-environments: 
-  ... 
-  - GOLDEN_MACAROON: ...  
-  - API_METADATA_URL=http://host.docker.internal:3002/v1
-  .. 
-dpc_admin: 
-  ...
-  - API_METADATA_URL=${API_METADATA URL}
-  - GOLDEN_MACAROON: ...
-```
+`curl -X POST -w '\n' http://localhost:9903/tasks/generate-token`
 
 ### Manual JAR execution
 

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -22,6 +22,9 @@ services:
       - REDIS_URL=redis://redis
       - DATABASE_URL=postgresql://db/dpc-website_development
       - TEST_DATABASE_URL=postgresql://db/dpc-website_test
+      - API_METADATA_URL=http://api:3002/v1
+      - API_ADMIN_URL=http://api:9900
+      - GOLDEN_MACAROON=${GOLDEN_MACAROON}
       - DB_USER=postgres
       - DB_PASS=dpc-safe
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
@@ -62,6 +65,7 @@ services:
       - REDIS_URL=redis://redis
       - GOLDEN_MACAROON=${GOLDEN_MACAROON}
       - API_METADATA_URL=http://api:3002/v1
+      - API_ADMIN_URL=http://api:9900
       - DATABASE_URL=postgresql://db/dpc-website_development
       - TEST_DATABASE_URL=postgresql://db/dpc-website_test
       - DB_USER=postgres
@@ -130,6 +134,7 @@ services:
       - TEST_DATABASE_URL=postgresql://db/dpc-portal_test
       - GOLDEN_MACAROON=${GOLDEN_MACAROON}
       - API_METADATA_URL=http://api:3002/v1
+      - API_ADMIN_URL=http://api:9900
       - DB_USER=postgres
       - DB_PASS=dpc-safe
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true

--- a/dpc-admin/docker/entrypoint.sh
+++ b/dpc-admin/docker/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 if [ "$1" == "admin" ]; then
   # Autogenerate fresh golden macaroons in local development
-  if [[ "$RAILS_ENV" == "production" ]] && [[ -z "$GOLDEN_MACAROON" ]]; then
+  if [[ "$RAILS_ENV" != "production" ]] && [[ -z "$GOLDEN_MACAROON" ]]; then
     echo "No golden macaroon found. Attempting to generate a new one..."
     export GOLDEN_MACAROON=$(curl -X POST -w '\n' ${API_ADMIN_URL}/tasks/generate-token || echo '')
 

--- a/dpc-admin/docker/entrypoint.sh
+++ b/dpc-admin/docker/entrypoint.sh
@@ -8,7 +8,19 @@ if [ -f tmp/pids/server.pid ]; then
 fi
 
 if [ "$1" == "admin" ]; then
-  # Start the database service (and make accessible outside the Docker container)
+  # Autogenerate fresh golden macaroons in local development
+  if [[ "$RAILS_ENV" == "production" ]] && [[ -z "$GOLDEN_MACAROON" ]]; then
+    echo "No golden macaroon found. Attempting to generate a new one..."
+    export GOLDEN_MACAROON=$(curl -X POST -w '\n' ${API_ADMIN_URL}/tasks/generate-token || echo '')
+
+    if [ -n "$GOLDEN_MACAROON" ]; then
+      echo "Successfully generated new golden macaroon."
+    else
+      echo "Could not generate a valid golden macaroon. Check that the API service is running."
+      echo "Starting Portal without a golden macaroon; certain functionality may not work correctly."
+    fi
+  fi
+
   echo "Starting Rails server..."
   if [[ -n "$JACOCO" ]]; then
     bundle exec rails server -b 0.0.0.0 -p 3000

--- a/dpc-portal/bin/dev
+++ b/dpc-portal/bin/dev
@@ -8,4 +8,16 @@ fi
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
+if [ -z "$GOLDEN_MACAROON" ]; then
+  echo "No golden macaroon found. Attempting to generate a new one..."
+  export GOLDEN_MACAROON=$(curl -X POST -w '\n' ${API_ADMIN_URL}/tasks/generate-token || echo '')
+
+  if [ -n "$GOLDEN_MACAROON" ]; then
+    echo "Successfully generated new golden macaroon."
+  else
+    echo "Could not generate a valid golden macaroon. Check that the API service is running."
+    echo "Starting Portal without a golden macaroon; certain functionality may not work correctly."
+  fi
+fi
+
 exec foreman start -f Procfile.dev "$@"

--- a/dpc-web/docker/entrypoint.sh
+++ b/dpc-web/docker/entrypoint.sh
@@ -16,7 +16,7 @@ if [ "$1" == "web" ]; then
   # This step is not needed, as there is no database seed data yet
 
   # Autogenerate fresh golden macaroons in local development
-  if [[ "$RAILS_ENV" == "production" ]] && [[ -z "$GOLDEN_MACAROON" ]]; then
+  if [[ "$RAILS_ENV" != "production" ]] && [[ -z "$GOLDEN_MACAROON" ]]; then
     echo "No golden macaroon found. Attempting to generate a new one..."
     export GOLDEN_MACAROON=$(curl -X POST -w '\n' ${API_ADMIN_URL}/tasks/generate-token || echo '')
 

--- a/dpc-web/docker/entrypoint.sh
+++ b/dpc-web/docker/entrypoint.sh
@@ -15,6 +15,19 @@ if [ "$1" == "web" ]; then
   # Seed the database
   # This step is not needed, as there is no database seed data yet
 
+  # Autogenerate fresh golden macaroons in local development
+  if [[ "$RAILS_ENV" == "production" ]] && [[ -z "$GOLDEN_MACAROON" ]]; then
+    echo "No golden macaroon found. Attempting to generate a new one..."
+    export GOLDEN_MACAROON=$(curl -X POST -w '\n' ${API_ADMIN_URL}/tasks/generate-token || echo '')
+
+    if [ -n "$GOLDEN_MACAROON" ]; then
+      echo "Successfully generated new golden macaroon."
+    else
+      echo "Could not generate a valid golden macaroon. Check that the API service is running."
+      echo "Starting Portal without a golden macaroon; certain functionality may not work correctly."
+    fi
+  fi
+
   # Start the database service (and make accessible outside the Docker container)
   echo "Starting Rails server..."
   if [[ -n "$JACOCO" ]]; then


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

- Update docker entrypoint scripts to generate golden macaroon on startup

## ℹ️ Context for reviewers

This removes a manual step required to call the API and generate golden macaroons. If the API is running when a frontend application starts, we will automatically generate a new macaroon If the API is not running, we will continue as normal and log a message noting that there is no macaroon.

## ✅ Acceptance Validation

Ran `make portal && make start-portal` with and without a golden macaroon set in the docker-compose file and observed both behaviors.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
