### PR TITLE
Replace tabs with spaces

### DIFF
--- a/dpc-portal/app/components/page/client_token/new_token_component.html.erb
+++ b/dpc-portal/app/components/page/client_token/new_token_component.html.erb
@@ -7,10 +7,10 @@
     <%= form_tag organization_client_tokens_path(organization_id: organization.path_id), method: :post do %>
 
     <%= render(Core::Form::TextInputComponent.new(label: 'Label',
-	attribute: :label,
-	hint: 'Choose a descriptive name to make your token easily identifiable to you.',
-	default: params[:label],
-	input_options: { maxlength: 25 })) %>
+        attribute: :label,
+        hint: 'Choose a descriptive name to make your token easily identifiable to you.',
+        default: params[:label],
+        input_options: { maxlength: 25 })) %>
     <%= submit_tag "Create token", class: "usa-button", data: { test: "form-submit" } %>
     <% end %>
   </div>

--- a/dpc-portal/app/components/page/client_token/show_token_component.html.erb
+++ b/dpc-portal/app/components/page/client_token/show_token_component.html.erb
@@ -7,9 +7,9 @@
     <%= render(Core::Form::TextAreaComponent.new(label: 'Your token', attribute: :token, default: client_token['token'], input_options: { rows: 9, readonly: :readonly })) %>
     <div class="usa-alert usa-alert--warning margin-bottom-4">
       <div class="usa-alert__body">
-	<p class="usa-alert__text">
-	  Copy or download your token right now! You won't be able to see it again.
-	</p>
+        <p class="usa-alert__text">
+          Copy or download your token right now! You won't be able to see it again.
+        </p>
       </div>
     </div>
     <%= render(Core::Button::ButtonComponent.new(label: 'Return to portal', destination: root_url)) %>

--- a/dpc-portal/app/components/page/credential_delegate/invitation_success_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/invitation_success_component.html.erb
@@ -4,7 +4,7 @@
   <div class="usa-alert usa-alert--success">
     <div class="usa-alert__body">
       <p class="usa-alert__text">
-	This is a succinct, helpful success message.
+        This is a succinct, helpful success message.
       </p>
     </div>
   </div>

--- a/dpc-portal/app/components/page/organization/new_organization_component.html.erb
+++ b/dpc-portal/app/components/page/organization/new_organization_component.html.erb
@@ -6,7 +6,7 @@
 
     <%= render(Core::Form::TextInputComponent.new(
         label: 'What is your Type 2 NPI?',
-	      attribute: :npi,
+        attribute: :npi,
         default: params[:npi],
         input_options: { maxlength: 10 },
         error_msg: @npi_error


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Replaced tabs with spaces in components.

## ℹ️ Context for reviewers

Tabs don't play well with all editors.

## ✅ Acceptance Validation

grepped and didn't find any more tabs

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
