### PR TITLE
DPC-4015 AO Invitations

### DIFF
--- a/dpc-portal/.rubocop.yml
+++ b/dpc-portal/.rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
+    - "lib/tasks/dpc.rake"
 
 Metrics/MethodLength:
   Max: 20

--- a/dpc-portal/app/controllers/authorized_official_invitations_controller.rb
+++ b/dpc-portal/app/controllers/authorized_official_invitations_controller.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# Handles acceptance of Authorized Official invitations
 class AuthorizedOfficialInvitationsController < ApplicationController
   before_action :load_organization
   def accept

--- a/dpc-portal/app/controllers/authorized_official_invitations_controller.rb
+++ b/dpc-portal/app/controllers/authorized_official_invitations_controller.rb
@@ -1,0 +1,6 @@
+class AuthorizedOfficialInvitationsController < ApplicationController
+  before_action :load_organization
+  def accept
+    render inline: '<h1>Not implemented</h1>', layout: :default, status: :not_implemented
+  end
+end

--- a/dpc-portal/app/mailers/invitation_mailer.rb
+++ b/dpc-portal/app/mailers/invitation_mailer.rb
@@ -12,6 +12,8 @@ class InvitationMailer < ApplicationMailer
 
   def invite_ao
     @invitation = params[:invitation]
+    @given_name = params[:given_name]
+    @family_name = params[:family_name]
     mail(
       to: @invitation.invited_email,
       subject: 'You have been offered authorized official authority in Data at the Point of Care'

--- a/dpc-portal/app/mailers/invitation_mailer.rb
+++ b/dpc-portal/app/mailers/invitation_mailer.rb
@@ -9,4 +9,12 @@ class InvitationMailer < ApplicationMailer
       subject: 'You have been granted credential delegate authority in Data at the Point of Care'
     )
   end
+
+  def invite_ao
+    @invitation = params[:invitation]
+    mail(
+      to: @invitation.invited_email,
+      subject: 'You have been offered authorized official authority in Data at the Point of Care'
+    )
+  end
 end

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -32,7 +32,7 @@ class Invitation < ApplicationRecord
 
   def accepted?
     if invitation_type == 'credential_delegate'
-      CdOrgLink.where(invitation: self).exists? 
+      CdOrgLink.where(invitation: self).exists?
     elsif invitation_type == 'authorized_official'
       AoOrgLink.where(invitation: self).exists?
     end
@@ -40,15 +40,19 @@ class Invitation < ApplicationRecord
 
   def match_user?(user)
     if invitation_type == 'credential_delegate'
-      invited_given_name.downcase == user.given_name.downcase &&
-        invited_family_name.downcase == user.family_name.downcase &&
-        invited_email.downcase == user.email.downcase
+      cd_match?(user)
     elsif invitation_type == 'authorized_official'
       invited_email.downcase == user.email.downcase
     end
   end
 
   private
+
+  def cd_match?(user)
+    invited_given_name.downcase == user.given_name.downcase &&
+      invited_family_name.downcase == user.family_name.downcase &&
+      invited_email.downcase == user.email.downcase
+  end
 
   def needs_validation?
     new_record? && invitation_type == 'credential_delegate'

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -4,16 +4,16 @@
 class Invitation < ApplicationRecord
   attr_reader :phone_raw
 
-  validates :invited_given_name, :invited_family_name, :phone_raw, :invited_email, :invited_email_confirmation,
-            presence: true, if: :new_record?
+  validates :invited_by, :invited_given_name, :invited_family_name, :phone_raw, presence: true, if: :needs_validation?
+  validates :invited_email, :invited_email_confirmation, presence: true, if: :new_record?
   validates :invited_email, format: Devise.email_regexp, confirmation: true, if: :new_record?
   validates :invitation_type, presence: true
-  validates :invited_phone, format: { with: /\A[0-9]{10}\z/ }, if: :new_record?
+  validates :invited_phone, format: { with: /\A[0-9]{10}\z/ }, if: :needs_validation?
 
-  enum invitation_type: %i[credential_delegate]
+  enum invitation_type: %i[credential_delegate authorized_official]
 
   belongs_to :provider_organization, required: true
-  belongs_to :invited_by, class_name: 'User', required: true
+  belongs_to :invited_by, class_name: 'User', required: false
 
   def phone_raw=(nbr)
     @phone_raw = nbr
@@ -31,12 +31,26 @@ class Invitation < ApplicationRecord
   end
 
   def accepted?
-    CdOrgLink.where(invitation: self).exists?
+    if invitation_type == 'credential_delegate'
+      CdOrgLink.where(invitation: self).exists? 
+    elsif invitation_type == 'authorized_official'
+      AoOrgLink.where(invitation: self).exists?
+    end
   end
 
   def match_user?(user)
-    invited_given_name.downcase == user.given_name.downcase &&
-      invited_family_name.downcase == user.family_name.downcase &&
+    if invitation_type == 'credential_delegate'
+      invited_given_name.downcase == user.given_name.downcase &&
+        invited_family_name.downcase == user.family_name.downcase &&
+        invited_email.downcase == user.email.downcase
+    elsif invitation_type == 'authorized_official'
       invited_email.downcase == user.email.downcase
+    end
+  end
+
+  private
+
+  def needs_validation?
+    new_record? && invitation_type == 'credential_delegate'
   end
 end

--- a/dpc-portal/app/services/ao_invitation_service.rb
+++ b/dpc-portal/app/services/ao_invitation_service.rb
@@ -6,6 +6,7 @@ class AoInvitationService
     organization = ProviderOrganization.find_or_create_by(npi: org_npi) do |org|
       org.name = org_name(org_npi)
     end
+
     invitation = Invitation.create(invited_given_name: ao_given_name,
                                    invited_family_name: ao_family_name,
                                    invited_email: ao_email,
@@ -14,11 +15,15 @@ class AoInvitationService
                                    invitation_type: 'authorized_official')
 
     InvitationMailer.with(invitation:).invite_ao.deliver_now
+
+    invitation
   end
 
   def org_name(npi)
+    raise AoInvitationServiceError, 'Bad NPI' unless Luhnacy.valid?("80840#{npi}")
+
     org_info = client.org_info(npi)
-    raise AoInvitationServiceError, 'No such organization' if org_info['code'].to_s == '404'
+    raise AoInvitationServiceError, "No organization with npi: #{npi}" if org_info['code'].to_s == '404'
 
     org_info.dig('provider', 'orgName')
   end

--- a/dpc-portal/app/services/ao_invitation_service.rb
+++ b/dpc-portal/app/services/ao_invitation_service.rb
@@ -6,12 +6,14 @@ class AoInvitationService
     organization = ProviderOrganization.find_or_create_by(npi: org_npi) do |org|
       org.name = org_name(org_npi)
     end
-    Invitation.create(invited_given_name: ao_given_name,
-                      invited_family_name: ao_family_name,
-                      invited_email: ao_email,
-                      invited_email_confirmation: ao_email,
-                      provider_organization: organization,
-                      invitation_type: 'authorized_official')
+    invitation = Invitation.create(invited_given_name: ao_given_name,
+                                   invited_family_name: ao_family_name,
+                                   invited_email: ao_email,
+                                   invited_email_confirmation: ao_email,
+                                   provider_organization: organization,
+                                   invitation_type: 'authorized_official')
+
+    InvitationMailer.with(invitation:).invite_ao.deliver_now
   end
 
   def org_name(npi)

--- a/dpc-portal/app/services/ao_invitation_service.rb
+++ b/dpc-portal/app/services/ao_invitation_service.rb
@@ -2,9 +2,30 @@
 
 # A service that verifies generates an ao invitation
 class AoInvitationService
