### PR TITLE
[DPC-3903] Create and Link DPC API organization after provider_organization record is created

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -163,6 +163,8 @@ services:
       - DATABASE_URL=postgresql://db/dpc-portal_development
       - DB_USER=postgres
       - DB_PASS=dpc-safe
+      - GOLDEN_MACAROON=${GOLDEN_MACAROON}
+      - API_METADATA_URL=http://api:3002/v1
     depends_on:
       - redis
       - db

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -157,7 +157,7 @@ services:
       context: .
       dockerfile: dpc-portal/Dockerfile
     command: sidekiq
-    image: dpc-portal-sidekiq:latest
+    image: dpc-web-portal:latest
     environment:
       - REDIS_URL=redis://redis
       - DATABASE_URL=postgresql://db/dpc-portal_development

--- a/dpc-portal/README.md
+++ b/dpc-portal/README.md
@@ -28,10 +28,27 @@ Emails are not viewable in lookbook, but rather [here](http://localhost:3100/por
 
 Read more about the assets pipeline [here](/docs/portal/assets-pipeline.md).
 
-## Unit testing
+## Rails cheat sheet
+
+### Unit testing
 
 To run unit tests during development, do the following:
 
 1. SSH into the dpc-portal container
 2. `rails db:create RAILS_ENV=test` to create the test database
 3. `bundle exec rspec path/to/test`
+
+### Testing SyncOrganizationJob
+
+Since SyncOrganizationJob depends on [api_client](/engines/api_client), you'll need to make sure that a golden macaroon has been fetched. With the API running, run the following:
+```
+curl -X POST -w '\n' http://localhost:9903/tasks/generate-token
+```
+Then take the output and set an environment variable in your shell:
+```
+export GOLDEN_MACAROON={insert macaroon here}
+```
+
+Then run `make start-portal`. You can confirm that this worked by opening the Rails console and checking `ENV.fetch('GOLDEN_MACAROON')`.
+
+You can check the status of any jobs by going to the Sidekiq dashboard at `http://localhost:3100/portal/sidekiq`

--- a/dpc-portal/README.md
+++ b/dpc-portal/README.md
@@ -27,3 +27,11 @@ Emails are not viewable in lookbook, but rather [here](http://localhost:3100/por
 ## Assets Pipeline
 
 Read more about the assets pipeline [here](/docs/portal/assets-pipeline.md).
+
+## Unit testing
+
+To run unit tests during development, do the following:
+
+1. SSH into the dpc-portal container
+2. `rails db:create RAILS_ENV=test` to create the test database
+3. `bundle exec rspec path/to/test`

--- a/dpc-portal/app/jobs/sync_organization_job.rb
+++ b/dpc-portal/app/jobs/sync_organization_job.rb
@@ -1,0 +1,68 @@
+class SyncOrganizationJob < ApplicationJob
+  queue_as :portal
+
+  def perform(provider_organization_id)
+    po = ProviderOrganization.find(provider_organization_id)
+    if po == nil
+      Rails.logger.error "provider_organization #{provider_organization_id} not found"
+      raise SyncOrganizationJobError("provider_organization #{provider_organization_id} not found")
+    end
+
+    api_response = api_client.get_organization_by_npi(po.npi)
+    if api_response.entry.length == 0
+      create_dpc_api_org(po)
+    elsif api_response.entry.length == 1
+      org_id = api_response.entry[0].resource.id
+      po.dpc_api_organization_id = org_id
+      po.save
+    else
+      Rails.logger.error "multiple orgs found for NPI #{po.npi} in dpc_attribution"
+      raise SyncOrganizationJobError("multiple orgs found for NPI #{po.npi} in dpc_attribution")
+    end
+  end
+
+  private
+
+  def create_dpc_api_org(provider_organization)
+    org = OrgObject.new(provider_organization.name, provider_organization.npi)
+    fhir_endpoint = {
+      "status" => "test",
+      "name" => "#{provider_organization.name} Endpoint",
+      "uri" => "http://test-address.nope"
+    }
+    create_org_response = api_client.create_organization(org, fhir_endpoint:)
+    if create_org_response.response_successful?
+      org_id = create_org_response.response_body["id"]
+      provider_organization.dpc_api_organization_id = org_id
+      provider_organization.save
+    else
+      Rails.logger.error "DpcClient.create_organization failed for provider_organization #{provider_organization.id}"
+      raise SyncOrganizationJobError("DpcClient.create_organization failed for provider_organization #{provider_organization.id}")
+    end
+  end
+
+  def api_client
+    DpcClient.new
+  end
+end
+
+class SyncOrganizationJobError < StandardError; end
+
+class OrgObject
+  # rubocop:disable Naming/VariableNumber
+  attr_reader :npi, :name, :address_use, :address_type, :address_city, :address_state, :address_street,
+              :address_street_2, :address_zip
+
+  def initialize(name, npi)
+    randy = Random.new
+    @name = name
+    @npi = npi
+    @address_use = 'work'
+    @address_type = 'both'
+    @address_street = "#{randy.rand(1000)} Elm Street"
+    @address_street_2 = "Suite #{randy.rand(100)}"
+    @address_city = 'Akron'
+    @address_state = 'OH'
+    @address_zip = '22222'
+  end
+end

--- a/dpc-portal/app/jobs/sync_organization_job.rb
+++ b/dpc-portal/app/jobs/sync_organization_job.rb
@@ -17,7 +17,7 @@ class SyncOrganizationJob < ApplicationJob
     if api_response.entry.empty?
       create_dpc_api_org(po)
     elsif api_response.entry.length == 1
-      org_id = api_response.entry[0].resource.id
+      org_id = api_response.entry.first.resource.id
       po.dpc_api_organization_id = org_id
       po.save
     else
@@ -49,7 +49,7 @@ class SyncOrganizationJob < ApplicationJob
   end
 
   def api_client
-    DpcClient.new
+    @api_client ||= DpcClient.new
   end
 end
 

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -10,9 +10,7 @@ class ProviderOrganization < ApplicationRecord
   has_many :cd_org_links
 
   after_create do
-    unless dpc_api_organization_id.present?
-      SyncOrganizationJob.perform_later(id)
-    end
+    SyncOrganizationJob.perform_later(id) unless dpc_api_organization_id.present?
   end
 
   def public_keys

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -9,6 +9,12 @@ class ProviderOrganization < ApplicationRecord
   has_many :ao_org_links
   has_many :cd_org_links
 
+  after_create do
+    unless dpc_api_organization_id.present?
+      SyncOrganizationJob.perform_later(id)
+    end
+  end
+
   def public_keys
     @keys ||= []
     if dpc_api_organization_id.present?

--- a/dpc-portal/spec/jobs/sync_organization_job_spec.rb
+++ b/dpc-portal/spec/jobs/sync_organization_job_spec.rb
@@ -1,5 +1,134 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe SyncOrganizationJob, type: :job do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include ActiveJob::TestHelper
+
+  let(:mock_dpc_client) { instance_double(DpcClient) }
+  let(:create_organization_success_response) do
+    MockOrgResponse.new(response_successful: true, response_body: {
+                          'resourceType' => 'Organization',
+                          'id' => '352dda55-6925-4bdb-bcee-1af0bc163699'
+                        })
+  end
+  let(:create_organization_unsuccessful_response) { MockOrgResponse.new(response_successful: false, response_body: {}) }
+  let(:get_organization_zero_entries) { MockFHIRResponse.new(entries_count: 0) }
+  let(:get_organization_one_entry) { MockFHIRResponse.new(entries_count: 1) }
+  let(:get_organization_two_entries) { MockFHIRResponse.new(entries_count: 2) }
+
+  let(:fhir_endpoint) do
+    {
+      'status' => 'test',
+      'name' => 'Test Endpoint',
+      'uri' => 'http://test-address.nope'
+    }
+  end
+
+  before(:all) do
+    ActiveJob::Base.queue_adapter = :test
+  end
+
+  before(:each) do
+    @po = ProviderOrganization.new(npi: 10.times.map { rand(0..9) }.join, name: 'Test', id: 1)
+    SyncOrganizationJob.perform_later(@po.id)
+  end
+
+  before do
+    allow(DpcClient).to receive(:new).and_return(mock_dpc_client)
+  end
+
+  describe 'perform' do
+    it 'creates an org in dpc-api if api_client returns no entry, then updates api org id' do
+      assert_enqueued_with(job: SyncOrganizationJob, args: [@po.id])
+      allow(ProviderOrganization).to receive(:find).with(@po.id).and_return(@po)
+      expect(mock_dpc_client).to receive(:get_organization_by_npi).with(@po.npi)
+                                                                  .and_return(get_organization_zero_entries)
+      expect(mock_dpc_client).to receive(:create_organization).with(have_attributes(name: @po.name, npi: @po.npi),
+                                                                    fhir_endpoint:)
+                                                              .and_return(create_organization_success_response)
+
+      perform_enqueued_jobs
+    end
+
+    it 'updates provider_organization.npi if api_client returns an entry' do
+      assert_enqueued_with(job: SyncOrganizationJob, args: [@po.id])
+      allow(ProviderOrganization).to receive(:find).with(@po.id).and_return(@po)
+      expect(mock_dpc_client).to receive(:get_organization_by_npi).with(@po.npi)
+                                                                  .and_return(get_organization_one_entry)
+      expect(@po).to receive(:dpc_api_organization_id=).with(get_organization_one_entry.entry[0].resource.id)
+
+      perform_enqueued_jobs
+    end
+
+    it 'raises an error if the provided unique ID is not found' do
+      assert_enqueued_with(job: SyncOrganizationJob, args: [@po.id])
+      allow(ProviderOrganization).to receive(:find).with(@po.id).and_raise(ActiveRecord::RecordNotFound)
+      expect do
+        SyncOrganizationJob.perform_now(@po.id)
+      end.to raise_error(SyncOrganizationJobError, "provider_organization #{@po.id} not found")
+    end
+
+    it 'raises an error if multiple orgs are found for the NPI in dpc_attribution' do
+      assert_enqueued_with(job: SyncOrganizationJob, args: [@po.id])
+      allow(ProviderOrganization).to receive(:find).with(@po.id).and_return(@po)
+      expect(mock_dpc_client).to receive(:get_organization_by_npi).with(@po.npi)
+                                                                  .and_return(get_organization_two_entries)
+      expect do
+        SyncOrganizationJob.perform_now(@po.id)
+      end.to raise_error(SyncOrganizationJobError, "multiple orgs found for NPI #{@po.npi} in dpc_attribution")
+    end
+
+    it 'raises an error if api_client.create_organization is unsuccessful' do
+      assert_enqueued_with(job: SyncOrganizationJob, args: [@po.id])
+      allow(ProviderOrganization).to receive(:find).with(@po.id).and_return(@po)
+      expect(mock_dpc_client).to receive(:get_organization_by_npi).with(@po.npi)
+                                                                  .and_return(get_organization_zero_entries)
+      expect(mock_dpc_client).to receive(:create_organization).with(have_attributes(name: @po.name, npi: @po.npi),
+                                                                    fhir_endpoint:)
+                                                              .and_return(create_organization_unsuccessful_response)
+
+      expect do
+        SyncOrganizationJob.perform_now(@po.id)
+      end.to raise_error(SyncOrganizationJobError,
+                         "DpcClient.create_organization failed for provider_organization #{@po.id}")
+    end
+  end
+end
+
+class MockFHIRResponse
+  attr_reader :entry
+
+  def initialize(entries_count: 0)
+    @entry = entries_count.times.map { MockEntry.new }
+  end
+end
+
+class MockEntry
+  attr_reader :resource
+
+  def initialize
+    @resource = MockResource.new
+  end
+end
+
+class MockResource
+  attr_reader :id
+
+  def initialize
+    @id = rand(0..9)
+  end
+end
+
+class MockOrgResponse
+  attr_reader :response_body
+
+  def initialize(response_successful: true, response_body: {})
+    @response_successful = response_successful
+    @response_body = response_body
+  end
+
+  def response_successful?
+    @response_successful
+  end
 end

--- a/dpc-portal/spec/jobs/sync_organization_job_spec.rb
+++ b/dpc-portal/spec/jobs/sync_organization_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SyncOrganizationJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/dpc-portal/spec/models/provider_organization_spec.rb
+++ b/dpc-portal/spec/models/provider_organization_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe ProviderOrganization, type: :model do
       po = ProviderOrganization.new(
         npi: 10.times.map { rand(0..9) }.join,
         name: 'Test org',
-        dpc_api_organization_id: 1)
+        dpc_api_organization_id: 1
+      )
       po.save
       assert_no_enqueued_jobs
     end

--- a/dpc-portal/spec/models/provider_organization_spec.rb
+++ b/dpc-portal/spec/models/provider_organization_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe ProviderOrganization, type: :model do
+  include ActiveJob::TestHelper
+
   describe :validations do
     it 'should pass if it has an npi' do
       expect(ProviderOrganization.new(npi: '1111111111')).to be_valid
@@ -10,6 +12,15 @@ RSpec.describe ProviderOrganization, type: :model do
 
     it 'should fail without npi' do
       expect(ProviderOrganization.new).to_not be_valid
+    end
+  end
+
+  describe 'after_create' do
+    it 'should trigger SyncOrganizationJob' do
+      ActiveJob::Base.queue_adapter = :test
+      po = ProviderOrganization.new(npi: 10.times.map { rand(0..9) }.join, name: 'Test org')
+      po.save
+      assert_enqueued_with(job: SyncOrganizationJob, args: [po.id])
     end
   end
 end

--- a/dpc-portal/spec/models/provider_organization_spec.rb
+++ b/dpc-portal/spec/models/provider_organization_spec.rb
@@ -22,5 +22,15 @@ RSpec.describe ProviderOrganization, type: :model do
       po.save
       assert_enqueued_with(job: SyncOrganizationJob, args: [po.id])
     end
+
+    it 'should not trigger job if PO has dpc_api_organization_id' do
+      ActiveJob::Base.queue_adapter = :test
+      po = ProviderOrganization.new(
+        npi: 10.times.map { rand(0..9) }.join,
+        name: 'Test org',
+        dpc_api_organization_id: 1)
+      po.save
+      assert_no_enqueued_jobs
+    end
   end
 end

--- a/engines/api_client/app/services/dpc_client.rb
+++ b/engines/api_client/app/services/dpc_client.rb
@@ -29,7 +29,7 @@ class DpcClient
     uri_string = "#{base_url}/Admin"
     client = FHIR::Client.new(uri_string)
     client.additional_headers = auth_header(golden_macaroon)
-    client.search(FHIR::Organization, search: { parameters: { npis: "npi|#{npi}" }}).resource
+    client.search(FHIR::Organization, search: { parameters: { npis: "npi|#{npi}" } }).resource
   end
 
   def update_organization(reg_org, api_id, api_endpoint_ref)

--- a/engines/api_client/app/services/dpc_client.rb
+++ b/engines/api_client/app/services/dpc_client.rb
@@ -25,6 +25,13 @@ class DpcClient
     client.read(FHIR::Organization, api_id).resource
   end
 
+  def get_organization_by_npi(npi)
+    uri_string = "#{base_url}/Admin"
+    client = FHIR::Client.new(uri_string)
+    client.additional_headers = auth_header(golden_macaroon)
+    client.search(FHIR::Organization, search: { parameters: { npis: "npi|#{npi}" }}).resource
+  end
+
   def update_organization(reg_org, api_id, api_endpoint_ref)
     fhir_org = FhirResourceBuilder.new.fhir_org(reg_org, api_id, api_endpoint_ref)
     fhir_client_update_request(api_id, fhir_org, api_id)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3903

## 🛠 Changes

This creates a background job that runs after a ProviderOrganization is created. It uses the ApiClient to query dpc-api, and checks if there's an organization in dpc_attribution with our new ProviderOrganization's NPI. If it does exist in attribution, the job then updates the ProviderOrganzation to link with the UUID of the corresponding dpc_attribution organization. If it does not exist in attribution,  the job sends a request to create a new organization in attribution with the correct data. 



## ℹ️ Context for reviewers

Currently, we're using largely mock data to create the organization in dpc_attribution. From our new ProviderOrganization, we're only sending the name and NPI.

## ✅ Acceptance Validation
Unit tests, and ran all of the use cases on my machine.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
