### PR TITLE
DPC-3823 Credential Audit Log

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # based on the POSTGRES_MULTIPLE_DATABASES variable above.
       - ./docker/postgres:/docker-entrypoint-initdb.d
       # Mount persistent volume to ensure data is not erased across containers.
-      - pgdata14:/var/lib/postgresql/data
+      - pgdata3823:/var/lib/postgresql/data
 
   aggregation:
     image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-aggregation}:latest
@@ -117,7 +117,7 @@ services:
     network_mode: host
 
 volumes:
-  pgdata14:
+  pgdata3823:
   export-volume:
     driver: local
     driver_opts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # based on the POSTGRES_MULTIPLE_DATABASES variable above.
       - ./docker/postgres:/docker-entrypoint-initdb.d
       # Mount persistent volume to ensure data is not erased across containers.
-      - pgdata3823:/var/lib/postgresql/data
+      - pgdata14:/var/lib/postgresql/data
 
   aggregation:
     image: ${ECR_HOST:-755619740999.dkr.ecr.us-east-1.amazonaws.com/dpc-aggregation}:latest
@@ -117,7 +117,7 @@ services:
     network_mode: host
 
 volumes:
-  pgdata3823:
+  pgdata14:
   export-volume:
     driver: local
     driver_opts:

--- a/dpc-portal/app/components/core/table/row_component.rb
+++ b/dpc-portal/app/components/core/table/row_component.rb
@@ -16,15 +16,17 @@ module Core
         @delete_path = delete_path
         @obj_name = obj_name
         keys.each do |key|
+          logger.debug(obj[key])
           attributes << format_if_date(obj[key] || key)
         end
       end
 
       def format_if_date(str)
         # verification_code ABC123 parses
-        return str unless str.length > 6
+        return str unless str.length > 18
 
-        datetime = DateTime.parse(str)
+        # Using strict parsing because guids were being parsed
+        datetime = DateTime.strptime(str[..18], '%Y-%m-%dT%H:%M:%S')
         datetime.strftime('%m/%d/%Y at %l:%M%p UTC')
       rescue Date::Error
         str

--- a/dpc-portal/app/components/core/table/row_component.rb
+++ b/dpc-portal/app/components/core/table/row_component.rb
@@ -16,7 +16,6 @@ module Core
         @delete_path = delete_path
         @obj_name = obj_name
         keys.each do |key|
-          logger.debug(obj[key])
           attributes << format_if_date(obj[key] || key)
         end
       end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -81,4 +81,15 @@ class ApplicationController < ActionController::Base
     has_ao_link = current_user.ao_org_links.where(provider_organization: @organization).exists?
     has_ao_link ? 'verification' : 'cd_access'
   end
+
+  def log_credential_action(credential_type, dpc_api_credential_id, action)
+    log = CredentialAuditLog.create(user: current_user,
+                                    credential_type:,
+                                    dpc_api_credential_id:,
+                                    action:)
+    return if log.valid?
+
+    logger.error("Unable to create client token CredentialAuditLog #{action} on #{token_id}")
+  end
+
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -82,13 +82,13 @@ class ApplicationController < ActionController::Base
     has_ao_link ? 'verification' : 'cd_access'
   end
 
-  def log_credential_action(credential_type, dpc_api_credential_id, action)
-    log = CredentialAuditLog.create(user: current_user,
-                                    credential_type:,
-                                    dpc_api_credential_id:,
-                                    action:)
-    return if log.valid?
+  def log_credential_action(credential_type, action)
+    log = CredentialAuditLog.new(user: current_user,
+                                 credential_type:,
+                                 provider_organization: @organization,
+                                 action:)
+    return if log.save
 
-    logger.error("CredentialAuditLog failure: unable to #{action} #{credential_type} #{dpc_api_credential_id}")
+    logger.error("CredentialAuditLog failure: unable to #{action} #{credential_type} for #{@organization.id}")
   end
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -89,13 +89,13 @@ class ApplicationController < ActionController::Base
     CurrentAttributes.save_user_attributes(current_user)
   end
 
-  def log_credential_action(credential_type, action)
+  def log_credential_action(credential_type, dpc_api_credential_id, action)
     log = CredentialAuditLog.new(user: current_user,
                                  credential_type:,
-                                 provider_organization: @organization,
+                                 dpc_api_credential_id:,
                                  action:)
     return if log.save
 
-    logger.error(['CredentialAuditLog failure', { action:, credential_type:, org: @organization.id }])
+    logger.error(['CredentialAuditLog failure', { action:, credential_type:, dpc_api_credential_id: }])
   end
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -96,6 +96,6 @@ class ApplicationController < ActionController::Base
                                  action:)
     return if log.save
 
-    logger.error("CredentialAuditLog failure: unable to #{action} #{credential_type} for #{@organization.id}")
+    logger.error(['CredentialAuditLog failure', { action:, credential_type:, org: @organization.id }])
   end
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -89,7 +89,7 @@ class ApplicationController < ActionController::Base
                                     action:)
     return if log.valid?
 
-    logger.error("Unable to create client token CredentialAuditLog #{action} on #{token_id}")
+    logger.error("CredentialAuditLog failure: unable to #{action} #{credential_type} #{token_id}")
   end
 
 end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -89,7 +89,6 @@ class ApplicationController < ActionController::Base
                                     action:)
     return if log.valid?
 
-    logger.error("CredentialAuditLog failure: unable to #{action} #{credential_type} #{token_id}")
+    logger.error("CredentialAuditLog failure: unable to #{action} #{credential_type} #{dpc_api_credential_id}")
   end
-
 end

--- a/dpc-portal/app/controllers/client_tokens_controller.rb
+++ b/dpc-portal/app/controllers/client_tokens_controller.rb
@@ -18,10 +18,10 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if manager.create_client_token(label: params[:label])
       @client_token = manager.client_token
-      log_credential_action(:client_token, :add)
+      log_credential_action(:client_token, @client_token['id'], :add)
       render(Page::ClientToken::ShowTokenComponent.new(@organization, @client_token))
     else