-  def initialize
-    @cpi_api_gw_client = CpiApiGatewayClient.new
+  def create_invitation(ao_given_name, ao_family_name, ao_email, org_npi)
+    organization = ProviderOrganization.find_or_create_by(npi: org_npi) do |org|
+      org.name = org_name(org_npi)
+    end
+    Invitation.create(invited_given_name: ao_given_name,
+                      invited_family_name: ao_family_name,
+                      invited_email: ao_email,
+                      invited_email_confirmation: ao_email,
+                      provider_organization: organization,
+                      invitation_type: 'authorized_official')
   end
 
-  def org_name(npi); end
+  def org_name(npi)
+    org_info = client.org_info(npi)
+    raise AoInvitationServiceError, 'No such organization' if org_info['code'].to_s == '404'
+
+    org_info.dig('provider', 'orgName')
+  end
+
+  private
+
+  def client
+    @client ||= CpiApiGatewayClient.new
+  end
 end
+
+class AoInvitationServiceError < StandardError; end

--- a/dpc-portal/app/services/ao_invitation_service.rb
+++ b/dpc-portal/app/services/ao_invitation_service.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# A service that verifies generates an ao invitation
+class AoInvitationService
+  def initialize
+    @cpi_api_gw_client = CpiApiGatewayClient.new
+  end
+
+  def org_name(npi); end
+end

--- a/dpc-portal/app/services/ao_invitation_service.rb
+++ b/dpc-portal/app/services/ao_invitation_service.rb
@@ -2,19 +2,17 @@
 
 # A service that verifies generates an ao invitation
 class AoInvitationService
-  def create_invitation(ao_given_name, ao_family_name, ao_email, org_npi)
+  def create_invitation(given_name, family_name, ao_email, org_npi)
     organization = ProviderOrganization.find_or_create_by(npi: org_npi) do |org|
       org.name = org_name(org_npi)
     end
 
-    invitation = Invitation.create(invited_given_name: ao_given_name,
-                                   invited_family_name: ao_family_name,
-                                   invited_email: ao_email,
+    invitation = Invitation.create(invited_email: ao_email,
                                    invited_email_confirmation: ao_email,
                                    provider_organization: organization,
                                    invitation_type: 'authorized_official')
 
-    InvitationMailer.with(invitation:).invite_ao.deliver_now
+    InvitationMailer.with(invitation:, given_name:, family_name:).invite_ao.deliver_now
 
     invitation
   end

--- a/dpc-portal/app/services/cpi_api_gateway_client.rb
+++ b/dpc-portal/app/services/cpi_api_gateway_client.rb
@@ -69,6 +69,8 @@ class CpiApiGatewayClient
     fetch_med_sanctions_and_waivers(body)
   end
 
+  alias org_info fetch_med_sanctions_and_waivers_by_org_npi
+
   private
 
   def fetch_token

--- a/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
+++ b/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Dear <%= @invitation.invited_given_name %> <%= @invitation.invited_family_name %>,</h1>
+    <p>You have been invited top exercise Authorized Official management of
+      <%= @invitation.provider_organization.name %> within Data at the Point of Care.</p>
+    <p><%= link_to 'Accept this invitation', accept_organization_authorized_official_invitation_url(@invitation.provider_organization, @invitation) %></p>
+    <p>Sincerely,</p>
+
+    <p>The Data at the Point of Care Team</p>
+  </body>
+</html>

--- a/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
+++ b/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
@@ -4,7 +4,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <h1>Dear <%= @invitation.invited_given_name %> <%= @invitation.invited_family_name %>,</h1>
+    <h1>Dear <%= @given_name %> <%= @family_name %>,</h1>
     <p>You have been invited to exercise Authorized Official management of
       <%= @invitation.provider_organization.name %> within Data at the Point of Care.</p>
     <p><%= link_to 'Accept this invitation', accept_organization_authorized_official_invitation_url(@invitation.provider_organization, @invitation) %></p>

--- a/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
+++ b/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
@@ -5,7 +5,7 @@
   </head>
   <body>
     <h1>Dear <%= @invitation.invited_given_name %> <%= @invitation.invited_family_name %>,</h1>
-    <p>You have been invited top exercise Authorized Official management of
+    <p>You have been invited to exercise Authorized Official management of
       <%= @invitation.provider_organization.name %> within Data at the Point of Care.</p>
     <p><%= link_to 'Accept this invitation', accept_organization_authorized_official_invitation_url(@invitation.provider_organization, @invitation) %></p>
     <p>Sincerely,</p>

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -28,6 +28,9 @@ Rails.application.routes.draw do
       post 'confirm', on: :member
       get 'success', on: :member
     end
+    resources :authorized_official_invitations, only: [] do
+      get 'accept', on: :member
+    end
     get 'tos_form', on: :member
     post 'sign_tos', on: :member
     get 'success', on: :member

--- a/dpc-portal/lib/tasks/dpc.rake
+++ b/dpc-portal/lib/tasks/dpc.rake
@@ -2,7 +2,22 @@
 
 require './vendor/api_client/app/services/dpc_client'
 require './vendor/api_client/app/serializers/organization_submit_serializer'
+
 namespace :dpc do
+  desc <<~DESC
+    Create an Invitation for an Authorized Official
+    provide comma-separated values in INVITE: given name, family name, email, org npi
+    e.g. rails dpc:invite_ao INVITE=Bob,Hoskins,bob@example.com,11111111111
+  DESC
+  task invite_ao: :environment do
+    ao_given_name, ao_family_name, ao_email, org_npi = ENV['INVITE'].split(',')
+    service = AoInvitationService.new
+    invitation = service.create_invitation(ao_given_name, ao_family_name, ao_email, org_npi)
+    puts "Invitation created for #{ao_given_name} #{ao_family_name} for #{invitation.provider_organization.name}"
+  rescue AoInvitationServiceError => e
+    puts "Unable to create invitation: #{e.message}"
+  end
+
   desc 'Create a new organization with random attributes. Prints link.'
   task :make_org do
     raise BadEnvironmentError, 'Only for local development' unless ENV['ENV'] == 'local'

--- a/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
     end
 
     let(:org) { ComponentSupport::MockOrg.new }
-    let(:cd_invite) { Invitation.new }
+    let(:cd_invite) { Invitation.new(invitation_type: 'credential_delegate') }
 
     let(:component) { described_class.new(org, cd_invite) }
 

--- a/dpc-portal/spec/factories/ao_org_links.rb
+++ b/dpc-portal/spec/factories/ao_org_links.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
   factory :ao_org_link do
     user { build(:user) }
     provider_organization { build(:provider_organization) }
+    invitation { build(:invitation, :ao) }
   end
 end

--- a/dpc-portal/spec/factories/cd_org_links.rb
+++ b/dpc-portal/spec/factories/cd_org_links.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
   factory :cd_org_link do
     user { build(:user) }
     provider_organization { build(:provider_organization) }
-    invitation { build(:invitation) }
+    invitation { build(:invitation, :cd) }
   end
 end

--- a/dpc-portal/spec/factories/invitations.rb
+++ b/dpc-portal/spec/factories/invitations.rb
@@ -3,12 +3,18 @@
 FactoryBot.define do
   factory :invitation do
     provider_organization
-    invited_by
-    invited_given_name { 'Bob' }
-    invited_family_name { 'Hodges' }
-    phone_raw { '111-111-1111' }
     invited_email { 'bob@testy.com' }
     invited_email_confirmation { 'bob@testy.com' }
-    invitation_type { 'credential_delegate' }
+    trait :ao do
+      invitation_type { 'authorized_official' }
+    end
+
+    trait :cd do
+      invited_by
+      invited_given_name { 'Bob' }
+      invited_family_name { 'Hodges' }
+      phone_raw { '111-111-1111' }
+      invitation_type { 'credential_delegate' }
+    end
   end
 end

--- a/dpc-portal/spec/mailers/invitation_spec.rb
+++ b/dpc-portal/spec/mailers/invitation_spec.rb
@@ -15,9 +15,8 @@ RSpec.describe InvitationMailer, type: :mailer do
   end
   describe :invite_ao do
     it 'has link to invitation' do
-      invited_by = build(:user)
       provider_organization = build(:provider_organization, id: 2)
-      invitation = build(:invitation, id: 4, invited_by:, provider_organization:)
+      invitation = build(:invitation, id: 4, provider_organization:)
       mailer = InvitationMailer.with(invitation:).invite_ao
       expected_url = 'http://localhost:3100/portal/organizations/2/authorized_official_invitations/4/accept'
       expect(mailer.body).to match(expected_url)

--- a/dpc-portal/spec/mailers/invitation_spec.rb
+++ b/dpc-portal/spec/mailers/invitation_spec.rb
@@ -13,4 +13,14 @@ RSpec.describe InvitationMailer, type: :mailer do
       expect(mailer.body).to match(expected_url)
     end
   end
+  describe :invite_ao do
+    it 'has link to invitation' do
+      invited_by = build(:user)
+      provider_organization = build(:provider_organization, id: 2)
+      invitation = build(:invitation, id: 4, invited_by:, provider_organization:)
+      mailer = InvitationMailer.with(invitation:).invite_ao
+      expected_url = 'http://localhost:3100/portal/organizations/2/authorized_official_invitations/4/accept'
+      expect(mailer.body).to match(expected_url)
+    end
+  end
 end

--- a/dpc-portal/spec/mailers/invitation_spec.rb
+++ b/dpc-portal/spec/mailers/invitation_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe InvitationMailer, type: :mailer do
     it 'has link to invitation' do
       provider_organization = build(:provider_organization, id: 2)
       invitation = build(:invitation, id: 4, provider_organization:)
-      mailer = InvitationMailer.with(invitation:).invite_ao
+      given_name = family_name = ''
+      mailer = InvitationMailer.with(invitation:, given_name:, family_name:).invite_ao
       expected_url = 'http://localhost:3100/portal/organizations/2/authorized_official_invitations/4/accept'
       expect(mailer.body).to match(expected_url)
     end

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -4,193 +4,350 @@ require 'rails_helper'
 
 RSpec.describe Invitation, type: :model do
   let(:organization) { build(:provider_organization) }
-  let(:authorized_official) { build(:user) }
-  let(:valid_new_cd_invite) { build(:invitation) }
 
-  describe :create do
-    it 'passes validations' do
-      expect(valid_new_cd_invite.valid?).to eq true
+  describe :ao do
+    let(:valid_new_ao_invite) { build(:invitation, :ao) }
+    describe :create do
+      it 'passes validations' do
+        expect(valid_new_ao_invite.valid?).to eq(true), valid_new_ao_invite.errors.inspect
+      end
+
+      it 'fails if no provider organization' do
+        valid_new_ao_invite.provider_organization = nil
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:provider_organization]).to eq ['must exist']
+      end
+
+      it 'does not fail if no invited by' do
+        valid_new_ao_invite.invited_by = nil
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'fails on blank invitation type' do
+        valid_new_ao_invite.invitation_type = nil
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:invitation_type]).to eq ["can't be blank"]
+      end
+
+      it 'fails on invalid invitation type' do
+        expect do
+          valid_new_ao_invite.invitation_type = :birthday_party
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'does not fail on blank given name' do
+        valid_new_ao_invite.invited_given_name = ''
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'does not fail on blank family name' do
+        valid_new_ao_invite.invited_family_name = ''
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'does not fail on blank phone' do
+        valid_new_ao_invite.phone_raw = ''
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'fails on bad email' do
+        valid_new_ao_invite.invited_email_confirmation = valid_new_ao_invite.invited_email = 'rob-at-example.com'
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:invited_email]).to eq ['is invalid']
+      end
+
+      it 'fails on blank email' do
+        valid_new_ao_invite.invited_email_confirmation = valid_new_ao_invite.invited_email = ''
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 3
+        expect(valid_new_ao_invite.errors[:invited_email]).to eq ["can't be blank", 'is invalid']
+        expect(valid_new_ao_invite.errors[:invited_email_confirmation]).to eq ["can't be blank"]
+      end
+
+      it 'fails on non-matching email confirmation' do
+        valid_new_ao_invite.invited_email_confirmation = 'robert@example.com'
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:invited_email_confirmation]).to eq ["doesn't match Invited email"]
+      end
     end
 
