### PR TITLE
DPC-3888: Handle SQS/SNS-wrapped event notifications for Opt Out Import

### DIFF
--- a/lambda/opt-out-import/main.go
+++ b/lambda/opt-out-import/main.go
@@ -57,8 +57,8 @@ func handler(ctx context.Context, s3Event events.S3Event) (string, error) {
 		TimestampFormat:   time.RFC3339Nano,
 	})
 	for _, e := range s3Event.Records {
+		log.Info(e)
 		if e.EventName == "ObjectCreated:Put" {
-			log.Info(e)
 			success, err := importOptOutFile(e.S3.Bucket.Name, e.S3.Object.Key)
 			log.Info(success)
 			if err != nil {
@@ -68,6 +68,7 @@ func handler(ctx context.Context, s3Event events.S3Event) (string, error) {
 			return e.S3.Object.Key, err
 		}
 	}
+
 	return "", nil
 }
 

--- a/lambda/opt-out-import/main.go
+++ b/lambda/opt-out-import/main.go
@@ -60,7 +60,7 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (string, error) {
 	s3Event, err := ParseSQSEvent(sqsEvent)
 
 	if err != nil {
-		log.Errorf("Failed to parse S3 event: %w", err)
+		log.Errorf("Failed to parse S3 event: %v", err)
 		return "", err
 	} else if s3Event == nil {
 		log.Infof("No S3 event found, skipping safely.")

--- a/lambda/opt-out-import/main.go
+++ b/lambda/opt-out-import/main.go
@@ -57,11 +57,14 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (string, error) {
 		TimestampFormat:   time.RFC3339Nano,
 	})
 
-	log.Info(sqsEvent.Records[0].Body)
 	s3Event, err := ParseSQSEvent(sqsEvent)
 
 	if err != nil {
+		log.Errorf("Failed to parse S3 event: %w", err)
 		return "", err
+	} else if s3Event == nil {
+		log.Infof("No S3 event found, skipping safely.")
+		return "", nil
 	}
 
 	for _, e := range s3Event.Records {
@@ -76,6 +79,7 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (string, error) {
 		}
 	}
 
+	log.Warningf("No ObjectCreated:Put events found, skipping safely.")
 	return "", nil
 }
 

--- a/lambda/opt-out-import/main.go
+++ b/lambda/opt-out-import/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -60,38 +58,21 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (string, error) {
 	})
 
 	log.Info(sqsEvent.Records[0].Body)
+	s3Event, err := ParseSQSEvent(sqsEvent)
 
