### PR TITLE
DPC-3952: Add additional logs to export lambda

### DIFF
--- a/lambda/opt-out-export/db.go
+++ b/lambda/opt-out-export/db.go
@@ -52,6 +52,9 @@ var getAttributionData = func(dbUser string, dbPassword string, patientInfos map
 			log.Warningf("Error reading data: %v", err)
 		} else {
 			count += 1
+			if count%10000 == 0 {
+				log.Infof("Read %d rows", count)
+			}
 		}
 
 		patientInfos[perPatientInfo.beneficiary_id] = perPatientInfo

--- a/lambda/opt-out-export/main.go
+++ b/lambda/opt-out-export/main.go
@@ -40,7 +40,7 @@ func main() {
 		var filename, err = generateBeneAlignmentFile()
 		if err != nil {
 			log.Error(err)
-		} else {		
+		} else {
 			log.Println(filename)
 		}
 	} else {
@@ -157,7 +157,7 @@ func formatFileData(fileName string, patientInfos map[string]PatientInfo) (bytes
 		recordCount += 1
 	}
 	buff.WriteString(fmt.Sprintf("TRL_BENEDATAREQ%s%010d", curr_date, recordCount))
-	log.WithField("num_patients", len(patientInfos)).Info(fmt.Sprintf("Successfully generated beneficiary alignment file for file: %s", fileName))
+	log.WithField("num_patients", len(patientInfos)).WithField("request_filename", fileName).WithField("request_filesize", buff.Len()).Info(fmt.Sprintf("Successfully generated beneficiary alignment file for file: %s", fileName))
 	return buff, nil
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3952

## 🛠 Changes

- Add periodic logs while scanning patients table
- Add request_filename and request_filesize

## ℹ️ Context for reviewers

Adding some logs to:
- Show that the lambda is doing work while scanning the patients table
- Show request file information in the dashboard

## ✅ Acceptance Validation

Verified in the updated dashboard and in logs as part of integration test.

![CleanShot 2024-03-15 at 16 58 05@2x](https://github.com/CMSgov/dpc-app/assets/2308368/bee1a3a1-9760-4cca-9fdf-67de2459706f)

Matches the generated filesize in S3:
![CleanShot 2024-03-15 at 16 59 52@2x](https://github.com/CMSgov/dpc-app/assets/2308368/f7e85a64-70b9-4428-9367-83287a7eae94)


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