-    it 'fails if no provider organization' do
-      valid_new_cd_invite.provider_organization = nil
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:provider_organization]).to eq ['must exist']
+    describe :update do
+      let(:saved_ao_invite) do
+        valid_new_ao_invite.save!
+        valid_new_ao_invite
+      end
+      it 'should allow blank invitation values' do
+        saved_ao_invite.invited_given_name = ''
+        saved_ao_invite.invited_family_name = ''
+        saved_ao_invite.invited_phone = ''
+        saved_ao_invite.invited_email = ''
+        saved_ao_invite.invited_email_confirmation = ''
+        expect(saved_ao_invite.valid?).to eq true
+      end
+
+      it 'should allow blank phone_raw' do
+        saved_ao_invite.phone_raw = ''
+        expect(saved_ao_invite.valid?).to eq true
+      end
+
+      it 'fails if no provider organization' do
+        saved_ao_invite.provider_organization = nil
+        expect(saved_ao_invite.valid?).to eq false
+        expect(saved_ao_invite.errors.size).to eq 1
+        expect(saved_ao_invite.errors[:provider_organization]).to eq ['must exist']
+      end
+
+      it 'fails on blank invitation type' do
+        saved_ao_invite.invitation_type = nil
+        expect(saved_ao_invite.valid?).to eq false
+        expect(saved_ao_invite.errors.size).to eq 1
+        expect(saved_ao_invite.errors[:invitation_type]).to eq ["can't be blank"]
+      end
+
+      it 'fails on invalid invitation type' do
+        expect do
+          saved_ao_invite.invitation_type = :birthday_party
+        end.to raise_error(ArgumentError)
+      end
     end
 
-    it 'fails if no invited by' do
-      valid_new_cd_invite.invited_by = nil
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invited_by]).to eq ['must exist']
+    describe :expired do
+      it 'should not be expired if less than 2 days old' do
+        invitation = create(:invitation, :ao, created_at: 47.hours.ago)
+        expect(invitation.expired?).to eq false
+      end
+      it 'should be expired if more than 2 days old' do
+        invitation = create(:invitation, :ao, created_at: 49.hours.ago)
+        expect(invitation.expired?).to eq true
+      end
+      it 'should be expired if 2 days old' do
+        invitation = create(:invitation, :ao, created_at: 2.days.ago)
+        expect(invitation.expired?).to eq true
+      end
     end
 
-    it 'fails on blank invitation type' do
-      valid_new_cd_invite.invitation_type = nil
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invitation_type]).to eq ["can't be blank"]
+    describe :accepted do
+      it 'should be accepted if has ao_org_link' do
+        link = create(:ao_org_link)
+        expect(link.invitation.accepted?).to eq true
+      end
+      it 'should not be accepted if not have ao_org_link' do
+        invitation = create(:invitation, :ao)
+        expect(invitation.accepted?).to eq false
+      end
     end
 
