### PR TITLE
Remove sandbox /portal path

### DIFF
--- a/dpc-web/app/controllers/client_tokens_controller.rb
+++ b/dpc-web/app/controllers/client_tokens_controller.rb
@@ -64,6 +64,6 @@ class ClientTokensController < ApplicationController
 
   def unauthorized
     flash[:error] = 'Unauthorized'
-    redirect_to portal_path
+    redirect_to authenticated_root_path
   end
 end

--- a/dpc-web/app/controllers/organizations_controller.rb
+++ b/dpc-web/app/controllers/organizations_controller.rb
@@ -11,7 +11,7 @@ class OrganizationsController < ApplicationController
     @organization = current_user.organizations.find(id_param)
     if @organization.update organization_params
       flash[:notice] = 'Organization updated.'
-      redirect_to portal_path
+      redirect_to authenticated_root_path
     else
       flash[:alert] = "Organization could not be updated: #{model_error_string(@organization)}"
       render :edit

--- a/dpc-web/app/controllers/public_keys_controller.rb
+++ b/dpc-web/app/controllers/public_keys_controller.rb
@@ -74,6 +74,6 @@ class PublicKeysController < ApplicationController
 
   def unauthorized
     flash[:error] = 'Unauthorized'
-    redirect_to root_path
+    redirect_to authenticated_root_path
   end
 end

--- a/dpc-web/app/controllers/public_keys_controller.rb
+++ b/dpc-web/app/controllers/public_keys_controller.rb
@@ -38,7 +38,7 @@ class PublicKeysController < ApplicationController
     )
 
     if new_public_key[:response]
-      redirect_to portal_path
+      redirect_to authenticated_root_path
     else
       render_error new_public_key[:message]
     end
@@ -74,6 +74,6 @@ class PublicKeysController < ApplicationController
 
   def unauthorized
     flash[:error] = 'Unauthorized'
-    redirect_to portal_path
+    redirect_to root_path
   end
 end

--- a/dpc-web/app/views/client_tokens/show.html.erb
+++ b/dpc-web/app/views/client_tokens/show.html.erb
@@ -18,7 +18,7 @@
     </div>
   </section>
   <div>
-    <%= link_to portal_path, class: "ds-c-button ds-c-button--primary", data: { test: 'portal-link' } do %>
+    <%= link_to authenticated_root_path, class: "ds-c-button ds-c-button--primary", data: { test: 'portal-link' } do %>
       Go to portal
       <svg class="icon ds-u-margin-left--1" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
         <use xlink:href="/assets/solid.svg#arrow-right"></use>

--- a/dpc-web/config/routes.rb
+++ b/dpc-web/config/routes.rb
@@ -10,8 +10,6 @@ Rails.application.routes.draw do
     root 'portal#show', as: :authenticated_root, via: :get
   end
 
-  match '/portal', to: 'portal#show', via: :get
-
   resources :organizations, only: [:edit, :update] do
     resources :client_tokens, only: [:new, :create, :destroy]
     resources :public_keys, only: [:new, :create, :destroy]

--- a/dpc-web/spec/controllers/client_tokens_controller_spec.rb
+++ b/dpc-web/spec/controllers/client_tokens_controller_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe ClientTokensController, type: :controller do
       context 'with invalid organization id' do
         it 'redirects to portal' do
           other_org = create(:organization)
-          expect(get :new, params: {
+          expect(get(:new, params: {
             organization_id: other_org.id
-          }).to redirect_to(authenticated_root_path)
+          })).to redirect_to(authenticated_root_path)
         end
       end
     end
@@ -119,11 +119,11 @@ RSpec.describe ClientTokensController, type: :controller do
 
         it 'redirects to portal if invalid org' do
           other_org = create(:organization)
-          expect(post :create, params: { 
-            organization_id: other_org.id, 
-            label: 'Test', 
+          expect(post(:create, params: {
+            organization_id: other_org.id,
+            label: 'Test',
             api_environment: 'sandbox'
-          }).to redirect_to(authenticated_root_path)
+          })).to redirect_to(authenticated_root_path)
         end
       end
 

