### PR TITLE
[DPC-3882] Remove PII from dpc-web portal page title

### DIFF
--- a/dpc-web/app/views/devise/password_expired/show.html.erb
+++ b/dpc-web/app/views/devise/password_expired/show.html.erb
@@ -1,3 +1,5 @@
+<% title "Password expired" %>
+
 <div class="ds-l-row">
   <div class="ds-l-col--12 ds-l-md-col--6 ds-u-margin-bottom--1 ds-u-margin-x--auto">
     <div class="card card--border-top card--shadow">

--- a/dpc-web/app/views/portal/show.html.erb
+++ b/dpc-web/app/views/portal/show.html.erb
@@ -1,4 +1,4 @@
-<% title "Welcome, #{@user.first_name}!" %>
+<% title "Welcome!" %>
 
 <div class="ds-l-container">
 

--- a/dpc-web/spec/features/authentication/user_sign_in_spec.rb
+++ b/dpc-web/spec/features/authentication/user_sign_in_spec.rb
@@ -42,6 +42,6 @@ RSpec.feature 'user signs in' do
 
     visit confirmation_link
 
-    expect(page.body).to include("Welcome, #{unconfirmed.first_name}!")
+    expect(page.body).to include('Welcome!')
   end
 end

--- a/dpc-web/spec/features/confirmation/user_confirmation_email_spec.rb
+++ b/dpc-web/spec/features/confirmation/user_confirmation_email_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'user resends confirmation instructions' do
 
       visit confirmation_link
 
-      expect(page.body).to include("Welcome, #{user.first_name}!")
+      expect(page.body).to include('Welcome!')
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3882

## 🛠 Changes

- Removes the username of a logged in user from the logged-in home title
- Adds a title for the password expired page

## ℹ️ Context for reviewers

All other page-level view components in dpc-web have been confirmed to a) have a title, and b) expose no PII in the title.

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