-	for _, sqsRecord := range sqsEvent.Records {
-		var snsEvent events.SNSEvent
-		err := json.Unmarshal([]byte(sqsRecord.Body), &snsEvent)
+	if err != nil {
+		return "", err
+	}
 
-		unmarshalTypeErr := new(json.UnmarshalTypeError)
-		if errors.As(err, &unmarshalTypeErr) {
-			log.Warn("Skipping event due to unrecognized format for SNS")
-			continue
-		}
-
-		for _, snsRecord := range snsEvent.Records {
-			var s3Event events.S3Event
-			err := json.Unmarshal([]byte(snsRecord.SNS.Message), &s3Event)
-
-			unmarshalTypeErr := new(json.UnmarshalTypeError)
-			if errors.As(err, &unmarshalTypeErr) {
-				log.Warn("Skipping event due to unrecognized format for S3")
-				continue
+	for _, e := range s3Event.Records {
+		if e.EventName == "ObjectCreated:Put" {
+			success, err := importOptOutFile(e.S3.Bucket.Name, e.S3.Object.Key)
+			log.Info(success)
+			if err != nil {
+				return e.S3.Object.Key, err
 			}
-
-			for _, e := range s3Event.Records {
-				if e.EventName == "ObjectCreated:Put" {
-					success, err := importOptOutFile(e.S3.Bucket.Name, e.S3.Object.Key)
-					log.Info(success)
-					if err != nil {
-						return e.S3.Object.Key, err
-					}
-					err = deleteS3File(e.S3.Bucket.Name, e.S3.Object.Key)
-					return e.S3.Object.Key, err
-				}
-			}
+			err = deleteS3File(e.S3.Bucket.Name, e.S3.Object.Key)
+			return e.S3.Object.Key, err
 		}
 	}
 

--- a/lambda/opt-out-import/main_test.go
+++ b/lambda/opt-out-import/main_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -239,7 +239,7 @@ func getSQSEvent(bucketName string, fileName string) events.SQSEvent {
 	}
 	defer jsonFile.Close()
 
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/lambda/opt-out-import/main_test.go
+++ b/lambda/opt-out-import/main_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,7 +27,7 @@ func TestHandler(t *testing.T) {
 		err    error
 	}{
 		{
-			event:  getS3Event("demo-bucket", "file_path"),
+			event:  getSQSEvent("demo-bucket", "file_path"),
 			expect: "file_path",
 			err:    nil,
 		},
@@ -47,7 +48,7 @@ func TestHandlerDatabaseTimeoutError(t *testing.T) {
 	createConnectionVar = func(string, string) (*sql.DB, error) { return nil, errors.New("Connection attempt timed out") }
 	defer func() { createConnectionVar = ofn }()
 
-	event := getS3Event("demo-bucket", "P.NGD.DPC.RSP.D240123.T1122001.IN")
+	event := getSQSEvent("demo-bucket", "P.NGD.DPC.RSP.D240123.T1122001.IN")
 	_, err := handler(context.Background(), event)
 
 	assert.EqualError(t, err, "Connection attempt timed out")
@@ -231,9 +232,7 @@ func TestIntegrationDeleteS3File(t *testing.T) {
 	}
 }
 
-func getS3Event(bucketName string, fileName string) events.SQSEvent {
-	var s3event events.SQSEvent
-
+func getSQSEvent(bucketName string, fileName string) events.SQSEvent {
 	jsonFile, err := os.Open("testdata/s3event.json")
 	if err != nil {
 		fmt.Println(err)
@@ -245,13 +244,26 @@ func getS3Event(bucketName string, fileName string) events.SQSEvent {
 		fmt.Println(err)
 	}
 
+	var s3event events.S3Event
 	err = json.Unmarshal([]byte(byteValue), &s3event)
 	if err != nil {
 		fmt.Println(err)
 	}
-	// s3event.Records[0].S3.Bucket.Name = bucketName
-	// s3event.Records[0].S3.Object.Key = fileName
-	return s3event
+
+	s3event.Records[0].S3.Bucket.Name = bucketName
+	s3event.Records[0].S3.Object.Key = fileName
+
+	val, err := json.Marshal(s3event)
+
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	body := fmt.Sprintf("{\"Type\" : \"Notification\",\n  \"MessageId\" : \"123456-1234-1234-1234-6e06896db643\",\n  \"TopicArn\" : \"my-topic\",\n  \"Subject\" : \"Amazon S3 Notification\",\n  \"Message\" : %s}", strconv.Quote(string(val[:])))
+	event := events.SQSEvent{
+		Records: []events.SQSMessage{{Body: body}},
+	}
+	return event
 }
 
 func loadS3() {

--- a/lambda/opt-out-import/main_test.go
+++ b/lambda/opt-out-import/main_test.go
@@ -21,7 +21,7 @@ import (
 func TestHandler(t *testing.T) {
 
 	tests := []struct {
-		event  events.S3Event
+		event  events.SQSEvent
 		expect string
 		err    error
 	}{
@@ -231,8 +231,8 @@ func TestIntegrationDeleteS3File(t *testing.T) {
 	}
 }
 
-func getS3Event(bucketName string, fileName string) events.S3Event {
-	var s3event events.S3Event
+func getS3Event(bucketName string, fileName string) events.SQSEvent {
+	var s3event events.SQSEvent
 
 	jsonFile, err := os.Open("testdata/s3event.json")
 	if err != nil {
@@ -249,8 +249,8 @@ func getS3Event(bucketName string, fileName string) events.S3Event {
 	if err != nil {
 		fmt.Println(err)
 	}
-	s3event.Records[0].S3.Bucket.Name = bucketName
-	s3event.Records[0].S3.Object.Key = fileName
+	// s3event.Records[0].S3.Bucket.Name = bucketName
+	// s3event.Records[0].S3.Object.Key = fileName
 	return s3event
 }
 

--- a/lambda/opt-out-import/parsers.go
+++ b/lambda/opt-out-import/parsers.go
@@ -102,7 +102,7 @@ func ParseSQSEvent(event events.SQSEvent) (*events.S3Event, error) {
 	unmarshalTypeErr := new(json.UnmarshalTypeError)
 	if errors.As(err, &unmarshalTypeErr) {
 		log.Warn("Skipping event due to unrecognized format for SNS")
-		return nil, err
+		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}

--- a/lambda/opt-out-import/parsers.go
+++ b/lambda/opt-out-import/parsers.go
@@ -3,14 +3,17 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/google/uuid"
 	"github.com/ianlopshire/go-fixedwidth"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 func ParseMetadata(bucket string, filename string) (OptOutFilenameMetadata, error) {
@@ -89,4 +92,31 @@ func ConvertSharingPreference(pref string) (string, error) {
 	} else {
 		return "", errors.New(fmt.Sprintf("Unexpected value %s for sharing preference", pref))
 	}
+}
+
+// TODO: Iterate over records
+func ParseSQSEvent(event events.SQSEvent) (*events.S3Event, error) {
+	var snsEntity events.SNSEntity
+	err := json.Unmarshal([]byte(event.Records[0].Body), &snsEntity)
+
+	unmarshalTypeErr := new(json.UnmarshalTypeError)
+	if errors.As(err, &unmarshalTypeErr) {
+		log.Warn("Skipping event due to unrecognized format for SNS")
+		return nil, err
+	} else if err != nil {
+		return nil, err
+	}
+
+	var s3Event events.S3Event
+	err = json.Unmarshal([]byte(snsEntity.Message), &s3Event)
+
+	unmarshalTypeErr = new(json.UnmarshalTypeError)
+	if errors.As(err, &unmarshalTypeErr) {
+		log.Warn("Skipping event due to unrecognized format for S3")
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return &s3Event, nil
 }

--- a/lambda/opt-out-import/parsers_test.go
+++ b/lambda/opt-out-import/parsers_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-lambda-go/events"
 	"github.com/ianlopshire/go-fixedwidth"
 	giterr "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -127,4 +128,16 @@ func TestParseRecord_InvalidData(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.expErr)
 		})
 	}
+}
+
+func TestParseSQSEvent(t *testing.T) {
+	body := "{\n  \"Type\" : \"Notification\",\n  \"MessageId\" : \"27e4306f-db21-52e8-ac8b-6e06896db643\",\n  \"TopicArn\" : \"arn:aws:sns:us-east-1:577373831711:bfd-test-eft-inbound-received-s3-dpc\",\n  \"Subject\" : \"Amazon S3 Notification\",\n  \"Message\" : \"{\\\"Records\\\":[{\\\"eventVersion\\\":\\\"2.1\\\",\\\"eventSource\\\":\\\"aws:s3\\\",\\\"awsRegion\\\":\\\"us-east-1\\\",\\\"eventTime\\\":\\\"2024-03-11T18:40:11.978Z\\\",\\\"eventName\\\":\\\"ObjectCreated:Put\\\",\\\"userIdentity\\\":{\\\"principalId\\\":\\\"AWS:AROAYM3RJQIP6E7GYLGEM:GitHubActions\\\"},\\\"requestParameters\\\":{\\\"sourceIPAddress\\\":\\\"52.159.142.207\\\"},\\\"responseElements\\\":{\\\"x-amz-request-id\\\":\\\"1FBF7M97BMGBA51P\\\",\\\"x-amz-id-2\\\":\\\"HTuKjp1ErjzUZRXSrcwqrKGd+R8pZwM/Xe7ozkCqJguFgSJw8MyIuW8+AE0SIxTDffnQs9wahu4+BE6IGIWKBjgB6JMUaJSYNVdUwMxp2RQ=\\\"},\\\"s3\\\":{\\\"s3SchemaVersion\\\":\\\"1.0\\\",\\\"configurationId\\\":\\\"bfd-test-eft-inbound-received-s3-dpc\\\",\\\"bucket\\\":{\\\"name\\\":\\\"bfd-test-eft\\\",\\\"ownerIdentity\\\":{\\\"principalId\\\":\\\"A5VBSMJFI0FCE\\\"},\\\"arn\\\":\\\"arn:aws:s3:::bfd-test-eft\\\"},\\\"object\\\":{\\\"key\\\":\\\"bfdeft01/dpc/in/P.NGD.DPC.RSP.D240311.T1840071.IN\\\",\\\"size\\\":148,\\\"eTag\\\":\\\"ab963837c0a2bb70c7f0d3aa886bf24c\\\",\\\"sequencer\\\":\\\"0065EF500BCCA7C4C6\\\"}}}]}\",\n  \"Timestamp\" : \"2024-03-11T18:40:12.630Z\",\n  \"SignatureVersion\" : \"1\",\n  \"Signature\" : \"W2xExh3H6n7j3U9RFliPV4gaG3oLAps2ilrpStqQaAkJ5ebf4+/gB2NKk9LH6e7rlX4+JAFlAwVGVNX+fdKNbBVKPpt+uyk+Ng586yQxVPoAFdbnnVu/KnyKnZ42iilNSR2vridid/LQBGkRWEqpBhYbtg/Ny/rZWD6PzqW0RktiNLscgat/i/PwOY6bmhz9fmd2NysRqh+BptrE4NZtEc6YxT1AOLswnj8KVcSlv0sEuD+/71Qrd69XKK+62yoXnH65+adLrejEVFQcv8MYVGsexvkhesQjWooTu6Kw2y/b/atp250d1yJPLR+UTuYAII0Z1rcmCIwpvB/wUuzBBw==\",\n  \"SigningCertURL\" : \"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-60eadc530605d63b8e62a523676ef735.pem\",\n  \"UnsubscribeURL\" : \"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:577373831711:bfd-test-eft-inbound-received-s3-dpc:5a305355-b238-4c5b-b1fb-e987474b09e4\"\n}"
+	event := events.SQSEvent{
+		Records: []events.SQSMessage{{Body: body}},
+	}
+
+	s3Event, err := ParseSQSEvent(event)
+	assert.Nil(t, err)
+	println(s3Event.Records[0].S3.Bucket.Name)
+	assert.NotNil(t, s3Event)
 }


### PR DESCRIPTION
## 🎫 Ticket

[DPC-3888](https://jira.cms.gov/browse/DPC-3888)

## 🛠 Changes

- Unwrap S3 events from SNS events from SQS events

## ℹ️ Context for reviewers

The pipeline from S3 --> Lambda includes hops from S3 --> SNS --> SQS --> Lambda, and each of those steps end up wrapping the previous message in another event wrapper.

This updates our parsing code to unwrap the S3 event from those other wrappers.

## ✅ Acceptance Validation

I have manually verified in AWS that the uploaded integration test file is parsed correctly.

![CleanShot 2024-03-11 at 16 17 46@2x](https://github.com/CMSgov/dpc-app/assets/2308368/a007d778-2942-4dbb-9608-d7c145784609)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
