### PR TITLE
Me/dpc 3874 fix ci app

### DIFF
--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -64,6 +64,7 @@ docker-compose up start_api_dependencies
 docker-compose up --exit-code-from tests tests
 
 docker-compose down
+docker volume rm dpc-app_pgdata
 docker-compose up start_core_dependencies
 docker-compose up start_api_dependencies
 

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -56,6 +56,7 @@ if [ -n "$REPORT_COVERAGE" ]; then
 fi
 
 docker-compose down
+docker volume rm dpc-app_pgdata
 docker-compose up start_core_dependencies
 docker-compose up start_api_dependencies
 
@@ -63,7 +64,6 @@ docker-compose up start_api_dependencies
 docker-compose up --exit-code-from tests tests
 
 docker-compose down
-docker volume rm dpc-app_pgdata
 docker-compose up start_core_dependencies
 docker-compose up start_api_dependencies
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3874

## 🛠 Changes

Drop `dpc-app_pgdata` both before and after running integration tests.

## ℹ️ Context for reviewers

Normally we would drop this volume after the integration tests run in `dpc-test.sh`, but when a test fails it would get skipped.  This would leave test data from the current failed run in the DB for the next run, and it was causing future integration tests and the `DPC - Docker Build` pipeline to occasionally fail.  See [here](https://management.dpc.cms.gov/job/DPC%20-%20Docker%20Build/3528/console) for example.  Now we drop the DB before the tests run as well, to make sure the DB is clean.

Note: The specific tests that were failing had to do with opt outs.  We make sure we can load a particular patient resource, then opt them out, then make sure we can't load them.  If the DB isn't wiped, the patient starts already opted out and we're not able to load them at all.

## ✅ Acceptance Validation

Pipeline is running successfully now.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
