### PR TITLE
DPC-3956: Update logging metrics for import job

### DIFF
--- a/lambda/opt-out-import/Makefile
+++ b/lambda/opt-out-import/Makefile
@@ -15,13 +15,13 @@ test-build:
 	go tool cover -html=coverage/int_coverage.out -o coverage/int_coverage.html
 
 test:
-	IS_TESTING=true DB_USER_DPC_CONSENT="postgres" DB_PASS_DPC_CONSENT="dpc-safe" ENV="local" go test -v -covermode=count -coverprofile=coverage/full_coverage.out
+	IS_TESTING=true DB_USER_DPC_CONSENT="postgres" DB_PASS_DPC_CONSENT="dpc-safe" ENV="local" DB_HOST="localhost" go test -v -covermode=count -coverprofile=coverage/full_coverage.out
 	go tool cover -html=coverage/full_coverage.out -o coverage/full_coverage.html
 unit-test:
 	IS_TESTING=true DB_USER_DPC_CONSENT="postgres" DB_PASS_DPC_CONSENT="dpc-safe" go test -short -v -covermode=count -coverprofile=coverage/unit_coverage.out
 	go tool cover -html=coverage/unit_coverage.out -o coverage/unit_coverage.html
 integration-test:
-	IS_TESTING=true DB_USER_DPC_CONSENT="postgres" DB_PASS_DPC_CONSENT="dpc-safe" ENV="local" go test -run TestIntegration -v -covermode=count -coverprofile=coverage/unit_coverage.out
+	IS_TESTING=true DB_USER_DPC_CONSENT="postgres" DB_PASS_DPC_CONSENT="dpc-safe" ENV="local" DB_HOST="localhost" go test -run TestIntegration -v -covermode=count -coverprofile=coverage/unit_coverage.out
 	go tool covdata percent -i=coverage
 	go tool covdata textfmt -i=coverage -o=coverage/int_coverage.out
 	go tool cover -html=coverage/int_coverage.out -o coverage/int_coverage.html

--- a/lambda/opt-out-import/db.go
+++ b/lambda/opt-out-import/db.go
@@ -139,7 +139,7 @@ func insertConsentRecords(db *sql.DB, optOutFileId string, records []*OptOutReco
 				query += "\n"
 			}
 		}
-		query += "RETURNING id, mbi, effective_date, opt_out_file_id"
+		query += "RETURNING id, mbi, effective_date, policy_code, opt_out_file_id"
 
 		rows, err := db.Query(query)
 		if err != nil {
@@ -149,9 +149,16 @@ func insertConsentRecords(db *sql.DB, optOutFileId string, records []*OptOutReco
 			}
 			return createdRecords, fmt.Errorf("insertConsentRecords: failed to insert to consent table: %w", err)
 		}
