### PR TITLE
DPC-3872: AO invites CD

### DIFF
--- a/dpc-portal/app/components/core/form/masked_input_component.html.erb
+++ b/dpc-portal/app/components/core/form/masked_input_component.html.erb
@@ -1,0 +1,4 @@
+          <%= label_tag attribute, label, class: "usa-label" %>
+          <%= raw %[<p class="usa-hint">#{hint}</p>] if hint.present? %>
+          <%= raw %[<p style="color: #b50909;">#{error_msg}</p>] if error_msg.present? %>
+          <%= text_field_tag attribute, default, input_options %>

--- a/dpc-portal/app/components/core/form/masked_input_component.rb
+++ b/dpc-portal/app/components/core/form/masked_input_component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Core
+  module Form
+    # Renders masked input fields
+    class MaskedInputComponent < ViewComponent::Base
+      attr_accessor :label, :attribute, :default, :input_options, :hint, :error_msg
+
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(label:, attribute:, mask:, default: '', hint: '', error_msg: '')
+        super
+        @label = label
+        @attribute = attribute
+        @input_options = { class: %w[usa-input usa-masked] }
+        @hint = hint
+        @error_msg = error_msg
+        @default = default
+        @input_options[:class] << 'usa-input--error' if error_msg.present?
+        case mask
+        when 'us-phone'
+          @input_options[:placeholder] = '___-___-____'
+          @input_options[:pattern] = '\d{3}-\d{3}-\d{4}'
+          @input_options['aria-describedby'] = 'telHint'
+        end
+      end
+      # rubocop:enable Metrics/ParameterLists
+    end
+  end
+end

--- a/dpc-portal/app/components/core/form/masked_input_component_preview.rb
+++ b/dpc-portal/app/components/core/form/masked_input_component_preview.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Core
+  module Form
+    # Preview of masked input component
+    # https://designsystem.digital.gov/components/input-mask/
+    class MaskedInputComponentPreview < ViewComponent::Preview
+      # @after_render :wrap_in_form
+      #
+      # @param label textarea
+      # @param hint textarea
+      # @param error textarea
+      def parameterized(label: 'Some label', hint: 'Here is a hint', error: '')
+        render(Core::Form::MaskedInputComponent.new(label: label, attribute: :foo, mask: 'us-phone', hint: hint,
+                                                    error_msg: error))
+      end
+
+      private
+
+      def wrap_in_form(html, _context)
+        <<~HTML
+           <form>
+            #{html}
+          </form>
+        HTML
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/core/form/text_input_component.html.erb
+++ b/dpc-portal/app/components/core/form/text_input_component.html.erb
@@ -1,6 +1,7 @@
         <div class="margin-bottom-4">
           <%= label_tag attribute, label, class: "usa-label" %>
           <%= raw %[<p class="usa-hint">#{hint}</p>] if hint.present? %>
+          <%= raw %[<p style="color: #b50909;">#{error_msg}</p>] if error_msg.present? %>
           <%= text_field_tag attribute, default, input_options  %>
         </div>
 

--- a/dpc-portal/app/components/core/form/text_input_component.rb
+++ b/dpc-portal/app/components/core/form/text_input_component.rb
@@ -4,18 +4,22 @@ module Core
   module Form
     # Renders <input type="text"...
     class TextInputComponent < ViewComponent::Base
-      attr_accessor :label, :attribute, :default, :input_options, :hint
+      attr_accessor :label, :attribute, :default, :input_options, :hint, :error_msg
 
-      def initialize(label:, attribute:, default: '', input_options: {}, hint: '')
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(label:, attribute:, default: '', input_options: {}, hint: '', error_msg: '')
         super
         @label = label
         @attribute = attribute
         @input_options = input_options
         @hint = hint
+        @error_msg = error_msg
         @default = default
-        input_options[:class] ||= []
-        input_options[:class] << 'usa-input'
+        @input_options[:class] ||= []
+        @input_options[:class] << 'usa-input' unless @input_options[:class].include?('usa-input')
+        @input_options[:class] << 'usa-input--error' if error_msg.present?
       end
+      # rubocop:enable Metrics/ParameterLists
     end
   end
 end

--- a/dpc-portal/app/components/core/form/text_input_component_preview.rb
+++ b/dpc-portal/app/components/core/form/text_input_component_preview.rb
@@ -7,8 +7,9 @@ module Core
       #
       # @param label textarea
       # @param hint textarea
-      def parameterized(label: 'Some label', hint: 'Here is a hint')
-        render(Core::Form::TextInputComponent.new(label: label, attribute: :foo, hint: hint))
+      # @param error textarea
+      def parameterized(label: 'Some label', hint: 'Here is a hint', error: '')
+        render(Core::Form::TextInputComponent.new(label: label, attribute: :foo, hint: hint, error_msg: error))
       end
     end
   end

--- a/dpc-portal/app/components/core/modal/modal_component.html.erb
+++ b/dpc-portal/app/components/core/modal/modal_component.html.erb
@@ -1,0 +1,31 @@
+<div class="usa-modal" id="<%= modal_id %>" aria-labelledby="<%= modal_id %>-heading" aria-describedby="<%= modal_id %>-description">
+  <div class="usa-modal__content">
+    <div class="usa-modal__main">
+      <h2 class="usa-modal__heading" id="<%= modal_id %>-heading">
+        <%= raw heading %>
+      </h2>
+      <div class="usa-prose">
+        <p id="<%= modal_id %>-description">
+          <%= raw description %>
+        </p>
+      </div>
+      <div class="usa-modal__footer">
+        <ul class="usa-button-group">
+          <li class="usa-button-group__item">
+            <%= raw yes_action %>
+          </li>
+          <li class="usa-button-group__item">
+            <button type="button" class="usa-button usa-button--unstyled padding-105 text-center" data-close-modal>
+              <%= raw no_message %>
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <button type="button" class="usa-button usa-modal__close" aria-label="Close this window" data-close-modal>
+      <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+        <use xlink:href="/assets/img/sprite.svg#close"></use>
+      </svg>
+    </button>
+  </div>
+</div>

--- a/dpc-portal/app/components/core/modal/modal_component.rb
+++ b/dpc-portal/app/components/core/modal/modal_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Core
+  module Modal
+    # Render a USWDS-styled modal.
+    class ModalComponent < ViewComponent::Base
+      attr_reader :heading, :description, :yes_action, :no_message, :modal_id
+
+      # prompt: text on button on page
+      def initialize(heading, description, yes_action, no_message, modal_id)
+        super
+        @heading = heading
+        @description = description
+        @yes_action = yes_action
+        @no_message = no_message
+        @modal_id = modal_id
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/core/modal/modal_component_preview.rb
+++ b/dpc-portal/app/components/core/modal/modal_component_preview.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Core
+  module Modal
+    # Modal Component
+    # ----------------
+    #
+    # [See at USWDS](https://designsystem.digital.gov/components/modal/)
+    #
+    class ModalComponentPreview < ViewComponent::Preview
+      # @after_render :add_launcher
+      def default
+        render(Core::Modal::ModalComponent.new('For reals?', 'Are you sure?',
+                                               '<a href="#" class="usa-button">Yes</a>', 'No',
+                                               'verify-modal'))
+      end
+
+      private
+
+      def add_launcher(html, _context)
+        <<~HTML
+          <a href="#verify-modal" aria-controls="verify-modal" data-open-modal="data-open-modal" class="usa-button">
+            Do thing
+          </a>
+          #{html}
+        HTML
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/core/table/row_component.html.erb
+++ b/dpc-portal/app/components/core/table/row_component.html.erb
@@ -5,56 +5,12 @@
   <% end %>
   <% if delete_path %>
   <td>
-      <a
-	href="#delete-modal-<%= obj['id'] %>"
-	aria-controls="delete-modal-<%= obj['id'] %>"
-	data-open-modal
-	>X</a>
-      <div
-	class="usa-modal"
-	id="delete-modal-<%= obj['id'] %>"
-	aria-labelledby="delete-modal-<%= obj['id'] %>-heading"
-	aria-describedby="delete-modal-<%= obj['id'] %>-description"
-	>
-	<div class="usa-modal__content">
-	  <div class="usa-modal__main">
-            <h2 class="usa-modal__heading" id="delete-modal-<%= obj['id'] %>-heading">
-              Permanently revoke <%= obj_name %>?
-            </h2>
-            <div class="usa-prose">
-              <p id="delete-modal-<%= obj['id'] %>-description">
-		Once revoked, this <%= obj_name %> will not work to access production data.
-              </p>
-            </div>
-            <div class="usa-modal__footer">
-              <ul class="usa-button-group">
-		<li class="usa-button-group__item">
-		  <%= button_to "Yes, revoke #{obj_name.split.last}", "#{delete_path}/#{obj['id']}", method: :delete, class: 'usa-button' %>
-		</li>
-		<li class="usa-button-group__item">
-		  <button
-                    type="button"
-                    class="usa-button usa-button--unstyled padding-105 text-center"
-                    data-close-modal
-		    >
-                    No, go back
-		  </button>
-		</li>
-              </ul>
-            </div>
-	  </div>
-	  <button
-            type="button"
-            class="usa-button usa-modal__close"
-            aria-label="Close this window"
-            data-close-modal
-	    >
-            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
-              <use xlink:href="/assets/img/sprite.svg#close"></use>
-            </svg>
-	  </button>
-	</div>
-      </div>
+    <a href="#delete-modal-<%= obj['id'] %>" aria-controls="delete-modal-<%= obj['id'] %>" data-open-modal>X</a>
+    <%= render(Core::Modal::ModalComponent.new("Permanently revoke #{obj_name}?",
+        "Once revoked, the #{obj_name} will not work to access production data.",
+        button_to("Yes, revoke #{obj_name.split.last}", "#{delete_path}/#{obj['id']}", method: :delete, class: 'usa-button'),
+        'No, go back',
+        "delete-modal-#{obj['id']}")) %>
   </td>
   <% end %>
 </tr>

--- a/dpc-portal/app/components/page/credential_delegate/invitation_success_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/invitation_success_component.html.erb
@@ -1,0 +1,14 @@
+<div>
+  <div class="margin-bottom-5">&larr; <%= link_to @organization.name, organization_path(organization.path_id) %></div>
+  <h1>Credential delegate invite sent</h1>
+  <div class="usa-alert usa-alert--success">
+    <div class="usa-alert__body">
+      <p class="usa-alert__text">
+	This is a succinct, helpful success message.
+      </p>
+    </div>
+  </div>
+  <div class="margin-top-5">
+    <%= link_to 'Return home', root_path, class: ['usa-button', 'usa-button--outline'] %>
+  </div>
+</div>

--- a/dpc-portal/app/components/page/credential_delegate/invitation_success_component.rb
+++ b/dpc-portal/app/components/page/credential_delegate/invitation_success_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Page
+  module CredentialDelegate
+    # Page shown after successful completion of invitation form.
+    class InvitationSuccessComponent < ViewComponent::Base
+      attr_reader :organization
+
+      def initialize(organization)
+        super
+        @organization = organization
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/page/credential_delegate/invitation_success_component_preview.rb
+++ b/dpc-portal/app/components/page/credential_delegate/invitation_success_component_preview.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Page
+  module CredentialDelegate
+    # Previews Invite Credential Delegate Success Page
+    class InvitationSuccessComponentPreview < ViewComponent::Preview
+      def default
+        render(Page::CredentialDelegate::InvitationSuccessComponent.new(MockOrg.new('Health Hut')))
+      end
+    end
+
+    # Mocks dpc-api organization
+    class MockOrg
+      attr_accessor :name, :path_id
+
+      def initialize(name)
+        @name = name
+        @path_id = 'some-guid'
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
@@ -23,12 +23,12 @@
           default: cd_invite.family_name,
           error_msg: cd_invite.errors[:family_name]&.first,
           input_options: { maxlength: 25 })) %>
-      <%= render(Core::Form::TextInputComponent.new(label: 'Primary phone number',
+      <%= render(Core::Form::MaskedInputComponent.new(label: 'Primary phone number',
           attribute: :phone_raw,
           hint: '10-digit, U.S. only, for example 999-999-9999',
           default: cd_invite.phone_raw,
           error_msg: cd_invite.errors[:phone_raw]&.first || cd_invite.errors[:phone]&.first,
-          input_options: @phone_input_options)) %>
+          mask: 'us-phone')) %>
       <%= render(Core::Form::TextInputComponent.new(label: 'Email',
           attribute: :email,
           error_msg: cd_invite.errors[:email]&.first,

--- a/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
@@ -1,0 +1,51 @@
+<div>
+  <h1>Invite new user</h1>
+  <div class="usa-alert usa-alert--warning margin-bottom-4">
+    <div class="usa-alert__body">
+      <h4 class="usa-alert__heading">Exact match required</h4>
+      <p class="usa-alert__text">
+        The name and contact info you enter must be an exact match to the name and contact info your Credential Delegate will provide after receiving this invite.
+      </p>
+    </div>
+  </div>
+  <div>
+    <h2>Contact Information</h2>
+    <%= form_tag organization_credential_delegate_invitations_path(@organization.path_id), method: :post, class: ['usa-form'], id: "cd-form" do %>
+      <%= render(Core::Form::TextInputComponent.new(label: 'First or given name',
+          attribute: :given_name,
+          hint: 'For example, Jose, Darren, or Mai',
+          default: cd_invite.given_name,
+          error_msg: cd_invite.errors[:given_name]&.first,
+          input_options: { maxlength: 25 })) %>
+      <%= render(Core::Form::TextInputComponent.new(label: 'Last or family name',
+          attribute: :family_name,
+          hint: 'For example, Martinez Gonzalez, Gu, or Smith',
+          default: cd_invite.family_name,
+          error_msg: cd_invite.errors[:family_name]&.first,
+          input_options: { maxlength: 25 })) %>
+      <%= render(Core::Form::TextInputComponent.new(label: 'Primary phone number',
+          attribute: :phone_raw,
+          hint: '10-digit, U.S. only, for example 999-999-9999',
+          default: cd_invite.phone_raw,
+          error_msg: cd_invite.errors[:phone_raw]&.first || cd_invite.errors[:phone]&.first,
+          input_options: @phone_input_options)) %>
+      <%= render(Core::Form::TextInputComponent.new(label: 'Email',
+          attribute: :email,
+          error_msg: cd_invite.errors[:email]&.first,
+          default: cd_invite.email)) %>
+      <%= render(Core::Form::TextInputComponent.new(label: 'Confirm email',
+          attribute: :email_confirmation,
+          error_msg: cd_invite.errors[:email_confirmation]&.first,
+          default: cd_invite.email_confirmation)) %>
+    <% end %>
+    <%= link_to 'Go Back', organization_path(organization.path_id), class: ['usa-button', 'usa-button--outline'] %>
+    <a href="#verify-modal" aria-controls="verify-modal" class="usa-button" data-open-modal>Send invite</a>
+    <%= render(Core::Modal::ModalComponent.new(
+        'Are you sure?',
+        'Messaging for AO Invite agreement',
+        link_to("Yes, assign CD", "#", class: "usa-button", onclick: "document.getElementById('cd-form').submit();"),
+        'No, go back',
+        'verify-modal')) %>
+  </div>
+</div>
+

--- a/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
@@ -43,7 +43,7 @@
     <%= render(Core::Modal::ModalComponent.new(
         'Are you sure?',
         'Messaging for AO Invite agreement',
-        link_to("Yes, assign CD", "#", class: "usa-button", onclick: "document.getElementById('cd-form').submit();"),
+        submit_tag("Yes, assign CD", class: "usa-button", form: "cd-form"),
         'No, go back',
         'verify-modal')) %>
   </div>

--- a/dpc-portal/app/components/page/credential_delegate/new_invitation_component.rb
+++ b/dpc-portal/app/components/page/credential_delegate/new_invitation_component.rb
@@ -4,13 +4,12 @@ module Page
   module CredentialDelegate
     # Render a USWDS-styled invite-cd form for a controller.
     class NewInvitationComponent < ViewComponent::Base
-      attr_reader :organization, :cd_invite, :phone_input_options
+      attr_reader :organization, :cd_invite
 
       def initialize(organization, cd_invite)
         super
         @organization = organization
         @cd_invite = cd_invite
-        @phone_input_options = { maxlength: 12, placeholder: '___-___-____' }
       end
     end
   end

--- a/dpc-portal/app/components/page/credential_delegate/new_invitation_component.rb
+++ b/dpc-portal/app/components/page/credential_delegate/new_invitation_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Page
+  module CredentialDelegate
+    # Render a USWDS-styled invite-cd form for a controller.
+    class NewInvitationComponent < ViewComponent::Base
+      attr_reader :organization, :cd_invite, :phone_input_options
+
+      def initialize(organization, cd_invite)
+        super
+        @organization = organization
+        @cd_invite = cd_invite
+        @phone_input_options = { maxlength: 12, placeholder: '___-___-____' }
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/page/credential_delegate/new_invitation_component_preview.rb
+++ b/dpc-portal/app/components/page/credential_delegate/new_invitation_component_preview.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Page
+  module CredentialDelegate
+    # Previews Invite Credential Delegate form
+    class NewInvitationComponentPreview < ViewComponent::Preview
+      def new
+        render(Page::CredentialDelegate::NewInvitationComponent.new(MockOrg.new('Health Hut'), CdInvitation.new))
+      end
+
+      def filled_in
+        cd_invite = CdInvitation.new(given_name: 'Bob',
+                                     family_name: 'Hogan',
+                                     phone_raw: '877-288-3131',
+                                     email: 'bob@example.com',
+                                     email_confirmation: 'bob@example.com')
+        render(Page::CredentialDelegate::NewInvitationComponent.new(MockOrg.new('Health Hut'), cd_invite))
+      end
+
+      def errors
+        cd_invite = CdInvitation.new
+        cd_invite.valid?
+        render(Page::CredentialDelegate::NewInvitationComponent.new(MockOrg.new('Health Hut'), cd_invite))
+      end
+    end
+
+    # Mocks dpc-api organization
+    class MockOrg
+      attr_accessor :name, :path_id
+
+      def initialize(name)
+        @name = name
+        @path_id = 'some-guid'
+      end
+    end
+  end
+end

--- a/dpc-portal/app/controllers/credential_delegate_invitations_controller.rb
+++ b/dpc-portal/app/controllers/credential_delegate_invitations_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Manages invitations to become a Credential Delegate
+class CredentialDelegateInvitationsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :load_organization
+
+  def new
+    render(Page::CredentialDelegate::NewInvitationComponent.new(@organization, CdInvitation.new))
+  end
+
+  def create
+    permitted = params.permit(:given_name, :family_name, :phone_raw, :email, :email_confirmation)
+    cd_invitation = CdInvitation.new(**permitted.to_h)
+    if cd_invitation.valid?
+      redirect_to success_organization_credential_delegate_invitation_path(@organization.path_id, 'new-invitation')
+    else
+      render(Page::CredentialDelegate::NewInvitationComponent.new(@organization, cd_invitation), status: :bad_request)
+    end
+  end
+
+  def success
+    render(Page::CredentialDelegate::InvitationSuccessComponent.new(@organization))
+  end
+
+  private
+
+  def load_organization
+    @organization = case ENV.fetch('ENV', nil)
+                    when 'prod-sbx'
+                      redirect_to root_url
+                    when 'test'
+                      Organization.new('6a1dbf47-825b-40f3-b81d-4a7ffbbdc270')
+                    when 'dev'
+                      Organization.new('78d02106-2837-4d07-8c51-8d73332aff09')
+                    else
+                      Organization.new(params[:organization_id])
+                    end
+  end
+end

--- a/dpc-portal/app/models/cd_invitation.rb
+++ b/dpc-portal/app/models/cd_invitation.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Placeholder for eventual ActiveRecord for saving this
+class CdInvitation
+  include ActiveModel::API
+
+  attr_accessor :given_name, :family_name, :phone, :email, :email_confirmation
+  attr_reader :phone_raw
+
+  validates :given_name, :family_name, :phone_raw, :email, :email_confirmation, presence: true
+  validates :email, format: Devise.email_regexp, confirmation: true
+  validates :phone, format: { with: /\A[0-9]{10}\z/ }
+
+  def initialize(**args)
+    @given_name = args.fetch(:given_name, '')
+    @family_name = args.fetch(:family_name, '')
+    @phone_raw = args.fetch(:phone_raw, '')
+    @phone = @phone_raw.tr('^0-9', '')
+    @email = args.fetch(:email, '')
+    @email_confirmation = args.fetch(:email_confirmation, '')
+  end
+
+  def phone_raw=(nbr)
+    @phone_raw = nbr
+    @phone = @phone_raw.tr('^0-9', '')
+  end
+end

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -23,6 +23,9 @@ Rails.application.routes.draw do
     resources :client_tokens, only: [:new, :create, :destroy]
     resources :public_keys, only: [:new, :create, :destroy]
     resources :ip_addresses, only: [:new, :create, :destroy]
+    resources :credential_delegate_invitations, only: [:new, :create, :destroy] do
+      get 'success', on: :member
+    end
   end
 
   match '/download_snippet', to: 'public_keys#download_snippet', as: 'download_snippet', via: :post

--- a/dpc-portal/spec/components/core/form/masked_input_component_spec.rb
+++ b/dpc-portal/spec/components/core/form/masked_input_component_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Core::Form::MaskedInputComponent, type: :component do
+  describe 'html' do
+    subject(:html) do
+      render_inline(component)
+      rendered_content
+    end
+
+    before do
+      render_inline(component)
+    end
+
+    context 'us-phone mask' do
+      let(:component) { described_class.new(label: 'Some Label', attribute: 'attr', mask: 'us-phone') }
+      let(:expected_html) do
+        <<~HTML
+          <label class="usa-label" for="attr">Some Label</label>
+          <input type="text" name="attr" id="attr" value="" class="usa-input usa-masked"
+           placeholder="___-___-____" pattern="\\d{3}-\\d{3}-\\d{4}" aria-describedby="telHint" />
+        HTML
+      end
+      it { is_expected.to match_html_fragment(expected_html) }
+    end
+
+    context 'invalid mask' do
+      let(:component) { described_class.new(label: 'Some Label', attribute: 'attr', mask: :foo) }
+      let(:expected_html) do
+        <<~HTML
+          <label class="usa-label" for="attr">Some Label</label>
+          <input type="text" name="attr" id="attr" value="" class="usa-input usa-masked" />
+        HTML
+      end
+      it { is_expected.to match_html_fragment(expected_html) }
+    end
+
+    context 'hint' do
+      let(:component) { described_class.new(label: 'Some Label', attribute: 'attr', mask: :foo, hint: 'Hint') }
+      let(:expected_html) do
+        <<~HTML
+           <label class="usa-label" for="attr">Some Label</label>
+          <p class="usa-hint">Hint</p>
+           <input type="text" name="attr" id="attr" value="" class="usa-input usa-masked" />
+        HTML
+      end
+      it { is_expected.to match_html_fragment(expected_html) }
+    end
+
+    context 'error' do
+      let(:component) do
+        described_class.new(label: 'Some Label', attribute: 'attr', mask: :foo, error_msg: 'Bad Input')
+      end
+      let(:expected_html) do
+        <<~HTML
+          <label class="usa-label" for="attr">Some Label</label>
+          <p style="color: #b50909;">Bad Input</p>
+          <input type="text" name="attr" id="attr" value="" class="usa-input usa-masked usa-input--error" />
+        HTML
+      end
+      it { is_expected.to match_html_fragment(expected_html) }
+    end
+  end
+end

--- a/dpc-portal/spec/components/core/form/text_input_component_spec.rb
+++ b/dpc-portal/spec/components/core/form/text_input_component_spec.rb
@@ -66,5 +66,19 @@ RSpec.describe Core::Form::TextInputComponent, type: :component do
       end
       it { is_expected.to match_html_fragment(expected_html) }
     end
+
+    context 'error' do
+      let(:component) { described_class.new(label: 'Some Label', attribute: 'attr', error_msg: 'Bad Input') }
+      let(:expected_html) do
+        <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="attr">Some Label</label>
+            <p style="color: #b50909;">Bad Input</p>
+            <input type="text" name="attr" id="attr" value="" class="usa-input usa-input--error" />
+           </div>
+        HTML
+      end
+      it { is_expected.to match_html_fragment(expected_html) }
+    end
   end
 end

--- a/dpc-portal/spec/components/core/modal/modal_component_spec.rb
+++ b/dpc-portal/spec/components/core/modal/modal_component_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Core::Modal::ModalComponent, type: :component do
+  include ComponentSupport
+  describe 'html' do
+    subject(:html) do
+      render_inline(component)
+      normalize_space(rendered_content)
+    end
+
+    let(:component) do
+      described_class.new('For reals?',
+                          'Are you sure?',
+                          '<a href="#" class="usa-button">Yes</a>',
+                          'No',
+                          'verify-modal')
+    end
+    let(:expected_html) do
+      <<~HTML
+        <div class="usa-modal" id="verify-modal" aria-labelledby="verify-modal-heading" aria-describedby="verify-modal-description">
+          <div class="usa-modal__content">
+            <div class="usa-modal__main">
+              <h2 class="usa-modal__heading" id="verify-modal-heading">
+                For reals?
+              </h2>
+              <div class="usa-prose">
+                <p id="verify-modal-description">
+                  Are you sure?
+                </p>
+              </div>
+              <div class="usa-modal__footer">
+                <ul class="usa-button-group">
+                  <li class="usa-button-group__item">
+                    <a href="#" class="usa-button">Yes</a>
+                  </li>
+                  <li class="usa-button-group__item">
+                    <button type="button" class="usa-button usa-button--unstyled padding-105 text-center" data-close-modal>
+                      No
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
+            <button type="button" class="usa-button usa-modal__close" aria-label="Close this window" data-close-modal>
+              <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+                <use xlink:href="/assets/img/sprite.svg#close"></use>
+              </svg>
+            </button>
+          </div>
+        </div>
+      HTML
+    end
+    before do
+      render_inline(component)
+    end
+
+    it { is_expected.to match_html_fragment(expected_html) }
+  end
+end

--- a/dpc-portal/spec/components/page/credential_delegate/invitation_success_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/invitation_success_component_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page::CredentialDelegate::InvitationSuccessComponent, type: :component do
+  include ComponentSupport
+  describe 'html' do
+    subject(:html) do
+      render_inline(component)
+      normalize_space(rendered_content)
+    end
+
+    let(:org) { ComponentSupport::MockOrg.new }
+
+    let(:component) { described_class.new(org) }
+    let(:expected_html) do
+      <<~HTML
+        <div>
+          <div class="margin-bottom-5">← <a href="/portal/organizations/#{org.path_id}">#{org.name}</a></div>
+           <h1>Credential delegate invite sent</h1>
+           <div class="usa-alert usa-alert--success">
+             <div class="usa-alert__body">
+               <p class="usa-alert__text">
+                 This is a succinct, helpful success message.
+               </p>
+            </div>
+          </div>
+          <div class="margin-top-5">
+            <a class="usa-button usa-button--outline" href="/portal/">Return home</a>
+          </div>
+        </div>
+      HTML
+    end
+    before do
+      render_inline(component)
+    end
+
+    it { is_expected.to match_html_fragment(expected_html) }
+  end
+end

--- a/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
@@ -66,14 +66,12 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
       end
 
       it 'should have empty phone stanza' do
-        phone = <<~HTML
-          <div class="margin-bottom-4">
-            <label class="usa-label" for="phone_raw">Primary phone number</label>
-            <p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>
-            <input type="text" name="phone_raw" id="phone_raw" value="" maxlength="12" placeholder="___-___-____" class="usa-input" />
-          </div>
-        HTML
-        is_expected.to include(normalize_space(phone))
+        phone = ['<label class="usa-label" for="phone_raw">Primary phone number</label>',
+                 '<p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>',
+                 '<input type="text" name="phone_raw" id="phone_raw" value="" ',
+                 'class="usa-input usa-masked" placeholder="___-___-____" ',
+                 'pattern="\\d{3}-\\d{3}-\\d{4}" aria-describedby="telHint" />'].join
+        is_expected.to include(phone)
       end
 
       it 'should have empty email stanza' do
@@ -131,19 +129,17 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
         is_expected.to include(normalize_space(family_name))
       end
 
-      it 'should have empty phone stanza' do
-        phone = <<~HTML
-          <div class="margin-bottom-4">
-            <label class="usa-label" for="phone_raw">Primary phone number</label>
-            <p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>
-            <p style="color: #b50909;">can't be blank</p>
-            <input type="text" name="phone_raw" id="phone_raw" value="" maxlength="12" placeholder="___-___-____" class="usa-input usa-input--error" />
-          </div>
-        HTML
+      it 'should have errored phone stanza' do
+        phone = ['<label class="usa-label" for="phone_raw">Primary phone number</label>',
+                 '<p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>',
+                 %(<p style="color: #b50909;">can't be blank</p>),
+                 '<input type="text" name="phone_raw" id="phone_raw" value="" ',
+                 'class="usa-input usa-masked usa-input--error" placeholder="___-___-____" ',
+                 'pattern="\\d{3}-\\d{3}-\\d{4}" aria-describedby="telHint" />'].join
         is_expected.to include(normalize_space(phone))
       end
 
-      it 'should have empty email stanza' do
+      it 'should have errored email stanza' do
         email = <<~HTML
           <div class="margin-bottom-4">
             <label class="usa-label" for="email">Email</label>
@@ -154,7 +150,7 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
         is_expected.to include(normalize_space(email))
       end
 
-      it 'should have empty email confirmation stanza' do
+      it 'should have errored email confirmation stanza' do
         email_confirmation = <<~HTML
           <div class="margin-bottom-4">
             <label class="usa-label" for="email_confirmation">Confirm email</label>
@@ -197,13 +193,11 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
       end
 
       it 'should have filled phone stanza' do
-        phone = <<~HTML
-          <div class="margin-bottom-4">
-            <label class="usa-label" for="phone_raw">Primary phone number</label>
-            <p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>
-            <input type="text" name="phone_raw" id="phone_raw" value="222-222-2222" maxlength="12" placeholder="___-___-____" class="usa-input" />
-          </div>
-        HTML
+        phone = ['<label class="usa-label" for="phone_raw">Primary phone number</label>',
+                 '<p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>',
+                 '<input type="text" name="phone_raw" id="phone_raw" value="222-222-2222" ',
+                 'class="usa-input usa-masked" placeholder="___-___-____" ',
+                 'pattern="\\d{3}-\\d{3}-\\d{4}" aria-describedby="telHint" />'].join
         is_expected.to include(normalize_space(phone))
       end
 

--- a/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :component do
+  include ComponentSupport
+  describe 'html' do
+    subject(:html) do
+      render_inline(component)
+      normalize_space(rendered_content)
+    end
+
+    let(:org) { ComponentSupport::MockOrg.new }
+    let(:cd_invite) { CdInvitation.new }
+
+    let(:component) { described_class.new(org, cd_invite) }
+
+    before do
+      render_inline(component)
+    end
+
+    context 'New form' do
+      it 'should match header' do
+        header = <<~HTML
+          <h1>Invite new user</h1>
+            <div class="usa-alert usa-alert--warning margin-bottom-4">
+              <div class="usa-alert__body">
+                <h4 class="usa-alert__heading">Exact match required</h4>
+                <p class="usa-alert__text">
+                  The name and contact info you enter must be an exact match to the name and contact info your Credential Delegate will provide after receiving this invite.
+                </p>
+              </div>
+            </div>
+          <div>
+        HTML
+        is_expected.to include(normalize_space(header))
+      end
+
+      it 'should match form tag' do
+        form_tag = ['<form class="usa-form" id="cd-form"',
+                    %(action="/portal/organizations/#{org.path_id}/credential_delegate_invitations"),
+                    'accept-charset="UTF-8" method="post">'].join(' ')
+        is_expected.to include(form_tag)
+      end
+
+      it 'should have empty given name stanza' do
+        first_name = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="given_name">First or given name</label>
+            <p class="usa-hint">For example, Jose, Darren, or Mai</p>
+            <input type="text" name="given_name" id="given_name" value="" maxlength="25" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(first_name))
+      end
+
+      it 'should have empty family name stanza' do
+        family_name = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="family_name">Last or family name</label>
+            <p class="usa-hint">For example, Martinez Gonzalez, Gu, or Smith</p>
+            <input type="text" name="family_name" id="family_name" value="" maxlength="25" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(family_name))
+      end
+
+      it 'should have empty phone stanza' do
+        phone = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="phone_raw">Primary phone number</label>
+            <p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>
+            <input type="text" name="phone_raw" id="phone_raw" value="" maxlength="12" placeholder="___-___-____" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(phone))
+      end
+
+      it 'should have empty email stanza' do
+        email = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="email">Email</label>
+            <input type="text" name="email" id="email" value="" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(email))
+      end
+
+      it 'should have empty email confirmation stanza' do
+        email_confirmation = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="email_confirmation">Confirm email</label>
+            <input type="text" name="email_confirmation" id="email_confirmation" value="" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(email_confirmation))
+      end
+
+      it 'should have modal prompt' do
+        modal_prompt = ['<a href="#verify-modal" aria-controls="verify-modal" ',
+                        'class="usa-button" data-open-modal>',
+                        'Send invite',
+                        '</a>'].join
+        is_expected.to include(modal_prompt)
+      end
+    end
+
+    context 'Errors' do
+      before { cd_invite.valid? }
+      it 'should have errored given name stanza' do
+        first_name = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="given_name">First or given name</label>
+            <p class="usa-hint">For example, Jose, Darren, or Mai</p>
+            <p style="color: #b50909;">can't be blank</p>
+            <input type="text" name="given_name" id="given_name" value="" maxlength="25" class="usa-input usa-input--error" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(first_name))
+      end
+
+      it 'should have errored family name stanza' do
+        family_name = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="family_name">Last or family name</label>
+            <p class="usa-hint">For example, Martinez Gonzalez, Gu, or Smith</p>
+            <p style="color: #b50909;">can't be blank</p>
+            <input type="text" name="family_name" id="family_name" value="" maxlength="25" class="usa-input usa-input--error" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(family_name))
+      end
+
+      it 'should have empty phone stanza' do
+        phone = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="phone_raw">Primary phone number</label>
+            <p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>
+            <p style="color: #b50909;">can't be blank</p>
+            <input type="text" name="phone_raw" id="phone_raw" value="" maxlength="12" placeholder="___-___-____" class="usa-input usa-input--error" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(phone))
+      end
+
+      it 'should have empty email stanza' do
+        email = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="email">Email</label>
+            <p style="color: #b50909;">can't be blank</p>
+            <input type="text" name="email" id="email" value="" class="usa-input usa-input--error" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(email))
+      end
+
+      it 'should have empty email confirmation stanza' do
+        email_confirmation = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="email_confirmation">Confirm email</label>
+            <p style="color: #b50909;">can't be blank</p>
+            <input type="text" name="email_confirmation" id="email_confirmation" value="" class="usa-input usa-input--error" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(email_confirmation))
+      end
+    end
+
+    context 'Pre-filled' do
+      before do
+        cd_invite.given_name = 'Bob'
+        cd_invite.family_name = 'Hodges'
+        cd_invite.phone_raw = '222-222-2222'
+        cd_invite.email = cd_invite.email_confirmation = 'bob@example.com'
+      end
+
+      it 'should have filled given name stanza' do
+        first_name = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="given_name">First or given name</label>
+            <p class="usa-hint">For example, Jose, Darren, or Mai</p>
+            <input type="text" name="given_name" id="given_name" value="Bob" maxlength="25" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(first_name))
+      end
+
+      it 'should have filled family name stanza' do
+        family_name = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="family_name">Last or family name</label>
+            <p class="usa-hint">For example, Martinez Gonzalez, Gu, or Smith</p>
+            <input type="text" name="family_name" id="family_name" value="Hodges" maxlength="25" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(family_name))
+      end
+
+      it 'should have filled phone stanza' do
+        phone = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="phone_raw">Primary phone number</label>
+            <p class="usa-hint">10-digit, U.S. only, for example 999-999-9999</p>
+            <input type="text" name="phone_raw" id="phone_raw" value="222-222-2222" maxlength="12" placeholder="___-___-____" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(phone))
+      end
+
+      it 'should have filled email stanza' do
+        email = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="email">Email</label>
+            <input type="text" name="email" id="email" value="bob@example.com" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(email))
+      end
+
+      it 'should have filled email confirmation stanza' do
+        email_confirmation = <<~HTML
+          <div class="margin-bottom-4">
+            <label class="usa-label" for="email_confirmation">Confirm email</label>
+            <input type="text" name="email_confirmation" id="email_confirmation" value="bob@example.com" class="usa-input" />
+          </div>
+        HTML
+        is_expected.to include(normalize_space(email_confirmation))
+      end
+    end
+  end
+end

