### PR TITLE
Fix sonarqube not scanning dpc-portal

### DIFF
--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -74,7 +74,8 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
 
-  gem 'simplecov'
+  # Version 0.18 has a breaking change for sonarqube
+  gem 'simplecov', '<= 0.17'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -478,12 +478,11 @@ GEM
       rack (< 3)
       sidekiq (>= 5, < 8)
       webrick (>= 1, < 2)
-    simplecov (0.22.0)
+    simplecov (0.17.0)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.4)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     spring (2.1.1)
@@ -608,7 +607,7 @@ DEPENDENCIES
   selenium-webdriver
   sidekiq (~> 7.1)
   sidekiq_alive (~> 2.1.5)
-  simplecov
+  simplecov (<= 0.17)
   spring
   spring-watcher-listen (~> 2.0.0)
   truemail
@@ -623,4 +622,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.6
+   2.5.7


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3971

## 🛠 Changes

Reverted simplecov gem to 0.17

## ℹ️ Context for reviewers

Sonarqube stopped processing portal code coverage on Mar 5; the day the rails upgrade was merged into master. As part of the upgrade simplecov was not pinned to 0.17. Simplecov 0.18+ breaking ci is a [known issue](https://github.com/codeclimate/test-reporter/issues/413).
There was comment (present in the other gemfiles) warning not to upgrade, but it was removed because for some reason, when I run `bundle install` after sshing into the docker container, it will fail if there are too many bytes in the Gemfile. I removed "extraneous" comments, which meant I missed this.

## ✅ Acceptance Validation

[Ran the build](https://management.dpc.cms.gov/job/DPC%20-%20Docker%20Build/3666/) and [checked the coverage](https://sonarqube.cloud.cms.gov/dashboard?branch=jd%2Fdpc-3971-portal-sonarqube&id=bcda-dpc-portal).

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
