### PR TITLE
Me/dpc 3880 retrofit auth to portal

### DIFF
--- a/dpc-portal/app/controllers/client_tokens_controller.rb
+++ b/dpc-portal/app/controllers/client_tokens_controller.rb
@@ -2,6 +2,7 @@
 
 # Hanles client token requests
 class ClientTokensController < ApplicationController
+  before_action :authenticate_user!
   before_action :load_organization
 
   def new

--- a/dpc-portal/app/controllers/ip_addresses_controller.rb
+++ b/dpc-portal/app/controllers/ip_addresses_controller.rb
@@ -2,6 +2,7 @@
 
 # Handles IP address requests
 class IpAddressesController < ApplicationController
+  before_action :authenticate_user!
   before_action :load_organization
 
   def new

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -2,6 +2,7 @@
 
 # Shows Credential Delegates info about the organizations they manage the credentials for
 class OrganizationsController < ApplicationController
+  before_action :authenticate_user!
   before_action :load_organization
 
   def index

--- a/dpc-portal/app/controllers/public_keys_controller.rb
+++ b/dpc-portal/app/controllers/public_keys_controller.rb
@@ -2,6 +2,7 @@
 
 # Handles public key requests
 class PublicKeysController < ApplicationController
+  before_action :authenticate_user!
   before_action :load_organization
 
   def new

--- a/dpc-portal/spec/factories/users.rb
+++ b/dpc-portal/spec/factories/users.rb
@@ -3,5 +3,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user#{n}@example.com" }
+    password { '12345ABCDEfghi!' }
+    password_confirmation { '12345ABCDEfghi!' }
   end
 end

--- a/dpc-portal/spec/rails_helper.rb
+++ b/dpc-portal/spec/rails_helper.rb
@@ -35,6 +35,11 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
+  # Devise test helpers
+  config.include Devise::Test::IntegrationHelpers, type: :request
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root}/spec/fixtures"
 

--- a/dpc-portal/spec/requests/client_tokens_spec.rb
+++ b/dpc-portal/spec/requests/client_tokens_spec.rb
@@ -5,7 +5,17 @@ require 'rails_helper'
 RSpec.describe 'ClientTokens', type: :request do
   include DpcClientSupport
 