--- a/dpc-portal/spec/factories/users.rb
+++ b/dpc-portal/spec/factories/users.rb
@@ -3,5 +3,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
+    password { '12345ABCDEfghi!' }
+    password_confirmation { '12345ABCDEfghi!' }
   end
 end

--- a/dpc-portal/spec/models/cd_invitation_spec.rb
+++ b/dpc-portal/spec/models/cd_invitation_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CdInvitation, type: :model do
+  let(:valid_cd_invite) do
+    CdInvitation.new(given_name: 'Bob',
+                     family_name: 'Hogan',
+                     phone_raw: '877-288-3131',
+                     email: 'bob@example.com',
+                     email_confirmation: 'bob@example.com')
+  end
+  it 'passes validations' do
+    expect(valid_cd_invite.valid?).to eq true
+  end
+
+  it 'fails on blank given name' do
+    valid_cd_invite.given_name = ''
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 1
+    expect(valid_cd_invite.errors[:given_name]).to eq ["can't be blank"]
+  end
+
+  it 'fails on blank family name' do
+    valid_cd_invite.family_name = ''
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 1
+    expect(valid_cd_invite.errors[:family_name]).to eq ["can't be blank"]
+  end
+
+  it 'fails on fewer-than-nine digits in phone' do
+    valid_cd_invite.phone_raw = '877-288-313'
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 1
+    expect(valid_cd_invite.errors[:phone]).to eq ['is invalid']
+  end
+
+  it 'fails on more-than-nine digits in phone' do
+    valid_cd_invite.phone_raw = '877-288-31333'
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 1
+    expect(valid_cd_invite.errors[:phone]).to eq ['is invalid']
+  end
+
+  it 'fails on blank phone' do
+    valid_cd_invite.phone_raw = ''
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 2
+    expect(valid_cd_invite.errors[:phone_raw]).to eq ["can't be blank"]
+    expect(valid_cd_invite.errors[:phone]).to eq ['is invalid']
+  end
+
+  it 'fails on bad email' do
+    valid_cd_invite.email_confirmation = valid_cd_invite.email = 'rob-at-example.com'
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 1
+    expect(valid_cd_invite.errors[:email]).to eq ['is invalid']
+  end
+
+  it 'fails on blank email' do
+    valid_cd_invite.email_confirmation = valid_cd_invite.email = ''
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 3
+    expect(valid_cd_invite.errors[:email]).to eq ["can't be blank", 'is invalid']
+    expect(valid_cd_invite.errors[:email_confirmation]).to eq ["can't be blank"]
+  end
+
+  it 'fails on non-matching email confirmation' do
+    valid_cd_invite.email_confirmation = 'robert@example.com'
+    expect(valid_cd_invite.valid?).to eq false
+    expect(valid_cd_invite.errors.size).to eq 1
+    expect(valid_cd_invite.errors[:email_confirmation]).to eq ["doesn't match Email"]
+  end
+end

