### PR TITLE
DPC-3888: Fix effective dates in confirmation file

### DIFF
--- a/lambda/opt-out-import/db.go
+++ b/lambda/opt-out-import/db.go
@@ -123,8 +123,8 @@ func insertOptOutMetadata(db *sql.DB, optOutMetadata *OptOutFilenameMetadata) (O
 	return *optOutFile, nil
 }
 
-func insertConsentRecords(db *sql.DB, optOutFileId string, records []*OptOutRecord) ([]OptOutRecord, error) {
-	createdRecords := []OptOutRecord{}
+func insertConsentRecords(db *sql.DB, optOutFileId string, records []*OptOutRecord) ([]*OptOutRecord, error) {
+	createdRecords := []*OptOutRecord{}
 	query := `INSERT INTO consent (id, mbi, effective_date, policy_code, loinc_code, opt_out_file_id, created_at, updated_at) 
 			  VALUES `
 	for i, rec := range records {
@@ -152,7 +152,7 @@ func insertConsentRecords(db *sql.DB, optOutFileId string, records []*OptOutReco
 			return createdRecords, fmt.Errorf("insertConsentRecords: Failed to read newly created consent records: %w", err)
 		}
 		record.Status = Accepted
-		createdRecords = append(createdRecords, record)
+		createdRecords = append(createdRecords, &record)
 	}
 
 	// We're inserting all records in one batch, so if there wasn't an error they were all processed successfully

--- a/lambda/opt-out-import/main.go
+++ b/lambda/opt-out-import/main.go
@@ -143,7 +143,7 @@ func importOptOutFile(bucket string, file string) (bool, error) {
 		log.Info(fmt.Sprintf("ID: %s", rec.ID))
 	}
 
-	confirmationFile, err := generateConfirmationFile(true, records, fixedwidth.Marshal)
+	confirmationFile, err := generateConfirmationFile(true, createdRecords, fixedwidth.Marshal)
 	if err != nil {
 		log.Warning(fmt.Sprintf("Failed to generate confirmation file: %s", err))
 		return false, err


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3888

## 🛠 Changes

- Ensure the effective date in confirmation file is set

## ℹ️ Context for reviewers

Noticed the effective date is always 01-01-01. We should be using the `createdRecords` array which has the effective date set on each record 👍 

## ✅ Acceptance Validation

Verified the generated confirmation file in S3 after integration test.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
