### PR TITLE
DPC-4126: Fix JSON logging and add standardized fields

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -29,6 +29,7 @@ services:
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - DPC_CA_CERT=${DPC_CA_CERT}
       - RUBY_YJIT_ENABLE=1
+      - DISABLE_JSON_LOGGER=true
     ports:
       - "3900:3500"
     depends_on:
@@ -49,6 +50,7 @@ services:
       - DATABASE_URL=postgresql://db/dpc-website_development
       - DB_USER=postgres
       - DB_PASS=dpc-safe
+      - DISABLE_JSON_LOGGER=true
     depends_on:
       - redis
       - db
@@ -73,6 +75,7 @@ services:
       - DB_PASS=dpc-safe
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - RUBY_YJIT_ENABLE=1
+      - DISABLE_JSON_LOGGER=true
     ports:
       - "3000:3000"
     depends_on:
@@ -93,6 +96,7 @@ services:
       - DATABASE_URL=postgresql://db/dpc-website_development
       - DB_USER=postgres
       - DB_PASS=dpc-safe
+      - DISABLE_JSON_LOGGER=true
     depends_on:
       - redis
       - db
@@ -145,6 +149,7 @@ services:
       - IDP_HOST=idp.int.identitysandbox.gov
       - RUBY_YJIT_ENABLE=1
       - ENV=local
+      - DISABLE_JSON_LOGGER=true
     ports:
       - "3100:3100"
     depends_on:
@@ -172,6 +177,7 @@ services:
       - CMS_IDM_OAUTH_URL=http://localhost:4567/
       - RUBY_YJIT_ENABLE=1
       - ENV=local
+      - DISABLE_JSON_LOGGER=true
     depends_on:
       - redis
       - db

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -47,8 +47,6 @@ class ApplicationController < ActionController::Base
     params[:organization_id]
   end
 
-  attr_reader :organization
-
   def load_organization
     @organization = ProviderOrganization.find(organization_id)
     CurrentAttributes.organization = {

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -86,24 +86,21 @@ class ApplicationController < ActionController::Base
   # See usage in lograge initializer
   def append_info_to_payload(payload)
     super
+    return unless current_user
 
-    if current_user
-      payload[:current_user] = {
-        id: current_user.id,
-        external_id: current_user.uid,
-        pac_id: current_user.pac_id
-      }
+    payload[:current_user] = {
+      id: current_user.id,
+      external_id: current_user.uid,
+      pac_id: current_user.pac_id
+    }
 
-      if @organization
-        payload[:organization] = {
-          id: @organization.id,
-          dpc_api_organization_id: @organization.dpc_api_organization_id,
-          is_authorized_official: current_user.ao?(@organization),
-          is_credential_delegate: current_user.cd?(@organization)
-        }
-      end
-    end
+    return unless @organization
 
-    info
+    payload[:organization] = {
+      id: @organization.id,
+      dpc_api_organization_id: @organization.dpc_api_organization_id,
+      is_authorized_official: current_user.ao?(@organization),
+      is_credential_delegate: current_user.cd?(@organization)
+    }
   end
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -81,4 +81,17 @@ class ApplicationController < ActionController::Base
     has_ao_link = current_user.ao_org_links.where(provider_organization: @organization).exists?
     has_ao_link ? 'verification' : 'cd_access'
   end
+
+  # Appends information to payload for use in request-context logging.
+  # See usage in lograge initializer
+  def append_info_to_payload(payload)
+    super
+    return unless current_user
+
+    payload[:current_user] = {
+      id: current_user.id,
+      verification_status: current_user.verification_status,
+      verification_reason: current_user.verification_reason
+    }
+  end
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -88,11 +88,4 @@ class ApplicationController < ActionController::Base
     CurrentAttributes.set_request_attributes(request)
     CurrentAttributes.set_user_attributes(current_user)
   end
-
-  # Appends information to payload for use in request-context logging.
-  # See usage in lograge initializer
-  def append_info_to_payload(payload)
-    super
-    logger.info('This is a test')
-  end
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
 
   def load_organization
     @organization = ProviderOrganization.find(organization_id)
-    CurrentAttributes.set_organization_attributes(@organization, current_user)
+    CurrentAttributes.save_organization_attributes(@organization, current_user)
   rescue ActiveRecord::RecordNotFound
     render file: "#{Rails.root}/public/404.html", layout: false, status: :not_found
   end
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_current_request_attributes
-    CurrentAttributes.set_request_attributes(request)
-    CurrentAttributes.set_user_attributes(current_user)
+    CurrentAttributes.save_request_attributes(request)
+    CurrentAttributes.save_user_attributes(current_user)
   end
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -93,15 +93,15 @@ class ApplicationController < ActionController::Base
         external_id: current_user.uid,
         pac_id: current_user.pac_id
       }
-    end
 