--- a/dpc-portal/spec/models/cd_invitation_spec.rb
+++ b/dpc-portal/spec/models/cd_invitation_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe CdInvitation, type: :model do
     expect(valid_cd_invite.errors[:family_name]).to eq ["can't be blank"]
   end
 
-  it 'fails on fewer-than-nine digits in phone' do
+  it 'fails on fewer than ten digits in phone' do
     valid_cd_invite.phone_raw = '877-288-313'
     expect(valid_cd_invite.valid?).to eq false
     expect(valid_cd_invite.errors.size).to eq 1
     expect(valid_cd_invite.errors[:phone]).to eq ['is invalid']
   end
 
-  it 'fails on more-than-nine digits in phone' do
+  it 'fails on more than ten digits in phone' do
     valid_cd_invite.phone_raw = '877-288-31333'
     expect(valid_cd_invite.valid?).to eq false
     expect(valid_cd_invite.errors.size).to eq 1

--- a/dpc-portal/spec/rails_helper.rb
+++ b/dpc-portal/spec/rails_helper.rb
@@ -35,6 +35,11 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  # Devise test helpers
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root}/spec/fixtures"
 

--- a/dpc-portal/spec/requests/credential_delegate_invitations_spec.rb
+++ b/dpc-portal/spec/requests/credential_delegate_invitations_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'CredentialDelegateInvitations', type: :request do
+  include DpcClientSupport
+
+  describe 'GET /new not logged in' do
+    it 'redirects to login' do
+      get '/organizations/no-such-id/credential_delegate_invitations/new'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
+  describe 'GET /new' do
+    let!(:user) { create(:user) }
+
+    before { sign_in user }
+    it 'returns success' do
+      api_id = SecureRandom.uuid
+      stub_api_client(message: :get_organization,
+                      response: default_get_org_response(api_id))
+      get "/organizations/#{api_id}/credential_delegate_invitations/new"
+      expect(assigns(:organization).api_id).to eq api_id
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'POST /create' do
+    let!(:user) { create(:user) }
+    let!(:api_id) { SecureRandom.uuid }
+    let!(:successful_parameters) do
+      { given_name: 'Bob',
+        family_name: 'Hodges',
+        phone_raw: '222-222-2222',
+        email: 'bob@example.com',
+        email_confirmation: 'bob@example.com' }
+    end
+
+    before do
+      sign_in user
+      stub_api_client(message: :get_organization,
+                      response: default_get_org_response(api_id))
+    end
+    it 'redirects on success' do
+      post "/organizations/#{api_id}/credential_delegate_invitations", params: successful_parameters
+      expect(response).to redirect_to(success_organization_credential_delegate_invitation_path(api_id,
+                                                                                               'new-invitation'))
+    end
+
+    it 'does not redirect on failure' do
+      successful_parameters['given_name'] = ''
+      post "/organizations/#{api_id}/credential_delegate_invitations", params: successful_parameters
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe 'GET /success' do
+    let!(:user) { create(:user) }
+
+    before { sign_in user }
+    it 'returns success' do
+      api_id = SecureRandom.uuid
+      stub_api_client(message: :get_organization,
+                      response: default_get_org_response(api_id))
+      get "/organizations/#{api_id}/credential_delegate_invitations/foo/success"
+      expect(assigns(:organization).api_id).to eq api_id
+      expect(response).to have_http_status(200)
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3872