-    it 'fails on invalid invitation type' do
-      expect do
-        valid_new_cd_invite.invitation_type = :birthday_party
-      end.to raise_error(ArgumentError)
-    end
-
-    it 'fails on blank given name' do
-      valid_new_cd_invite.invited_given_name = ''
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invited_given_name]).to eq ["can't be blank"]
-    end
-
-    it 'fails on blank family name' do
-      valid_new_cd_invite.invited_family_name = ''
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invited_family_name]).to eq ["can't be blank"]
-    end
-
-    it 'fails on fewer than ten digits in phone' do
-      valid_new_cd_invite.phone_raw = '877-288-313'
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invited_phone]).to eq ['is invalid']
-    end
-
-    it 'fails on more than ten digits in phone' do
-      valid_new_cd_invite.phone_raw = '877-288-31333'
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invited_phone]).to eq ['is invalid']
-    end
-
-    it 'fails on blank phone' do
-      valid_new_cd_invite.phone_raw = ''
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 2
-      expect(valid_new_cd_invite.errors[:phone_raw]).to eq ["can't be blank"]
-      expect(valid_new_cd_invite.errors[:invited_phone]).to eq ['is invalid']
-    end
-
-    it 'fails on bad email' do
-      valid_new_cd_invite.invited_email_confirmation = valid_new_cd_invite.invited_email = 'rob-at-example.com'
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invited_email]).to eq ['is invalid']
-    end
-
-    it 'fails on blank email' do
-      valid_new_cd_invite.invited_email_confirmation = valid_new_cd_invite.invited_email = ''
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 3
-      expect(valid_new_cd_invite.errors[:invited_email]).to eq ["can't be blank", 'is invalid']
-      expect(valid_new_cd_invite.errors[:invited_email_confirmation]).to eq ["can't be blank"]
-    end
-
-    it 'fails on non-matching email confirmation' do
-      valid_new_cd_invite.invited_email_confirmation = 'robert@example.com'
-      expect(valid_new_cd_invite.valid?).to eq false
-      expect(valid_new_cd_invite.errors.size).to eq 1
-      expect(valid_new_cd_invite.errors[:invited_email_confirmation]).to eq ["doesn't match Invited email"]
+    describe :match_user do
+      let(:ao_invite) { build(:invitation, :ao) }
+      let(:user) do
+        build(:user, given_name: 'Hugo',
+                     family_name: 'Boss',
+                     email: ao_invite.invited_email)
+      end
+      it 'should match user if email correct' do
+        expect(ao_invite.match_user?(user)).to eq true
+      end
+      it 'should match user if email different case' do
+        user.email = user.email.upcase_first
+        expect(ao_invite.match_user?(user)).to eq true
+      end
+      it 'should not match user if email not correct' do
+        user.email = "not #{ao_invite.invited_email}"
+        expect(ao_invite.match_user?(user)).to eq false
+      end
     end
   end
+  describe :cd do
+    let(:valid_new_cd_invite) { build(:invitation, :cd) }
+    describe :create do
+      it 'passes validations' do
+        expect(valid_new_cd_invite.valid?).to eq true
+      end
 
-  describe :update do
-    let(:saved_cd_invite) do
-      valid_new_cd_invite.save!
-      valid_new_cd_invite
-    end
-    it 'should allow blank invitation values' do
-      saved_cd_invite.invited_given_name = ''
-      saved_cd_invite.invited_family_name = ''
-      saved_cd_invite.invited_phone = ''
-      saved_cd_invite.invited_email = ''
-      saved_cd_invite.invited_email_confirmation = ''
-      expect(saved_cd_invite.valid?).to eq true
+      it 'fails if no provider organization' do
+        valid_new_cd_invite.provider_organization = nil
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:provider_organization]).to eq ['must exist']
+      end
+
+      it 'fails if no invited by' do
+        valid_new_cd_invite.invited_by = nil
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invited_by]).to eq ["can't be blank"]
+      end
+
+      it 'fails on blank invitation type' do
+        valid_new_cd_invite.invitation_type = nil
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invitation_type]).to eq ["can't be blank"]
+      end
+
+      it 'fails on invalid invitation type' do
+        expect do
+          valid_new_cd_invite.invitation_type = :birthday_party
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'fails on blank given name' do
+        valid_new_cd_invite.invited_given_name = ''
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invited_given_name]).to eq ["can't be blank"]
+      end
+
+      it 'fails on blank family name' do
+        valid_new_cd_invite.invited_family_name = ''
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invited_family_name]).to eq ["can't be blank"]
+      end
+
+      it 'fails on fewer than ten digits in phone' do
+        valid_new_cd_invite.phone_raw = '877-288-313'
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invited_phone]).to eq ['is invalid']
+      end
+
+      it 'fails on more than ten digits in phone' do
+        valid_new_cd_invite.phone_raw = '877-288-31333'
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invited_phone]).to eq ['is invalid']
+      end
+
+      it 'fails on blank phone' do
+        valid_new_cd_invite.phone_raw = ''
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 2
+        expect(valid_new_cd_invite.errors[:phone_raw]).to eq ["can't be blank"]
+        expect(valid_new_cd_invite.errors[:invited_phone]).to eq ['is invalid']
+      end
+
+      it 'fails on bad email' do
+        valid_new_cd_invite.invited_email_confirmation = valid_new_cd_invite.invited_email = 'rob-at-example.com'
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invited_email]).to eq ['is invalid']
+      end
+
+      it 'fails on blank email' do
+        valid_new_cd_invite.invited_email_confirmation = valid_new_cd_invite.invited_email = ''
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 3
+        expect(valid_new_cd_invite.errors[:invited_email]).to eq ["can't be blank", 'is invalid']
+        expect(valid_new_cd_invite.errors[:invited_email_confirmation]).to eq ["can't be blank"]
+      end
+
+      it 'fails on non-matching email confirmation' do
+        valid_new_cd_invite.invited_email_confirmation = 'robert@example.com'
+        expect(valid_new_cd_invite.valid?).to eq false
+        expect(valid_new_cd_invite.errors.size).to eq 1
+        expect(valid_new_cd_invite.errors[:invited_email_confirmation]).to eq ["doesn't match Invited email"]
+      end
     end
 
-    it 'should allow blank phone_raw' do
-      saved_cd_invite.phone_raw = ''
-      expect(saved_cd_invite.valid?).to eq true
+    describe :update do
+      let(:saved_cd_invite) do
+        valid_new_cd_invite.save!
+        valid_new_cd_invite
+      end
+      it 'should allow blank invitation values' do
+        saved_cd_invite.invited_given_name = ''
+        saved_cd_invite.invited_family_name = ''
+        saved_cd_invite.invited_phone = ''
+        saved_cd_invite.invited_email = ''
+        saved_cd_invite.invited_email_confirmation = ''
+        expect(saved_cd_invite.valid?).to eq true
+      end
+
+      it 'should allow blank phone_raw' do
+        saved_cd_invite.phone_raw = ''
+        expect(saved_cd_invite.valid?).to eq true
+      end
+
+      it 'fails if no provider organization' do
+        saved_cd_invite.provider_organization = nil
+        expect(saved_cd_invite.valid?).to eq false
+        expect(saved_cd_invite.errors.size).to eq 1
+        expect(saved_cd_invite.errors[:provider_organization]).to eq ['must exist']
+      end
+
+      it 'fails on blank invitation type' do
+        saved_cd_invite.invitation_type = nil
+        expect(saved_cd_invite.valid?).to eq false
+        expect(saved_cd_invite.errors.size).to eq 1
+        expect(saved_cd_invite.errors[:invitation_type]).to eq ["can't be blank"]
+      end
+
+      it 'fails on invalid invitation type' do
+        expect do
+          saved_cd_invite.invitation_type = :birthday_party
+        end.to raise_error(ArgumentError)
+      end
     end
 
