### PR TITLE
[DPC-4039] set logger to info in relevant namespaces

### DIFF
--- a/dpc-aggregation/src/main/resources/application.yml
+++ b/dpc-aggregation/src/main/resources/application.yml
@@ -44,6 +44,7 @@ logging:
   level: ERROR
   loggers:
     "liquibase": INFO
+    "gov.cms.dpc.aggregation.engine": INFO
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -45,6 +45,7 @@ logging:
   level: ERROR
   loggers:
     "liquibase": INFO
+    "gov.cms.dpc.api.resources.v1": INFO
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4039

## 🛠 Changes

Explicitly sets the logging level of certain namespaces to INFO, so that broken dashboards work.

## ℹ️ Context for reviewers

A blanket INFO level for all unspecified namespaces potentially could have resulted in a flood of logs from all over our codebase, and a higher AWS bill. This approach ensures we're only turning on logs that we want to pick up on the dashboards.

## ✅ Acceptance Validation

Deployed this branch to `dev` and ran a number of API calls, ensuring that logs were captured as expected, and that they render successfully from the dashboards in question (pointed to dev).

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
