### PR TITLE
Fix USWDS asset paths

### DIFF
--- a/docs/portal/assets-pipeline.md
+++ b/docs/portal/assets-pipeline.md
@@ -8,4 +8,6 @@ All CSS must be imported by the [application.sass.scss](/dpc-portal/app/assets/s
 
 The `assets:precompile` step in the Dockerfile takes care of everything else, compiling all linked assets in the Sprockets [manifest.js](/dpc-portal/app/assets/config/manifest.js) file into the `public/assets` folder with digest strings embedded into each filename. This causes automatic browser cache-busting to ensure that users always receive the newest version of an asset after a deployment.
 
+Additionally, the [USWDS initializer](/dpc-portal/config/initializers/uswds.rb) adds the compiled USWDS dist folder to Rails asset paths for ease of use.
+
 Read more about Sprockets [here](https://github.com/rails/sprockets/blob/main/guides/how_sprockets_works.md).

--- a/dpc-portal/app/assets/config/manifest.js
+++ b/dpc-portal/app/assets/config/manifest.js
@@ -3,6 +3,12 @@
 // the public/assets folder when running assets:precompile.
 
 // Link assets provided by USWDS installation.
+//
+// This serves a couple different purposes:
+// - Ensures that images and fonts are exposed properly on the client-side,
+//   since USWDS CSS references specific assets for their design components.
+// - Ensures that the js files are exposed properly for use in the application layout.
+//
 //= link_tree ../../../node_modules/@uswds/uswds/dist/img
 //= link_tree ../../../node_modules/@uswds/uswds/dist/fonts
 //= link @uswds/uswds/dist/js/uswds-init.min.js

--- a/dpc-portal/app/assets/stylesheets/uswds-theme.scss
+++ b/dpc-portal/app/assets/stylesheets/uswds-theme.scss
@@ -2,7 +2,8 @@
     // USWDS assets are compiled from the node_modules folder, so we need
     // to ensure that the compiled assets are referenced correctly.
     //
-    // See also: config/initializers/uswds.rb
+    // See also: assets/config/manifest.js
+    //           config/initializers/uswds.rb
     $theme-image-path: "@uswds/uswds/dist/img",
     $theme-font-path: "@uswds/uswds/dist/fonts",
     $theme-show-compile-warnings: true,

--- a/dpc-portal/config/initializers/uswds.rb
+++ b/dpc-portal/config/initializers/uswds.rb
@@ -1,9 +1,10 @@
-# Ensure the USWDS dist folder is compiled as part of assets. 
-# 
-# This serves a couple different purposes:
-# - Ensures that images and fonts are exposed properly on the client-side,
-#   since USWDS CSS references specific assets for their design components.
-# - Ensures that the js files are exposed properly for use in the application layout.
+# Ensure the USWDS dist folder is included in asset paths. This allows us 
+# to reference assets like so:
+#   'img/usa-icons/my-icon.svg'
 #
-# See also: app/assets/stylesheets/uswds-theme.scss
-Rails.application.config.assets.paths << Rails.root.join('node_modules/@uswds/uswds/dist')
+# instead of:
+#   '@uswds/uswds/dist/img/usa-icons/my-icon.svg'
+# 
+# See also: assets/config/manifest.js
+#           app/assets/stylesheets/uswds-theme.scss
+Rails.application.config.assets.paths << Rails.root.join('@uswds/uswds/dist')


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

- Fix USWDS asset paths to match compiled paths
- Update comments to be more accurate

## ℹ️ Context for reviewers

This fixes our USWDS initializer to add the correct path to the Rails asset paths. This will allow us to use tags like `image_tag` and `asset_path` without having to specify the `@uswds/uswds/dist` prefix for all of the assets.

Previously, this initializer didn't actually do anything because it had the wrong prefix. We didn't notice because we aren't referencing USWDS images or fonts in any of our custom HTML. 

## ✅ Acceptance Validation

Verified locally in Lookbook by adding the location_city.svg icon from USWDS:

![CleanShot 2024-03-13 at 09 35 04@2x](https://github.com/CMSgov/dpc-app/assets/2308368/17e9fc78-635a-4b90-bb8a-6b2d6f71a0f8)

```
<%= image_tag 'img/usa-icons/location_city.svg' %>
```

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