-    it 'fails if no provider organization' do
-      saved_cd_invite.provider_organization = nil
-      expect(saved_cd_invite.valid?).to eq false
-      expect(saved_cd_invite.errors.size).to eq 1
-      expect(saved_cd_invite.errors[:provider_organization]).to eq ['must exist']
+    describe :expired do
+      it 'should not be expired if less than 2 days old' do
+        invitation = create(:invitation, :cd, created_at: 47.hours.ago)
+        expect(invitation.expired?).to eq false
+      end
+      it 'should be expired if more than 2 days old' do
+        invitation = create(:invitation, :cd, created_at: 49.hours.ago)
+        expect(invitation.expired?).to eq true
+      end
+      it 'should be expired if 2 days old' do
+        invitation = create(:invitation, :cd, created_at: 2.days.ago)
+        expect(invitation.expired?).to eq true
+      end
     end
 
-    it 'fails on blank invitation type' do
-      saved_cd_invite.invitation_type = nil
-      expect(saved_cd_invite.valid?).to eq false
-      expect(saved_cd_invite.errors.size).to eq 1
-      expect(saved_cd_invite.errors[:invitation_type]).to eq ["can't be blank"]
+    describe :accepted do
+      it 'should be accepted if has cd_org_link' do
+        link = create(:cd_org_link)
+        expect(link.invitation.accepted?).to eq true
+      end
+      it 'should not be accepted if not have cd_org_link' do
+        invitation = create(:invitation, :cd)
+        expect(invitation.accepted?).to eq false
+      end
     end
 
-    it 'fails on invalid invitation type' do
-      expect do
-        saved_cd_invite.invitation_type = :birthday_party
-      end.to raise_error(ArgumentError)
-    end
-  end
-
-  describe :expired do
-    it 'should not be expired if less than 2 days old' do
-      invitation = create(:invitation, created_at: 47.hours.ago)
-      expect(invitation.expired?).to eq false
-    end
-    it 'should be expired if more than 2 days old' do
-      invitation = create(:invitation, created_at: 49.hours.ago)
-      expect(invitation.expired?).to eq true
-    end
-    it 'should be expired if 2 days old' do
-      invitation = create(:invitation, created_at: 2.days.ago)
-      expect(invitation.expired?).to eq true
-    end
-  end
-
-  describe :accepted do
-    it 'should be accepted if has cd_org_link' do
-      link = create(:cd_org_link)
-      expect(link.invitation.accepted?).to eq true
-    end
-    it 'should not be accepted if not have cd_org_link' do
-      invitation = create(:invitation)
-      expect(invitation.accepted?).to eq false
-    end
-  end
-
-  describe :match_user do
-    let(:cd_invite) { build(:invitation) }
-    let(:user) do
-      build(:user, given_name: cd_invite.invited_given_name,
-                   family_name: cd_invite.invited_family_name,
-                   email: cd_invite.invited_email)
-    end
-    it 'should match user if names and email correct' do
-      expect(cd_invite.match_user?(user)).to eq true
-    end
-    it 'should match user if names and email different case' do
-      user.given_name.upcase!
-      user.family_name.downcase!
-      user.email = user.email.upcase_first
-      expect(cd_invite.match_user?(user)).to eq true
-    end
-    it 'should not match user if given name not correct' do
-      user.given_name = "not #{cd_invite.invited_given_name}"
-      expect(cd_invite.match_user?(user)).to eq false
-    end
-    it 'should not match user if family name not correct' do
-      user.family_name = "not #{cd_invite.invited_family_name}"
-      expect(cd_invite.match_user?(user)).to eq false
-    end
-    it 'should not match user if email not correct' do
-      user.email = "not #{cd_invite.invited_email}"
-      expect(cd_invite.match_user?(user)).to eq false
+    describe :match_user do
+      let(:cd_invite) { build(:invitation, :cd) }
+      let(:user) do
+        build(:user, given_name: cd_invite.invited_given_name,
+                     family_name: cd_invite.invited_family_name,
+                     email: cd_invite.invited_email)
+      end
+      it 'should match user if names and email correct' do
+        expect(cd_invite.match_user?(user)).to eq true
+      end
+      it 'should match user if names and email different case' do
+        user.given_name.upcase!
+        user.family_name.downcase!
+        user.email = user.email.upcase_first
+        expect(cd_invite.match_user?(user)).to eq true
+      end
+      it 'should not match user if given name not correct' do
+        user.given_name = "not #{cd_invite.invited_given_name}"
+        expect(cd_invite.match_user?(user)).to eq false
+      end
+      it 'should not match user if family name not correct' do
+        user.family_name = "not #{cd_invite.invited_family_name}"
+        expect(cd_invite.match_user?(user)).to eq false
+      end
+      it 'should not match user if email not correct' do
+        user.email = "not #{cd_invite.invited_email}"
+        expect(cd_invite.match_user?(user)).to eq false
+      end
     end
   end
 end

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -5,162 +5,6 @@ require 'rails_helper'
 RSpec.describe Invitation, type: :model do
   let(:organization) { build(:provider_organization) }
 
