### PR TITLE
Me/dpc 3860 hapi exception fix

### DIFF
--- a/dpc-api/src/test/java/gov/cms/dpc/api/cli/OrganizationTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/cli/OrganizationTests.java
@@ -6,6 +6,7 @@ import gov.cms.dpc.api.DPCAPIService;
 import gov.cms.dpc.api.cli.organizations.OrganizationDelete;
 import gov.cms.dpc.api.cli.organizations.OrganizationList;
 import gov.cms.dpc.api.cli.organizations.OrganizationRegistration;
+import gov.cms.dpc.testing.DummyJarLocation;
 import io.dropwizard.core.cli.Cli;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.util.JarLocation;
@@ -20,8 +21,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class OrganizationTests extends AbstractApplicationTest {
     private final PrintStream originalOut = System.out;
@@ -37,9 +36,8 @@ public class OrganizationTests extends AbstractApplicationTest {
 
     @BeforeEach
     void cliSetup() {
-        // Setup necessary mock
-        final JarLocation location = mock(JarLocation.class);
-        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+        // Setup dummy JarLocation
+        final JarLocation location = new DummyJarLocation();
 
         // Add commands you want to test
         final Bootstrap<DPCAPIConfiguration> bootstrap = new Bootstrap<>(new DPCAPIService());

--- a/dpc-api/src/test/java/gov/cms/dpc/api/cli/PublicKeyTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/cli/PublicKeyTests.java
@@ -8,6 +8,7 @@ import gov.cms.dpc.api.cli.keys.KeyList;
 import gov.cms.dpc.api.cli.keys.KeyUpload;
 import gov.cms.dpc.api.cli.organizations.OrganizationRegistration;
 import gov.cms.dpc.api.resources.v1.KeyResource;
+import gov.cms.dpc.testing.DummyJarLocation;
 import io.dropwizard.core.cli.Cli;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.util.JarLocation;
@@ -30,8 +31,6 @@ import java.util.stream.Collectors;
 
 import static gov.cms.dpc.testing.APIAuthHelpers.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class PublicKeyTests extends AbstractApplicationTest {
 
@@ -49,9 +48,8 @@ public class PublicKeyTests extends AbstractApplicationTest {
 
     @BeforeEach
     void cliSetup() {
-        // Setup necessary mock
-        final JarLocation location = mock(JarLocation.class);
-        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+        // Setup dummy JarLocation
+        final JarLocation location = new DummyJarLocation();
 
         // Add commands you want to test
         final Bootstrap<DPCAPIConfiguration> bootstrap = new Bootstrap<>(new DPCAPIService());

--- a/dpc-api/src/test/java/gov/cms/dpc/api/cli/TokenTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/cli/TokenTests.java
@@ -7,6 +7,7 @@ import gov.cms.dpc.api.cli.organizations.OrganizationRegistration;
 import gov.cms.dpc.api.cli.tokens.TokenCreate;
 import gov.cms.dpc.api.cli.tokens.TokenDelete;
 import gov.cms.dpc.api.cli.tokens.TokenList;
+import gov.cms.dpc.testing.DummyJarLocation;
 import io.dropwizard.core.cli.Cli;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.util.JarLocation;
@@ -26,8 +27,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class TokenTests extends AbstractApplicationTest {
 
@@ -45,9 +44,8 @@ class TokenTests extends AbstractApplicationTest {
 
     @BeforeEach
     void cliSetup() {
-        // Setup necessary mock
-        final JarLocation location = mock(JarLocation.class);
-        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+        // Setup dummy JarLocation
+        final JarLocation location = new DummyJarLocation();
 
         // Add commands you want to test
         final Bootstrap<DPCAPIConfiguration> bootstrap = new Bootstrap<>(new DPCAPIService());

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/cli/SeedCommandTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/cli/SeedCommandTest.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.attribution.cli;
 
 import gov.cms.dpc.attribution.DPCAttributionConfiguration;
 import gov.cms.dpc.attribution.DPCAttributionService;
+import gov.cms.dpc.testing.DummyJarLocation;
 import gov.cms.dpc.testing.IntegrationTest;
 import io.dropwizard.core.cli.Cli;
 import io.dropwizard.core.setup.Bootstrap;
@@ -18,8 +19,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @IntegrationTest
 public class SeedCommandTest {
@@ -32,8 +31,7 @@ public class SeedCommandTest {
 
     @BeforeEach
     void setup() {
-        final JarLocation location = mock(JarLocation.class);
-        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+        final JarLocation location = new DummyJarLocation();
 
         // Configure bootstrap - adapted from DropwizardTestSupport
         DPCAttributionService app = new DPCAttributionService();

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/AbstractFHIRExceptionHandler.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/AbstractFHIRExceptionHandler.java
@@ -4,7 +4,6 @@ import gov.cms.dpc.fhir.annotations.FHIR;
 import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 
 import javax.ws.rs.container.ResourceInfo;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
@@ -15,7 +14,7 @@ public abstract class AbstractFHIRExceptionHandler<E extends Throwable> extends 
 
     protected static final String ERROR_MSG_FMT = "There was an error processing your request. It has been logged (ID %016x): %s";
 
-    AbstractFHIRExceptionHandler(@Context ResourceInfo info) {
+    AbstractFHIRExceptionHandler(ResourceInfo info) {
         super();
         this.info = info;
     }

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/HAPIExceptionHandler.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/HAPIExceptionHandler.java
@@ -2,35 +2,30 @@ package gov.cms.dpc.fhir.dropwizard.handlers.exceptions;
 
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import gov.cms.dpc.fhir.FHIRMediaTypes;
+import io.dropwizard.jersey.errors.LoggingExceptionMapper;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 
 import javax.inject.Inject;
-import javax.ws.rs.container.ResourceInfo;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
 
+/**
+ * All BaseServerResponseExceptions are HAPI FHIR exceptions and should be treated the same.  It's possible to have a
+ * non-FHIR end point make a FHIR call that throws a BaseServerResponseException, and in that case we'll still return
+ * an OperationOutcome in the response body and the correct HTTP status code.
+ */
 @Provider
-public class HAPIExceptionHandler extends AbstractFHIRExceptionHandler<BaseServerResponseException> {
+public class HAPIExceptionHandler extends LoggingExceptionMapper<BaseServerResponseException> {
 
     @Inject
-    HAPIExceptionHandler(@Context ResourceInfo info) {
-        super(info);
-    }
+    HAPIExceptionHandler() {super();}
 
     @Override
     public Response toResponse(BaseServerResponseException exception) {
-        if (isFHIRResource()) {
-            return handleFHIRException(exception);
-        } else {
-            return handleNonFHIRException(exception);
-        }
-    }
-
-    @Override
-    Response handleFHIRException(BaseServerResponseException exception) {
         final long exceptionID = super.logException(exception);
+
+        // If the exception contains a FHIR OperationOutcome, use it.  If not, create one.
         OperationOutcome operationOutcome = (OperationOutcome) exception.getOperationOutcome();
         if (operationOutcome == null) {
             operationOutcome = new OperationOutcome();
@@ -39,17 +34,12 @@ public class HAPIExceptionHandler extends AbstractFHIRExceptionHandler<BaseServe
                     .setSeverity(OperationOutcome.IssueSeverity.ERROR)
                     .setDiagnostics(exception.getMessage());
         }
-        operationOutcome.setId(exceptionIDtoHex(exceptionID));
+        operationOutcome.setId(String.format("%016x", exceptionID));
 
         return Response
                 .status(exception.getStatusCode())
                 .type(FHIRMediaTypes.FHIR_JSON)
                 .entity(operationOutcome)
                 .build();
-    }
-
-    @Override
-    Response handleNonFHIRException(BaseServerResponseException exception) {
-        throw new IllegalStateException("Cannot return HAPI exception for non-FHIR method");
     }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/HAPIExceptionHandlerTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/HAPIExceptionHandlerTest.java
@@ -37,7 +37,7 @@ public class HAPIExceptionHandlerTest {
                 .setSeverity(OperationOutcome.IssueSeverity.ERROR)
                 .setDiagnostics(errMsg);
 
-        Response response = handler.toResponse(new ServerResponseException(HttpStatus.NOT_FOUND_404, errMsg));
+        Response response = handler.toResponse(new ServerResponseException(HttpStatus.NOT_FOUND_404, errMsg, outcome));
         assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
 
         OperationOutcome.OperationOutcomeIssueComponent issue = ((OperationOutcome) response.getEntity()).getIssueFirstRep();

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/HAPIExceptionHandlerTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/handlers/exceptions/HAPIExceptionHandlerTest.java
@@ -1,25 +1,19 @@
 package gov.cms.dpc.fhir.dropwizard.handlers.exceptions;
 
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
-import gov.cms.dpc.fhir.annotations.FHIR;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.OperationOutcome;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.Response;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class HAPIExceptionHandlerTest {
 
     @Test
-    void testToResponse_fhirException() {
-        ResourceInfo info = Mockito.mock(ResourceInfo.class);
-        Mockito.when(info.getResourceClass()).thenAnswer(answer -> FHIRResourceClass.class);
-        final HAPIExceptionHandler handler = new HAPIExceptionHandler(info);
+    void testToResponse_noOperationOutcome() {
+        final HAPIExceptionHandler handler = new HAPIExceptionHandler();
 
         String errMsg = "FHIR exception";
         Response response = handler.toResponse(new ServerResponseException(HttpStatus.NOT_FOUND_404, errMsg));
@@ -32,25 +26,35 @@ public class HAPIExceptionHandlerTest {
     }
 
     @Test
-    void testToResponse_nonFhirException() {
-        final HAPIExceptionHandler handler = new HAPIExceptionHandler(Mockito.mock(ResourceInfo.class));
+    void testToResponse_hasOperationOutcome() {
+        final HAPIExceptionHandler handler = new HAPIExceptionHandler();
 
-        try {
-            handler.toResponse(new ServerResponseException(HttpStatus.NOT_FOUND_404, ""));
-            fail("This call is supposed to fail.");
-        } catch (IllegalStateException exception) {
-            assertEquals("Cannot return HAPI exception for non-FHIR method", exception.getMessage());
-        }
+        String errMsg = "FHIR exception";
+
+        OperationOutcome outcome = new OperationOutcome();
+        outcome.addIssue()
+                .setCode(OperationOutcome.IssueType.EXCEPTION)
+                .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+                .setDiagnostics(errMsg);
+
+        Response response = handler.toResponse(new ServerResponseException(HttpStatus.NOT_FOUND_404, errMsg));
+        assertEquals(HttpStatus.NOT_FOUND_404, response.getStatus());
+
+        OperationOutcome.OperationOutcomeIssueComponent issue = ((OperationOutcome) response.getEntity()).getIssueFirstRep();
+        assertEquals(OperationOutcome.IssueType.EXCEPTION, issue.getCode());
+        assertEquals(OperationOutcome.IssueSeverity.ERROR, issue.getSeverity());
+        assertEquals(errMsg, issue.getDiagnostics());
     }
 
     static class ServerResponseException extends BaseServerResponseException {
+        OperationOutcome outcome;
+
         public ServerResponseException(int theStatusCode, String theMessage) {
             super(theStatusCode, theMessage);
         }
-    }
-
-    @FHIR
-    static class FHIRResourceClass {
-
+        public ServerResponseException(int theStatusCode, String theMessage, OperationOutcome outcome) {
+            super(theStatusCode, theMessage);
+            this.outcome = outcome;
+        }
     }
 }

--- a/dpc-consent/src/test/java/gov/cms/dpc/consent/cli/ConsentCommandsTest.java
+++ b/dpc-consent/src/test/java/gov/cms/dpc/consent/cli/ConsentCommandsTest.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.consent.cli;
 import ch.qos.logback.classic.LoggerContext;
 import gov.cms.dpc.consent.DPCConsentConfiguration;
 import gov.cms.dpc.consent.DPCConsentService;
+import gov.cms.dpc.testing.DummyJarLocation;
 import gov.cms.dpc.testing.IntegrationTest;
 import io.dropwizard.core.cli.Cli;
 import io.dropwizard.core.setup.Bootstrap;
@@ -16,8 +17,6 @@ import java.io.PrintStream;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @IntegrationTest
@@ -55,8 +54,7 @@ class ConsentCommandsTest {
         System.setOut(new PrintStream(stdOut));
         System.setErr(new PrintStream(stdErr));
 
-        final JarLocation location = mock(JarLocation.class);
-        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+        final JarLocation location = new DummyJarLocation();
 
         cli = new Cli(location, bs, stdOut, stdErr);
     }

--- a/dpc-consent/src/test/java/gov/cms/dpc/consent/cli/SeedCommandTest.java
+++ b/dpc-consent/src/test/java/gov/cms/dpc/consent/cli/SeedCommandTest.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.consent.cli;
 
 import gov.cms.dpc.consent.DPCConsentConfiguration;
 import gov.cms.dpc.consent.DPCConsentService;
+import gov.cms.dpc.testing.DummyJarLocation;
 import io.dropwizard.core.cli.Cli;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.util.JarLocation;
@@ -16,8 +17,6 @@ import java.io.PrintStream;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @Disabled
 class SeedCommandTest {
@@ -37,8 +36,7 @@ class SeedCommandTest {
 
     @BeforeEach
     void cliSetup() {
-        final JarLocation location = mock(JarLocation.class);
-        when(location.getVersion()).thenReturn(Optional.of("1.0.0"));
+        final JarLocation location = new DummyJarLocation();
 
         final Bootstrap<DPCConsentConfiguration> bootstrap = new Bootstrap<>(new DPCConsentService());
         bootstrap.addCommand(new SeedCommand(bootstrap.getApplication()));

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/DummyJarLocation.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/DummyJarLocation.java
@@ -1,0 +1,15 @@
+package gov.cms.dpc.testing;
+
+import io.dropwizard.util.JarLocation;
+
+import java.util.Optional;
+
+public class DummyJarLocation extends JarLocation {
+    public DummyJarLocation() {
+        super(DummyJarLocation.class);
+    }
+
+    public Optional<String> getVersion() {
+        return Optional.of("1.0.0");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -617,7 +617,7 @@
                 <plugin>
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>3.4.1</version>
                     <configuration>
                         <to>
                             <image>${jib.ecr.root}/${project.artifactId}</image>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3860

## 🛠 Changes

- Updated `HAPIExceptionHandler` so that all exceptions it handles return the correct HTTP status.
- Bumps Jib so that we can use the newest version of Docker without getting the LayerSources error when attempting to build dpc.
- Fixed broken CLI tests that won't run locally, but were running in GHA.

## ℹ️ Context for reviewers

The previous version of this code used an injected `ResourceInfo` object to determine if the end point from which the exception was thrown was a FHIR end point or not.  If it was a FHIR end point the correct http status was returned, and if it wasn't another exception was thrown and a 500 was returned.  The problem is that at least some of the time, and only in our persisted environments, Jersey failed to fill out the `ResourceInfo` object.  That lead to this handler returning 500's when it shouldn't have.

In the new version, we don't care if the end point the exception was thrown from was a FHIR end point or not.  In either case, we return the correct http status to the caller and fill out the response body with an `OperationOutcome`. 

Also, this handler only works on `BaseServerResponseExceptions`, which are defined in HAPI FHIR.  The only way to get a `BaseServerResponseException` outside of a FHIR end point is to have a non-FHIR end point make a FHIR call with the HAPI client and for it to throw an exception.  I'm not sure that's possible in our code, so worrying about whether an exception comes from a FHIR end point or not is probably moot.

## ✅ Acceptance Validation

Code updated and automated and manual tests are passing.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
