### PR TITLE
Me/dpc 3861 update rails vulnerability

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -48,7 +48,7 @@ gem 'lograge'
 gem 'macaroons'
 gem 'truemail'
 # < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.13.10'
+gem 'nokogiri', '>= 1.16.2'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: vendor/api_client
+  specs:
+    api_client (0.1.0)
+      active_model_serializers
+      activemodel (~> 7.0.7.1)
+      fhir_client
+      macaroons
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -228,7 +237,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     minitest (5.19.0)
     msgpack (1.7.2)
     multi_json (1.15.0)
@@ -245,10 +254,8 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.16.0)
     nio4r (2.5.9)
-    nokogiri (1.15.3)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -473,6 +480,7 @@ DEPENDENCIES
   activerecord (~> 7.0.7.1)
   activestorage (~> 7.0.7.1)
   activesupport (~> 7.0.7.1)
+  api_client!
   bootsnap (>= 1.4.2)
   bundler (>= 1.15.0)
   bundler-audit
@@ -497,7 +505,7 @@ DEPENDENCIES
   luhnacy (~> 0.2.1)
   macaroons
   newrelic_rpm (~> 8.10)
-  nokogiri (>= 1.13.10)
+  nokogiri (>= 1.16.2)
   octokit
   omniauth-github (~> 1.4.0)
   omniauth-oktaoauth (~> 0.1.6)
@@ -536,4 +544,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.4.17
+   2.5.6

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -49,7 +49,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'view_component', '~> 3.9'
 
 # < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.13.10'
+gem 'nokogiri', '>= 1.16.2'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -85,7 +85,6 @@ GEM
       i18n
     bcrypt (3.1.19)
     bindata (2.4.15)
-    bindex (0.8.1)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -269,7 +268,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0808)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     minitest (5.20.0)
     msgpack (1.7.2)
     multi_json (1.15.0)
@@ -286,7 +285,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.16.0)
     nio4r (2.7.0)
-    nokogiri (1.15.4)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (1.4.11)
@@ -554,7 +553,7 @@ DEPENDENCIES
   luhnacy (~> 0.2.1)
   macaroons
   newrelic_rpm (~> 8.10)
-  nokogiri (>= 1.13.10)
+  nokogiri (>= 1.16.2)
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   pg (>= 0.18, < 2.0)
@@ -589,4 +588,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.5.4
+   2.4.20

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -48,7 +48,7 @@ gem 'redis-namespace'
 gem 'bootstrap-table-rails'
 
 # < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.13.10'
+gem 'nokogiri', '>= 1.16.2'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -1,3 +1,12 @@
+PATH
+  remote: vendor/api_client
+  specs:
+    api_client (0.1.0)
+      active_model_serializers
+      activemodel (~> 7.0.7.1)
+      fhir_client
+      macaroons
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -242,7 +251,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     minitest (5.19.0)
     msgpack (1.7.2)
     multi_json (1.15.0)
@@ -259,10 +268,8 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.16.0)
     nio4r (2.5.9)
-    nokogiri (1.15.3)
+    nokogiri (1.16.2)
       mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -454,6 +461,7 @@ DEPENDENCIES
   activerecord (~> 7.0.7.1)
   activestorage (~> 7.0.7.1)
   activesupport (~> 7.0.7.1)
+  api_client!
   bootsnap (>= 1.1.0)
   bootstrap-table-rails
   brakeman
@@ -483,7 +491,7 @@ DEPENDENCIES
   luhnacy (~> 0.2.1)
   macaroons
   newrelic_rpm (~> 8.10)
-  nokogiri (>= 1.13.10)
+  nokogiri (>= 1.16.2)
   pg (>= 0.18, < 2.0)
   pry
   pry-nav
@@ -515,4 +523,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.4.20
+   2.5.6

--- a/engines/api_client/Gemfile
+++ b/engines/api_client/Gemfile
@@ -11,7 +11,7 @@ gem 'active_model_serializers'
 gem 'macaroons'
 gem 'fhir_client'
 # rubocop:enable Bundler/OrderedGems
-gem 'nokogiri'
+gem 'nokogiri', '>= 1.16.2'
 gem 'rspec-rails'
 gem 'rubocop'
 gem 'simplecov'

--- a/engines/api_client/Gemfile.lock
+++ b/engines/api_client/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     netrc (0.11.0)
-    nokogiri (1.15.4-aarch64-linux)
+    nokogiri (1.16.2-aarch64-linux)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -231,7 +231,7 @@ DEPENDENCIES
   api_client!
   fhir_client
   macaroons
-  nokogiri
+  nokogiri (>= 1.16.2)
   rspec-rails
   rubocop
   simplecov


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3861

## 🛠 Changes

Updated gemfile.lock for doc-admin, dpc-web, doc-portal and api_client.  

## ℹ️ Context for reviewers

Updated the gemfiles in #2033 needed to run `bundle install` and update the lock files, too.

## ✅ Acceptance Validation

gemfile.lock is updated for each project.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
