### PR TITLE
DPC_4025 User Info Service

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -142,6 +142,7 @@ services:
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - CPI_API_GW_BASE_URL=http://localhost:4567/
       - CMS_IDM_OAUTH_URL=http://localhost:4567/
+      - IDP_HOST=idp.int.identitysandbox.gov
       - RUBY_YJIT_ENABLE=1
       - ENV=local
     ports:

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -26,7 +26,7 @@ class InvitationsController < ApplicationController
   def login
     login_session
     client_id = "urn:gov:cms:openidconnect.profiles:sp:sso:cms:dpc:#{ENV.fetch('ENV')}"
-    url = URI::HTTPS.build(host: 'idp.int.identitysandbox.gov',
+    url = URI::HTTPS.build(host: ENV.fetch('IDP_HOST'),
                            path: '/openid_connect/authorize',
                            query: { acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
                                     client_id:,

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -9,7 +9,7 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
     user = User.find_or_create_by(provider: auth.provider, uid: auth.uid) do |user_to_create|
       assign_user_properties(user_to_create, auth)
     end
-    maybe_update_user(user, auth)
+    ial_2_actions(user, auth)
     sign_in(:user, user)
     redirect_to session[:user_return_to] || organizations_path
   end
@@ -26,10 +26,12 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
 
   private
 
-  def maybe_update_user(user, auth)
+  def ial_2_actions(user, auth)
     data = auth.extra.raw_info
     return unless data.ial == 'http://idmanagement.gov/ns/assurance/ial/2'
 
+    session[:login_dot_gov_token] = auth.credentials.token
+    session[:login_dot_gov_token_exp] = auth.credentials.expires_in.seconds.from_now
     user.update(given_name: data.given_name,
                 family_name: data.family_name)
   end

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -6,6 +6,7 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
 
   def openid_connect
     auth = request.env['omniauth.auth']
+
     user = User.find_or_create_by(provider: auth.provider, uid: auth.uid) do |user_to_create|
       assign_user_properties(user_to_create, auth)
     end
@@ -32,8 +33,7 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
 
     session[:login_dot_gov_token] = auth.credentials.token
     session[:login_dot_gov_token_exp] = auth.credentials.expires_in.seconds.from_now
-    user.update(given_name: data.given_name,
-                family_name: data.family_name)
+    user.update(given_name: data.given_name, family_name: data.family_name)
   end
 
   def assign_user_properties(user, auth)

--- a/dpc-portal/app/services/user_info_service.rb
+++ b/dpc-portal/app/services/user_info_service.rb
@@ -2,7 +2,7 @@
 
 # A service that verifies generates an ao invitation
 class UserInfoService
-  USER_INFO_URI = URI('https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+  USER_INFO_URI = URI("https://#{ENV.fetch('IDP_HOST')}/api/openid_connect/userinfo")
 
   def user_info(session)
     validate_session(session)

--- a/dpc-portal/app/services/user_info_service.rb
+++ b/dpc-portal/app/services/user_info_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# A service that verifies generates an ao invitation
+class UserInfoService
+  USER_INFO_URI = URI('https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+
+  def user_info(session)
+    validate_session(session)
+
+    request_info(session[:login_dot_gov_token])
+  end
+
+  private
+
+  def auth_header(token)
+    { Authorization: "Bearer #{token}" }
+  end
+
+  def validate_session(session)
+    raise UserInfoServiceError, 'no_token' unless session[:login_dot_gov_token].present?
+    raise UserInfoServiceError, 'no_token_exp' unless session[:login_dot_gov_token_exp].present?
+    raise UserInfoServiceError, 'expired_token' unless session[:login_dot_gov_token_exp] > Time.now
+  end
+
+  def request_info(token)
+    response = Net::HTTP.get_response(USER_INFO_URI, auth_header(token))
+    case response.code.to_i
+    when 200...299
+      parsed_response(response)
+    when 401
+      raise UserInfoServiceError, 'unauthorized'
+    else
+      Rails.logger.error "User Info Error: #{response.body}"
+      raise UserInfoServiceError, 'server_error'
+    end
+  rescue Errno::ECONNREFUSED
+    connection_error
+  end
+
+  def parsed_response(response)
+    return if response.body.blank?
+
+    JSON.parse response.body
+  end
+
+  def connection_error
+    Rails.logger.error 'Could not connect to login.gov'
+    raise UserInfoServiceError, 'connection_error'
+  end
+end
+
+class UserInfoServiceError < StandardError; end

--- a/dpc-portal/app/services/user_info_service.rb
+++ b/dpc-portal/app/services/user_info_service.rb
@@ -34,18 +34,14 @@ class UserInfoService
       raise UserInfoServiceError, 'server_error'
     end
   rescue Errno::ECONNREFUSED
-    connection_error
+    Rails.logger.error 'Could not connect to login.gov'
+    raise UserInfoServiceError, 'connection_error'
   end
 
   def parsed_response(response)
     return if response.body.blank?
 
     JSON.parse response.body
-  end
-
-  def connection_error
-    Rails.logger.error 'Could not connect to login.gov'
-    raise UserInfoServiceError, 'connection_error'
   end
 end
 

--- a/dpc-portal/config/initializers/devise.rb
+++ b/dpc-portal/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
          end
   config.omniauth :openid_connect, {
                     name: :openid_connect,
-                    issuer: 'https://idp.int.identitysandbox.gov/',
+                    issuer: "https://#{ENV.fetch('IDP_HOST')}/",
                     discovery: true,
                     scope: %i[openid email all_emails],
                     response_type: :code,
@@ -34,7 +34,7 @@ Devise.setup do |config|
                     client_options: {
                       port: 443,
                       scheme: 'https',
-                      host: 'idp.int.identitysandbox.gov',
+                      host: ENV.fetch('IDP_HOST'),
                       identifier: "urn:gov:cms:openidconnect.profiles:sp:sso:cms:dpc:#{ENV['ENV']}",
                       private_key: private_key,
                       redirect_uri: "#{host}/portal/users/auth/openid_connect/callback"

--- a/dpc-portal/config/initializers/devise.rb
+++ b/dpc-portal/config/initializers/devise.rb
@@ -23,9 +23,10 @@ Devise.setup do |config|
          else
            "https://#{ENV['ENV']}.dpc.cms.gov"
          end
+  idp_host = ENV.fetch('IDP_HOST', 'idp.int.identitysandbox.gov')
   config.omniauth :openid_connect, {
                     name: :openid_connect,
-                    issuer: "https://#{ENV.fetch('IDP_HOST')}/",
+                    issuer: "https://#{idp_host}/",
                     discovery: true,
                     scope: %i[openid email all_emails],
                     response_type: :code,
@@ -34,7 +35,7 @@ Devise.setup do |config|
                     client_options: {
                       port: 443,
                       scheme: 'https',
-                      host: ENV.fetch('IDP_HOST'),
+                      host: idp_host,
                       identifier: "urn:gov:cms:openidconnect.profiles:sp:sso:cms:dpc:#{ENV['ENV']}",
                       private_key: private_key,
                       redirect_uri: "#{host}/portal/users/auth/openid_connect/callback"

--- a/dpc-portal/spec/services/user_info_service_spec.rb
+++ b/dpc-portal/spec/services/user_info_service_spec.rb
@@ -14,11 +14,11 @@ describe UserInfoService do
       {
         'sub' => '097d06f7-e9ad-4327-8db3-0ba193b7a2c2',
         'iss' => 'https://idp.int.identitysandbox.gov/',
-        'email' => 'jeffreydettmann+testtwo@navapbc.com',
+        'email' => 'david@example.com',
         'email_verified' => true,
         'all_emails' => [
-          'jeffreydettmann+testtwo@navapbc.com',
-          'jeffreydettmann+testtwoextra@navapbc.com'
+          'david@example.com',
+          'david2@example.com'
         ],
         'given_name' => 'David',
         'family_name' => 'Davis',

--- a/dpc-portal/spec/services/user_info_service_spec.rb
+++ b/dpc-portal/spec/services/user_info_service_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe UserInfoService do
+  let(:service) { UserInfoService.new }
+  let(:token) { 'bearer-token' }
+  let(:exp) { 2.hours.from_now }
+  let(:valid_session) { { login_dot_gov_token: token, login_dot_gov_token_exp: exp } }
+
+  context :valid_session do
+    let(:response) do
+      {
+        'sub' => '097d06f7-e9ad-4327-8db3-0ba193b7a2c2',
+        'iss' => 'https://idp.int.identitysandbox.gov/',
+        'email' => 'jeffreydettmann+testtwo@navapbc.com',
+        'email_verified' => true,
+        'all_emails' => [
+          'jeffreydettmann+testtwo@navapbc.com',
+          'jeffreydettmann+testtwoextra@navapbc.com'
+        ],
+        'given_name' => 'David',
+        'family_name' => 'Davis',
+        'birthdate' => '1938-10-06',
+        'social_security_number' => '900888888',
+        'phone' => '+19174216435',
+        'phone_verified' => true,
+        'verified_at' => 1_704_834_157,
+        'ial' => 'http://idmanagement.gov/ns/assurance/ial/2',
+        'aal' => 'urn:gov:gsa:ac:classes:sp:PasswordProtectedTransport:duo'
+      }
+    end
+
+    before do
+      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+        .with(headers: { Authorization: "Bearer #{token}" })
+        .to_return(body: response.to_json, status: 200)
+    end
+
+    it 'should return info with valid session' do
+      expect(service.user_info(valid_session)).to eq response
+    end
+  end
+
+  context :bad_request do
+    it 'should throw error if status is 401' do
+      error = '{"error":"No can do"}'
+      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+        .with(headers: { Authorization: "Bearer #{token}" })
+        .to_return(body: error, status: 401)
+      expect do
+        service.user_info(valid_session)
+      end.to raise_error(UserInfoServiceError, 'unauthorized')
+    end
+    it 'should throw error if status is 500' do
+      error = '{"error":"shrug"}'
+      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+        .with(headers: { Authorization: "Bearer #{token}" })
+        .to_return(body: error, status: 500)
+      expect do
+        service.user_info(valid_session)
+      end.to raise_error(UserInfoServiceError, 'server_error')
+    end
+    it 'should throw error if cannot connect' do
+      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+        .with(headers: { Authorization: "Bearer #{token}" })
+        .to_raise(Errno::ECONNREFUSED)
+      expect do
+        service.user_info(valid_session)
+      end.to raise_error(UserInfoServiceError, 'connection_error')
+    end
+  end
+
+  context :invalid_session do
+    it 'should throw error if no token' do
+      invalid = valid_session.merge(login_dot_gov_token: nil)
+      expect do
+        service.user_info(invalid)
+      end.to raise_error(UserInfoServiceError, 'no_token')
+    end
+    it 'should throw error if no token expiration' do
+      invalid = valid_session.merge(login_dot_gov_token_exp: nil)
+      expect do
+        service.user_info(invalid)
+      end.to raise_error(UserInfoServiceError, 'no_token_exp')
+    end
+    context :expired_session do
+      let(:exp) { 1.second.ago }
+      it 'should throw error' do
+        expect do
+          service.user_info(valid_session)
+        end.to raise_error(UserInfoServiceError, 'expired_token')
+      end
+    end
+  end
+end

--- a/dpc-portal/spec/services/user_info_service_spec.rb
+++ b/dpc-portal/spec/services/user_info_service_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'rails_helper'
 
 describe UserInfoService do
+  let(:user_info_url) { UserInfoService::USER_INFO_URI }
   let(:service) { UserInfoService.new }
   let(:token) { 'bearer-token' }
   let(:exp) { 2.hours.from_now }
@@ -33,7 +34,7 @@ describe UserInfoService do
     end
 
     before do
-      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+      stub_request(:get, user_info_url)
         .with(headers: { Authorization: "Bearer #{token}" })
         .to_return(body: response.to_json, status: 200)
     end
@@ -46,7 +47,7 @@ describe UserInfoService do
   context :bad_request do
     it 'should throw error if status is 401' do
       error = '{"error":"No can do"}'
-      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+      stub_request(:get, user_info_url)
         .with(headers: { Authorization: "Bearer #{token}" })
         .to_return(body: error, status: 401)
       expect do
@@ -55,7 +56,7 @@ describe UserInfoService do
     end
     it 'should throw error if status is 500' do
       error = '{"error":"shrug"}'
-      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+      stub_request(:get, user_info_url)
         .with(headers: { Authorization: "Bearer #{token}" })
         .to_return(body: error, status: 500)
       expect do
@@ -63,7 +64,7 @@ describe UserInfoService do
       end.to raise_error(UserInfoServiceError, 'server_error')
     end
     it 'should throw error if cannot connect' do
-      stub_request(:get, 'https://idp.int.identitysandbox.gov/api/openid_connect/userinfo')
+      stub_request(:get, user_info_url)
         .with(headers: { Authorization: "Bearer #{token}" })
         .to_raise(Errno::ECONNREFUSED)
       expect do


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4025

## 🛠 Changes

- UserInfo service added to call login.gov user-info endpoint
- LoginDotGov controller stores token in session if IAL/2
- Move Login.gov url to env variable

## ℹ️ Context for reviewers

Will be used in invitations controller

## ✅ Acceptance Validation

Put service in invitations controller, where it logged information (changes not committed)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
