### PR TITLE
Make local dev sidekiq more robust

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -165,7 +165,9 @@ services:
       - DB_USER=postgres
       - DB_PASS=dpc-safe
       - GOLDEN_MACAROON=${GOLDEN_MACAROON}
+      - API_ADMIN_URL=http://api:9900
       - API_METADATA_URL=http://api:3002/v1
+      - ENV=local
     depends_on:
       - redis
       - db

--- a/dpc-portal/bin/sidekiq-dev
+++ b/dpc-portal/bin/sidekiq-dev
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+if [ -z "$GOLDEN_MACAROON" ]; then
+  echo "No golden macaroon found. Attempting to generate a new one..."
+  export GOLDEN_MACAROON=$(curl -X POST -w '\n' ${API_ADMIN_URL}/tasks/generate-token || echo '')
+
+  if [ -n "$GOLDEN_MACAROON" ]; then
+    echo "Successfully generated new golden macaroon."
+  else
+    echo "Could not generate a valid golden macaroon. Check that the API service is running."
+    echo "Starting Portal without a golden macaroon; certain functionality may not work correctly."
+  fi
+fi
+
+echo "Starting sidekiq"
+bundle exec sidekiq -q portal

--- a/dpc-portal/bin/sidekiq-dev
+++ b/dpc-portal/bin/sidekiq-dev
@@ -8,7 +8,7 @@ if [ -z "$GOLDEN_MACAROON" ]; then
     echo "Successfully generated new golden macaroon."
   else
     echo "Could not generate a valid golden macaroon. Check that the API service is running."
-    echo "Starting Portal without a golden macaroon; certain functionality may not work correctly."
+    echo "Starting Portal Sidekiq without a golden macaroon; certain functionality may not work correctly."
   fi
 fi
 

--- a/dpc-portal/config/environments/test.rb
+++ b/dpc-portal/config/environments/test.rb
@@ -57,6 +57,9 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  # Tell ActiveJob to not send real requests
+  config.active_job.queue_adapter = :test
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/dpc-portal/docker/entrypoint.sh
+++ b/dpc-portal/docker/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 if [ "$1" == "portal" ]; then
   # Start the database service (and make accessible outside the Docker container)
   echo "Starting Rails server..."
-  
+
   echo "Migrating the database..."
   bundle exec rails db:migrate
 
@@ -28,5 +28,11 @@ fi
 
 if [ "$1" == "sidekiq" ]; then
   # Start Sidekiq job processing
-  bundle exec sidekiq -q portal
+  if [[ "$ENV" == "local" ]]; then
+    echo "Starting in development"
+    ./bin/sidekiq-dev
+  else
+    echo "Starting in non-local"
+    bundle exec sidekiq -q portal
+  fi
 fi

--- a/dpc-portal/spec/jobs/sync_organization_job_spec.rb
+++ b/dpc-portal/spec/jobs/sync_organization_job_spec.rb
@@ -32,10 +32,6 @@ RSpec.describe SyncOrganizationJob, type: :job do
     }
   end
 
-  before(:all) do
-    ActiveJob::Base.queue_adapter = :test
-  end
-
   before(:each) do
     SyncOrganizationJob.perform_later(provider_organization.id)
   end


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

- Local portal-sidekiq loads GOLDEN_MACAROON if not present
- ActiveJob queue adapter set to :test in test environment

## ℹ️ Context for reviewers

- I noticed that ProviderOrganizations were not being created in the API on create when developing locally. The sidekiq logs showed it did not have permission to create the organization in the API. We already optionally set the GOLDEN_MACAROON on boot for the rails apps, so I ported the code to run before starting local portal sidekiq as well.
- I also noticed that some tests were calling redis when a provider organization was created. Setting the queue adapter to :test fixed the issue.

## ✅ Acceptance Validation

- Tests that made calls to sidekiq no longer do
- Making a provider organization locally creates the organization in the API

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
