### PR TITLE
Upgrade spring gem

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -78,7 +78,7 @@ group :development do
   gem 'simplecov', '<= 0.17'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen', '~> 2.1.0'
 
   gem 'letter_opener'
 end

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -440,10 +440,10 @@ GEM
     simplecov-html (0.10.2)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
+    spring (4.1.3)
+    spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
+      spring (>= 4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -555,7 +555,7 @@ DEPENDENCIES
   sidekiq_alive (~> 2.1.5)
   simplecov (<= 0.17)
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen (~> 2.1.0)
   sprockets-rails (>= 3.4.2)
   truemail
   turbolinks (~> 5)

--- a/dpc-admin/config/environments/test.rb
+++ b/dpc-admin/config/environments/test.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   config.cache_classes = false
-  config.action_view.cache_template_loading = true
+  config.action_view.cache_template_loading = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -77,7 +77,7 @@ group :development do
   # Version 0.18 has a breaking change for sonarqube
   gem 'simplecov', '<= 0.17'
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen', '~> 2.1.0'
 end
 
 group :test do

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -481,10 +481,10 @@ GEM
     simplecov-html (0.10.2)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
+    spring (4.1.3)
+    spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
+      spring (>= 4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -604,7 +604,7 @@ DEPENDENCIES
   sidekiq_alive (~> 2.1.5)
   simplecov (<= 0.17)
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen (~> 2.1.0)
   truemail
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -83,7 +83,7 @@ group :development do
   gem 'web-console', '>= 4.2.0'
   gem 'listen', '~> 3.5'
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen', '~> 2.1.0'
 
   gem 'rubocop', '>= 1.12.0', require: false
   gem 'rubocop-performance', '>= 1.10.2', require: false

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -437,10 +437,10 @@ GEM
     simplecov-html (0.10.2)
     simpleidn (0.2.1)
       unf (~> 0.1.4)
-    spring (2.1.1)
-    spring-watcher-listen (2.0.1)
+    spring (4.1.3)
+    spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
+      spring (>= 4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -546,7 +546,7 @@ DEPENDENCIES
   sidekiq_alive (~> 2.1.5)
   simplecov (<= 0.17)
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen (~> 2.1.0)
   sprockets-rails (>= 3.4.2)
   truemail
   tzinfo-data

--- a/dpc-web/config/environments/test.rb
+++ b/dpc-web/config/environments/test.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that


### PR DESCRIPTION
## 🎫 Ticket

no ticket
## 🛠 Changes

[Spring](https://github.com/rails/spring) (a gem for speeding up tests) and spring-watcher-listen updated

## ℹ️ Context for reviewers

Old version of spring was blocking `rails console` from running.
Update just in "development" stanza, so should not impact production

## ✅ Acceptance Validation

Tests pass, can run rails console

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
