### PR TITLE
[DPC-3905] Add admin endpoint for fetching an organization by NPI

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/AdminResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/AdminResource.java
@@ -1,30 +1,25 @@
 package gov.cms.dpc.api.resources.v1;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Timed;
+import com.google.inject.name.Named;
+import gov.cms.dpc.api.auth.annotations.AdminOperation;
+import gov.cms.dpc.api.resources.AbstractAdminResource;
+import gov.cms.dpc.fhir.annotations.FHIR;
+import io.swagger.annotations.*;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Organization;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
-
-import com.codahale.metrics.annotation.ExceptionMetered;
-import com.codahale.metrics.annotation.Timed;
-import com.google.inject.name.Named;
-
-import ca.uhn.fhir.rest.client.api.IGenericClient;
-import gov.cms.dpc.api.auth.annotations.AdminOperation;
-import gov.cms.dpc.api.resources.AbstractAdminResource;
-import gov.cms.dpc.fhir.annotations.FHIR;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import io.swagger.annotations.Authorization;
-import org.hl7.fhir.dstu3.model.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 @Api(value = "Admin", authorizations = @Authorization(value = "access_token"))
@@ -43,14 +38,14 @@ public class AdminResource extends AbstractAdminResource{
     @Timed
     @AdminOperation
     @ExceptionMetered
-    @ApiOperation(value = "Get organizations by UUIDs",
+    @ApiOperation(value = "Get organizations by NPIs",
             notes = "FHIR endpoint which returns list of Organization resources that are currently registered with the application.",
             authorizations = @Authorization(value = "access_token"))
     @ApiResponses(value = {
             @ApiResponse(code = 401, message = "Only administrators can use this endpoint")})
-    public Bundle getOrganizations(@NotNull @QueryParam(value="ids") String ids) {
+    public Bundle getOrganizations(@NotNull @QueryParam(value="npis") String npis) {
         Map<String, List<String>> searchParams = new HashMap<>();
-        searchParams.put("identifier", Collections.singletonList(ids));
+        searchParams.put("identifier", Collections.singletonList(npis));
         Bundle bundle = this.client
                     .search()
                     .forResource(Organization.class)

--- a/dpc-api/src/test/java/gov/cms/dpc/api/AbstractSecureApplicationTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/AbstractSecureApplicationTest.java
@@ -74,6 +74,10 @@ public class AbstractSecureApplicationTest {
         return String.format("http://localhost:%d/tasks/", APPLICATION.getAdminPort());
     }
 
+    protected String getAdminResourceURL() {
+        return String.format("http://localhost:%d/v1/Admin", APPLICATION.getLocalPort());
+    }
+
     @BeforeAll
     public static void setup() throws Exception {
         APITestHelpers.setupApplication(APPLICATION);

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/AdminResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/AdminResourceTest.java
@@ -44,7 +44,7 @@ public class AdminResourceTest extends AbstractSecureApplicationTest{
         IGenericClient client = APIAuthHelpers.buildAdminClient(ctx, getAdminResourceURL(), GOLDEN_MACAROON, false);
 
         Map<String, List<String>> searchParams = new HashMap<>();
-        searchParams.put("npis", Collections.singletonList(DPCIdentifierSystem.MBI.getSystem() + "|" + APITestHelpers.ORGANIZATION_NPI));
+        searchParams.put("npis", Collections.singletonList(DPCIdentifierSystem.NPPES.getSystem() + "|" + APITestHelpers.ORGANIZATION_NPI));
 
         final Bundle orgBundle = client
                 .search()

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/AdminResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/AdminResourceTest.java
@@ -19,26 +19,8 @@ import java.net.URL;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AdminResourceTest extends AbstractSecureApplicationTest{
-
-    @Test
-    void testGetOrganizations() throws IOException, URISyntaxException {
-        UUID orgID1 = UUID.randomUUID();
-        UUID orgID2 = UUID.randomUUID();
-        URL url = new URL(getBaseURL() + "/Admin/Organization/?ids=id|"+orgID1.toString() + "," + orgID2.toString());
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setRequestMethod(HttpMethod.GET);
-        conn.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/fhir+json");
-        conn.setRequestProperty(HttpHeaders.AUTHORIZATION, "Bearer " + GOLDEN_MACAROON);
-
-        conn.setDoOutput(true);
-
-        assertNotNull(conn.getResponseCode());
-        assertEquals(HttpStatus.OK_200, conn.getResponseCode());
-        conn.disconnect();
-    }
 
     @Test
     void testNoGoldenMacaroon() throws IOException, URISyntaxException {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3905

## 🛠 Changes

Renamed the current `/Admin/Organization` end point to indicate that it's searching by NPI and not id.

## ℹ️ Context for reviewers

Despite the fact that it said it was searching by id, the admin end point we already have is actually searching by NPI.  The initial tests we had never caught it because they were only checking for a 200, not verifying the results.  I added a new integration test to AdminResourceTest that performs the search by NPI and ensures that a valid org is returned.

## ✅ Acceptance Validation

Passes new integration tests.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