-    if @organization
-      payload[:organization] = {
-        id: @organization.id,
-        dpc_api_organization_id: @organization.dpc_api_organization_id,
-        is_authorized_official: current_user.ao?(@organization),
-        is_credential_delegate: current_user.cd?(@organization)
-      }
+      if @organization
+        payload[:organization] = {
+          id: @organization.id,
+          dpc_api_organization_id: @organization.dpc_api_organization_id,
+          is_authorized_official: current_user.ao?(@organization),
+          is_credential_delegate: current_user.cd?(@organization)
+        }
+      end
     end
 
     info

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -86,12 +86,24 @@ class ApplicationController < ActionController::Base
   # See usage in lograge initializer
   def append_info_to_payload(payload)
     super
-    return unless current_user
 
-    payload[:current_user] = {
-      id: current_user.id,
-      verification_status: current_user.verification_status,
-      verification_reason: current_user.verification_reason
-    }
+    if current_user
+      payload[:current_user] = {
+        id: current_user.id,
+        external_id: current_user.uid,
+        pac_id: current_user.pac_id
+      }
+    end
+
+    if @organization
+      payload[:organization] = {
+        id: @organization.id,
+        dpc_api_organization_id: @organization.dpc_api_organization_id,
+        is_authorized_official: current_user.ao?(@organization),
+        is_credential_delegate: current_user.cd?(@organization)
+      }
+    end
+
+    info
   end
 end

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -11,7 +11,6 @@ class OrganizationsController < ApplicationController
   before_action :tos_accepted, only: %i[show]
 
   def index
-    raise StandardError.new('some error has occurred')
     @links = current_user.provider_links
     ao_or_cd = @links.any? { |link| link.is_a?(AoOrgLink) }
     render(Page::Organization::OrganizationListComponent.new(ao_or_cd:, links: @links))

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -11,6 +11,7 @@ class OrganizationsController < ApplicationController
   before_action :tos_accepted, only: %i[show]
 
   def index
+    raise StandardError.new('some error has occurred')
     @links = current_user.provider_links
     ao_or_cd = @links.any? { |link| link.is_a?(AoOrgLink) }
     render(Page::Organization::OrganizationListComponent.new(ao_or_cd:, links: @links))

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -11,7 +11,6 @@ class OrganizationsController < ApplicationController
   before_action :tos_accepted, only: %i[show]
 
   def index
-    raise StandardError.new('this is an error that is bad')
     @links = current_user.provider_links
     ao_or_cd = @links.any? { |link| link.is_a?(AoOrgLink) }
     render(Page::Organization::OrganizationListComponent.new(ao_or_cd:, links: @links))

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -11,6 +11,7 @@ class OrganizationsController < ApplicationController
   before_action :tos_accepted, only: %i[show]
 
   def index
+    raise StandardError.new('this is an error that is bad')
     @links = current_user.provider_links
     ao_or_cd = @links.any? { |link| link.is_a?(AoOrgLink) }
     render(Page::Organization::OrganizationListComponent.new(ao_or_cd:, links: @links))

--- a/dpc-portal/app/lib/dpc_json_logger.rb
+++ b/dpc-portal/app/lib/dpc_json_logger.rb
@@ -36,6 +36,16 @@ class DpcJsonLogger < ActiveSupport::Logger
     super(value, &nil)
   end
 