-      logger.error(['Unable to create client token', JSON.parse(manager.client_token || '{}')])
+      log_create_failure(manager)
       render_error 'Client token could not be created.'
     end
   end
@@ -30,7 +30,7 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if manager.delete_client_token(id: params[:id])
       flash[:notice] = 'Client token successfully deleted.'
-      log_credential_action(:client_token, :remove)
+      log_credential_action(:client_token, params[:id], :remove)
     else
       flash[:alert] = 'Client token could not be deleted.'
     end
@@ -46,5 +46,9 @@ class ClientTokensController < ApplicationController
   def render_error(msg)
     flash.now.alert = msg
     render Page::ClientToken::NewTokenComponent.new(@organization)
+  end
+
+  def log_create_failure(manager)
+    logger.error(['Unable to create client token', JSON.parse(manager.client_token || '{}')])
   end
 end

--- a/dpc-portal/app/controllers/client_tokens_controller.rb
+++ b/dpc-portal/app/controllers/client_tokens_controller.rb
@@ -13,14 +13,15 @@ class ClientTokensController < ApplicationController
   end
 
   def create
+    return render_error 'Label required.' unless params_present?
+
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
-    if params_present? && manager.create_client_token(label: params[:label])
+    if manager.create_client_token(label: params[:label])
       @client_token = manager.client_token
       log_credential_action(:client_token, :add)
       render(Page::ClientToken::ShowTokenComponent.new(@organization, @client_token))
     else
-      return render_error 'Label required.' unless params_present?
-
+      logger.error(['Unable to create client token', JSON.parse(manager.client_token || '{}')])
       render_error 'Client token could not be created.'
     end
   end

--- a/dpc-portal/app/controllers/client_tokens_controller.rb
+++ b/dpc-portal/app/controllers/client_tokens_controller.rb
@@ -16,7 +16,7 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if params_present? && manager.create_client_token(label: params[:label])
       @client_token = manager.client_token
-      log_credential_action(:client_token, @client_token['id'], :add)
+      log_credential_action(:client_token, :add)
       render(Page::ClientToken::ShowTokenComponent.new(@organization, @client_token))
     else
       return render_error 'Label required.' unless params_present?
@@ -29,7 +29,7 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if manager.delete_client_token(id: params[:id])
       flash[:notice] = 'Client token successfully deleted.'
-      log_credential_action(:client_token, params[:id], :remove)
+      log_credential_action(:client_token, :remove)
     else
       flash[:alert] = 'Client token could not be deleted.'
     end

--- a/dpc-portal/app/controllers/client_tokens_controller.rb
+++ b/dpc-portal/app/controllers/client_tokens_controller.rb
@@ -16,7 +16,7 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if params_present? && manager.create_client_token(label: params[:label])
       @client_token = manager.client_token
-      log_action(@client_token['id'], 'add')
+      log_credential_action(:client_token, @client_token['id'], :add)
       render(Page::ClientToken::ShowTokenComponent.new(@organization, @client_token))
     else
       return render_error 'Label required.' unless params_present?
@@ -29,7 +29,7 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if manager.delete_client_token(id: params[:id])
       flash[:notice] = 'Client token successfully deleted.'
-      log_action(params[:id], 'remove')
+      log_credential_action(:client_token, params[:id], :remove)
     else
       flash[:alert] = 'Client token could not be deleted.'
     end
@@ -37,16 +37,6 @@ class ClientTokensController < ApplicationController
   end
 
   private
-
-  def log_action(token_id, action)
-    log = CredentialAuditLog.create(user: current_user,
-                                    credential_type: :client_token,
-                                    dpc_api_credential_id: token_id,
-                                    action:)
-    return if log.valid?
-
-    logger.error("Unable to create client token CredentialAuditLog #{action} on #{token_id}")
-  end
 
   def params_present?
     params[:label].present?

--- a/dpc-portal/app/controllers/client_tokens_controller.rb
+++ b/dpc-portal/app/controllers/client_tokens_controller.rb
@@ -16,6 +16,7 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if params_present? && manager.create_client_token(label: params[:label])
       @client_token = manager.client_token
+      log_action(@client_token['id'], 'add')
       render(Page::ClientToken::ShowTokenComponent.new(@organization, @client_token))
     else
       return render_error 'Label required.' unless params_present?
@@ -28,6 +29,7 @@ class ClientTokensController < ApplicationController
     manager = ClientTokenManager.new(@organization.dpc_api_organization_id)
     if manager.delete_client_token(id: params[:id])
       flash[:notice] = 'Client token successfully deleted.'
+      log_action(params[:id], 'remove')
     else
       flash[:alert] = 'Client token could not be deleted.'
     end
@@ -35,6 +37,16 @@ class ClientTokensController < ApplicationController
   end
 
   private
+
+  def log_action(token_id, action)
+    log = CredentialAuditLog.create(user: current_user,
+                                    credential_type: :client_token,
+                                    dpc_api_credential_id: token_id,
+                                    action:)
+    return if log.valid?
+
+    logger.error("Unable to create client token CredentialAuditLog #{action} on #{token_id}")
+  end
 
   def params_present?
     params[:label].present?

--- a/dpc-portal/app/controllers/ip_addresses_controller.rb
+++ b/dpc-portal/app/controllers/ip_addresses_controller.rb
@@ -17,7 +17,7 @@ class IpAddressesController < ApplicationController
     manager = IpAddressManager.new(@organization.dpc_api_organization_id)
     new_ip_address = manager.create_ip_address(ip_address: params[:ip_address], label: params[:label])
     if new_ip_address[:response]
-      log_credential_action(:ip_address, :add)
+      log_credential_action(:ip_address, new_ip_address.dig(:message, 'id'), :add)
       flash[:notice] = 'IP address successfully created.'
       redirect_to organization_path(@organization)
     else
@@ -30,7 +30,7 @@ class IpAddressesController < ApplicationController
     manager = IpAddressManager.new(@organization.dpc_api_organization_id)
     if manager.delete_ip_address(params)
       flash[:notice] = 'IP address successfully deleted.'
