### PR TITLE
Me/dpc 4005 missing logs

### DIFF
--- a/dpc-aggregation/src/main/resources/application.yml
+++ b/dpc-aggregation/src/main/resources/application.yml
@@ -41,13 +41,15 @@ server:
             application: ${APPLICATION:-"dpc-aggregation"}
 
 logging:
-  level: ERROR
+  level: WARN
   loggers:
     "liquibase": INFO
     "gov.cms.dpc.aggregation.engine": INFO
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR
+    "gov.cms.dpc.api.auth": INFO
+    "gov.cms.dpc.common.logging.filters": INFO
   appenders:
     - type: console
       timeZone: UTC

--- a/dpc-aggregation/src/test/resources/test.application.yml
+++ b/dpc-aggregation/src/test/resources/test.application.yml
@@ -42,12 +42,14 @@ server:
             application: ${APPLICATION:-"dpc-aggregation"}
 
 logging:
-  level: ERROR
+  level: WARN
   loggers:
     "liquibase": ERROR
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR
+    "gov.cms.dpc.api.auth": INFO
+    "gov.cms.dpc.common.logging.filters": INFO
   appenders:
     - type: console
       timeZone: UTC

--- a/dpc-aggregation/src/test/resources/test.application.yml
+++ b/dpc-aggregation/src/test/resources/test.application.yml
@@ -42,7 +42,7 @@ server:
             application: ${APPLICATION:-"dpc-aggregation"}
 
 logging:
-  level: WARN
+  level: DEBUG
   loggers:
     "liquibase": ERROR
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG

--- a/dpc-aggregation/src/test/resources/test.application.yml
+++ b/dpc-aggregation/src/test/resources/test.application.yml
@@ -42,7 +42,7 @@ server:
             application: ${APPLICATION:-"dpc-aggregation"}
 
 logging:
-  level: DEBUG
+  level: INFO
   loggers:
     "liquibase": ERROR
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -42,13 +42,15 @@ server:
             application: ${APPLICATION:-"dpc-api"}
 
 logging:
-  level: ERROR
+  level: WARN
   loggers:
     "liquibase": INFO
     "gov.cms.dpc.api.resources.v1": INFO
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR
+    "gov.cms.dpc.api.auth": INFO
+    "gov.cms.dpc.common.logging.filters": INFO
   appenders:
     - type: console
       timeZone: UTC

--- a/dpc-api/src/test/resources/test.application.yml
+++ b/dpc-api/src/test/resources/test.application.yml
@@ -44,12 +44,14 @@ server:
           - type: token-filter-factory
 
 logging:
-  level: ERROR
+  level: WARN
   loggers:
     "liquibase": ERROR
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR
+    "gov.cms.dpc.api.auth": INFO
+    "gov.cms.dpc.common.logging.filters": INFO
   appenders:
     - type: console
       timeZone: UTC

--- a/dpc-api/src/test/resources/test.application.yml
+++ b/dpc-api/src/test/resources/test.application.yml
@@ -44,7 +44,7 @@ server:
           - type: token-filter-factory
 
 logging:
-  level: DEBUG
+  level: INFO
   loggers:
     "liquibase": ERROR
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG

--- a/dpc-api/src/test/resources/test.application.yml
+++ b/dpc-api/src/test/resources/test.application.yml
@@ -44,7 +44,7 @@ server:
           - type: token-filter-factory
 
 logging:
-  level: WARN
+  level: DEBUG
   loggers:
     "liquibase": ERROR
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG

--- a/dpc-attribution/src/main/resources/application.yml
+++ b/dpc-attribution/src/main/resources/application.yml
@@ -32,7 +32,7 @@ server:
             application: ${APPLICATION:-"dpc-attribution"}
 
 logging:
-  level: ERROR
+  level: WARN
   appenders:
     - type: console
       timeZone: UTC
@@ -53,6 +53,8 @@ logging:
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR
+    "gov.cms.dpc.api.auth": INFO
+    "gov.cms.dpc.common.logging.filters": INFO
 
 expirationThreshold: 90 # In days
 migrationEnabled: true

--- a/dpc-attribution/src/test/resources/test.application.yml
+++ b/dpc-attribution/src/test/resources/test.application.yml
@@ -33,7 +33,7 @@ server:
             application: ${APPLICATION:-"dpc-attribution"}
 
 logging:
-  level: ERROR
+  level: WARN
   appenders:
     - type: console
       timeZone: UTC
@@ -54,6 +54,8 @@ logging:
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR
+    "gov.cms.dpc.api.auth": INFO
+    "gov.cms.dpc.common.logging.filters": INFO
 
 expirationThreshold: 90 # In days
 migrationEnabled: true

--- a/dpc-attribution/src/test/resources/test.application.yml
+++ b/dpc-attribution/src/test/resources/test.application.yml
@@ -33,7 +33,7 @@ server:
             application: ${APPLICATION:-"dpc-attribution"}
 
 logging:
-  level: WARN
+  level: DEBUG
   appenders:
     - type: console
       timeZone: UTC

--- a/dpc-attribution/src/test/resources/test.application.yml
+++ b/dpc-attribution/src/test/resources/test.application.yml
@@ -33,7 +33,7 @@ server:
             application: ${APPLICATION:-"dpc-attribution"}
 
 logging:
-  level: DEBUG
+  level: INFO
   appenders:
     - type: console
       timeZone: UTC


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4005

## 🛠 Changes

- Set loggers for `DPCAuthFilter`, `GeneratedRequestIdFilter` and `LogResponseFilter` to `INFO` so that contextual information is written to our Splunk logs for easier debugging.
- Set default log levels to `WARN` instead of `ERROR`.

## ℹ️ Context for reviewers

We noticed that certain logs from the above classes were no longer getting written out, and it was because they are logged at `INFO` and our log levels were set to `ERROR`.  

We talked about potentially setting the default log level to `INFO` in a previous ticket (#2158), but the thought was that it might lead to flooding our logs.  As a bit of a compromise, I set them to WARN in this ticket, but I'm open to changing them if anyone feels strongly about it.  If we find more missing logs we can always turn logging up to `INFO`, and if the logs get a little too crowded we can turn them back to `ERROR`.

## ✅ Acceptance Validation

Ran locally and ensured the logs are getting produced.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