## 🛠 Changes

- Updated TextInputComponent to show errors
- Added MaskedInputComponent to support Phone Mask (must be child of form tag)
- Added a ModalComponent for use by NewInvitationComponent and RowComponent
- Added components for credential delegate invitation page and success page
- Added mock CD Invitation until we have a db schema to handle validations
- Added CredentialDelegateInvitation controller (with authentication required)

## ℹ️ Context for reviewers

Just getting the views working. No actual logic beyond validations.

## ✅ Acceptance Validation

Screenshots
![Screenshot 2024-02-16 at 4 42 09 PM](https://github.com/CMSgov/dpc-app/assets/145699825/54b2d71d-0179-43e9-9550-3886eed5d107)
![Screenshot 2024-02-16 at 4 42 23 PM](https://github.com/CMSgov/dpc-app/assets/145699825/d7aef6d4-d654-4ddf-af77-94e316f6d877)
![Screenshot 2024-02-16 at 4 43 09 PM](https://github.com/CMSgov/dpc-app/assets/145699825/a781acb3-a00c-4242-a5e6-f176700b9207)
![Screenshot 2024-02-16 at 4 43 55 PM](https://github.com/CMSgov/dpc-app/assets/145699825/228ab1c4-30a0-49cc-b06d-41970555f3f6)
![Screenshot 2024-02-16 at 4 44 09 PM](https://github.com/CMSgov/dpc-app/assets/145699825/76dd0d0c-1760-4159-8957-5d20d31b41cb)

