### PR TITLE
Update sidekiq for security

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -22,7 +22,7 @@ gem 'puma', '~> 6.4.2'
 gem 'redis', '~> 4.0'
 gem 'luhnacy', '~> 0.2.1'
 gem 'omniauth-rails_csrf_protection', '~> 0.1.2'
-gem 'sidekiq', '~> 7.1'
+gem 'sidekiq', '~> 7.2.4'
 gem 'turbolinks', '~> 5'
 gem 'newrelic_rpm', '~> 8.10'
 gem 'rexml', '>= 3.2.5' # adding for CVE-2021-28965

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
     rdoc (6.6.2)
       psych (>= 4.0.0)
     redis (4.8.1)
-    redis-client (0.20.0)
+    redis-client (0.22.1)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -424,7 +424,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.2.2)
+    sidekiq (7.2.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
@@ -551,7 +551,7 @@ DEPENDENCIES
   rubocop-performance
   sassc-rails (>= 2.1.2)
   selenium-webdriver
-  sidekiq (~> 7.1)
+  sidekiq (~> 7.2.4)
   sidekiq_alive (~> 2.1.5)
   simplecov (<= 0.17)
   spring

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -44,7 +44,7 @@ gem 'redis', '~> 4.0'
 gem 'redis-namespace'
 gem 'rexml', '>= 3.2.5' # adding for CVE-2021-28965
 gem 'sassc-rails', '>= 2.1.2'
-gem 'sidekiq', '~> 7.1'
+gem 'sidekiq', '~> 7.2.4'
 gem 'sidekiq_alive', '~> 2.1.5'
 gem 'sinatra'
 gem 'thin'

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -410,7 +410,7 @@ GEM
       psych (>= 4.0.0)
     redcarpet (3.6.0)
     redis (4.8.1)
-    redis-client (0.20.0)
+    redis-client (0.22.1)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -477,7 +477,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.2.2)
+    sidekiq (7.2.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
@@ -622,7 +622,7 @@ DEPENDENCIES
   rubocop-performance
   sassc-rails (>= 2.1.2)
   selenium-webdriver
-  sidekiq (~> 7.1)
+  sidekiq (~> 7.2.4)
   sidekiq_alive (~> 2.1.5)
   simplecov (<= 0.17)
   sinatra

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -25,7 +25,7 @@ gem 'redis', '~> 4.0'
 gem 'coffee-rails', '~> 5.0', '>= 5.0.0'
 gem 'kramdown', '~> 2.3', '>= 2.3.1'
 gem 'luhnacy', '~> 0.2.1'
-gem 'sidekiq', '~> 7.1'
+gem 'sidekiq', '~> 7.2.4'
 gem 'newrelic_rpm', '~> 8.10'
 gem 'rexml', '>= 3.2.5' # adding for CVE-2021-28965
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
     rdoc (6.6.2)
       psych (>= 4.0.0)
     redis (4.8.1)
-    redis-client (0.20.0)
+    redis-client (0.22.1)
       connection_pool
     redis-namespace (1.11.0)
       redis (>= 4)
@@ -421,7 +421,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sidekiq (7.2.2)
+    sidekiq (7.2.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
@@ -542,7 +542,7 @@ DEPENDENCIES
   rubocop-performance (>= 1.10.2)
   sassc-rails (>= 2.1.2)
   selenium-webdriver
-  sidekiq (~> 7.1)
+  sidekiq (~> 7.2.4)
   sidekiq_alive (~> 2.1.5)
   simplecov (<= 0.17)
   spring


### PR DESCRIPTION
## 🎫 Ticket

no-ticket

## 🛠 Changes

Sidekiq updated to 7.2.4 in dpc-admin, dpc-portal, and dpc-web

## ℹ️ Context for reviewers

Docker build breaking over https://github.com/sidekiq/sidekiq/security/advisories/GHSA-q655-3pj8-9fxq

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