--- a/dpc-web/spec/controllers/client_tokens_controller_spec.rb
+++ b/dpc-web/spec/controllers/client_tokens_controller_spec.rb
@@ -32,8 +32,9 @@ RSpec.describe ClientTokensController, type: :controller do
       context 'with invalid organization id' do
         it 'redirects to portal' do
           other_org = create(:organization)
-          get :new, params: { organization_id: other_org.id }
-          expect(response.location).to include(portal_path)
+          expect(get :new, params: {
+            organization_id: other_org.id
+          }).to redirect_to(authenticated_root_path)
         end
       end
     end
@@ -118,8 +119,11 @@ RSpec.describe ClientTokensController, type: :controller do
 
         it 'redirects to portal if invalid org' do
           other_org = create(:organization)
-          post :create, params: { organization_id: other_org.id, label: 'Test', api_environment: 'sandbox' }
-          expect(response.location).to include(portal_path)
+          expect(post :create, params: { 
+            organization_id: other_org.id, 
+            label: 'Test', 
+            api_environment: 'sandbox'
+          }).to redirect_to(root_path)
         end
       end
 

--- a/dpc-web/spec/controllers/client_tokens_controller_spec.rb
+++ b/dpc-web/spec/controllers/client_tokens_controller_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe ClientTokensController, type: :controller do
             organization_id: other_org.id, 
             label: 'Test', 
             api_environment: 'sandbox'
-          }).to redirect_to(root_path)
+          }).to redirect_to(authenticated_root_path)
         end
       end
 

--- a/dpc-web/spec/controllers/public_keys_controller_spec.rb
+++ b/dpc-web/spec/controllers/public_keys_controller_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe PublicKeysController, type: :controller do
           organization_id: org.id,
           public_key: 'test key',
           label: 'aaaaabbbbbcccccddddd'
-        }).to redirect_to(portal_path)
+        }).to redirect_to(authenticated_root_path)
       end
     end
   end
@@ -247,7 +247,7 @@ RSpec.describe PublicKeysController, type: :controller do
 
       expect(get :new, params: {
         organization_id: '1'
-      }).to redirect_to(portal_path)
+      }).to redirect_to(root_path)
     end
   end
 end

--- a/dpc-web/spec/controllers/public_keys_controller_spec.rb
+++ b/dpc-web/spec/controllers/public_keys_controller_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe PublicKeysController, type: :controller do
           organization_id: org.id,
           public_key: 'test key',
           label: 'aaaaabbbbbcccccddddd'
-        }).to redirect_to(authenticated_root_path)
+        }).to redirect_to(root_path)
       end
     end
   end
@@ -247,7 +247,7 @@ RSpec.describe PublicKeysController, type: :controller do
 
       expect(get :new, params: {
         organization_id: '1'
-      }).to redirect_to(root_path)
+      }).to redirect_to(authenticated_root_path)
     end
   end
 end

--- a/dpc-web/spec/features/portal/managing_api_credentials_spec.rb
+++ b/dpc-web/spec/features/portal/managing_api_credentials_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'managing api credentials' do
     end
 
     it 'cannot manage api credentials' do
-      visit root_path
+      visit authenticated_root_path
       expect(page).not_to have_css('[data-test="new-client-token"]')
       expect(page).not_to have_css('[data-test="new-public-key"]')
     end
@@ -29,7 +29,7 @@ RSpec.feature 'managing api credentials' do
     end
 
     it 'cannot manage api credentials' do
-      visit root_path
+      visit authenticated_root_path
       expect(page).not_to have_css('[data-test="new-client-token"]')
       expect(page).not_to have_css('[data-test="new-public-key"]')
     end
@@ -55,7 +55,7 @@ RSpec.feature 'managing api credentials' do
       api_client = stub_empty_key_request
       api_client = stub_empty_token_request(api_client)
 
