### PR TITLE
[DPC-3970] Added invitation_id to ao_org_links

### DIFF
--- a/dpc-portal/app/models/ao_org_link.rb
+++ b/dpc-portal/app/models/ao_org_link.rb
@@ -4,7 +4,10 @@
 class AoOrgLink < ApplicationRecord
   validates :user_id,
             uniqueness: { scope: :provider_organization_id, message: 'already exists for this provider.' }
+  validates :invitation_id,
+            uniqueness: { scope: :invitation_id, message: 'already exists for this invitation.' }
 
   belongs_to :user, required: true
   belongs_to :provider_organization, required: true
+  belongs_to :invitation, required: false
 end

--- a/dpc-portal/db/migrate/20240401144012_add_invitation_ref_to_ao_org_link.rb
+++ b/dpc-portal/db/migrate/20240401144012_add_invitation_ref_to_ao_org_link.rb
@@ -1,0 +1,5 @@
+class AddInvitationRefToAoOrgLink < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :ao_org_links, :invitation, null: true, foreign_key: true
+  end
+end

--- a/dpc-portal/db/schema.rb
+++ b/dpc-portal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_07_213217) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_01_144012) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_07_213217) do
     t.integer "provider_organization_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "invitation_id"
+    t.index ["invitation_id"], name: "index_ao_org_links_on_invitation_id"
     t.index ["user_id", "provider_organization_id"], name: "index_ao_org_links_on_user_id_and_provider_organization_id", unique: true
   end
 
@@ -73,6 +75,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_07_213217) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "ao_org_links", "invitations"
   add_foreign_key "ao_org_links", "provider_organizations"
   add_foreign_key "ao_org_links", "users"
   add_foreign_key "cd_org_links", "invitations"

--- a/dpc-portal/spec/models/ao_org_link_spec.rb
+++ b/dpc-portal/spec/models/ao_org_link_spec.rb
@@ -3,19 +3,42 @@
 require 'rails_helper'
 
 RSpec.describe AoOrgLink, type: :model do
-  let(:provider_organization) { build(:provider_organization) }
   let(:user) { build(:user) }
-  let(:ao_org_link) { build(:ao_org_link, user:, provider_organization:) }
 
-  it 'has foreign keys' do
-    expect(ao_org_link.user).to eq user
-    expect(ao_org_link.provider_organization).to eq provider_organization
+  describe 'has no invitation' do
+    let(:provider_organization) { build(:provider_organization) }
+    let(:ao_org_link) { build(:ao_org_link, user:, provider_organization:) }
+
+    it 'has foreign keys' do
+      expect(ao_org_link.user).to eq user
+      expect(ao_org_link.provider_organization).to eq provider_organization
+    end
+
+    it 'does not allow for duplicate user-org pairs' do
+      create(:ao_org_link, user:, provider_organization:)
+      duplicate = build(:ao_org_link, user:, provider_organization:)
+      expect(duplicate.valid?).to be_falsy
+      expect(duplicate.errors.full_messages).to include 'User already exists for this provider.'
+    end
   end
 
-  it 'does not allow for duplicate user-org pairs' do
-    create(:ao_org_link, user:, provider_organization:)
-    duplicate = build(:ao_org_link, user:, provider_organization:)
-    expect(duplicate.valid?).to be_falsy
-    expect(duplicate.errors.full_messages).to include 'User already exists for this provider.'
+  describe 'has an invitation' do
+    let(:provider_organization1) { build(:provider_organization) }
+    let(:provider_organization2) { build(:provider_organization) }
+    let(:invitation) { build(:invitation) }
+    let(:ao_org_link) { build(:ao_org_link, user:, provider_organization: provider_organization1, invitation:) }
+
+    it 'has foreign keys' do
+      expect(ao_org_link.user).to eq user
+      expect(ao_org_link.provider_organization).to eq provider_organization1
+      expect(ao_org_link.invitation).to eq invitation
+    end
+
+    it 'does not allow for duplicate invitations' do
+      create(:ao_org_link, user:, provider_organization: provider_organization1, invitation:)
+      duplicate = build(:ao_org_link, user:, provider_organization: provider_organization2, invitation:)
+      expect(duplicate.valid?).to be_falsy
+      expect(duplicate.errors.full_messages).to include 'Invitation already exists for this invitation.'
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3970

## 🛠 Changes

Added `invitation_id` column to `ao_org_links` table as a foreign key to the `invitations` table.

## ℹ️ Context for reviewers

This ticket was to add `invitation_id` to `ao_org_links`, and `invited_by_id` to `invitations`, but the `invitations` table had already been previously updated so we only had to do `ao_org_links`.

## ✅ Acceptance Validation

Ran the migration locally and the new column was created as a foreign key.  All tests are passing.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
