### PR TITLE
DPC-4114: Fix Sync Organization

### DIFF
--- a/engines/api_client/app/services/dpc_client.rb
+++ b/engines/api_client/app/services/dpc_client.rb
@@ -22,13 +22,13 @@ class DpcClient
   def get_organization(api_id)
     uri_string = "#{base_url}/Organization/#{api_id}"
     org = get_fhir_request(uri_string, delegated_macaroon(api_id))
-    org.blank? ? nil : FHIR::Organization.new(org)
+    response_successful? ? FHIR::Organization.new(org) : nil
   end
 
   def get_organization_by_npi(npi)
     uri_string = "#{base_url}/Admin/Organization?npis=npi|#{npi}"
     org = get_fhir_request(uri_string, golden_macaroon)
-    org.blank? ? nil : FHIR::Organization.new(org)
+    response_successful? ? FHIR::Bundle.new(org) : nil
   end
 
   def update_organization(reg_org, api_id, api_endpoint_ref)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4114

## 🛠 Changes

DpcClient returns FHIR:Bundle from get_organization_by_npi

## ℹ️ Context for reviewers

get_organization_by_npi was trying to unmarshall the wrong object

## ✅ Acceptance Validation

- Updated tests
- Ran SyncOrganizationJob in dpc-portal rails console, and it interacted with the backend appropritately

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
