### PR TITLE
[DPC-4041] Analytics -- header_click and login

### DIFF
--- a/dpc-web/app/assets/javascripts/components/analytics_events.js
+++ b/dpc-web/app/assets/javascripts/components/analytics_events.js
@@ -7,12 +7,3 @@ siteLogo.addEventListener('click', function(e) {
     'link_url': siteLogo.href,
   });
 });
-
-const loginButton = document.querySelector('#login-button');
-loginButton.addEventListener('click', function (e) {
-  utag.link({
-    'event_name': 'login',
-    'link_type': 'link_other',
-    'link_url': 'login successful',
-  });
-});

--- a/dpc-web/app/assets/javascripts/components/analytics_events.js
+++ b/dpc-web/app/assets/javascripts/components/analytics_events.js
@@ -1,0 +1,18 @@
+const siteLogo = document.querySelector('a.site-logo');
+siteLogo.addEventListener('click', function(e) {
+  utag.link({
+    'event_name': 'header_click',
+    'link_type': 'link_other',
+    'text': siteLogo.text,
+    'link_url': siteLogo.href,
+  });
+});
+
+const loginButton = document.querySelector('#login-button');
+loginButton.addEventListener('click', function (e) {
+  utag.link({
+    'event_name': 'login',
+    'link_type': 'link_other',
+    'link_url': 'login successful',
+  });
+});

--- a/dpc-web/app/controllers/users/sessions_controller.rb
+++ b/dpc-web/app/controllers/users/sessions_controller.rb
@@ -10,9 +10,11 @@ module Users
     # end
 
     # POST /resource/sign_in
-    # def create
-    #   super
-    # end
+    def create
+      super do
+        session['login_successful'] = true
+      end
+    end
 
     # DELETE /resource/sign_out
     # def destroy

--- a/dpc-web/app/views/devise/sessions/new.html.erb
+++ b/dpc-web/app/views/devise/sessions/new.html.erb
@@ -19,7 +19,7 @@
         </div>
 
         <div class="actions ds-u-margin-top--3">
-          <%= f.submit "Log in", class: "ds-c-button ds-c-button--primary", data: { test: "submit" } %>
+          <%= f.submit "Log in", class: "ds-c-button ds-c-button--primary", id: "login-button", data: { test: "submit" } %>
         </div>
       <% end %>
     </div>

--- a/dpc-web/app/views/portal/show.html.erb
+++ b/dpc-web/app/views/portal/show.html.erb
@@ -1,4 +1,18 @@
 <% title "Welcome!" %>
+<% if session['login_successful'] == true %>
+  <script>
+    function fireLoginEvent() {
+      console.log('firing login event')
+      utag.link({
+        'event_name': 'login',
+        'link_type': 'link_other',
+        'link_url': 'login successful',
+      });
+    }
+
+    fireLoginEvent();
+  </script>
+<% end %>
 
 <div class="ds-l-container">
 

--- a/dpc-web/app/views/portal/show.html.erb
+++ b/dpc-web/app/views/portal/show.html.erb
@@ -1,15 +1,19 @@
 <% title "Welcome!" %>
-<% if session['login_successful'] == true %>
+<% if session['login_successful'] %>
   <script>
-    function fireLoginEvent() {
-      utag.link({
-        'event_name': 'login',
-        'link_type': 'link_other',
-        'link_url': 'login successful',
-      });
+    function submitLoginEvent() {
+      if (typeof utag != 'undefined' && typeof utag.link != 'undefined') {
+        utag.link({
+          'event_name': 'login',
+          'link_type': 'link_other',
+          'link_url': 'login successful',
+        });
+      } else {
+        setTimeout(submitLoginEvent, 200);
+      }
     }
 
-    fireLoginEvent();
+    submitLoginEvent();
   </script>
 <% end %>
 

--- a/dpc-web/app/views/portal/show.html.erb
+++ b/dpc-web/app/views/portal/show.html.erb
@@ -17,6 +17,8 @@
   </script>
 <% end %>
 
+<% session.delete 'login_successful' %>
+
 <div class="ds-l-container">
 
   <h1 class="ds-u-font-size--title ds-u-font-weight--normal ds-u-margin--0">Hi, <%= @user.first_name %></h1>

--- a/dpc-web/app/views/portal/show.html.erb
+++ b/dpc-web/app/views/portal/show.html.erb
@@ -2,7 +2,6 @@
 <% if session['login_successful'] == true %>
   <script>
     function fireLoginEvent() {
-      console.log('firing login event')
       utag.link({
         'event_name': 'login',
         'link_type': 'link_other',

--- a/dpc-web/spec/features/authentication/user_sign_in_spec.rb
+++ b/dpc-web/spec/features/authentication/user_sign_in_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'user signs in' do
     find('[data-test="submit"]').click
 
     expect(page).to have_css('[data-test="my-account-menu"]')
+    expect(page).to have_selector('script', text: 'function submitLoginEvent()', visible: false)
   end
 
   scenario 'user cannot sign in if account not confirmed' do

--- a/dpc-web/spec/features/authentication/user_sign_in_spec.rb
+++ b/dpc-web/spec/features/authentication/user_sign_in_spec.rb
@@ -15,6 +15,16 @@ RSpec.feature 'user signs in' do
     expect(page).to have_selector('script', text: 'function submitLoginEvent()', visible: false)
   end
 
+  scenario 'submitLoginEvent should not be declared after login and page reload' do
+    visit new_user_session_path
+    fill_in 'user_email', with: user.email
+    fill_in 'user_password', with: '12345ABCDEfghi!'
+    find('[data-test="submit"]').click
+
+    refresh
+    expect(page).not_to have_selector('script', text: 'function submitLoginEvent()', visible: false)
+  end
+
   scenario 'user cannot sign in if account not confirmed' do
     unconfirmed = create(:user, confirmed_at: nil)
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4041

## 🛠 Changes

- Fires off a `header_click` event whenever the CMS logo is clicked. 
- Fires off a `login` event after successful login.
- 
## ℹ️ Context for reviewers

- `header_click` only triggers on CMS logo because, [per spec](https://confluence.cms.gov/display/BLSTANALYT/AA+header_click), this event should not fire when a navigation link is clicked -- and all the other items in the header qualify as navigation links.

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
