### PR TITLE
[DPC-3762] No longer takes IpAddressEntity in POST request

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/models/CreateIpAddressRequest.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/models/CreateIpAddressRequest.java
@@ -1,0 +1,26 @@
+package gov.cms.dpc.api.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import gov.cms.dpc.api.converters.InetDeserializer;
+import io.hypersistence.utils.hibernate.type.basic.Inet;
+
+public class CreateIpAddressRequest {
+    private String label;
+    @JsonDeserialize(using = InetDeserializer.class)
+    private Inet ipAddress;
+
+    public String getLabel() {return this.label;}
+    public CreateIpAddressRequest setLabel(String label) {this.label = label; return this;}
+    public Inet getIpAddress() {return this.ipAddress;}
+    public CreateIpAddressRequest setIpAddress(Inet ipAddress) {this.ipAddress = ipAddress; return this;}
+
+    public CreateIpAddressRequest(@JsonProperty("ipAddress") Inet ipAddress, @JsonProperty("label") String label) {
+        this.setIpAddress(ipAddress);
+        this.setLabel(label);
+    }
+    public CreateIpAddressRequest(Inet ipAddress) {
+        this.setIpAddress(ipAddress);
+        this.setLabel(null);
+    }
+}

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractIpAddressResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractIpAddressResource.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.api.resources;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.entities.IpAddressEntity;
 import gov.cms.dpc.api.models.CollectionResponse;
+import gov.cms.dpc.api.models.CreateIpAddressRequest;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Path;
@@ -13,7 +14,7 @@ import java.util.UUID;
 public abstract class AbstractIpAddressResource {
     public abstract CollectionResponse<IpAddressEntity> getOrganizationIpAddresses(OrganizationPrincipal organizationPrincipal);
 
-    public abstract IpAddressEntity submitIpAddress(OrganizationPrincipal organizationPrincipal, IpAddressEntity ipAddressEntity);
+    public abstract IpAddressEntity submitIpAddress(OrganizationPrincipal organizationPrincipal, CreateIpAddressRequest createIpAddressRequest);
 
     public abstract Response deleteIpAddress(OrganizationPrincipal organizationPrincipal, @NotNull UUID ipAddressId);
 }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/models/CreateIpAddressRequestUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/models/CreateIpAddressRequestUnitTest.java
@@ -1,0 +1,33 @@
+package gov.cms.dpc.api.models;
+
+import io.hypersistence.utils.hibernate.type.basic.Inet;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CreateIpAddressRequestUnitTest {
+    @Test
+    public void testConstructor() {
+        CreateIpAddressRequest createIpAddressRequest = new CreateIpAddressRequest(new Inet("192.168.1.1"), "label");
+        assertEquals("192.168.1.1", createIpAddressRequest.getIpAddress().getAddress());
+        assertEquals("label", createIpAddressRequest.getLabel());
+    }
+
+    @Test
+    public void testAltConstructor() {
+        CreateIpAddressRequest createIpAddressRequest = new CreateIpAddressRequest(new Inet("192.168.1.1"));
+        assertEquals("192.168.1.1", createIpAddressRequest.getIpAddress().getAddress());
+        assertNull(createIpAddressRequest.getLabel());
+    }
+
+    @Test
+    public void testSettersAndSetters() {
+        CreateIpAddressRequest createIpAddressRequest = new CreateIpAddressRequest(new Inet("192.168.1.1"));
+
+        createIpAddressRequest.setIpAddress(new Inet("10.1.1.1"));
+        createIpAddressRequest.setLabel("new label");
+        assertEquals("10.1.1.1", createIpAddressRequest.getIpAddress().getAddress());
+        assertEquals("new label", createIpAddressRequest.getLabel());
+    }
+}

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/IpAddressResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/IpAddressResourceUnitTest.java
@@ -5,6 +5,8 @@ import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.entities.IpAddressEntity;
 import gov.cms.dpc.api.jdbi.IpAddressDAO;
 import gov.cms.dpc.api.models.CollectionResponse;
+import gov.cms.dpc.api.models.CreateIpAddressRequest;
+import io.hypersistence.utils.hibernate.type.basic.Inet;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,6 +21,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,18 +58,19 @@ class IpAddressResourceUnitTest {
 
     @Test
     public void testPost_happyPath() {
+        CreateIpAddressRequest createIpAddressRequest = new CreateIpAddressRequest(new Inet("192.168.1.1"));
         IpAddressEntity ipAddressEntity = new IpAddressEntity();
 
         when(ipAddressDAO.fetchIpAddresses(organizationPrincipal.getID())).thenReturn(List.of());
-        when(ipAddressDAO.persistIpAddress(ipAddressEntity)).thenReturn(ipAddressEntity);
+        when(ipAddressDAO.persistIpAddress(any())).thenReturn(ipAddressEntity);
 
-        IpAddressEntity response = ipAddressResource.submitIpAddress(organizationPrincipal, ipAddressEntity);
+        IpAddressEntity response = ipAddressResource.submitIpAddress(organizationPrincipal, createIpAddressRequest);
         assertSame(ipAddressEntity, response);
     }
 
     @Test
     public void testPost_tooManyIps() {
-        IpAddressEntity ipAddressEntity = new IpAddressEntity();
+        CreateIpAddressRequest createIpAddressRequest = new CreateIpAddressRequest(new Inet("192.168.1.1"));
 
         List<IpAddressEntity> existingIps = new ArrayList<>();
         for(int i=0; i <= 8; i++) {
@@ -76,7 +80,7 @@ class IpAddressResourceUnitTest {
         when(ipAddressDAO.fetchIpAddresses(organizationPrincipal.getID())).thenReturn(existingIps);
 
         assertThrows(WebApplicationException.class, () -> {
-            ipAddressResource.submitIpAddress(organizationPrincipal, ipAddressEntity);
+            ipAddressResource.submitIpAddress(organizationPrincipal, createIpAddressRequest);
         });
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -408,6 +408,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration combine.self="override">
                             <groups>Integration</groups>
+                            <forkedProcessExitTimeoutInSeconds>600</forkedProcessExitTimeoutInSeconds>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3762

## 🛠 Changes

Updates POST request to create an IpAddress so that it no longer takes an IpAddressEntity and requires an org_id.

## ℹ️ Context for reviewers

For context, see this PR comment https://github.com/CMSgov/dpc-app/pull/2006#discussion_r1446793809

## ✅ Acceptance Validation

Tested locally.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
