### PR TITLE
Remove web-console from dpc-portal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,9 +136,9 @@ down-dpc:
 down-portals: ## Shut down all services
 down-portals: down-dpc
 
-down-start-v1-portals: ## Shut down all services
-down-start-v1-portals: down-dpc
-
+down-start-v1-portals: ## Shut down test services
+down-start-v1-portals:
+	@docker-compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml down
 
 # Utility commands
 # =================

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -69,10 +69,6 @@ group :development, :test do
 end
 
 group :development do
-  # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'listen', '~> 3.2'
-  gem 'web-console', '>= 3.3.0'
-
   gem 'rbnacl'
   gem 'rbnacl-libsodium'
 

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.19)
-    bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -461,11 +460,6 @@ GEM
       method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (4.2.1)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webdrivers (5.3.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -516,7 +510,6 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   kaminari
   letter_opener
-  listen (~> 3.2)
   lograge
   lookbook (>= 2.1.1)
   luhnacy (~> 0.2.1)
@@ -553,7 +546,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   view_component (~> 3.9)
-  web-console (>= 3.3.0)
   webdrivers
   webmock
 


### PR DESCRIPTION
## 🛠 Changes

- Removed listener and web-console gems from development stanza of Gemfile
- Updated makefile to stop the supporting services of ci-portal, etc, which dpc-down wasn't doing for me

## ℹ️ Context for reviewers

Should not have effect on production services

## ✅ Acceptance Validation

Nothing should change in terms of how things work

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
