### PR TITLE
Upgrade nookogiri

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -17,6 +17,7 @@ services:
     volumes:
       - "./dpc-web/coverage:/dpc-web/coverage"
       - ./tmp/letter_opener/web:/dpc-web/tmp/letter_opener
+      - "./dpc-web/Gemfile.lock:/dpc-web/Gemfile.lock"
 
     environment:
       - REDIS_URL=redis://redis
@@ -62,6 +63,7 @@ services:
     volumes:
       - "./dpc-admin/coverage:/dpc-admin/coverage"
       - ./tmp/letter_opener/admin:/dpc-admin/tmp/letter_opener
+      - "./dpc-admin/Gemfile.lock:/dpc-admin/Gemfile.lock"
     environment:
       - REDIS_URL=redis://redis
       - GOLDEN_MACAROON=${GOLDEN_MACAROON}

--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -47,8 +47,8 @@ gem 'lograge'
 gem 'macaroons'
 gem 'sprockets-rails', '>= 3.4.2'
 gem 'truemail'
-# < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.16.2'
+# < 1.16.5 has a vulnerability, and is required by other gems
+gem 'nokogiri', '>= 1.16.5'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.16.0)
     nio4r (2.7.1)
-    nokogiri (1.16.4)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (1.4.11)
@@ -529,7 +529,7 @@ DEPENDENCIES
   luhnacy (~> 0.2.1)
   macaroons
   newrelic_rpm (~> 8.10)
-  nokogiri (>= 1.16.2)
+  nokogiri (>= 1.16.5)
   octokit
   omniauth-github (~> 1.4.0)
   omniauth-oktaoauth (~> 0.1.6)

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -54,8 +54,8 @@ gem 'uglifier', '>= 1.3.0'
 gem 'view_component', '~> 3.9'
 gem 'yard', '>= 0.9.36'
 
-# < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.16.2'
+# < 1.16.5 has a vulnerability, and is required by other gems
+gem 'nokogiri', '>= 1.16.5'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.16.0)
     nio4r (2.7.1)
-    nokogiri (1.16.4)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (1.4.11)
@@ -605,7 +605,7 @@ DEPENDENCIES
   luhnacy (~> 0.2.1)
   macaroons
   newrelic_rpm (~> 8.10)
-  nokogiri (>= 1.16.2)
+  nokogiri (>= 1.16.5)
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   pg (>= 0.18, < 2.0)

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -48,8 +48,8 @@ gem 'rack', '~> 2.2.8.1'
 gem 'redis-namespace'
 gem 'bootstrap-table-rails'
 
-# < 1.13.2 has a vulnerability, and is required by other gems
-gem 'nokogiri', '>= 1.16.2'
+# < 1.16.5 has a vulnerability, and is required by other gems
+gem 'nokogiri', '>= 1.16.5'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -290,7 +290,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (8.16.0)
     nio4r (2.7.1)
-    nokogiri (1.16.4)
+    nokogiri (1.16.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (1.4.11)
@@ -437,10 +437,6 @@ GEM
     simplecov-html (0.10.2)
     simpleidn (0.2.2)
       unf (~> 0.1.4)
-    spring (4.2.1)
-    spring-watcher-listen (2.1.0)
-      listen (>= 2.7, < 4.0)
-      spring (>= 4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -526,7 +522,7 @@ DEPENDENCIES
   luhnacy (~> 0.2.1)
   macaroons
   newrelic_rpm (~> 8.10)
-  nokogiri (>= 1.16.2)
+  nokogiri (>= 1.16.5)
   pg (>= 0.18, < 2.0)
   pry
   pry-nav
@@ -545,8 +541,6 @@ DEPENDENCIES
   sidekiq (~> 7.2.4)
   sidekiq_alive (~> 2.1.5)
   simplecov (<= 0.17)
-  spring
-  spring-watcher-listen (~> 2.1.0)
   sprockets-rails (>= 3.4.2)
   truemail
   tzinfo-data


### PR DESCRIPTION
## 🎫 Ticket

No ticket
## 🛠 Changes

The nokogiri gem was updated to 1.16.5 in dpc-admin, dpc-portal, and dpc-web

## ℹ️ Context for reviewers

- A security vulnerability was fixed in 1.16.5, and as we were using an earlier version, our checks would not pass CI.
- Gemfile.lock was added to volumes to make sure the changes rippled

## ✅ Acceptance Validation

Passed CI

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
