### PR TITLE
[DPC-4124] update mockserver version to 5.15.0

### DIFF
--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <mainClass>gov.cms.dpc.api.DPCAPIService</mainClass>
         <jjwt.version>0.11.4</jjwt.version>
-        <mockserverVersion>5.14.0</mockserverVersion>
+        <mockserverVersion>5.15.0</mockserverVersion>
     </properties>
 
     <dependencies>
@@ -209,10 +209,6 @@
             <artifactId>mockserver-netty</artifactId>
             <version>${mockserverVersion}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>

--- a/dpc-bluebutton/pom.xml
+++ b/dpc-bluebutton/pom.xml
@@ -13,7 +13,7 @@
     <name>DPC BlueButton Interaction Client</name>
 
     <properties>
-        <mockserverVersion>5.14.0</mockserverVersion>
+        <mockserverVersion>5.15.0</mockserverVersion>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4124

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context

The [previous PR failed](https://github.com/CMSgov/dpc-app/actions/runs/9602217342/job/26482573585?pr=2199) due to an inability to resolve `io/netty/handler/codec/http2/Http2Connection` during `dpc-api` unit test execution. It turns out, `io.netty` dependencies of `mockserver` were excluded only for `dpc-api`. Removing that exclusion resolves that dependency issue. 

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

- [x] unit tests pass
- [x] smoke tests pass
