### PR TITLE
DPC-3965 Allow local login to DPC-Web

### DIFF
--- a/dpc-web/config/environments/development.rb
+++ b/dpc-web/config/environments/development.rb
@@ -12,20 +12,11 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
+  # don't cache controller
+  config.action_controller.perform_caching = false
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  # use redis cache for session
+  config.cache_store = :redis_cache_store, { url: "#{ENV.fetch('REDIS_URL', 'redis://localhost')}:6379/1" }
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local

--- a/dpc-web/config/initializers/session_store.rb
+++ b/dpc-web/config/initializers/session_store.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :cache_store, key: '_dpc_app_session' unless Rails.env.local?
+Rails.application.config.session_store :cache_store, key: '_dpc_app_session'

--- a/dpc-web/config/initializers/session_store.rb
+++ b/dpc-web/config/initializers/session_store.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :cache_store, key: '_dpc_app_session'
+Rails.application.config.session_store :cache_store, key: '_dpc_app_session' unless Rails.env.local?


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3965

## 🛠 Changes

Conditional logic added so only store session in redis if not local

## ℹ️ Context for reviewers

Session was being stored in redis, but development cache is by default in memory. It seemed better to keep the default cache functionality for development than use redis.

## ✅ Acceptance Validation

Logged in locally

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