-      log_credential_action(:ip_address, :remove)
+      log_credential_action(:ip_address, params[:id], :remove)
     else
       flash[:alert] = "IP address could not be deleted: #{manager.errors.join(', ')}."
     end

--- a/dpc-portal/app/controllers/ip_addresses_controller.rb
+++ b/dpc-portal/app/controllers/ip_addresses_controller.rb
@@ -17,7 +17,7 @@ class IpAddressesController < ApplicationController
     manager = IpAddressManager.new(@organization.dpc_api_organization_id)
     new_ip_address = manager.create_ip_address(ip_address: params[:ip_address], label: params[:label])
     if new_ip_address[:response]
-      log_credential_action(:ip_address, new_ip_address.dig(:message, 'id'), :add)
+      log_credential_action(:ip_address, :add)
       flash[:notice] = 'IP address successfully created.'
       redirect_to organization_path(@organization)
     else
@@ -30,7 +30,7 @@ class IpAddressesController < ApplicationController
     manager = IpAddressManager.new(@organization.dpc_api_organization_id)
     if manager.delete_ip_address(params)
       flash[:notice] = 'IP address successfully deleted.'
-      log_credential_action(:ip_address, params[:id], :remove)
+      log_credential_action(:ip_address, :remove)
     else
       flash[:alert] = "IP address could not be deleted: #{manager.errors.join(', ')}."
     end

--- a/dpc-portal/app/controllers/ip_addresses_controller.rb
+++ b/dpc-portal/app/controllers/ip_addresses_controller.rb
@@ -17,6 +17,7 @@ class IpAddressesController < ApplicationController
     manager = IpAddressManager.new(@organization.dpc_api_organization_id)
     new_ip_address = manager.create_ip_address(ip_address: params[:ip_address], label: params[:label])
     if new_ip_address[:response]
+      log_credential_action(:ip_address, new_ip_address.dig(:message, 'id'), :add)
       flash[:notice] = 'IP address successfully created.'
       redirect_to organization_path(@organization)
     else
@@ -29,6 +30,7 @@ class IpAddressesController < ApplicationController
     manager = IpAddressManager.new(@organization.dpc_api_organization_id)
     if manager.delete_ip_address(params)
       flash[:notice] = 'IP address successfully deleted.'
+      log_credential_action(:ip_address, params[:id], :remove)
     else
       flash[:alert] = "IP address could not be deleted: #{manager.errors.join(', ')}."
     end

--- a/dpc-portal/app/controllers/public_keys_controller.rb
+++ b/dpc-portal/app/controllers/public_keys_controller.rb
@@ -26,7 +26,7 @@ class PublicKeysController < ApplicationController
     )
 
     if new_public_key[:response]
-      log_credential_action(:public_key, new_public_key.dig(:message, 'id'), :add)
+      log_credential_action(:public_key, :add)
       flash[:notice] = 'Public key successfully created.'
       redirect_to organization_path(@organization)
     else
@@ -38,7 +38,7 @@ class PublicKeysController < ApplicationController
   def destroy
     manager = PublicKeyManager.new(@organization.dpc_api_organization_id)
     if manager.delete_public_key(params)
-      log_credential_action(:public_key, params[:id], :remove)
+      log_credential_action(:public_key, :remove)
       flash[:notice] = 'Public key successfully deleted.'
       redirect_to organization_path(@organization)
     else

--- a/dpc-portal/app/controllers/public_keys_controller.rb
+++ b/dpc-portal/app/controllers/public_keys_controller.rb
@@ -26,7 +26,7 @@ class PublicKeysController < ApplicationController
     )
 
     if new_public_key[:response]
-      log_credential_action(:public_key, :add)
+      log_credential_action(:public_key, new_public_key.dig(:message, 'id'), :add)
       flash[:notice] = 'Public key successfully created.'
       redirect_to organization_path(@organization)
     else
@@ -38,7 +38,7 @@ class PublicKeysController < ApplicationController
   def destroy
     manager = PublicKeyManager.new(@organization.dpc_api_organization_id)
     if manager.delete_public_key(params)
-      log_credential_action(:public_key, :remove)
+      log_credential_action(:public_key, params[:id], :remove)
       flash[:notice] = 'Public key successfully deleted.'
       redirect_to organization_path(@organization)
     else

--- a/dpc-portal/app/controllers/public_keys_controller.rb
+++ b/dpc-portal/app/controllers/public_keys_controller.rb
@@ -26,6 +26,7 @@ class PublicKeysController < ApplicationController
     )
 
     if new_public_key[:response]
+      log_credential_action(:public_key, new_public_key.dig(:message, 'id'), :add)
       flash[:notice] = 'Public key successfully created.'
       redirect_to organization_path(@organization)
     else
@@ -37,6 +38,7 @@ class PublicKeysController < ApplicationController
   def destroy
     manager = PublicKeyManager.new(@organization.dpc_api_organization_id)
     if manager.delete_public_key(params)
+      log_credential_action(:public_key, params[:id], :remove)
       flash[:notice] = 'Public key successfully deleted.'
       redirect_to organization_path(@organization)
     else

--- a/dpc-portal/app/models/credential_audit_log.rb
+++ b/dpc-portal/app/models/credential_audit_log.rb
@@ -2,9 +2,10 @@
 
 # Record of an action on a credential type
 class CredentialAuditLog < ApplicationRecord
-  validates_presence_of %i[credential_type dpc_api_credential_id action]
+  validates_presence_of %i[credential_type action]
   enum credential_type: %i[client_token ip_address public_key]
   enum action: %i[add remove]
 
-  belongs_to :user
+  belongs_to :user, optional: true
+  belongs_to :provider_organization
 end

--- a/dpc-portal/app/models/credential_audit_log.rb
+++ b/dpc-portal/app/models/credential_audit_log.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Record of an action on a credential type
+class CredentialAuditLog < ApplicationRecord
+  validates_presence_of %i[credential_type dpc_api_credential_id action]
+  enum credential_type: %i[client_token ip_address public_key]
+  enum action: %i[add remove]
+
+  belongs_to :user
+end