+  def fatal(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  def unknown(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
   private
 
   def as_hash(msg, attribs = {})

--- a/dpc-portal/app/lib/dpc_json_logger.rb
+++ b/dpc-portal/app/lib/dpc_json_logger.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Custom JSON logger for DPC.
+#
+# Usage:
+#  logger.info("Doing a thing", attempt: 2)
+#
+class DpcJsonLogger < ActiveSupport::Logger
+  def self.formatter
+    proc do |severity, time, progname, msg|
+      metadata = { level: severity, time:, application: progname, environment: ENV['ENV'] || :development }
+      msg = { message: msg } if msg.is_a?(String)
+      "#{metadata.merge(msg).compact.to_json}\n"
+    end
+  end
+
+  def debug(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  def info(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  def warn(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  def error(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  private
+
+  def as_hash(msg, attribs = {})
+    msg = yield if block_given?
+    raise ArgumentError, 'message must be a string' unless msg.is_a?(String)
+
+    { message: msg }.merge(attribs || {}).merge(CurrentAttributes.to_log_hash)
+  end
+end

--- a/dpc-portal/app/models/current_attributes.rb
+++ b/dpc-portal/app/models/current_attributes.rb
@@ -8,6 +8,43 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
   attribute :current_user
   attribute :organization
 
+  def set_request_attributes(_req)
+    CurrentAttributes.request_id = request.request_id
+    CurrentAttributes.request_user_agent = request.user_agent
+    CurrentAttributes.request_ip = request.ip
+    CurrentAttributes.forwarded_for = request.headers['X-Forwarded-For']
+    CurrentAttributes.method = request.method
+    CurrentAttributes.path = request.path
+  end
+
+  def set_user_attributes(user)
+    return unless user
+
+    CurrentAttributes.current_user = {
+      id: user.id,
+      external_id: user.uid,
+      pac_id: user.pac_id
+    }
+  end
+
+  def set_organization_attributes(org, user)
+    return unless org
+
+    CurrentAttributes.organization = {
+      id: org.id,
+      dpc_api_organization_id: org.dpc_api_organization_id
+    }
+
+    return unless user
+
+    begin
+      payload[:organization][:is_authorized_official] = user.ao?(org)
+      payload[:organization][:is_credential_delegate] = user.cd?(org)
+    rescue err
+      Rails.logger.warn('Failed to pull user roles for organization')
+    end
+  end
+
   def to_log_hash
     {
       request_id: CurrentAttributes.request_id,

--- a/dpc-portal/app/models/current_attributes.rb
+++ b/dpc-portal/app/models/current_attributes.rb
@@ -8,7 +8,7 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
   attribute :current_user
   attribute :organization
 
-  def set_request_attributes(_req)
+  def save_request_attributes(request)
     CurrentAttributes.request_id = request.request_id
     CurrentAttributes.request_user_agent = request.user_agent
     CurrentAttributes.request_ip = request.ip
@@ -17,7 +17,7 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
     CurrentAttributes.path = request.path
   end
 
-  def set_user_attributes(user)
+  def save_user_attributes(user)
     return unless user
 
     CurrentAttributes.current_user = {
@@ -27,7 +27,7 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
     }
   end
 
-  def set_organization_attributes(org, user)
+  def save_organization_attributes(org, user)
     return unless org
 
     CurrentAttributes.organization = {

--- a/dpc-portal/app/models/current_attributes.rb
+++ b/dpc-portal/app/models/current_attributes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# ActiveSupport::CurrentAttributes gives us a thread-safe way
+# to store request-scope attributes such as request_id.
+class CurrentAttributes < ActiveSupport::CurrentAttributes
+  attribute :request_id, :request_user_agent, :request_ip, :forwarded_for
+  attribute :method, :path
+  attribute :current_user
+  attribute :organization
+end

--- a/dpc-portal/app/models/current_attributes.rb
+++ b/dpc-portal/app/models/current_attributes.rb
@@ -38,8 +38,8 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
     return unless user
 
     begin
-      payload[:organization][:is_authorized_official] = user.ao?(org)
-      payload[:organization][:is_credential_delegate] = user.cd?(org)
+      CurrentAttributes.organization[:is_authorized_official] = user.ao?(org)
+      CurrentAttributes.organization[:is_credential_delegate] = user.cd?(org)
     rescue err
       Rails.logger.warn('Failed to pull user roles for organization')
     end
@@ -50,6 +50,7 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
       request_id: CurrentAttributes.request_id,
       request_user_agent: CurrentAttributes.request_user_agent,
       request_ip: CurrentAttributes.request_ip,
+      forwarded_for: CurrentAttributes.forwarded_for,
       method: CurrentAttributes.method,
       path: CurrentAttributes.path,
       current_user: CurrentAttributes.current_user,

--- a/dpc-portal/app/models/current_attributes.rb
+++ b/dpc-portal/app/models/current_attributes.rb
@@ -7,4 +7,16 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
   attribute :method, :path
   attribute :current_user
   attribute :organization
+
+  def to_log_hash
+    {
+      request_id: CurrentAttributes.request_id,
+      request_user_agent: CurrentAttributes.request_user_agent,
+      request_ip: CurrentAttributes.request_ip,
+      method: CurrentAttributes.method,
+      path: CurrentAttributes.path,
+      current_user: CurrentAttributes.current_user,
+      organization: CurrentAttributes.organization
+    }
+  end
 end

--- a/dpc-portal/app/models/current_attributes.rb
+++ b/dpc-portal/app/models/current_attributes.rb
@@ -38,8 +38,11 @@ class CurrentAttributes < ActiveSupport::CurrentAttributes
     return unless user
 
     begin
-      CurrentAttributes.organization[:is_authorized_official] = user.ao?(org)
-      CurrentAttributes.organization[:is_credential_delegate] = user.cd?(org)
+      if user.ao?(org)
+        CurrentAttributes.organization[:current_user_role] = 'authorized_official'
+      elsif user.cd?(org)
+        CurrentAttributes.organization[:current_user_role] = 'credential_delegate'
+      end
     rescue err
       Rails.logger.warn('Failed to pull user roles for organization')
     end

--- a/dpc-portal/bin/nonprod
+++ b/dpc-portal/bin/nonprod
@@ -6,4 +6,4 @@ if ! gem list foreman -i --silent; then
 fi
 
 echo "Starting Procfile.nonprod"
-exec foreman start -f Procfile.nonprod "$@" | sed s/.*\|//
+exec foreman start -f Procfile.nonprod "$@" | sed s/.*?\|//

--- a/dpc-portal/bin/nonprod
+++ b/dpc-portal/bin/nonprod
@@ -6,4 +6,4 @@ if ! gem list foreman -i --silent; then
 fi
 
 echo "Starting Procfile.nonprod"
-exec foreman start -f Procfile.nonprod "$@"
+exec foreman start -f Procfile.nonprod "$@" | sed s/.*\|//

--- a/dpc-portal/bin/sidekiq-nonprod
+++ b/dpc-portal/bin/sidekiq-nonprod
@@ -6,4 +6,4 @@ if ! gem list foreman -i --silent; then
 fi
 
 echo "Starting Procfile.nonprod"
-exec foreman start -f Procfile.sidekiq-nonprod "$@"
+exec foreman start -f Procfile.sidekiq-nonprod "$@" | sed s/.*?\|//

--- a/dpc-portal/config/environments/production.rb
+++ b/dpc-portal/config/environments/production.rb
@@ -53,25 +53,12 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Lograge config
-  config.lograge.enabled = true
-
-  # This specifies to log in JSON format
-  config.lograge.formatter = Lograge::Formatters::Json.new
-
   ## Disables log coloration
   config.colorize_logging = false
-
-  # Log to a dedicated file
-  config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = ENV["LOG_LEVEL"] || :info
-
-
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/dpc-portal/config/environments/production.rb
+++ b/dpc-portal/config/environments/production.rb
@@ -91,19 +91,6 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
-
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -56,5 +56,7 @@ end
 
 Rails.application.configure do
     Rails.logger = DpcJsonLogger.new($stdout)
-    config.log_formatter = Rails.logger.formatter
+    config.logger = Rails.logger
+    config.logger.formatter = DpcJsonLogger.formatter
+    config.log_formatter = DpcJsonLogger.formatter
 end

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -41,16 +41,7 @@ class DpcJsonLogger < ActiveSupport::Logger
   def as_hash(msg, attribs = {})
     msg = yield if block_given?
     raise ArgumentError.new('message must be a string') unless msg.is_a?(String)
-
-    { message: msg }.merge(attribs || {}).merge(
-      request_id: CurrentAttributes.request_id,
-      request_user_agent: CurrentAttributes.request_user_agent,
-      request_ip: CurrentAttributes.request_ip,
-      method: CurrentAttributes.method,
-      path: CurrentAttributes.path,
-      current_user: CurrentAttributes.current_user,
-      organization: CurrentAttributes.organization
-    )
+    { message: msg }.merge(attribs || {}).merge(CurrentAttributes.to_log_hash)
   end
 end
 

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Custom JSON logger for DPC.
+#
+# Usage:
+#  logger.info("Doing a thing", attempt: 2)
+#
+class DpcJsonLogger < ActiveSupport::Logger
+  def self.formatter
+    proc do |severity, time, progname, msg|
+      metadata = { level: severity, time:, application: progname, environment: ENV['ENV'] || :development }
+      msg = { message: msg } if msg.is_a?(String)
+      "#{metadata.merge(msg).compact.to_json}\n"
+    end
+  end
+
+  def debug(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  def info(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  def warn(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  def error(*msg, &)
+    value = as_hash(msg[0], msg[1], &)
+    super(value, &nil)
+  end
+
+  private
+
+  def as_hash(msg, attribs = {})
+    msg = yield if block_given?
+    raise ArgumentError.new('message must be a string') unless msg.is_a?(String)
+
+    { message: msg }.merge(attribs || {}).merge(
+      request_id: CurrentAttributes.request_id,
+      request_user_agent: CurrentAttributes.request_user_agent,
+      request_ip: CurrentAttributes.request_ip,
+      method: CurrentAttributes.method,
+      path: CurrentAttributes.path,
+      current_user: CurrentAttributes.current_user,
+      organization: CurrentAttributes.organization
+    )
+  end
+end
+
+Rails.application.configure do
+    Rails.logger = DpcJsonLogger.new($stdout)
+    config.log_formatter = Rails.logger.formatter
+end

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -3,8 +3,10 @@
 require './app/lib/dpc_json_logger'
 
 Rails.application.configure do
+  unless ENV['DISABLE_JSON_LOGGER'] == 'true'
     Rails.logger = DpcJsonLogger.new($stdout)
     config.logger = Rails.logger
     config.logger.formatter = DpcJsonLogger.formatter
     config.log_formatter = DpcJsonLogger.formatter
+  end
 end

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -1,49 +1,6 @@
 # frozen_string_literal: true
 
-require 'json'
-
-# Custom JSON logger for DPC.
-#
-# Usage:
-#  logger.info("Doing a thing", attempt: 2)
-#
-class DpcJsonLogger < ActiveSupport::Logger
-  def self.formatter
-    proc do |severity, time, progname, msg|
-      metadata = { level: severity, time:, application: progname, environment: ENV['ENV'] || :development }
-      msg = { message: msg } if msg.is_a?(String)
-      "#{metadata.merge(msg).compact.to_json}\n"
-    end
-  end
-
-  def debug(*msg, &)
-    value = as_hash(msg[0], msg[1], &)
-    super(value, &nil)
-  end
-
-  def info(*msg, &)
-    value = as_hash(msg[0], msg[1], &)
-    super(value, &nil)
-  end
-
-  def warn(*msg, &)
-    value = as_hash(msg[0], msg[1], &)
-    super(value, &nil)
-  end
-
-  def error(*msg, &)
-    value = as_hash(msg[0], msg[1], &)
-    super(value, &nil)
-  end
-
-  private
-
-  def as_hash(msg, attribs = {})
-    msg = yield if block_given?
-    raise ArgumentError.new('message must be a string') unless msg.is_a?(String)
-    { message: msg }.merge(attribs || {}).merge(CurrentAttributes.to_log_hash)
-  end
-end
+require './app/lib/dpc_json_logger'
 
 Rails.application.configure do
     Rails.logger = DpcJsonLogger.new($stdout)

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
       info[:exception_backtrace] = Array(exception.backtrace).first(30).join("\n")
     end
 
+    # Insert optional information added during the request. See the ApplicationController.
     current_user = event.payload[:current_user]
     info[:current_user] = current_user if current_user
 

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -9,7 +9,6 @@ Rails.application.configure do
     info = { 
       ddsource: 'ruby',
       environment: ENV['ENV'] || :development,
-      exception: event.payload[:exception],
       level: ENV['LOG_LEVEL'] || :info,
       request_id: event.payload[:request].request_id,
     }

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
       request_ip: CurrentAttributes.request_ip,
       method: CurrentAttributes.method,
       path: CurrentAttributes.path,
+      time: Time.now
     }
 
     exception = event.payload[:exception_object]

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -10,7 +10,11 @@ Rails.application.configure do
       ddsource: 'ruby',
       environment: ENV['ENV'] || :development,
       level: ENV['LOG_LEVEL'] || :info,
-      request_id: event.payload[:request].request_id,
+      request_id: CurrentAttributes.request_id,
+      request_user_agent: CurrentAttributes.request_user_agent,
+      request_ip: CurrentAttributes.request_ip,
+      method: CurrentAttributes.method,
+      path: CurrentAttributes.path,
     }
 
     exception = event.payload[:exception_object]
@@ -18,14 +22,14 @@ Rails.application.configure do
     if exception
       info[:exception_message] = exception.message
       info[:exception_class] = exception.class
-      info[:exception_backtrace] = Array(exception.backtrace).first(30).join("\n")
+      info[:exception_backtrace] = Rails.backtrace_cleaner.clean(exception.backtrace)
     end
-
+    
     # Insert optional information added during the request. See the ApplicationController.
-    current_user = event.payload[:current_user]
+    current_user = CurrentAttributes.current_user
     info[:current_user] = current_user if current_user
 
-    organization = event.payload[:organization]
+    organization = CurrentAttributes.organization
     info[:organization] = organization if organization
     info
   end

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -1,12 +1,29 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
+  config.lograge.formatter = Lograge::Formatters::Json.new
+
   config.lograge.custom_options = lambda do |event|
-    { ddsource: 'ruby',
-      params: event.payload[:params].reject { |k| %w(controller action).include? k },
+    info = { 
+      ddsource: 'ruby',
       environment: ENV['ENV'] || :development,
       exception: event.payload[:exception],
-      level: ENV['LOG_LEVEL'] || :info
+      level: ENV['LOG_LEVEL'] || :info,
+      request_id: event.payload[:request].request_id,
     }
+
+    exception = event.payload[:exception_object]
+
+    if exception
+      info[:exception_message] = exception.message
+      info[:exception_class] = exception.class
+      info[:exception_backtrace] = exception.backtrace
+    end
+
+    current_user = event.payload[:current_user]
+    info[:current_user] = current_user if current_user    
+    info
   end
 end

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -23,7 +23,10 @@ Rails.application.configure do
     end
 
     current_user = event.payload[:current_user]
-    info[:current_user] = current_user if current_user    
+    info[:current_user] = current_user if current_user
+
+    organization = event.payload[:organization]
+    info[:organization] = organization if organization
     info
   end
 end

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
     if exception
       info[:exception_message] = exception.message
       info[:exception_class] = exception.class
-      info[:exception_backtrace] = exception.backtrace
+      info[:exception_backtrace] = Array(exception.backtrace).first(30).join("\n")
     end
 
     current_user = event.payload[:current_user]

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -10,13 +10,8 @@ Rails.application.configure do
       ddsource: 'ruby',
       environment: ENV['ENV'] || :development,
       level: ENV['LOG_LEVEL'] || :info,
-      request_id: CurrentAttributes.request_id,
-      request_user_agent: CurrentAttributes.request_user_agent,
-      request_ip: CurrentAttributes.request_ip,
-      method: CurrentAttributes.method,
-      path: CurrentAttributes.path,
       time: Time.now
-    }
+    }.merge(CurrentAttributes.to_log_hash)
 
     exception = event.payload[:exception_object]
 
@@ -26,12 +21,6 @@ Rails.application.configure do
       info[:exception_backtrace] = Rails.backtrace_cleaner.clean(exception.backtrace)
     end
     
-    # Insert optional information added during the request. See the ApplicationController.
-    current_user = CurrentAttributes.current_user
-    info[:current_user] = current_user if current_user
-
-    organization = CurrentAttributes.organization
-    info[:organization] = organization if organization
     info
   end
 end

--- a/dpc-portal/spec/factories/users.rb
+++ b/dpc-portal/spec/factories/users.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :user, aliases: %i[invited_by] do
+    sequence(:uid) { |n| n }
     email { "user#{rand(0..100_000)}@example.com" }
     password { '12345ABCDEfghi!' }
     password_confirmation { '12345ABCDEfghi!' }

--- a/dpc-portal/spec/lib/dpc_json_logger_spec.rb
+++ b/dpc-portal/spec/lib/dpc_json_logger_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DpcJsonLogger do
+  let(:strout) { StringIO.new }
+  let(:logger) do
+    lgr = DpcJsonLogger.new(strout)
+    lgr.formatter = DpcJsonLogger.formatter
+    lgr
+  end
+
+  describe :info do
+    it 'logs info' do
+      logger.info('This is a test', key: 'value')
+      json_result = JSON.parse(strout.string)
+      expect(json_result['level']).to eq('INFO')
+      expect(json_result['message']).to eq('This is a test')
+      expect(json_result['key']).to eq('value')
+    end
+
+    it 'calculates message from block if provided' do
+      logger.info do
+        'Calculated message'
+      end
+      json_result = JSON.parse(strout.string)
+      expect(json_result['level']).to eq('INFO')
+      expect(json_result['message']).to eq('Calculated message')
+    end
+
+    it 'raises error if message is not a string' do
+      expect { logger.info(1234).to raise_error(ArgumentError) }
+    end
+  end
+
+  describe :other_methods do
+    it 'logs warning' do
+      logger.warn('This is a test', key: 'value')
+      json_result = JSON.parse(strout.string)
+      expect(json_result['level']).to eq('WARN')
+      expect(json_result['message']).to eq('This is a test')
+      expect(json_result['key']).to eq('value')
+    end
+
+    it 'logs debug' do
+      logger.debug('This is a test', key: 'value')
+      json_result = JSON.parse(strout.string)
+      expect(json_result['level']).to eq('DEBUG')
+      expect(json_result['message']).to eq('This is a test')
+      expect(json_result['key']).to eq('value')
+    end
+
+    it 'logs error' do
+      logger.error('This is a test', key: 'value')
+      json_result = JSON.parse(strout.string)
+      expect(json_result['level']).to eq('ERROR')
+      expect(json_result['message']).to eq('This is a test')
+      expect(json_result['key']).to eq('value')
+    end
+  end
+end

--- a/dpc-portal/spec/lib/dpc_json_logger_spec.rb
+++ b/dpc-portal/spec/lib/dpc_json_logger_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe DpcJsonLogger do
+RSpec.shared_examples 'logger method' do |log_method|
   let(:strout) { StringIO.new }
   let(:logger) do
     lgr = DpcJsonLogger.new(strout)
@@ -10,21 +10,21 @@ RSpec.describe DpcJsonLogger do
     lgr
   end
 
-  describe :info do
-    it 'logs info' do
-      logger.info('This is a test', key: 'value')
+  describe log_method do
+    it "logs #{log_method}" do
+      logger.send(log_method, 'This is a test', key: 'value')
       json_result = JSON.parse(strout.string)
-      expect(json_result['level']).to eq('INFO')
+      expect(json_result['level']).to eq(log_method.upcase)
       expect(json_result['message']).to eq('This is a test')
       expect(json_result['key']).to eq('value')
     end
 
     it 'calculates message from block if provided' do
-      logger.info do
+      logger.send(log_method) do
         'Calculated message'
       end
       json_result = JSON.parse(strout.string)
-      expect(json_result['level']).to eq('INFO')
+      expect(json_result['level']).to eq(log_method.upcase)
       expect(json_result['message']).to eq('Calculated message')
     end
 
@@ -32,30 +32,11 @@ RSpec.describe DpcJsonLogger do
       expect { logger.info(1234).to raise_error(ArgumentError) }
     end
   end
+end
 
-  describe :other_methods do
-    it 'logs warning' do
-      logger.warn('This is a test', key: 'value')
-      json_result = JSON.parse(strout.string)
-      expect(json_result['level']).to eq('WARN')
-      expect(json_result['message']).to eq('This is a test')
-      expect(json_result['key']).to eq('value')
-    end
-
-    it 'logs debug' do
-      logger.debug('This is a test', key: 'value')
-      json_result = JSON.parse(strout.string)
-      expect(json_result['level']).to eq('DEBUG')
-      expect(json_result['message']).to eq('This is a test')
-      expect(json_result['key']).to eq('value')
-    end
-
-    it 'logs error' do
-      logger.error('This is a test', key: 'value')
-      json_result = JSON.parse(strout.string)
-      expect(json_result['level']).to eq('ERROR')
-      expect(json_result['message']).to eq('This is a test')
-      expect(json_result['key']).to eq('value')
-    end
-  end
+RSpec.describe DpcJsonLogger do
+  include_examples 'logger method', 'debug'
+  include_examples 'logger method', 'info'
+  include_examples 'logger method', 'warn'
+  include_examples 'logger method', 'error'
 end

--- a/dpc-portal/spec/lib/dpc_json_logger_spec.rb
+++ b/dpc-portal/spec/lib/dpc_json_logger_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.shared_examples 'logger method' do |log_method|
+RSpec.shared_examples 'logger method' do |log_method, level_name|
   let(:strout) { StringIO.new }
   let(:logger) do
     lgr = DpcJsonLogger.new(strout)
@@ -14,7 +14,7 @@ RSpec.shared_examples 'logger method' do |log_method|
     it "logs #{log_method}" do
       logger.send(log_method, 'This is a test', key: 'value')
       json_result = JSON.parse(strout.string)
-      expect(json_result['level']).to eq(log_method.upcase)
+      expect(json_result['level']).to eq(level_name)
       expect(json_result['message']).to eq('This is a test')
       expect(json_result['key']).to eq('value')
     end
@@ -24,7 +24,7 @@ RSpec.shared_examples 'logger method' do |log_method|
         'Calculated message'
       end
       json_result = JSON.parse(strout.string)
-      expect(json_result['level']).to eq(log_method.upcase)
+      expect(json_result['level']).to eq(level_name)
       expect(json_result['message']).to eq('Calculated message')
     end
 
@@ -35,8 +35,10 @@ RSpec.shared_examples 'logger method' do |log_method|
 end
 
 RSpec.describe DpcJsonLogger do
-  include_examples 'logger method', 'debug'
-  include_examples 'logger method', 'info'
-  include_examples 'logger method', 'warn'
-  include_examples 'logger method', 'error'
+  include_examples 'logger method', 'debug', 'DEBUG'
+  include_examples 'logger method', 'info', 'INFO'
+  include_examples 'logger method', 'warn', 'WARN'
+  include_examples 'logger method', 'error', 'ERROR'
+  include_examples 'logger method', 'fatal', 'FATAL'
+  include_examples 'logger method', 'unknown', 'ANY'
 end

--- a/dpc-portal/spec/models/current_attributes_spec.rb
+++ b/dpc-portal/spec/models/current_attributes_spec.rb
@@ -75,8 +75,7 @@ RSpec.describe CurrentAttributes do
       CurrentAttributes.organization = {
         id: 987,
         dpc_api_organization_id: '876-45',
-        is_authorized_official: true,
-        is_credential_delegate: false
+        current_user_role: 'authorized_official'
       }
 
       expect(CurrentAttributes.to_log_hash).to eq(

--- a/dpc-portal/spec/models/current_attributes_spec.rb
+++ b/dpc-portal/spec/models/current_attributes_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CurrentAttributes do
+  before(:each) do
+    CurrentAttributes.reset
+  end
+
+  describe :save_user_attributes do
+    it 'does nothing when user is nil' do
+      CurrentAttributes.save_user_attributes(nil)
+      expect(CurrentAttributes.current_user).to eq(nil)
+    end
+
+    it 'records user attributes when user exists' do
+      user = build(:user, id: rand(0..100_000), pac_id: rand(0..100_000).to_s)
+      CurrentAttributes.save_user_attributes(user)
+      expect(CurrentAttributes.current_user).to eq(
+        {
+          id: user.id,
+          external_id: user.uid,
+          pac_id: user.pac_id
+        }
+      )
+    end
+  end
+
+  describe :save_organization_attributes do
+    it 'does nothing when organization is nil' do
+      CurrentAttributes.save_organization_attributes(nil, nil)
+      expect(CurrentAttributes.organization).to eq(nil)
+    end
+
+    it 'records organization attributes when user is nil' do
+      org = build(:provider_organization, id: rand(0..100_000), dpc_api_organization_id: rand(0..100_000).to_s)
+      CurrentAttributes.save_organization_attributes(org, nil)
+      expect(CurrentAttributes.organization).to eq(
+        {
+          id: org.id,
+          dpc_api_organization_id: org.dpc_api_organization_id
+        }
+      )
+    end
+
+    it 'records role attributes when user exists' do
+      user = create(:user, id: rand(0..100_000), pac_id: rand(0..100_000).to_s)
+      org = create(:provider_organization, id: rand(0..100_000), dpc_api_organization_id: rand(0..100_000).to_s)
+      create(:ao_org_link, user:, provider_organization: org)
+
+      CurrentAttributes.save_organization_attributes(org, user)
+      expect(CurrentAttributes.organization).to eq(
+        {
+          id: org.id,
+          dpc_api_organization_id: org.dpc_api_organization_id,
+          is_authorized_official: true,
+          is_credential_delegate: false
+        }
+      )
+    end
+  end
+
+  describe :to_log_hash do
+    it 'records all attributes' do
+      CurrentAttributes.request_id = 1234
+      CurrentAttributes.request_user_agent = 'Chrome'
+      CurrentAttributes.request_ip = '127.0.0.1'
+      CurrentAttributes.forwarded_for = '127.0.0.2'
+      CurrentAttributes.method = 'POST'
+      CurrentAttributes.path = 'my/path'
+      CurrentAttributes.current_user = {
+        id: 1234,
+        external_id: '2345',
+        pac_id: '3456'
+      }
+      CurrentAttributes.organization = {
+        id: 987,
+        dpc_api_organization_id: '876-45',
+        is_authorized_official: true,
+        is_credential_delegate: false
+      }
+
+      expect(CurrentAttributes.to_log_hash).to eq(
+        {
+          request_id: 1234,
+          request_user_agent: 'Chrome',
+          request_ip: '127.0.0.1',
+          forwarded_for: '127.0.0.2',
+          method: 'POST',
+          path: 'my/path',
+          current_user: {
+            id: 1234,
+            external_id: '2345',
+            pac_id: '3456'
+          },
+          organization: {
+            id: 987,
+            dpc_api_organization_id: '876-45',
+            is_authorized_official: true,
+            is_credential_delegate: false
+          }
+        }
+      )
+    end
+  end
+end

--- a/dpc-portal/spec/models/current_attributes_spec.rb
+++ b/dpc-portal/spec/models/current_attributes_spec.rb
@@ -53,8 +53,7 @@ RSpec.describe CurrentAttributes do
         {
           id: org.id,
           dpc_api_organization_id: org.dpc_api_organization_id,
-          is_authorized_official: true,
-          is_credential_delegate: false
+          current_user_role: 'authorized_official'
         }
       )
     end
@@ -96,8 +95,7 @@ RSpec.describe CurrentAttributes do
           organization: {
             id: 987,
             dpc_api_organization_id: '876-45',
-            is_authorized_official: true,
-            is_credential_delegate: false
+            current_user_role: 'authorized_official'
           }
         }
       )


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4126

## 🛠 Changes

- Hide Foreman service log prefixes in nonprod (deployed environments)
- Add request-global log attributes for current_user info, organization info, and any raised exceptions
- Fix request_id attribute

## ℹ️ Context for reviewers

Noticed a few issues while auditing the logs produced by the portal in splunk:

- Since we are using foreman to run the fake CPI API GW in nonprod, it is prefixing the service name. This breaks the JSON formatting of each log line, which breaks splunk parsing. Added sed commands to fix this.
- The request_id is not logged because it uses the Rails default `log_tags` functionality. Since we use lograge for request logs, this is not picked up in the logs.
- The normal logs using `Rails.logger` are not printed via JSON.

I also added some helpful information to each request related to the current logged in user, the relevant organization for the API/page request, and any exception details if there was an uncaught exception raised during the request.

## ✅ Acceptance Validation

Verified locally.

Lograge custom log with current_user and organization:

```json
{
  "method": "GET",
  "path": "/portal/organizations/1/invitations/1/accept",
  "format": "html",
  "controller": "InvitationsController",
  "action": "accept",
  "status": 200,
  "allocations": 11634,
  "duration": 72.23,
  "view": 25.18,
  "db": 1.14,
  "ddsource": "ruby",
  "environment": "local",
  "level": "info",
  "request_id": "b225bb9b-72bf-400e-9b28-733fbc9e16e1",
  "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0",
  "request_ip": "REDACTED",
  "current_user": {
    "id": 1,
    "external_id": "60119c5b-606f-4526-b33c-4e691e2d4d3b",
    "pac_id": null
  },
  "organization": {
    "id": 1,
    "dpc_api_organization_id": null,
    "is_authorized_official": false,
    "is_credential_delegate": false
  }
}
```

Custom Rails.logger log:

```json
{
  "level": "INFO",
  "time": "2024-06-19T18:56:02.963+00:00",
  "environment": "local",
  "message": "This is a test",
  "request_id": "16b9c4c6-e84a-4bd0-805f-9a34d966f475",
  "request_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0",
  "request_ip": "REDACTED",
  "method": "GET",
  "path": "/portal/organizations/1/invitations/1/accept",
  "organization": {
    "id": 1,
    "dpc_api_organization_id": null
  }
}

```

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