-  describe :ao do
-    let(:valid_new_ao_invite) { build(:invitation, :ao) }
-    describe :create do
-      it 'passes validations' do
-        expect(valid_new_ao_invite.valid?).to eq(true), valid_new_ao_invite.errors.inspect
-      end
-
-      it 'fails if no provider organization' do
-        valid_new_ao_invite.provider_organization = nil
-        expect(valid_new_ao_invite.valid?).to eq false
-        expect(valid_new_ao_invite.errors.size).to eq 1
-        expect(valid_new_ao_invite.errors[:provider_organization]).to eq ['must exist']
-      end
-
-      it 'does not fail if no invited by' do
-        valid_new_ao_invite.invited_by = nil
-        expect(valid_new_ao_invite.valid?).to eq true
-      end
-
-      it 'fails on blank invitation type' do
-        valid_new_ao_invite.invitation_type = nil
-        expect(valid_new_ao_invite.valid?).to eq false
-        expect(valid_new_ao_invite.errors.size).to eq 1
-        expect(valid_new_ao_invite.errors[:invitation_type]).to eq ["can't be blank"]
-      end
-
-      it 'fails on invalid invitation type' do
-        expect do
-          valid_new_ao_invite.invitation_type = :birthday_party
-        end.to raise_error(ArgumentError)
-      end
-
-      it 'does not fail on blank given name' do
-        valid_new_ao_invite.invited_given_name = ''
-        expect(valid_new_ao_invite.valid?).to eq true
-      end
-
-      it 'does not fail on blank family name' do
-        valid_new_ao_invite.invited_family_name = ''
-        expect(valid_new_ao_invite.valid?).to eq true
-      end
-
-      it 'does not fail on blank phone' do
-        valid_new_ao_invite.phone_raw = ''
-        expect(valid_new_ao_invite.valid?).to eq true
-      end
-
-      it 'fails on bad email' do
-        valid_new_ao_invite.invited_email_confirmation = valid_new_ao_invite.invited_email = 'rob-at-example.com'
-        expect(valid_new_ao_invite.valid?).to eq false
-        expect(valid_new_ao_invite.errors.size).to eq 1
-        expect(valid_new_ao_invite.errors[:invited_email]).to eq ['is invalid']
-      end
-
-      it 'fails on blank email' do
-        valid_new_ao_invite.invited_email_confirmation = valid_new_ao_invite.invited_email = ''
-        expect(valid_new_ao_invite.valid?).to eq false
-        expect(valid_new_ao_invite.errors.size).to eq 3
-        expect(valid_new_ao_invite.errors[:invited_email]).to eq ["can't be blank", 'is invalid']
-        expect(valid_new_ao_invite.errors[:invited_email_confirmation]).to eq ["can't be blank"]
-      end
-
-      it 'fails on non-matching email confirmation' do
-        valid_new_ao_invite.invited_email_confirmation = 'robert@example.com'
-        expect(valid_new_ao_invite.valid?).to eq false
-        expect(valid_new_ao_invite.errors.size).to eq 1
-        expect(valid_new_ao_invite.errors[:invited_email_confirmation]).to eq ["doesn't match Invited email"]
-      end
-    end
-
-    describe :update do
-      let(:saved_ao_invite) do
-        valid_new_ao_invite.save!
-        valid_new_ao_invite
-      end
-      it 'should allow blank invitation values' do
-        saved_ao_invite.invited_given_name = ''
-        saved_ao_invite.invited_family_name = ''
-        saved_ao_invite.invited_phone = ''
-        saved_ao_invite.invited_email = ''
-        saved_ao_invite.invited_email_confirmation = ''
-        expect(saved_ao_invite.valid?).to eq true
-      end
-
-      it 'should allow blank phone_raw' do
-        saved_ao_invite.phone_raw = ''
-        expect(saved_ao_invite.valid?).to eq true
-      end
-
-      it 'fails if no provider organization' do
-        saved_ao_invite.provider_organization = nil
-        expect(saved_ao_invite.valid?).to eq false
-        expect(saved_ao_invite.errors.size).to eq 1
-        expect(saved_ao_invite.errors[:provider_organization]).to eq ['must exist']
-      end
-
-      it 'fails on blank invitation type' do
-        saved_ao_invite.invitation_type = nil
-        expect(saved_ao_invite.valid?).to eq false
-        expect(saved_ao_invite.errors.size).to eq 1
-        expect(saved_ao_invite.errors[:invitation_type]).to eq ["can't be blank"]
-      end
-
-      it 'fails on invalid invitation type' do
-        expect do
-          saved_ao_invite.invitation_type = :birthday_party
-        end.to raise_error(ArgumentError)
-      end
-    end
-
-    describe :expired do
-      it 'should not be expired if less than 2 days old' do
-        invitation = create(:invitation, :ao, created_at: 47.hours.ago)
-        expect(invitation.expired?).to eq false
-      end
-      it 'should be expired if more than 2 days old' do
-        invitation = create(:invitation, :ao, created_at: 49.hours.ago)
-        expect(invitation.expired?).to eq true
-      end
-      it 'should be expired if 2 days old' do
-        invitation = create(:invitation, :ao, created_at: 2.days.ago)
-        expect(invitation.expired?).to eq true
-      end
-    end
-
-    describe :accepted do
-      it 'should be accepted if has ao_org_link' do
-        link = create(:ao_org_link)
-        expect(link.invitation.accepted?).to eq true
-      end
-      it 'should not be accepted if not have ao_org_link' do
-        invitation = create(:invitation, :ao)
-        expect(invitation.accepted?).to eq false
-      end
-    end
-
-    describe :match_user do
-      let(:ao_invite) { build(:invitation, :ao) }
-      let(:user) do
-        build(:user, given_name: 'Hugo',
-                     family_name: 'Boss',
-                     email: ao_invite.invited_email)
-      end
-      it 'should match user if email correct' do
-        expect(ao_invite.match_user?(user)).to eq true
-      end
-      it 'should match user if email different case' do
-        user.email = user.email.upcase_first
-        expect(ao_invite.match_user?(user)).to eq true
-      end
-      it 'should not match user if email not correct' do
-        user.email = "not #{ao_invite.invited_email}"
-        expect(ao_invite.match_user?(user)).to eq false
-      end
-    end
-  end
   describe :cd do
     let(:valid_new_cd_invite) { build(:invitation, :cd) }
     describe :create do
@@ -347,6 +191,163 @@ RSpec.describe Invitation, type: :model do
       it 'should not match user if email not correct' do
         user.email = "not #{cd_invite.invited_email}"
         expect(cd_invite.match_user?(user)).to eq false
+      end
+    end
+  end
+
+  describe :ao do
+    let(:valid_new_ao_invite) { build(:invitation, :ao) }
+    describe :create do
+      it 'passes validations' do
+        expect(valid_new_ao_invite.valid?).to eq(true), valid_new_ao_invite.errors.inspect
+      end
+
+      it 'fails if no provider organization' do
+        valid_new_ao_invite.provider_organization = nil
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:provider_organization]).to eq ['must exist']
+      end
+
+      it 'does not fail if no invited by' do
+        valid_new_ao_invite.invited_by = nil
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'fails on blank invitation type' do
+        valid_new_ao_invite.invitation_type = nil
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:invitation_type]).to eq ["can't be blank"]
+      end
+
+      it 'fails on invalid invitation type' do
+        expect do
+          valid_new_ao_invite.invitation_type = :birthday_party
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'does not fail on blank given name' do
+        valid_new_ao_invite.invited_given_name = ''
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'does not fail on blank family name' do
+        valid_new_ao_invite.invited_family_name = ''
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'does not fail on blank phone' do
+        valid_new_ao_invite.phone_raw = ''
+        expect(valid_new_ao_invite.valid?).to eq true
+      end
+
+      it 'fails on bad email' do
+        valid_new_ao_invite.invited_email_confirmation = valid_new_ao_invite.invited_email = 'rob-at-example.com'
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:invited_email]).to eq ['is invalid']
+      end
+
+      it 'fails on blank email' do
+        valid_new_ao_invite.invited_email_confirmation = valid_new_ao_invite.invited_email = ''
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 3
+        expect(valid_new_ao_invite.errors[:invited_email]).to eq ["can't be blank", 'is invalid']
+        expect(valid_new_ao_invite.errors[:invited_email_confirmation]).to eq ["can't be blank"]
+      end
+
+      it 'fails on non-matching email confirmation' do
+        valid_new_ao_invite.invited_email_confirmation = 'robert@example.com'
+        expect(valid_new_ao_invite.valid?).to eq false
+        expect(valid_new_ao_invite.errors.size).to eq 1
+        expect(valid_new_ao_invite.errors[:invited_email_confirmation]).to eq ["doesn't match Invited email"]
+      end
+    end
+
+    describe :update do
+      let(:saved_ao_invite) do
+        valid_new_ao_invite.save!
+        valid_new_ao_invite
+      end
+      it 'should allow blank invitation values' do
+        saved_ao_invite.invited_given_name = ''
+        saved_ao_invite.invited_family_name = ''
+        saved_ao_invite.invited_phone = ''
+        saved_ao_invite.invited_email = ''
+        saved_ao_invite.invited_email_confirmation = ''
+        expect(saved_ao_invite.valid?).to eq true
+      end
+
+      it 'should allow blank phone_raw' do
+        saved_ao_invite.phone_raw = ''
+        expect(saved_ao_invite.valid?).to eq true
+      end
+
+      it 'fails if no provider organization' do
+        saved_ao_invite.provider_organization = nil
+        expect(saved_ao_invite.valid?).to eq false
+        expect(saved_ao_invite.errors.size).to eq 1
+        expect(saved_ao_invite.errors[:provider_organization]).to eq ['must exist']
+      end
+
+      it 'fails on blank invitation type' do
+        saved_ao_invite.invitation_type = nil
+        expect(saved_ao_invite.valid?).to eq false
+        expect(saved_ao_invite.errors.size).to eq 1
+        expect(saved_ao_invite.errors[:invitation_type]).to eq ["can't be blank"]
+      end
+
+      it 'fails on invalid invitation type' do
+        expect do
+          saved_ao_invite.invitation_type = :birthday_party
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    describe :expired do
+      it 'should not be expired if less than 2 days old' do
+        invitation = create(:invitation, :ao, created_at: 47.hours.ago)
+        expect(invitation.expired?).to eq false
+      end
+      it 'should be expired if more than 2 days old' do
+        invitation = create(:invitation, :ao, created_at: 49.hours.ago)
+        expect(invitation.expired?).to eq true
+      end
+      it 'should be expired if 2 days old' do
+        invitation = create(:invitation, :ao, created_at: 2.days.ago)
+        expect(invitation.expired?).to eq true
+      end
+    end
+
+    describe :accepted do
+      it 'should be accepted if has ao_org_link' do
+        link = create(:ao_org_link)
+        expect(link.invitation.accepted?).to eq true
+      end
+      it 'should not be accepted if not have ao_org_link' do
+        invitation = create(:invitation, :ao)
+        expect(invitation.accepted?).to eq false
+      end
+    end
+
+    describe :match_user do
+      let(:ao_invite) { build(:invitation, :ao) }
+      let(:user) do
+        build(:user, given_name: 'Hugo',
+                     family_name: 'Boss',
+                     email: ao_invite.invited_email)
+      end
+      it 'should match user if email correct' do
+        expect(ao_invite.match_user?(user)).to eq true
+      end
+      it 'should match user if email different case' do
+        user.email = user.email.upcase_first
+        expect(ao_invite.match_user?(user)).to eq true
+      end
+      it 'should not match user if email not correct' do
+        user.email = "not #{ao_invite.invited_email}"
+        expect(ao_invite.match_user?(user)).to eq false
       end
     end
   end