--- a/dpc-portal/app/models/credential_audit_log.rb
+++ b/dpc-portal/app/models/credential_audit_log.rb
@@ -2,10 +2,10 @@
 
 # Record of an action on a credential type
 class CredentialAuditLog < ApplicationRecord
-  validates_presence_of %i[credential_type action]
+  validates_presence_of %i[credential_type dpc_api_credential_id action]
   enum credential_type: %i[client_token ip_address public_key]
   enum action: %i[add remove]
 
+  # Optional because can be deleted when provider organization disabled
   belongs_to :user, optional: true
-  belongs_to :provider_organization
 end

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -15,7 +15,6 @@ class ProviderOrganization < ApplicationRecord
 
   has_many :ao_org_links
   has_many :cd_org_links
-  has_many :credential_audit_logs
 
   after_update :disable_rejected
 
@@ -68,10 +67,10 @@ class ProviderOrganization < ApplicationRecord
     ctm.client_tokens.each do |token|
       ctm.delete_client_token(token.with_indifferent_access)
       next if CredentialAuditLog.create(credential_type: :client_token,
-                                        provider_organization: self,
+                                        dpc_api_credential_id: token['id'],
                                         action: :remove)
 
-      logger.error("CredentialAuditLog failure: unable to remove client token for #{id}")
+      logger.error("CredentialAuditLog failure: unable to remove client token for #{token['id']}")
     end
   end
 end

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -15,6 +15,7 @@ class ProviderOrganization < ApplicationRecord
 
   has_many :ao_org_links
   has_many :cd_org_links
+  has_many :credential_audit_logs
 
   after_update :disable_rejected
 
@@ -66,6 +67,11 @@ class ProviderOrganization < ApplicationRecord
     ctm = ClientTokenManager.new(dpc_api_organization_id)
     ctm.client_tokens.each do |token|
       ctm.delete_client_token(token.with_indifferent_access)
+      next if CredentialAuditLog.create(credential_type: :client_token,
+                                        provider_organization: self,
+                                        action: :remove)
+
+      logger.error("CredentialAuditLog failure: unable to remove client token for #{id}")
     end
   end
 end

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -70,7 +70,8 @@ class ProviderOrganization < ApplicationRecord
                                         dpc_api_credential_id: token['id'],
                                         action: :remove)
 
-      logger.error("CredentialAuditLog failure: unable to remove client token for #{token['id']}")
+      logger.error(['CredentialAuditLog failure',
+                    { action: :remove, credential_type: :client_token, dpc_api_credential_id: token['id'] }])
     end
   end
 end

--- a/dpc-portal/config/initializers/lograge.rb
+++ b/dpc-portal/config/initializers/lograge.rb
@@ -2,7 +2,7 @@
 
 Rails.application.configure do
   config.lograge.enabled = true
-  config.lograge.logger = ActiveSupport::Logger.new(STDOUT)
+  config.lograge.logger = ActiveSupport::Logger.new(STDOUT) unless ENV['DISABLE_JSON_LOGGER'] == 'true'
   config.lograge.formatter = Lograge::Formatters::Json.new
 
   config.lograge.custom_options = lambda do |event|

--- a/dpc-portal/db/migrate/20240620201824_create_credential_audit_logs.rb
+++ b/dpc-portal/db/migrate/20240620201824_create_credential_audit_logs.rb
@@ -1,0 +1,11 @@
+class CreateCredentialAuditLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :credential_audit_logs do |t|
+      t.bigint :user_id, null: false
+      t.integer :credential_type, null: false
+      t.string :dpc_api_credential_id, null: false
+      t.integer :action, null: false
+      t.timestamps
+    end
+  end
+end

--- a/dpc-portal/db/migrate/20240620201824_create_credential_audit_logs.rb
+++ b/dpc-portal/db/migrate/20240620201824_create_credential_audit_logs.rb
@@ -2,12 +2,12 @@ class CreateCredentialAuditLogs < ActiveRecord::Migration[7.1]
   def change
     create_table :credential_audit_logs do |t|
       t.bigint :user_id
-      t.bigint :provider_organization_id, null: false
+      t.string :dpc_api_credential_id, null: false
       t.integer :credential_type, null: false
       t.integer :action, null: false
       t.timestamps
       t.index :user_id
-      t.index :provider_organization_id
+      t.index :dpc_api_credential_id
     end
   end
 end

--- a/dpc-portal/db/migrate/20240620201824_create_credential_audit_logs.rb
+++ b/dpc-portal/db/migrate/20240620201824_create_credential_audit_logs.rb
@@ -1,11 +1,13 @@
 class CreateCredentialAuditLogs < ActiveRecord::Migration[7.1]
   def change
     create_table :credential_audit_logs do |t|
-      t.bigint :user_id, null: false
+      t.bigint :user_id
+      t.bigint :provider_organization_id, null: false
       t.integer :credential_type, null: false
-      t.string :dpc_api_credential_id, null: false
       t.integer :action, null: false
       t.timestamps
+      t.index :user_id
+      t.index :provider_organization_id
     end
   end
 end

--- a/dpc-portal/db/schema.rb
+++ b/dpc-portal/db/schema.rb
@@ -38,12 +38,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_20_201824) do
 
   create_table "credential_audit_logs", force: :cascade do |t|
     t.bigint "user_id"
-    t.bigint "provider_organization_id", null: false
+    t.string "dpc_api_credential_id", null: false
     t.integer "credential_type", null: false
     t.integer "action", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["provider_organization_id"], name: "index_credential_audit_logs_on_provider_organization_id"
+    t.index ["dpc_api_credential_id"], name: "index_credential_audit_logs_on_dpc_api_credential_id"
     t.index ["user_id"], name: "index_credential_audit_logs_on_user_id"
   end
 

--- a/dpc-portal/db/schema.rb
+++ b/dpc-portal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_29_162554) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_20_201824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_29_162554) do
     t.integer "provider_organization_id", null: false
     t.integer "invitation_id", null: false
     t.datetime "disabled_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "credential_audit_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.integer "credential_type", null: false
