### PR TITLE
[DPC-4038] Me/dpc 4038 fix smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,10 @@ smoke:
 	if [ -d $$JENKINS_DIR ]; then \
       	echo "Rebuilding JMeter lib"; \
       	rm $$JENKINS_DIR/*.jar; \
-      	mvn dependency:copy-dependencies -pl dpc-smoketest -DoutputDirectory=$$JENKINS_DIR; \
+      	mvn dependency:copy-dependencies -pl dpc-smoketest -DoutputDirectory=$$JENKINS_DIR -am; \
     else \
         echo "Not running on Jenkins"; \
     fi
-	@mvn clean install -DskipTests -Djib.skip=True -pl dpc-common -am -ntp
-	@mvn clean install -DskipTests -Djib.skip=True -pl dpc-testing -am -ntp
 	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ smoke:
 	if [ -d $$JENKINS_DIR ]; then \
       	echo "Rebuilding JMeter lib"; \
       	rm $$JENKINS_DIR/*.jar; \
-      	mvn clean install -DskipTests -Djib.skip=True -pl dpc-common -am -ntp \
+      	mvn clean install -DskipTests -Djib.skip=True -pl dpc-common -am -ntp; \
       	mvn dependency:copy-dependencies -pl dpc-smoketest -DoutputDirectory=$$JENKINS_DIR; \
     else \
         echo "Not running on Jenkins"; \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ smoke:
     else \
         echo "Not running on Jenkins"; \
     fi
-	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
+	@mvn clean install -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local
 smoke/local: venv smoke

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ smoke: ## If running on Jenkins, purges JMeter's library, then copies all of dpc
 smoke:
 	@JENKINS_DIR="/var/jenkins_home/.bzt/jmeter-taurus/5.5/lib"; \
 	if [ -d $$JENKINS_DIR ]; then \
-      	echo "Rebuilding JMeter lib"; \
-      	rm $$JENKINS_DIR/*.jar; \
-      	mvn clean install -DskipTests -Djib.skip=True -pl dpc-common -am -ntp; \
-      	mvn dependency:copy-dependencies -pl dpc-smoketest -DoutputDirectory=$$JENKINS_DIR; \
-    else \
-        echo "Not running on Jenkins"; \
-    fi
+		echo "Rebuilding JMeter lib"; \
+		rm $$JENKINS_DIR/*.jar; \
+		mvn clean install -DskipTests -Djib.skip=True -pl dpc-common -am -ntp; \
+		mvn dependency:copy-dependencies -pl dpc-smoketest -DoutputDirectory=$$JENKINS_DIR; \
+	else \
+		echo "Not running on Jenkins"; \
+	fi
 	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,8 @@ smoke:
 	if [ -d $$JENKINS_DIR ]; then \
       	echo "Rebuilding JMeter lib"; \
       	rm $$JENKINS_DIR/*.jar; \
-      	mvn dependency:copy-dependencies -pl dpc-smoketest -DoutputDirectory=$$JENKINS_DIR -am; \
+      	mvn clean install -DskipTests -Djib.skip=True -pl dpc-common -am -ntp \
+      	mvn dependency:copy-dependencies -pl dpc-smoketest -DoutputDirectory=$$JENKINS_DIR; \
     else \
         echo "Not running on Jenkins"; \
     fi

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ smoke:
     else \
         echo "Not running on Jenkins"; \
     fi
-	@mvn clean install -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
+	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-common -pl dpc-testing -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local
 smoke/local: venv smoke

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ smoke:
     else \
         echo "Not running on Jenkins"; \
     fi
-	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-common -pl dpc-testing -pl dpc-smoketest -am -ntp
+	@mvn clean install -DskipTests -Djib.skip=True -pl dpc-common -am -ntp
+	@mvn clean install -DskipTests -Djib.skip=True -pl dpc-testing -am -ntp
+	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local
 smoke/local: venv smoke


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4038

## 🛠 Changes

Forces build and installation of dpc-common before attempting to copy dpc-smoketest's dependencies to JMeter.

## ℹ️ Context for reviewers

Forcing the install of dpc-common makes sure that the dpc-common.jar and dpc-testing.jar are available when Maven attempts to build and run the smoke tests on Jenkins.  

This isn't necessary every time smoke tests need to run, only when we change dpc-common or dpc-testing or purge the Maven cache, but this was the easiest way to make sure that they're always available.

## ✅ Acceptance Validation

Ran against dev and made sure smoke tests passed.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