+  describe 'GET /new not logged in' do
+    it 'redirects to login' do
+      get '/organizations/no-such-id/client_tokens/new'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'GET /new' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'returns success' do
       api_id = SecureRandom.uuid
       stub_api_client(message: :get_organization,
@@ -16,7 +26,17 @@ RSpec.describe 'ClientTokens', type: :request do
     end
   end
 
+  describe 'Post /create not logged in' do
+    it 'redirects to login' do
+      post '/organizations/no-such-id/client_tokens'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'POST /create' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'succeeds if label' do
       org_api_id = SecureRandom.uuid
       token_guid = SecureRandom.uuid
@@ -52,7 +72,17 @@ RSpec.describe 'ClientTokens', type: :request do
     end
   end
 
+  describe 'Delete /destroy not logged in' do
+    it 'redirects to login' do
+      delete '/organizations/no-such-id/client_tokens/no-such-id'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'DELETE /destroy' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'flashes success if succeeds' do
       org_api_id = SecureRandom.uuid
       token_guid = SecureRandom.uuid
@@ -66,6 +96,7 @@ RSpec.describe 'ClientTokens', type: :request do
       expect(flash[:notice]).to eq('Client token successfully deleted.')
       expect(response).to redirect_to(organization_path(org_api_id))
     end
+
     it 'renders error if error' do
       org_api_id = SecureRandom.uuid
       token_guid = SecureRandom.uuid

--- a/dpc-portal/spec/requests/ip_addresses_spec.rb
+++ b/dpc-portal/spec/requests/ip_addresses_spec.rb
@@ -5,7 +5,17 @@ require 'rails_helper'
 RSpec.describe 'IpAddresses', type: :request do
   include DpcClientSupport
 
+  describe 'GET /new not logged in' do
+    it 'redirects to login' do
+      get '/organizations/no-such-id/ip_addresses/new'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'GET /new' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'returns success' do
       api_id = SecureRandom.uuid
       stub_api_client(message: :get_organization,
@@ -16,7 +26,17 @@ RSpec.describe 'IpAddresses', type: :request do
     end
   end
 
+  describe 'Post /create not logged in' do
+    it 'redirects to login' do
+      post '/organizations/no-such-id/ip_addresses'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'POST /create' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'succeeds with valid params' do
       org_api_id = SecureRandom.uuid
       api_client = stub_api_client(message: :get_organization,
@@ -75,7 +95,17 @@ RSpec.describe 'IpAddresses', type: :request do
     end
   end
 
+  describe 'Delete /destroy not logged in' do
+    it 'redirects to login' do
+      delete '/organizations/no-such-id/ip_addresses/no-such-id'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'DELETE /destroy' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'flashes success if succeeds' do
       org_api_id = SecureRandom.uuid
       addr_guid = SecureRandom.uuid

--- a/dpc-portal/spec/requests/organizations_spec.rb
+++ b/dpc-portal/spec/requests/organizations_spec.rb
@@ -5,7 +5,17 @@ require 'rails_helper'
 RSpec.describe 'Organizations', type: :request do
   include DpcClientSupport
 
+  describe 'GET /index not logged in' do
+    it 'redirects to login' do
+      get '/organizations'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'GET /index' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'returns success' do
       api_id = SecureRandom.uuid
       stub_api_client(message: :get_organization,
@@ -14,7 +24,17 @@ RSpec.describe 'Organizations', type: :request do
     end
   end
 
+  describe 'GET /organizations/[organization_id] not logged in' do
+    it 'redirects to login' do
+      get '/organizations/no-such-id'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'GET /organizations/[organization_id]' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'returns success' do
       api_id = SecureRandom.uuid
       stub_client(api_id)

--- a/dpc-portal/spec/requests/public_keys_spec.rb
+++ b/dpc-portal/spec/requests/public_keys_spec.rb
@@ -5,7 +5,17 @@ require 'rails_helper'
 RSpec.describe 'PublicKeys', type: :request do
   include DpcClientSupport
 
+  describe 'GET /new not logged in' do
+    it 'redirects to login' do
+      get '/organizations/no-such-id/public_keys/new'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'GET /new' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'returns success' do
       api_id = SecureRandom.uuid
       stub_api_client(message: :get_organization,
@@ -16,7 +26,17 @@ RSpec.describe 'PublicKeys', type: :request do
     end
   end
 
+  describe 'Post /create not logged in' do
+    it 'redirects to login' do
+      post '/organizations/no-such-id/public_keys'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'POST /create' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'succeeds with params' do
       org_api_id = SecureRandom.uuid
       api_client = stub_api_client(message: :get_organization,
@@ -71,7 +91,17 @@ RSpec.describe 'PublicKeys', type: :request do
     end
   end
 
+  describe 'Delete /destroy not logged in' do
+    it 'redirects to login' do
+      delete '/organizations/no-such-id/public_keys/no-such-id'
+      expect(response).to redirect_to('/portal/users/sign_in')
+    end
+  end
+
   describe 'DELETE /destroy' do
+    let!(:user) { create(:user) }
+    before { sign_in user }
+
     it 'flashes success if succeeds' do
       org_api_id = SecureRandom.uuid
       key_guid = SecureRandom.uuid
@@ -85,6 +115,7 @@ RSpec.describe 'PublicKeys', type: :request do
       expect(flash[:notice]).to eq('Public key successfully deleted.')
       expect(response).to redirect_to(organization_path(org_api_id))
     end
+
     it 'renders error if error' do
       org_api_id = SecureRandom.uuid
       key_guid = SecureRandom.uuid


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3880

## 🛠 Changes

Added auth to client_tokens_controller, ip_addresses_controller, organizations_controller and public_keys_controller and updated tests.

## ℹ️ Context for reviewers

The goal was to put our existing page controllers behind authentication.

## ✅ Acceptance Validation

Updated tests for each controller to test the case when a user is not logged in and they're all currently passing.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