+    t.string "dpc_api_credential_id", null: false
+    t.integer "action", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/dpc-portal/db/schema.rb
+++ b/dpc-portal/db/schema.rb
@@ -37,12 +37,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_20_201824) do
   end
 
   create_table "credential_audit_logs", force: :cascade do |t|
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
+    t.bigint "provider_organization_id", null: false
     t.integer "credential_type", null: false
-    t.string "dpc_api_credential_id", null: false
     t.integer "action", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["provider_organization_id"], name: "index_credential_audit_logs_on_provider_organization_id"
+    t.index ["user_id"], name: "index_credential_audit_logs_on_user_id"
   end
 
   create_table "invitations", force: :cascade do |t|

--- a/dpc-portal/spec/components/core/table/row_component_spec.rb
+++ b/dpc-portal/spec/components/core/table/row_component_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Core::Table::RowComponent, type: :component do
     end
 
     context 'with date' do
-      let(:obj) { { 'a' => '2023-12-12 18:58', 'b' => 'Second' } }
+      let(:obj) { { 'a' => '2023-12-12T18:58:27.867', 'b' => 'Second' } }
       let(:expected_html) do
         <<~HTML
           <tbody>

--- a/dpc-portal/spec/factories/credential_audit_logs.rb
+++ b/dpc-portal/spec/factories/credential_audit_logs.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :credential_audit_log do
     user { build(:user) }
     credential_type { :client_token }
-    dpc_api_credential_id { SecureRandom.uuid }
+    provider_organization { build(:provider_organization) }
     action { :add }
   end
 end

--- a/dpc-portal/spec/factories/credential_audit_logs.rb
+++ b/dpc-portal/spec/factories/credential_audit_logs.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :credential_audit_log do
     user { build(:user) }
+    dpc_api_credential_id { SecureRandom.uuid }
     credential_type { :client_token }
-    provider_organization { build(:provider_organization) }
     action { :add }
   end
 end

--- a/dpc-portal/spec/factories/credential_audit_logs.rb
+++ b/dpc-portal/spec/factories/credential_audit_logs.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :credential_audit_log do
+    user { build(:user) }
+    credential_type { :client_token }
+    dpc_api_credential_id { SecureRandom.uuid }
+    action { :add }
+  end
+end

--- a/dpc-portal/spec/models/credential_audit_log_spec.rb
+++ b/dpc-portal/spec/models/credential_audit_log_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CredentialAuditLog, type: :model do
+  context :validations do
+    let(:log) { build(:credential_audit_log) }
+    it 'should pass with factory' do
+      expect(log).to be_valid
+    end
+
+    it 'fails if no user' do
+      log.user = nil
+      expect(log).to_not be_valid
+      expect(log.errors.size).to eq(1), log.errors.inspect
+      expect(log.errors[:user]).to eq ['must exist']
+    end
+
+    it 'fails if no credential type' do
+      log.credential_type = nil
+      expect(log).to_not be_valid
+      expect(log.errors.size).to eq(1), log.errors.inspect
+      expect(log.errors[:credential_type]).to eq ["can't be blank"]
+    end
+
+    it 'fails on invalid credential type' do
+      expect do
+        log.credential_type = :wasp_compliant
+      end.to raise_error(ArgumentError)
+    end
+
+    it 'fails if no dpc_api_credential_id' do
+      log.dpc_api_credential_id = nil
+      expect(log).to_not be_valid
+      expect(log.errors.size).to eq(1), log.errors.inspect
+      expect(log.errors[:dpc_api_credential_id]).to eq ["can't be blank"]
+    end
+
+    it 'fails if no action' do
+      log.action = nil
+      expect(log).to_not be_valid
+      expect(log.errors.size).to eq(1), log.errors.inspect
+      expect(log.errors[:action]).to eq ["can't be blank"]
+    end
+
+    it 'fails on invalid action' do
+      expect do
+        log.action = :finagle
+      end.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/dpc-portal/spec/models/credential_audit_log_spec.rb
+++ b/dpc-portal/spec/models/credential_audit_log_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe CredentialAuditLog, type: :model do
       end.to raise_error(ArgumentError)
     end
 
-    it 'fails if no provider organization' do
-      log.provider_organization = nil
+    it 'fails if no credential_id' do
+      log.dpc_api_credential_id = nil
       expect(log).to_not be_valid
       expect(log.errors.size).to eq(1), log.errors.inspect
-      expect(log.errors[:provider_organization]).to eq(['must exist'])
+      expect(log.errors[:dpc_api_credential_id]).to eq ["can't be blank"]
     end
 
     it 'fails if no action' do

--- a/dpc-portal/spec/models/credential_audit_log_spec.rb
+++ b/dpc-portal/spec/models/credential_audit_log_spec.rb
@@ -9,11 +9,9 @@ RSpec.describe CredentialAuditLog, type: :model do
       expect(log).to be_valid
     end
 
-    it 'fails if no user' do
+    it 'fail not fail if no user' do
       log.user = nil
-      expect(log).to_not be_valid
-      expect(log.errors.size).to eq(1), log.errors.inspect
-      expect(log.errors[:user]).to eq ['must exist']
+      expect(log).to be_valid
     end
 
     it 'fails if no credential type' do
@@ -29,11 +27,11 @@ RSpec.describe CredentialAuditLog, type: :model do
       end.to raise_error(ArgumentError)
     end
 
-    it 'fails if no dpc_api_credential_id' do
-      log.dpc_api_credential_id = nil
+    it 'fails if no provider organization' do
+      log.provider_organization = nil
       expect(log).to_not be_valid
       expect(log.errors.size).to eq(1), log.errors.inspect
-      expect(log.errors[:dpc_api_credential_id]).to eq ["can't be blank"]
+      expect(log.errors[:provider_organization]).to eq(['must exist'])
     end
 
     it 'fails if no action' do

--- a/dpc-portal/spec/models/provider_organization_spec.rb
+++ b/dpc-portal/spec/models/provider_organization_spec.rb
@@ -101,8 +101,9 @@ RSpec.describe ProviderOrganization, type: :model do
       expect do
         po.save
       end.to change { CredentialAuditLog.count }.by 2