--- a/dpc-portal/spec/requests/authorized_official_invitations_spec.rb
+++ b/dpc-portal/spec/requests/authorized_official_invitations_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "AuthorizedOfficialInvitations", type: :request do
+RSpec.describe 'AuthorizedOfficialInvitations', type: :request do
   describe 'GET /accept' do
     let!(:ao_invite) { create(:invitation, :ao) }
     let(:org) { create(:provider_organization) }

--- a/dpc-portal/spec/requests/authorized_official_invitations_spec.rb
+++ b/dpc-portal/spec/requests/authorized_official_invitations_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "AuthorizedOfficialInvitations", type: :request do
+  describe 'GET /accept' do
+    let!(:ao_invite) { create(:invitation, :ao) }
+    let(:org) { create(:provider_organization) }
+    it 'should show not implemented' do
+      get "/organizations/#{org.id}/authorized_official_invitations/#{ao_invite.id}/accept"
+      expect(response.status).to eq(501)
+    end
+  end
+end

--- a/dpc-portal/spec/requests/credential_delegate_invitations_spec.rb
+++ b/dpc-portal/spec/requests/credential_delegate_invitations_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'CredentialDelegateInvitations', type: :request do
   describe 'GET /accept' do
     let(:invited_by) { create(:invited_by) }
     let(:verification_code) { 'ABC123' }
