### PR TITLE
Update nokogiri gem

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -48,7 +48,7 @@ gem 'lograge'
 gem 'macaroons'
 gem 'truemail'
 # < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.13.10'
+gem 'nokogiri', '>= 1.16.2'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -49,7 +49,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'view_component', '~> 3.9'
 
 # < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.13.10'
+gem 'nokogiri', '>= 1.16.2'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -48,7 +48,7 @@ gem 'redis-namespace'
 gem 'bootstrap-table-rails'
 
 # < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.13.10'
+gem 'nokogiri', '>= 1.16.2'
 
 gem 'api_client', path: 'vendor/api_client'
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3861

## 🛠 Changes

Updates nokogiri to >= 1.16.2 in dpc-admin, dpc-web and dpc-portal to address [this](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xc9x-jj77-9p9j) vulnerability.

## ℹ️ Context for reviewers

Vulnerability checks were failing when we attempted to merge code to doc-app.

## ✅ Acceptance Validation

All tests are passing.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
