### PR TITLE
DPC-3858: Persist user on login

### DIFF
--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -6,9 +6,10 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
 
   def openid_connect
     auth = request.env['omniauth.auth']
-    user = User.new(email: auth.info.email,
-                    given_name: auth.extra.raw_info.given_name,
-                    family_name: auth.extra.raw_info.family_name)
+    user = User.find_or_create_by(provider: auth.provider, uid: auth.uid) do |user_to_create|
+      assign_user_properties(user_to_create, auth)
+    end
+    ssn_cookie(auth.extra.raw_info.social_security_number)
     sign_in(:user, user)
   end
 
@@ -20,5 +21,24 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
       @message = 'You have decided not to authenticate via login.gov.'
       logger.warn 'User decided not to continue logging in'
     end
+  end
+
+  private
+
+  def assign_user_properties(user, auth)
+    user.email = auth.info.email
+    user.given_name = auth.extra.raw_info.given_name
+    user.family_name = auth.extra.raw_info.family_name
+    user.password = user.password_confirmation = Devise.friendly_token[0, 20]
+  end
+
+  def ssn_cookie(ssn)
+    # We will be comparing against ssn in PECOS, which does not contain dashes
+    hex = Digest::SHA2.new(256).hexdigest(ssn.tr('^0-9', ''))
+    cookies.signed.encrypted[:ao_id] = {
+      value: hex,
+      http_only: true,
+      expires: 30.minutes
+    }
   end
 end

--- a/dpc-portal/spec/factories/users.rb
+++ b/dpc-portal/spec/factories/users.rb
@@ -3,5 +3,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
+    password { '12345ABCDEfghi!' }
+    password_confirmation { '12345ABCDEfghi!' }
   end
 end

--- a/dpc-portal/spec/rails_helper.rb
+++ b/dpc-portal/spec/rails_helper.rb
@@ -35,6 +35,8 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root}/spec/fixtures"
 

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -4,16 +4,47 @@ require 'rails_helper'
 
 RSpec.describe 'LoginDotGov', type: :request do
   describe 'POST /users/auth/openid_connect' do
-    it 'signs in a user' do
+    before do
       OmniAuth.config.test_mode = true
       OmniAuth.config.add_mock(:openid_connect,
                                { uid: '12345',
                                  info: { email: 'bob@example.com' },
                                  extra: { raw_info: { given_name: 'Bob',
-                                                      family_name: 'Hoskins' } } })
+                                                      family_name: 'Hoskins',
+                                                      social_security_number: '1-2-3' } } })
+    end
+
+    it 'signs in a user' do
       post '/users/auth/openid_connect'
       follow_redirect!
       expect(response.body).to include('Bob Hoskins')
+    end
+
+    it 'persists user if not exist' do
+      expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 0
+      expect do
+        post '/users/auth/openid_connect'
+        follow_redirect!
+      end.to change { User.count }.by(1)
+      expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
+                        family_name: 'Hoskins').count).to eq 1
+    end
+
+    it 'does not persist user if exists' do
+      create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com')
+      expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 1
+      expect do
+        post '/users/auth/openid_connect'
+        follow_redirect!
+      end.to change { User.count }.by(0)
+    end
+
+    it 'saves hashed ssn in session' do
+      post '/users/auth/openid_connect'
+      follow_redirect!
+      expect(cookies[:ao_id]).to_not be_blank
+      jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
+      expect(jar.signed.encrypted[:ao_id]).to eq(Digest::SHA2.new(256).hexdigest('123'))
     end
   end
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3858
## 🛠 Changes

Actually saving a user after logging in via login-dot-gov.

## ℹ️ Context for reviewers

Also saves the hash of the ssn, though not technically part of the ticket

## ✅ Acceptance Validation

Manual testing shows user created in db