-      expect(po.credential_audit_logs.count).to eq 2
-      po.credential_audit_logs.each { |log| expect(log.action).to eq 'remove' }
+      tokens.each do |token|
+        expect(CredentialAuditLog.where(dpc_api_credential_id: token['id'], action: 'remove')).to exist
+      end
     end
   end
 end

--- a/dpc-portal/spec/models/provider_organization_spec.rb
+++ b/dpc-portal/spec/models/provider_organization_spec.rb
@@ -91,14 +91,18 @@ RSpec.describe ProviderOrganization, type: :model do
 
   describe 'disable_rejected' do
     it 'should delete client tokens' do
-      po = create(:provider_organization, dpc_api_organization_id: 1, verification_status: :approved)
+      po = create(:provider_organization, dpc_api_organization_id: SecureRandom.uuid, verification_status: :approved)
       po.save
       tokens = [{ 'id' => 'abcdef' }, { 'id' => 'ftguiol' }]
       allow(mock_ctm).to receive(:client_tokens).and_return(tokens)
       expect(mock_ctm).to receive(:delete_client_token).with(tokens[0])
       expect(mock_ctm).to receive(:delete_client_token).with(tokens[1])
       po.verification_status = :rejected
-      po.save
+      expect do
+        po.save
+      end.to change { CredentialAuditLog.count }.by 2
+      expect(po.credential_audit_logs.count).to eq 2
+      po.credential_audit_logs.each { |log| expect(log.action).to eq 'remove' }
     end
   end
 end

--- a/dpc-portal/spec/requests/client_tokens_spec.rb
+++ b/dpc-portal/spec/requests/client_tokens_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe 'ClientTokens', type: :request do
   let(:terms_of_service_accepted_by) { create(:user) }
 
   describe 'common behavior' do
+    let(:create_params) { { label: 'New Token' } }
     let(:credential) { 'client_token' }
-    it_behaves_like "a credential resource"
+    it_behaves_like 'a credential resource'
   end
 
   describe 'GET /new' do

--- a/dpc-portal/spec/requests/client_tokens_spec.rb
+++ b/dpc-portal/spec/requests/client_tokens_spec.rb
@@ -8,10 +8,9 @@ RSpec.describe 'ClientTokens', type: :request do
 
   let(:terms_of_service_accepted_by) { create(:user) }
 
-  describe 'common behavior' do
+  it_behaves_like 'a credential resource' do
     let(:create_params) { { label: 'New Token' } }
     let(:credential) { 'client_token' }
-    it_behaves_like 'a credential resource'
   end
 
   describe 'GET /new' do

--- a/dpc-portal/spec/requests/client_tokens_spec.rb
+++ b/dpc-portal/spec/requests/client_tokens_spec.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/credential_resource_shared_examples'
 
 RSpec.describe 'ClientTokens', type: :request do
   include DpcClientSupport
 
   let(:terms_of_service_accepted_by) { create(:user) }
+
+  describe 'common behavior' do
+    let(:credential) { 'client_token' }
+    it_behaves_like "a credential resource"
+  end
+
   describe 'GET /new' do
     context 'not logged in' do
       it 'redirects to login' do
@@ -176,33 +183,10 @@ RSpec.describe 'ClientTokens', type: :request do
         expect(assigns(:client_token)['id']).to eq token_guid
       end
 
-      it 'adds a credential audit log record on success' do
-        token_guid = SecureRandom.uuid
-        api_client = stub_api_client(message: :get_organization,
-                                     response: default_get_org_response(org_api_id))
-        stub_self_returning_api_client(message: :create_client_token,
-                                       response: default_get_client_tokens(guid: token_guid)['entities'].first,
-                                       api_client:)
-        expect do
-          post "/organizations/#{org.id}/client_tokens", params: { label: 'New Token' }
-        end.to change { CredentialAuditLog.count }.by 1
-        log = CredentialAuditLog.last
-        expect(log.user).to eq user
-        expect(log.credential_type).to eq 'client_token'
-        expect(log.dpc_api_credential_id).to eq token_guid
-        expect(log.action).to eq 'add'
-      end
-
       it 'fails if no label' do
         post "/organizations/#{org.id}/client_tokens"
         expect(assigns(:organization)).to eq org
         expect(flash[:alert]).to eq('Label required.')
-      end
-
-      it 'does not add a credential audit log record on failure' do
-        expect do
-          post "/organizations/#{org.id}/client_tokens"
-        end.to change { CredentialAuditLog.count }.by 0
       end
 
       it 'shows error if problem' do
@@ -249,24 +233,6 @@ RSpec.describe 'ClientTokens', type: :request do
         expect(response).to redirect_to(organization_path(org.id))
       end
 