-      visit root_path
+      visit authenticated_root_path
 
       api_client = stub_token_creation_request(api_client)
       find('[data-test="new-client-token"]').click
@@ -80,7 +80,7 @@ RSpec.feature 'managing api credentials' do
       api_client = stub_empty_key_request
       api_client = stub_empty_token_request(api_client)
 
-      visit root_path
+      visit authenticated_root_path
       find('[data-test="new-public-key"]').click
 
       fill_in 'label', with: 'Sandbox Key 1'

--- a/dpc-web/spec/features/portal/managing_api_credentials_spec.rb
+++ b/dpc-web/spec/features/portal/managing_api_credentials_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'managing api credentials' do
     end
 
     it 'cannot manage api credentials' do
-      visit portal_path
+      visit root_path
       expect(page).not_to have_css('[data-test="new-client-token"]')
       expect(page).not_to have_css('[data-test="new-public-key"]')
     end
@@ -29,7 +29,7 @@ RSpec.feature 'managing api credentials' do
     end
 
     it 'cannot manage api credentials' do
-      visit portal_path
+      visit root_path
       expect(page).not_to have_css('[data-test="new-client-token"]')
       expect(page).not_to have_css('[data-test="new-public-key"]')
     end
@@ -55,7 +55,7 @@ RSpec.feature 'managing api credentials' do
       api_client = stub_empty_key_request
       api_client = stub_empty_token_request(api_client)
 
-      visit portal_path
+      visit root_path
 
       api_client = stub_token_creation_request(api_client)
       find('[data-test="new-client-token"]').click
@@ -80,7 +80,7 @@ RSpec.feature 'managing api credentials' do
       api_client = stub_empty_key_request
       api_client = stub_empty_token_request(api_client)
 
-      visit portal_path
+      visit root_path
       find('[data-test="new-public-key"]').click
 
       fill_in 'label', with: 'Sandbox Key 1'

--- a/dpc-web/spec/features/portal/updating_organization_spec.rb
+++ b/dpc-web/spec/features/portal/updating_organization_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'updating my organization' do
   scenario 'updating the org with a vailid Npi' do
     npi = LuhnacyLib.generate_npi
 
-    visit portal_path
+    visit root_path
     find('[data-test="edit-link"]').click
     fill_in 'organization_npi', with: npi
     fill_in 'organization_vendor', with: 'Cool EMR Vendor Name'
@@ -29,7 +29,7 @@ RSpec.feature 'updating my organization' do
   end
 
   scenario 'updating the org with an invalid Npi' do
-    visit portal_path
+    visit root_path
     find('[data-test="edit-link"]').click
     fill_in 'organization_npi', with: '123456789'
     find('[data-test="form-submit"]').click

--- a/dpc-web/spec/features/portal/updating_organization_spec.rb
+++ b/dpc-web/spec/features/portal/updating_organization_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'updating my organization' do
   scenario 'updating the org with a vailid Npi' do
     npi = LuhnacyLib.generate_npi
 
-    visit root_path
+    visit authenticated_root_path
     find('[data-test="edit-link"]').click
     fill_in 'organization_npi', with: npi
     fill_in 'organization_vendor', with: 'Cool EMR Vendor Name'
@@ -29,7 +29,7 @@ RSpec.feature 'updating my organization' do
   end
 
   scenario 'updating the org with an invalid Npi' do
-    visit root_path
+    visit authenticated_root_path
     find('[data-test="edit-link"]').click
     fill_in 'organization_npi', with: '123456789'
     find('[data-test="form-submit"]').click


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

@jdettmannnava surfaced that the `/portal` path is used in the sandbox to route back to the homepage. However, this conflicts with the routing set up for dpc-portal.

This removes the /portal routing (which is just a duplicate of the root / homepage). Instead, we should explicitly route people to the root path.

## ✅ Acceptance Validation

Unit tests, which have tests for redirection already.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
