### PR TITLE
[DPC-3783] Update JobBatchProcessor to only check most recent consent

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
@@ -224,14 +224,14 @@ public class JobBatchProcessor {
     private boolean isOptedOut(Optional<List<ConsentResult>> consentResultsOptional) {
         if (consentResultsOptional.isPresent()) {
             final List<ConsentResult> consentResults = consentResultsOptional.get();
-            long optOutCount = consentResults.stream().filter(consentResult -> {
-                final boolean isActive = consentResult.isActive();
-                final boolean isOptOut = ConsentResult.PolicyType.OPT_OUT.equals(consentResult.getPolicyType());
-                final boolean isFutureConsent = consentResult.getConsentDate().after(new Date());
-                return isActive && isOptOut && !isFutureConsent;
-            }).count();
-            return optOutCount > 0;
+            final ConsentResult latestConsent = Collections.max(consentResults, Comparator.comparing(consent -> consent.getConsentDate()));
+            final boolean isActive = latestConsent.isActive();
+            final boolean isOptOut = ConsentResult.PolicyType.OPT_OUT.equals(latestConsent.getPolicyType());
+            final boolean isFutureConsent = latestConsent.getConsentDate().after(new Date());
+            return isActive && isOptOut && !isFutureConsent;
         }
+        // This should never execute. Log an error.
+        logger.error("Consent result is unexpectedly empty.");
         return true;
     }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3783

## 🛠 Changes

The JobBatchProcessor has been updated so that, when checking if a patient is currently opted out, it only checks the most recent consent record. This way, if a patient decides to opt back in, the user will not be incorrectly flagged as opted out.

## ℹ️ Context for reviewers

Previous code checked the entire set of consent records for an opt out, effectively ignoring any opt-ins.

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