-      it 'adds a credential audit log record on success' do
-        token_guid = SecureRandom.uuid
-        api_client = stub_api_client(message: :get_organization,
-                                     response: default_get_org_response(org_api_id))
-        stub_self_returning_api_client(message: :delete_client_token,
-                                       response: nil,
-                                       with: [org_api_id, token_guid],
-                                       api_client:)
-        expect do
-          delete "/organizations/#{org.id}/client_tokens/#{token_guid}"
-        end.to change { CredentialAuditLog.count }.by 1
-        log = CredentialAuditLog.last
-        expect(log.user).to eq user
-        expect(log.credential_type).to eq 'client_token'
-        expect(log.dpc_api_credential_id).to eq token_guid
-        expect(log.action).to eq 'remove'
-      end
-
       it 'renders error if error' do
         token_guid = SecureRandom.uuid
         api_client = stub_api_client(message: :get_organization,
@@ -279,20 +245,6 @@ RSpec.describe 'ClientTokens', type: :request do
         delete "/organizations/#{org.id}/client_tokens/#{token_guid}"
         expect(flash[:alert]).to eq('Client token could not be deleted.')
         expect(response).to redirect_to(organization_path(org.id))
-      end
-
-      it 'does not add a credential audit log record on failure' do
-        token_guid = SecureRandom.uuid
-        api_client = stub_api_client(message: :get_organization,
-                                     response: default_get_org_response(org_api_id))
-        stub_self_returning_api_client(message: :delete_client_token,
-                                       response: nil,
-                                       success: false,
-                                       with: [org_api_id, token_guid],
-                                       api_client:)
-        expect do
-          delete "/organizations/#{org.id}/client_tokens/#{token_guid}"
-        end.to change { CredentialAuditLog.count }.by 0
       end
     end
   end

--- a/dpc-portal/spec/requests/ip_addresses_spec.rb
+++ b/dpc-portal/spec/requests/ip_addresses_spec.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/credential_resource_shared_examples'
 
 RSpec.describe 'IpAddresses', type: :request do
   include DpcClientSupport
 
   let(:terms_of_service_accepted_by) { create(:user) }
+
+  describe 'common behavior' do
+    let(:credential) { 'ip_address' }
+    let(:create_params) { { label: 'Public IP 1', ip_address: '136.226.19.87' } }
+    it_behaves_like 'a credential resource'
+  end
+
   describe 'GET /new' do
     context 'not logged in' do
       it 'redirects to login' do

--- a/dpc-portal/spec/requests/ip_addresses_spec.rb
+++ b/dpc-portal/spec/requests/ip_addresses_spec.rb
@@ -8,10 +8,9 @@ RSpec.describe 'IpAddresses', type: :request do
 
   let(:terms_of_service_accepted_by) { create(:user) }
 
-  describe 'common behavior' do
+  it_behaves_like 'a credential resource' do
     let(:credential) { 'ip_address' }
     let(:create_params) { { label: 'Public IP 1', ip_address: '136.226.19.87' } }
-    it_behaves_like 'a credential resource'
   end
 
   describe 'GET /new' do

--- a/dpc-portal/spec/requests/public_keys_spec.rb
+++ b/dpc-portal/spec/requests/public_keys_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe 'PublicKeys', type: :request do
         api_client = stub_api_client(message: :get_organization,
                                      response: default_get_org_response(org_api_id))
         stub_self_returning_api_client(message: :create_public_key,
-                                       response: default_get_public_keys,
+                                       response: default_get_public_keys['entities'].first,
                                        api_client:)
         post "/organizations/#{org.id}/public_keys", params: {
           label: 'New Key',

--- a/dpc-portal/spec/requests/public_keys_spec.rb
+++ b/dpc-portal/spec/requests/public_keys_spec.rb
@@ -8,14 +8,13 @@ RSpec.describe 'PublicKeys', type: :request do
 
   let(:terms_of_service_accepted_by) { create(:user) }
 
-  describe 'common behavior' do
+  it_behaves_like 'a credential resource' do
     let(:create_params) do
       { label: 'New Key',
         public_key: file_fixture('stubbed_key.pem').read,
         snippet_signature: 'test snippet signature' }
     end
     let(:credential) { 'public_key' }
-    it_behaves_like 'a credential resource'
   end
 
   describe 'GET /new' do

--- a/dpc-portal/spec/requests/public_keys_spec.rb
+++ b/dpc-portal/spec/requests/public_keys_spec.rb
@@ -1,11 +1,23 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'support/credential_resource_shared_examples'
 
 RSpec.describe 'PublicKeys', type: :request do
   include DpcClientSupport
 
   let(:terms_of_service_accepted_by) { create(:user) }
+
+  describe 'common behavior' do
+    let(:create_params) do
+      { label: 'New Key',
+        public_key: file_fixture('stubbed_key.pem').read,
+        snippet_signature: 'test snippet signature' }
+    end
+    let(:credential) { 'public_key' }
+    it_behaves_like 'a credential resource'
+  end
+
   describe 'GET /new' do
     context 'not logged in' do
       it 'redirects to login' do

--- a/dpc-portal/spec/support/component_support.rb
+++ b/dpc-portal/spec/support/component_support.rb
@@ -10,8 +10,8 @@ module ComponentSupport
       @name = 'Health'
       @npi = '11111'
       @row_count = row_count
-      @created = '2023-12-15 17:01'
-      @expires = '2023-12-16 17:01'
+      @created = '2023-12-15T17:01:01'
+      @expires = '2023-12-16T17:01:01'
       @guid = '99790463-de1f-4f7f-a529-3e4f59dc713'
     end
 

--- a/dpc-portal/spec/support/credential_resource_shared_examples.rb
+++ b/dpc-portal/spec/support/credential_resource_shared_examples.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples 'a credential resource' do
         log = CredentialAuditLog.last
         expect(log.user).to eq user
         expect(log.credential_type).to eq credential
-        expect(log.provider_organization).to eq org
+        expect(log.dpc_api_credential_id).to eq token_guid
         expect(log.action).to eq 'add'
       end
 
@@ -64,7 +64,7 @@ RSpec.shared_examples 'a credential resource' do
         log = CredentialAuditLog.last
         expect(log.user).to eq user
         expect(log.credential_type).to eq credential
-        expect(log.provider_organization).to eq org
+        expect(log.dpc_api_credential_id).to eq token_guid
         expect(log.action).to eq 'remove'
       end
 

--- a/dpc-portal/spec/support/credential_resource_shared_examples.rb
+++ b/dpc-portal/spec/support/credential_resource_shared_examples.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples 'a credential resource' do
         log = CredentialAuditLog.last
         expect(log.user).to eq user
         expect(log.credential_type).to eq credential
-        expect(log.dpc_api_credential_id).to eq token_guid
+        expect(log.provider_organization).to eq org
         expect(log.action).to eq 'add'
       end
 
@@ -64,7 +64,7 @@ RSpec.shared_examples 'a credential resource' do
         log = CredentialAuditLog.last
         expect(log.user).to eq user
         expect(log.credential_type).to eq credential
-        expect(log.dpc_api_credential_id).to eq token_guid
+        expect(log.provider_organization).to eq org
         expect(log.action).to eq 'remove'
       end
 

--- a/dpc-portal/spec/support/credential_resource_shared_examples.rb
+++ b/dpc-portal/spec/support/credential_resource_shared_examples.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-RSpec.shared_examples "a credential resource" do
+RSpec.shared_examples 'a credential resource' do
   describe 'Post /create' do
     context 'as cd' do
       let!(:user) { create(:user) }
@@ -16,10 +18,11 @@ RSpec.shared_examples "a credential resource" do
         api_client = stub_api_client(message: :get_organization,
                                      response: default_get_org_response(org_api_id))
         stub_self_returning_api_client(message: "create_#{credential}",
-                                       response: send("default_get_#{credential.pluralize}", guid: token_guid)['entities'].first,
+                                       response: send("default_get_#{credential.pluralize}",
+                                                      guid: token_guid)['entities'].first,
                                        api_client:)
         expect do
-          post "/organizations/#{org.id}/#{credential.pluralize}", params: { label: 'New Token' }
+          post "/organizations/#{org.id}/#{credential.pluralize}", params: create_params
         end.to change { CredentialAuditLog.count }.by 1
         log = CredentialAuditLog.last
         expect(log.user).to eq user

--- a/dpc-portal/spec/support/credential_resource_shared_examples.rb
+++ b/dpc-portal/spec/support/credential_resource_shared_examples.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.shared_examples "a credential resource" do
+  describe 'Post /create' do
+    context 'as cd' do
+      let!(:user) { create(:user) }
+      let(:org_api_id) { SecureRandom.uuid }
+      let!(:org) { create(:provider_organization, terms_of_service_accepted_by:, dpc_api_organization_id: org_api_id) }
+
+      before do
+        create(:cd_org_link, provider_organization: org, user:)
+        sign_in user
+      end
+      it 'adds a credential audit log record on success' do
+        token_guid = SecureRandom.uuid
+        api_client = stub_api_client(message: :get_organization,
+                                     response: default_get_org_response(org_api_id))
+        stub_self_returning_api_client(message: "create_#{credential}",
+                                       response: send("default_get_#{credential.pluralize}", guid: token_guid)['entities'].first,
+                                       api_client:)
+        expect do
+          post "/organizations/#{org.id}/#{credential.pluralize}", params: { label: 'New Token' }
+        end.to change { CredentialAuditLog.count }.by 1
+        log = CredentialAuditLog.last
+        expect(log.user).to eq user
+        expect(log.credential_type).to eq credential
+        expect(log.dpc_api_credential_id).to eq token_guid
+        expect(log.action).to eq 'add'
+      end
+
+      it 'does not add a credential audit log record on failure' do
+        expect do
+          post "/organizations/#{org.id}/#{credential.pluralize}"
+        end.to change { CredentialAuditLog.count }.by 0
+      end
+    end
+  end
+
+  describe 'Delete /destroy' do
+    context 'as cd' do
+      let!(:user) { create(:user) }
+      let(:org_api_id) { SecureRandom.uuid }
+      let!(:org) { create(:provider_organization, terms_of_service_accepted_by:, dpc_api_organization_id: org_api_id) }
+
+      before do
+        create(:cd_org_link, provider_organization: org, user:)
+        sign_in user
+      end
+
+      it 'adds a credential audit log record on success' do
+        token_guid = SecureRandom.uuid
+        api_client = stub_api_client(message: :get_organization,
+                                     response: default_get_org_response(org_api_id))
+        stub_self_returning_api_client(message: "delete_#{credential}",
+                                       response: nil,
+                                       with: [org_api_id, token_guid],
+                                       api_client:)
+        expect do
+          delete "/organizations/#{org.id}/#{credential.pluralize}/#{token_guid}"
+        end.to change { CredentialAuditLog.count }.by 1
+        log = CredentialAuditLog.last
+        expect(log.user).to eq user
+        expect(log.credential_type).to eq credential
+        expect(log.dpc_api_credential_id).to eq token_guid
+        expect(log.action).to eq 'remove'
+      end
+
+      it 'does not add a credential audit log record on failure' do
+        token_guid = SecureRandom.uuid
+        api_client = stub_api_client(message: :get_organization,
+                                     response: default_get_org_response(org_api_id))
+        stub_self_returning_api_client(message: "delete_#{credential}",
+                                       response: nil,
+                                       success: false,
+                                       with: [org_api_id, token_guid],
+                                       api_client:)
+        expect do
+          delete "/organizations/#{org.id}/#{credential.pluralize}/#{token_guid}"
+        end.to change { CredentialAuditLog.count }.by 0
+      end
+    end
+  end
+end

--- a/dpc-portal/spec/support/dpc_client_support.rb
+++ b/dpc-portal/spec/support/dpc_client_support.rb
@@ -54,9 +54,9 @@ koPuyOLZ4oalcqVMGJFeYpcCAwEAAQ==
          'expiresAt' => '2021-09-10T02:45:07.449+00:00' }] }
   end
 