+
+		cols, err := rows.Columns()
+
+		for _, col := range cols {
+			log.Info(col)
+		}
+
 		for rows.Next() {
 			record := OptOutRecord{}
-			if err := rows.Scan(&record.ID, &record.MBI, &record.EffectiveDt, &record.OptOutFileID); err != nil {
+			if err := rows.Scan(&record.ID, &record.MBI, &record.EffectiveDt, &record.PolicyCode, &record.OptOutFileID); err != nil {
 				return createdRecords, fmt.Errorf("insertConsentRecords: Failed to read newly created consent records: %w", err)
 			}
 			record.Status = Accepted

--- a/lambda/opt-out-import/db.go
+++ b/lambda/opt-out-import/db.go
@@ -150,12 +150,6 @@ func insertConsentRecords(db *sql.DB, optOutFileId string, records []*OptOutReco
 			return createdRecords, fmt.Errorf("insertConsentRecords: failed to insert to consent table: %w", err)
 		}
 
-		cols, err := rows.Columns()
-
-		for _, col := range cols {
-			log.Info(col)
-		}
-
 		for rows.Next() {
 			record := OptOutRecord{}
 			if err := rows.Scan(&record.ID, &record.MBI, &record.EffectiveDt, &record.PolicyCode, &record.OptOutFileID); err != nil {

--- a/lambda/opt-out-import/db_test.go
+++ b/lambda/opt-out-import/db_test.go
@@ -138,24 +138,26 @@ func TestInsertConsentRecords(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error when parsing opt out metadata %s", err)
 		}
-		metadata.FileID = "test_id"
+
+		fileId := "test_id"
+		metadata.FileID = fileId
 		consents, err := ParseConsentRecords(&metadata, f)
 		if err != nil {
 			t.Errorf("Error when parsing consent records %s", err)
 		}
-		rows := []string{"id", "mbi", "effective_date", "opt_out_file_id"}
+		rows := []string{"id", "mbi", "effective_date", "policy_code", "opt_out_file_id"}
 		mock.ExpectQuery("INSERT INTO consent").
 			WillReturnRows(sqlmock.NewRows(rows).
-				AddRow("(.*)", "5SJ0A00AA00", time.Date(2019, 07, 01, 0, 0, 0, 0, time.UTC), "test_id").
-				AddRow("(.*)", "4SF6G00AA00", time.Date(2019, 07, 29, 0, 0, 0, 0, time.UTC), "test_id").
-				AddRow("(.*)", "4SH0A00AA00", time.Date(0001, 01, 01, 0, 0, 0, 0, time.UTC), "test_id").
-				AddRow("(.*)", "8SG0A00AA00", time.Date(2019, 07, 19, 0, 0, 0, 0, time.UTC), "test_id"))
+				AddRow("(.*)", "5SJ0A00AA00", time.Date(2019, 07, 01, 0, 0, 0, 0, time.UTC), "OPTOUT", fileId).
+				AddRow("(.*)", "4SF6G00AA00", time.Date(2019, 07, 29, 0, 0, 0, 0, time.UTC), "OPTOUT", fileId).
+				AddRow("(.*)", "4SH0A00AA00", time.Date(0001, 01, 01, 0, 0, 0, 0, time.UTC), "OPTOUT", fileId).
+				AddRow("(.*)", "8SG0A00AA00", time.Date(2019, 07, 19, 0, 0, 0, 0, time.UTC), "OPTOUT", fileId))
 
 		rows = []string{"id", "import_status"}
 		mock.ExpectQuery("UPDATE opt_out_file").
 			WithArgs(ImportComplete, metadata.FileID).
 			WillReturnRows(sqlmock.NewRows(rows).AddRow(metadata.FileID, ImportComplete))
-		results, err := insertConsentRecords(db, "test_id", consents)
+		results, err := insertConsentRecords(db, fileId, consents)
 		log.Printf("results: %d", len(results))
 		if err != nil {
 			t.Error(err)
@@ -241,7 +243,7 @@ func TestInsertConsentRecordsEmptyFile(t *testing.T) {
 		{
 			name:          "empty file",
 			bucket:        "demo-bucket",
-			filename:      "T.NGD.DPC.RSP.D010424.T1122001.IN",	// File has header and footer, but no data rows
+			filename:      "T.NGD.DPC.RSP.D010424.T1122001.IN", // File has header and footer, but no data rows
 			expect:        true,
 			consentStatus: Accepted,
 		},
@@ -271,7 +273,7 @@ func TestInsertConsentRecordsEmptyFile(t *testing.T) {
 			t.Errorf("Error when parsing consent records %s", err)
 		}
 		assert.Empty(t, consents)
-		
+
 		rows := []string{"id", "import_status"}
 		mock.ExpectQuery("UPDATE opt_out_file").
 			WithArgs(ImportComplete, metadata.FileID).
@@ -294,7 +296,7 @@ func TestInsertConsentRecordsEmptyRecordsDirectCall(t *testing.T) {
 		err           error
 	}{
 		{
-			name:          "empty array",
+			name: "empty array",
 		},
 	}
 
@@ -308,7 +310,7 @@ func TestInsertConsentRecordsEmptyRecordsDirectCall(t *testing.T) {
 		fmt.Printf("~~~ %s test\n", test.name)
 
 		fileId := "test_id"
-		
+
 		rows := []string{"id", "import_status"}
 		mock.ExpectQuery("UPDATE opt_out_file").
 			WithArgs(ImportComplete, fileId).

--- a/lambda/opt-out-import/main.go
+++ b/lambda/opt-out-import/main.go
@@ -161,8 +161,10 @@ func importResponseFile(bucket string, file string) (int, int, string, error) {
 		log.Infof("ID: %s, Opt Out Preference: %s", rec.ID, rec.PolicyCode)
 		if rec.PolicyCode == "OPTIN" {
 			createdOptInCount++
-		} else {
+		} else if rec.PolicyCode == "OPTOUT" {
 			createdOptOutCount++
+		} else {
+			log.Warningf("Unknown policy code saved to database for consent record %s", rec.ID)
 		}
 	}
 

--- a/lambda/opt-out-import/main.go
+++ b/lambda/opt-out-import/main.go
@@ -74,7 +74,12 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (string, error) {
 	for _, e := range s3Event.Records {
 		if e.EventName == "ObjectCreated:Put" {
 			createdOptOutCount, createdOptInCount, confirmationFileName, err := importResponseFile(e.S3.Bucket.Name, e.S3.Object.Key)
-			logger := log.WithField("response_filename", e.S3.Object.Key).WithField("created_opt_outs_count", createdOptOutCount).WithField("created_opt_ins_count", createdOptInCount).WithField("confirmation_filename", confirmationFileName)
+			logger := log.WithFields(log.Fields{
+				"response_filename":      e.S3.Object.Key,
+				"created_opt_outs_count": createdOptOutCount,
+				"created_opt_ins_count":  createdOptInCount,
+				"confirmation_filename":  confirmationFileName,
+			})
 
 			if err != nil {
 				logger.Errorf("Failed to import response file: %s", err)

--- a/lambda/opt-out-import/main_test.go
+++ b/lambda/opt-out-import/main_test.go
@@ -27,15 +27,15 @@ func TestHandler(t *testing.T) {
 		err    error
 	}{
 		{
-			event:  getSQSEvent("demo-bucket", "file_path"),
-			expect: "file_path",
+			event:  getSQSEvent("demo-bucket", "bfdeft01/dpc/in/T.NGD.DPC.RSP.D240123.T1122001.IN"),
+			expect: "bfdeft01/dpc/in/T.NGD.DPC.RSP.D240123.T1122001.IN",
 			err:    nil,
 		},
 	}
 
 	for _, test := range tests {
 		response, err := handler(context.Background(), test.event)
-		assert.NotNil(t, err)
+		assert.Nil(t, err)
 		assert.Equal(t, test.expect, response)
 	}
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3956

## 🛠 Changes

- Distinguish between opt ins and opt outs
- Include response and confirmation filenames, if applicable, as part of final log messages
- Fix Printf statement which was causing logs to be picked up as warning in the dashboard
- Fix DB_HOST for running integration tests locally

## ℹ️ Context for reviewers

Updating logs to improve the information we have in the dashboard.

## ✅ Acceptance Validation

Updated Opt Out dashboard and confirmed graphs have data with the latest information from the integration test run.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