-    let!(:cd_invite) { build(:invitation, verification_code:) }
+    let!(:cd_invite) { build(:invitation, :cd, verification_code:) }
     let(:user) do
       create(:user, given_name: cd_invite.invited_given_name,
                     family_name: cd_invite.invited_family_name,
@@ -189,7 +189,7 @@ RSpec.describe 'CredentialDelegateInvitations', type: :request do
   describe 'POST /confirm' do
     let(:invited_by) { create(:invited_by) }
     let(:verification_code) { 'ABC123' }
-    let!(:cd_invite) { build(:invitation, verification_code:) }
+    let!(:cd_invite) { build(:invitation, :cd, verification_code:) }
     let(:user) do
       create(:user, given_name: cd_invite.invited_given_name,
                     family_name: cd_invite.invited_family_name,

--- a/dpc-portal/spec/requests/organizations_spec.rb
+++ b/dpc-portal/spec/requests/organizations_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Organizations', type: :request do
       end
 
       it 'does not assign invitations even if exist' do
-        create(:invitation, provider_organization: org, invited_by: user)
+        create(:invitation, :cd, provider_organization: org, invited_by: user)
         get "/organizations/#{org.id}"
         expect(assigns(:invitations)).to be_nil
       end
@@ -120,7 +120,7 @@ RSpec.describe 'Organizations', type: :request do
 
       context :invitations do
         it 'assigns if exist' do
-          create(:invitation, provider_organization: org, invited_by: user)
+          create(:invitation, :cd, provider_organization: org, invited_by: user)
           get "/organizations/#{org.id}"
           expect(assigns(:invitations).size).to eq 1
         end

--- a/dpc-portal/spec/services/ao_invitation_service_spec.rb
+++ b/dpc-portal/spec/services/ao_invitation_service_spec.rb
@@ -68,9 +68,7 @@ describe AoInvitationService do
         service.create_invitation(*params, organization_npi)
       end.to change { Invitation.count }.by 1
       organization = ProviderOrganization.find_by(npi: organization_npi)
-      matching_invitation = Invitation.where(invited_given_name: params[0],
-                                             invited_family_name: params[1],
-                                             invited_email: params[2],
+      matching_invitation = Invitation.where(invited_email: params[2],
                                              provider_organization: organization,
                                              invitation_type: 'authorized_official')
       expect(matching_invitation.count).to eq 1
@@ -79,7 +77,9 @@ describe AoInvitationService do
     it 'sends an invitation email on success' do
       stub_cpi_api_gw
       mailer = double(InvitationMailer)
-      expect(InvitationMailer).to receive(:with).with(invitation: instance_of(Invitation)).and_return(mailer)
+      expect(InvitationMailer).to receive(:with)
+        .with(invitation: instance_of(Invitation), given_name: params[0], family_name: params[1])
+        .and_return(mailer)
       expect(mailer).to receive(:invite_ao).and_return(mailer)
       expect(mailer).to receive(:deliver_now)
       service.create_invitation(*params, organization_npi)

--- a/dpc-portal/spec/services/ao_invitation_service_spec.rb
+++ b/dpc-portal/spec/services/ao_invitation_service_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 describe AoInvitationService do
   let(:client) { instance_double(CpiApiGatewayClient) }
   let(:service) { AoInvitationService.new }
-  let(:organization_npi) { '11111111111' }
+  let(:organization_npi) { '3624913885' }
   before do
     allow(CpiApiGatewayClient).to receive(:new).and_return(client)
   end
@@ -22,6 +22,16 @@ describe AoInvitationService do
       expect(client).to receive(:org_info)
         .with(organization_npi)
         .and_return({ 'code' => '404' })
+      expect do
+        service.org_name(organization_npi)
+      end.to raise_error(AoInvitationServiceError)
+    end
+
+    it 'raises exception if bad npi' do
+      luhnacy = class_double('Luhnacy').as_stubbed_const
+      expect(luhnacy).to receive(:valid?)
+        .with("80840#{organization_npi}")
+        .and_return(false)
       expect do
         service.org_name(organization_npi)
       end.to raise_error(AoInvitationServiceError)

--- a/dpc-portal/spec/services/ao_invitation_service_spec.rb
+++ b/dpc-portal/spec/services/ao_invitation_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe AoInvitationService do
+  describe 'create invitation' do
+    it 'verifies the npi' do
+      expect(cpi_api_gw_client).to receive(:org_info)
+        .with(organization_npi)
+        .and_return({
+                      'provider' => {
+                        'providerType' => 'org',
+                        'orgName' => 'Health Hut',
+                        'npi' => organization_npi.to_s,
+                        'addresses' => [
+                          {
+                            'addressLine1' => '1234 Company Ln.',
+                            'addressLine2' => '#2222',
+                            'city' => 'Fairfax',
+                            'stateCode' => 'VA',
+                            'zip' => '23230',
+                            'dataIndicator' => 'CURRENT'
+                          }
+                        ]
+                      }
+                    })
+    end
+    it 'does not create if org with npi exists'
+    it 'creates org wich PECOS name'
+    it 'creates invitation'
+    it 'sends email'
+  end
+end

--- a/dpc-portal/spec/services/ao_invitation_service_spec.rb
+++ b/dpc-portal/spec/services/ao_invitation_service_spec.rb
@@ -10,10 +10,10 @@ describe AoInvitationService do
   before do
     allow(CpiApiGatewayClient).to receive(:new).and_return(client)
   end
-  describe 'utilities' do
-    describe 'org_name'
+
+  describe 'org_name' do
     it 'fetches the name' do
-      stub_cpi_gw
+      stub_cpi_api_gw
       name = service.org_name(organization_npi)
       expect(name).to eq 'Health Hut'
     end
@@ -40,26 +40,30 @@ describe AoInvitationService do
 
   describe 'create invitation' do
     let(:params) { %w[Bob Hoskins bob@example.com] }
+
     it 'creates org if not exist' do
-      stub_cpi_gw
+      stub_cpi_api_gw
       expect do
         service.create_invitation(*params, organization_npi)
       end.to change { ProviderOrganization.count }.by 1
     end
+
     it 'does not create if org with npi exists' do
       create(:provider_organization, npi: organization_npi)
       expect do
         service.create_invitation(*params, organization_npi)
       end.to change { ProviderOrganization.count }.by 0
     end
+
     it 'creates org wich PECOS name' do
-      stub_cpi_gw
+      stub_cpi_api_gw
       service.create_invitation(*params, organization_npi)
       organization = ProviderOrganization.find_by(npi: organization_npi)
       expect(organization.name).to eq 'Health Hut'
     end
+
     it 'creates invitation' do
-      stub_cpi_gw
+      stub_cpi_api_gw
       expect do
         service.create_invitation(*params, organization_npi)
       end.to change { Invitation.count }.by 1
@@ -73,7 +77,7 @@ describe AoInvitationService do
     end
 
     it 'sends an invitation email on success' do
-      stub_cpi_gw
+      stub_cpi_api_gw
       mailer = double(InvitationMailer)
       expect(InvitationMailer).to receive(:with).with(invitation: instance_of(Invitation)).and_return(mailer)
       expect(mailer).to receive(:invite_ao).and_return(mailer)
@@ -82,7 +86,7 @@ describe AoInvitationService do
     end
   end
 
-  def stub_cpi_gw
+  def stub_cpi_api_gw
     expect(client).to receive(:org_info)
       .with(organization_npi)
       .and_return(org_stanza)

--- a/dpc-portal/spec/services/ao_invitation_service_spec.rb
+++ b/dpc-portal/spec/services/ao_invitation_service_spec.rb
@@ -4,31 +4,91 @@ require 'spec_helper'
 require 'rails_helper'
 
 describe AoInvitationService do
-  describe 'create invitation' do
-    it 'verifies the npi' do
-      expect(cpi_api_gw_client).to receive(:org_info)
+  let(:client) { instance_double(CpiApiGatewayClient) }
+  let(:service) { AoInvitationService.new }
+  let(:organization_npi) { '11111111111' }
+  before do
+    allow(CpiApiGatewayClient).to receive(:new).and_return(client)
+  end
+  describe 'utilities' do
+    describe 'org_name'
+    it 'fetches the name' do
+      expect(client).to receive(:org_info)
         .with(organization_npi)
-        .and_return({
-                      'provider' => {
-                        'providerType' => 'org',
-                        'orgName' => 'Health Hut',
-                        'npi' => organization_npi.to_s,
-                        'addresses' => [
-                          {
-                            'addressLine1' => '1234 Company Ln.',
-                            'addressLine2' => '#2222',
-                            'city' => 'Fairfax',
-                            'stateCode' => 'VA',
-                            'zip' => '23230',
-                            'dataIndicator' => 'CURRENT'
-                          }
-                        ]
-                      }
-                    })
+        .and_return(org_stanza)
+      name = service.org_name(organization_npi)
+      expect(name).to eq 'Health Hut'
     end
-    it 'does not create if org with npi exists'
-    it 'creates org wich PECOS name'
-    it 'creates invitation'
+
+    it 'raises exception if no org' do
+      expect(client).to receive(:org_info)
+        .with(organization_npi)
+        .and_return({ 'code' => '404' })
+      expect do
+        service.org_name(organization_npi)
+      end.to raise_error(AoInvitationServiceError)
+    end
+  end
+
+  describe 'create invitation' do
+    let(:params) { %w[Bob Hoskins bob@example.com] }
+    it 'creates org if not exist' do
+      expect(client).to receive(:org_info)
+        .with(organization_npi)
+        .and_return(org_stanza)
+      expect do
+        service.create_invitation(*params, organization_npi)
+      end.to change { ProviderOrganization.count }.by 1
+    end
+    it 'does not create if org with npi exists' do
+      create(:provider_organization, npi: organization_npi)
+      expect do
+        service.create_invitation(*params, organization_npi)
+      end.to change { ProviderOrganization.count }.by 0
+    end
+    it 'creates org wich PECOS name' do
+      expect(client).to receive(:org_info)
+        .with(organization_npi)
+        .and_return(org_stanza)
+      service.create_invitation(*params, organization_npi)
+      organization = ProviderOrganization.find_by(npi: organization_npi)
+      expect(organization.name).to eq 'Health Hut'
+    end
+    it 'creates invitation' do
+      expect(client).to receive(:org_info)
+        .with(organization_npi)
+        .and_return(org_stanza)
+      expect do
+        service.create_invitation(*params, organization_npi)
+      end.to change { Invitation.count }.by 1
+      organization = ProviderOrganization.find_by(npi: organization_npi)
+      matching_invitation = Invitation.where(invited_given_name: params[0],
+                                             invited_family_name: params[1],
+                                             invited_email: params[2],
+                                             provider_organization: organization,
+                                             invitation_type: 'authorized_official')
+      expect(matching_invitation.count).to eq 1
+    end
     it 'sends email'
+  end
+
+  def org_stanza
+    {
+      'provider' => {
+        'providerType' => 'org',
+        'orgName' => 'Health Hut',
+        'npi' => organization_npi.to_s,
+        'addresses' => [
+          {
+            'addressLine1' => '1234 Company Ln.',
+            'addressLine2' => '#2222',
+            'city' => 'Fairfax',
+            'stateCode' => 'VA',
+            'zip' => '23230',
+            'dataIndicator' => 'CURRENT'
+          }
+        ]
+      }
+    }
   end
 end

--- a/dpc-portal/spec/services/client_token_manager_spec.rb
+++ b/dpc-portal/spec/services/client_token_manager_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ClientTokenManager do
   include DpcClientSupport
   describe '#create_client_token' do
     context 'successful API request' do
-      it 'responds true with @client_token set', :focus do
+      it 'responds true with @client_token set' do
         api_id = SecureRandom.uuid
         token = 'exampleToken'
         label = { params: { label: 'Test Token 1' } }

--- a/dpc-portal/spec/spec_helper.rb
+++ b/dpc-portal/spec/spec_helper.rb
@@ -80,7 +80,7 @@ RSpec.configure do |config|
   #   # is tagged with `:focus`, all examples get run. RSpec also provides
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+  config.filter_run_when_matching :focus
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4015

## 🛠 Changes

- Invitation extended to allow authorized_official type
- Mailer for AO Invitation
- Minimal controller for handling AO invitation acceptance
- Service for generating an AO invitation and mailing invite
- Rake task for generating AO invitation

## ℹ️ Context for reviewers

We are adding the use of "invitations" to the AO-accept-org flow.

## ✅ Acceptance Validation

- Automated Testing
- Manual run of rake task

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