-  def default_get_ip_addresses
+  def default_get_ip_addresses(guid: '579dd199-3c2d-48e8-8594-cec35e223527')
     { 'entities' =>
-        [{ 'id' => '579dd199-3c2d-48e8-8594-cec35e223527',
+        [{ 'id' => guid,
            'ipAddress' => '136.226.19.87',
            'createdAt' => '2020-09-10T02:30:27.526+00:00',
            'label' => 'IP address for organization 4b15098b-d53f-432d-a2f3-416a9483527b.' }] }

--- a/dpc-portal/spec/support/dpc_client_support.rb
+++ b/dpc-portal/spec/support/dpc_client_support.rb
@@ -33,9 +33,9 @@ module DpcClientSupport
     )
   end
 
-  def default_get_public_keys
+  def default_get_public_keys(guid: '579dd199-3c2d-48e8-8594-cec35e223527')
     { 'entities' =>
-      [{ 'id' => '579dd199-3c2d-48e8-8594-cec35e223527',
+      [{ 'id' => guid,
          'publicKey' =>
          "-----BEGIN PUBLIC KEY-----
 MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAyLrLpbFduLeGG7Eh2KdD


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-3823

## 🛠 Changes

- Added CredentialAuditLog model with table
- Added method to application_controller for logging changes to credentials
- Call above method in each credential controller
- Log when client tokens removed from provider organization

## ℹ️ Context

We want to have a log of all credentials managed via the portal for auditing, debugging, and supporting future enhancements.

## 🧪 Validation

Automated and manual testing.
