### PR TITLE
DPC-4129 5 step registration flow

### DIFF
--- a/dpc-portal/app/components/core/navigation/step_indicator_component.html.erb
+++ b/dpc-portal/app/components/core/navigation/step_indicator_component.html.erb
@@ -1,0 +1,35 @@
+<div class="usa-step-indicator" aria-label="progress">
+  <ol class="usa-step-indicator__segments">
+    <% @steps.each_with_index do |step, current_index|
+    
+    if current_index < @index %>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--complete">
+      <span class="usa-step-indicator__segment-label">
+        <%= step %> <span class="usa-sr-only">completed</span></span>
+    </li>
+    <% elsif current_index > @index %>
+    <li class="usa-step-indicator__segment">
+      <span class="usa-step-indicator__segment-label">
+        <%= step %> <span class="usa-sr-only">not completed</span></span>
+    </li>
+    <% else %>
+    <li class="usa-step-indicator__segment usa-step-indicator__segment--current"
+      aria-current="true">
+      <span class="usa-step-indicator__segment-label"><%= step %></span>
+    </li>
+    <% end %>
+  <% end %>
+  </ol>
+  <% if @index < @steps.length %>
+  <div class="usa-step-indicator__header">
+    <h4 class="usa-step-indicator__heading">
+      <span class="usa-step-indicator__heading-counter">
+	<span class="usa-sr-only">Step</span>
+        <span class="usa-step-indicator__current-step"><%= @index + 1 %></span>
+        <span class="usa-step-indicator__total-steps">of <%= @steps.length %></span>
+      </span>
+      <span class="usa-step-indicator__heading-text"><%= @steps[@index] %></span>
+    </h4>
+  </div>
+  <% end %>
+</div>

--- a/dpc-portal/app/components/core/navigation/step_indicator_component.rb
+++ b/dpc-portal/app/components/core/navigation/step_indicator_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Core
+  module Navigation
+    # Step Indicator Component
+    # ----------------
+    #
+    # [Based on USWDS](https://designsystem.digital.gov/components/step-indicator/)
+    #
+    class StepIndicatorComponent < ViewComponent::Base
+      def initialize(steps, index)
+        super
+        @steps = steps
+        @index = index
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/core/navigation/step_indicator_component_preview.rb
+++ b/dpc-portal/app/components/core/navigation/step_indicator_component_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Core
+  module Navigation
+    # Step Indicator Component
+    # ----------------
+    #
+    # [Based on USWDS](https://designsystem.digital.gov/components/step-indicator/)
+    #
+    class StepIndicatorComponentPreview < ViewComponent::Preview
+      #
+      # @param steps
+      # @param index
+      def parameterized(steps: 'Step One,Step Two,Step Three', index: '1')
+        steps_a = steps.split(',')
+        index_i = index.to_i
+        render(Core::Navigation::StepIndicatorComponent.new(steps_a, index_i))
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/page/invitations/accept_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/accept_invitation_component.html.erb
@@ -1,3 +1,4 @@
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::STEPS, 1)) if @invitation.authorized_official? %>
 <div>
   <h1>Accept organization invite</h1>
   <div class="usa-alert usa-alert--info margin-bottom-4">

--- a/dpc-portal/app/components/page/invitations/accept_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/accept_invitation_component.html.erb
@@ -1,33 +1,21 @@
 <%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::STEPS, 1)) if @invitation.authorized_official? %>
 <div>
-  <h1>Accept organization invite</h1>
-  <div class="usa-alert usa-alert--info margin-bottom-4">
-    <div class="usa-alert__body">
-      <h4 class="usa-alert__heading">Key information</h4>
-      <p class="usa-alert__text">
-        <ul>
-          <li>Info one</li>
-          <li>Info two</li>
-          <li>Info three</li>
-          <li>Info four</li>
-        </ul>
-      </p>
-    </div>
-  </div>
+  <h1>Identity Verified</h1>
   <div>
     <% if @invitation.credential_delegate? %>
     <h2>Provide invite code</h2>
     <p>You are invited to <%= @organization.name %> by the Authorized Official (AO),
       <%= @invitation.invited_by&.given_name %> <%= @invitation.invited_by&.family_name %>.</p>
-    <%= form_tag confirm_organization_invitation_path(@organization, @invitation), method: :post, class: ['usa-form'], id: "cd-accept-form" do %>
+      <%= form_tag confirm_organization_invitation_path(@organization, @invitation), method: :post, class: ['usa-form'], id: "cd-accept-form" do %>
       <%= render(Core::Form::TextInputComponent.new(label: 'Enter the invite code:',
           attribute: :verification_code,
           error_msg: @invitation.errors[:verification_code]&.first,
           input_options: { maxlength: 6 })) %>
-      <%= submit_tag "Accept invite", class: "usa-button", data: { test: "form:submit" } %>
-    <% end %>
+      <%= submit_tag "Validate invite code", class: "usa-button", data: { test: "form:submit" } %>
+      <% end %>
     <% else %>
-    <%= render Core::Button::ButtonComponent.new(label: "Manage #{@organization.name}",
+    <p>Press the button below to verify that you are an authorized official for <strong><%= @organization.name %></strong>.</p>
+    <%= render Core::Button::ButtonComponent.new(label: "Verify provider organization",
 	destination: confirm_organization_invitation_path(@organization, @invitation),
 	method: :post) %>
     <% end %>

--- a/dpc-portal/app/components/page/invitations/register_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/register_component.html.erb
@@ -1,1 +1,16 @@
-<div>Add Page::Invitations::Register template here</div>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::STEPS, 2)) if @invitation.authorized_official? %>
+<div>
+  <div>
+    <% if @invitation.credential_delegate? %>
+    <h1>Invite code verified</h1>
+    <p>Press the button below to complete registration.</p>
+    <% else %>
+    <h1>Provider organization verified</h1>
+    <p>Press the button below to complete retistration for  <strong><%= @organization.name %></strong>.</p>
+    <% end %>
+    <%= render Core::Button::ButtonComponent.new(label: "Complete registration",
+	destination: register_organization_invitation_path(@organization, @invitation),
+	method: :post) %>
+  </div>
+</div>
+

--- a/dpc-portal/app/components/page/invitations/register_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/register_component.html.erb
@@ -6,7 +6,7 @@
     <p>Press the button below to complete registration.</p>
     <% else %>
     <h1>Provider organization verified</h1>
-    <p>Press the button below to complete retistration for  <strong><%= @organization.name %></strong>.</p>
+    <p>Press the button below to complete registration for  <strong><%= @organization.name %></strong>.</p>
     <% end %>
     <%= render Core::Button::ButtonComponent.new(label: "Complete registration",
 	destination: register_organization_invitation_path(@organization, @invitation),

--- a/dpc-portal/app/components/page/invitations/register_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/register_component.html.erb
@@ -1,0 +1,1 @@
+<div>Add Page::Invitations::Register template here</div>

--- a/dpc-portal/app/components/page/invitations/register_component.rb
+++ b/dpc-portal/app/components/page/invitations/register_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Page
+  module Invitations
+    # Page for registering
+    class RegisterComponent < ViewComponent::Base
+    end
+  end
+end

--- a/dpc-portal/app/components/page/invitations/register_component_preview.rb
+++ b/dpc-portal/app/components/page/invitations/register_component_preview.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Page
+  module Invitations
+    # Preview page for registering
+    class RegisterComponentPreview < ViewComponent::Preview
+      def default
+        render(Page::Invitations::RegisterComponent.new)
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/page/invitations/start_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/start_component.html.erb
@@ -1,0 +1,8 @@
+<div>
+<h1>You have been invited</h1>
+<p>This is an invitation to connect <strong><%= @organization.name %></strong> with Data at the Point of Care.</p>
+<p class="font-body-3xs">This invitation will expire in <strong><%= "#{@hours} hours and" if @hours %> <%= @minutes %> minutes</strong>.
+    <%= render Core::Button::ButtonComponent.new(label: 'Start',
+	destination: accept_organization_invitation_path(@organization, @invitation),
+	method: :get) %>
+</div>

--- a/dpc-portal/app/components/page/invitations/start_component.rb
+++ b/dpc-portal/app/components/page/invitations/start_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Page
+  module Invitations
+    # First page the user sees when accepting a valid invitation
+    class StartComponent < ViewComponent::Base
+      def initialize(organization, invitation)
+        super
+        @organization = organization
+        @invitation = invitation
+        @hours, @minutes = invitation.expires_in
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/page/invitations/start_component_preview.rb
+++ b/dpc-portal/app/components/page/invitations/start_component_preview.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Page
+  module Invitations
+    # First page the user sees when accepting a valid invitation
+    class StartComponentPreview < ViewComponent::Preview
+      def default
+        org = ProviderOrganization.new(id: 2, name: 'Health Hut')
+        invitation = Invitation.new(id: 4, invited_email: 'doug@example.com', invitation_type: :credential_delegate,
+                                    created_at: 2.hours.ago - 10.minutes)
+        render(Page::Invitations::StartComponent.new(org, invitation))
+      end
+    end
+  end
+end

--- a/dpc-portal/app/components/page/invitations/success_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/success_component.html.erb
@@ -1,0 +1,5 @@
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::STEPS, 3)) if @invitation.authorized_official? %>
+<div>
+  <h1>Registration completed</h1>
+</div>
+

--- a/dpc-portal/app/components/page/invitations/success_component.rb
+++ b/dpc-portal/app/components/page/invitations/success_component.rb
@@ -2,8 +2,8 @@
 
 module Page
   module Invitations
-    # Displays register invitation form
-    class RegisterComponent < ViewComponent::Base
+    # Displays successful registration message
+    class SuccessComponent < ViewComponent::Base
       def initialize(organization, invitation)
         super
         @organization = organization

--- a/dpc-portal/app/components/page/invitations/success_component_preview.rb
+++ b/dpc-portal/app/components/page/invitations/success_component_preview.rb
@@ -2,20 +2,20 @@
 
 module Page
   module Invitations
-    # Preview page for registering
-    class RegisterComponentPreview < ViewComponent::Preview
-      def register_cd
+    # Previews successful registration message
+    class SuccessComponentPreview < ViewComponent::Preview
+      def success_cd
         org = ProviderOrganization.new(id: 2, name: 'Health Hut')
         user = User.new(given_name: 'Robert', family_name: 'Hodges')
         invitation = Invitation.new(id: 4, invited_by: user, invitation_type: :credential_delegate)
-        render(Page::Invitations::RegisterComponent.new(org, invitation))
+        render(Page::Invitations::SuccessComponent.new(org, invitation))
       end
 
-      def register_ao
+      def success_ao
         org = ProviderOrganization.new(id: 2, name: 'Health Hut')
         user = User.new(given_name: 'Robert', family_name: 'Hodges')
         invitation = Invitation.new(id: 4, invited_by: user, invitation_type: :authorized_official)
-        render(Page::Invitations::RegisterComponent.new(org, invitation))
+        render(Page::Invitations::SuccessComponent.new(org, invitation))
       end
     end
   end

--- a/dpc-portal/app/components/page/session/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/session/invitation_login_component.html.erb
@@ -1,3 +1,4 @@
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::STEPS, 0)) if @invitation.authorized_official? %>
 <section class="usa-section">
       <h1 class="desktop:display-none font-sans-lg margin-bottom-4 tablet:margin-top-neg-3">
 	Invitation Login

--- a/dpc-portal/app/components/page/session/invitation_login_component_preview.rb
+++ b/dpc-portal/app/components/page/session/invitation_login_component_preview.rb
@@ -4,9 +4,12 @@ module Page
   module Session
     # Preview of Invitatation login (IAL/2 flow)
     class InvitationLoginComponentPreview < ViewComponent::Preview
-      def default
+      #
+      # @param for_ao toggle
+      def parameterized(for_ao: false)
         provider_organization = ProviderOrganization.new(id: 4, name: 'Health Hut')
-        invitation = Invitation.new(id: 2, provider_organization:)
+        invitation_type = for_ao ? :authorized_official : :credential_delegate
+        invitation = Invitation.new(id: 2, provider_organization:, invitation_type:)
         render(Page::Session::InvitationLoginComponent.new(invitation))
       end
     end

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -5,8 +5,12 @@ class InvitationsController < ApplicationController
   before_action :load_organization
   before_action :load_invitation
   before_action :validate_invitation, except: %i[renew]
-  before_action :authenticate_user!, except: %i[login renew]
+  before_action :authenticate_user!, except: %i[login renew show]
   before_action :invitation_matches_user, only: %i[confirm]
+
+  def show
+    render(Page::Invitations::StartComponent.new(@organization, @invitation))
+  end
 
   def accept
     if current_user.email != @invitation.invited_email

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -20,7 +20,7 @@ class InvitationsController < ApplicationController
 
   def confirm
     session["invitation_status_#{@invitation.id}"] = 'conditions_verified'
-    render(Page::Invitations::RegisterComponent.new)
+    render(Page::Invitations::RegisterComponent.new(@organization, @invitation))
   end
 
   def register
@@ -38,7 +38,7 @@ class InvitationsController < ApplicationController
                     status: :unprocessable_entity)
     end
     session.delete("invitation_status_#{@invitation.id}")
-    redirect_to organization_path(@organization)
+    render(Page::Invitations::SuccessComponent.new(@organization, @invitation))
   end
 
   def login

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -70,6 +70,13 @@ class Invitation < ApplicationRecord
     end
   end
 
+  def expires_in
+    diff = 48.hours - (Time.now - created_at).round
+    hours, seconds = diff.divmod(1.hour)
+    minutes = seconds / 1.minute
+    [hours, minutes]
+  end
+
   private
 
   def cd_match?(user_info)

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -17,6 +17,9 @@ class Invitation < ApplicationRecord
   belongs_to :provider_organization, required: true
   belongs_to :invited_by, class_name: 'User', required: false
 
+  STEPS = ['Connect with Login.gov', 'Verify your identity', 'Verify the provider organization',
+           'Complete Registration'].freeze
+
   def phone_raw=(nbr)
     @phone_raw = nbr
     self.invited_phone = @phone_raw.tr('^0-9', '')
@@ -56,8 +59,17 @@ class Invitation < ApplicationRecord
     if credential_delegate?
       cd_match?(user_info)
     elsif authorized_official?
-      ao_match?(user_info)
+      email_match?(user_info)
     end
+  end
+
+  def ao_match?(user_info)
+    service = AoVerificationService.new
+    result = service.check_eligibility(provider_organization.npi,
+                                       Digest::SHA2.new(256).hexdigest(user_info['social_security_number']))
+    raise InvitationError, result[:failure_reason] unless result[:success]
+
+    result[:success]
   end
 
   def unacceptable_reason
@@ -85,6 +97,10 @@ class Invitation < ApplicationRecord
 
     return false unless phone_match(user_info)
 
+    email_match?(user_info)
+  end
+
+  def email_match?(user_info)
     user_info['all_emails'].any? { |email| invited_email.downcase == email.downcase }
   end
 
@@ -101,15 +117,6 @@ class Invitation < ApplicationRecord
     end
   end
   # rubocop:enable Metrics/AbcSize
-
-  def ao_match?(user_info)
-    service = AoVerificationService.new
-    result = service.check_eligibility(provider_organization.npi,
-                                       Digest::SHA2.new(256).hexdigest(user_info['social_security_number']))
-    raise InvitationError, result[:failure_reason] unless result[:success]
-
-    result[:success]
-  end
 
   def cannot_cancel_accepted
     return unless status_was == 'accepted' && cancelled?

--- a/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
+++ b/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
@@ -8,7 +8,7 @@
     <h1>Dear <%= @given_name %> <%= @family_name %>,</h1>
     <p>You have been invited to exercise Authorized Official management of
       <%= @invitation.provider_organization.name %> within Data at the Point of Care.</p>
-    <p><%= link_to 'Accept this invitation', accept_organization_invitation_url(@invitation.provider_organization, @invitation) %></p>
+    <p><%= link_to 'Accept this invitation', organization_invitation_url(@invitation.provider_organization, @invitation) %></p>
     <p>Sincerely,</p>
 
     <p>The Data at the Point of Care Team</p>

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     resources :invitations, only: [:show] do
       get 'accept', on: :member
       post 'confirm', on: :member
+      post 'register', on: :member
       post 'login', on: :member
       post 'renew', on: :member
     end

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
     resources :credential_delegate_invitations, only: [:new, :create, :destroy] do
       get 'success', on: :member
     end
-    resources :invitations, only: [] do
+    resources :invitations, only: [:show] do
       get 'accept', on: :member
       post 'confirm', on: :member
       post 'login', on: :member

--- a/dpc-portal/spec/components/core/navigation/step_indicator_component_spec.rb
+++ b/dpc-portal/spec/components/core/navigation/step_indicator_component_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Core::Navigation::StepIndicatorComponent, type: :component do
+  describe 'three steps' do
+    let(:component) { described_class.new(steps, index) }
+    let(:steps) { ['Step One', 'Step Two', 'Step Three'] }
+
+    before { render_inline(component) }
+    context 'index 0' do
+      let(:index) { 0 }
+      it 'should render step content in order' do
+        expected_text = ['Step One', 'Step Two not completed', 'Step Three not completed']
+        nodes = page.all('.usa-step-indicator__segment')
+        expect(nodes.map { |node| node.text.strip }).to eq expected_text
+      end
+
+      it 'should render two not completed' do
+        nodes = page.all('.usa-step-indicator__segments .usa-sr-only')
+        expect(nodes.length).to eq 2
+        nodes.each { |node| expect(node.text).to eq 'not completed' }
+      end
+
+      it 'should render step 1 of 3' do
+        expected_text = %w[Step 1 of 3 Step One]
+        node = page.find('.usa-step-indicator__heading')
+        result_text = node.text.split.map(&:strip)
+        expect(result_text).to eq expected_text
+      end
+    end
+    context 'index 1' do
+      let(:index) { 1 }
+      it 'should render step content in order' do
+        expected_text = ['Step One completed', 'Step Two', 'Step Three not completed']
+        nodes = page.all('.usa-step-indicator__segment')
+        expect(nodes.map { |node| node.text.strip }).to eq expected_text
+      end
+
+      it 'should render two not completed' do
+        nodes = page.all('.usa-step-indicator__segments .usa-sr-only')
+        expect(nodes.length).to eq 2
+        expect(nodes.first.text).to eq 'completed'
+        expect(nodes.last.text).to eq 'not completed'
+      end
+
+      it 'should render step 2 of 3' do
+        expected_text = %w[Step 2 of 3 Step Two]
+        node = page.find('.usa-step-indicator__heading')
+        result_text = node.text.split.map(&:strip)
+        expect(result_text).to eq expected_text
+      end
+    end
+
+    context 'index 2' do
+      let(:index) { 2 }
+      it 'should render step content in order' do
+        expected_text = ['Step One completed', 'Step Two completed', 'Step Three']
+        nodes = page.all('.usa-step-indicator__segment')
+        expect(nodes.map { |node| node.text.strip }).to eq expected_text
+      end
+
+      it 'should render two not completed' do
+        nodes = page.all('.usa-step-indicator__segments .usa-sr-only')
+        expect(nodes.length).to eq 2
+        nodes.each { |node| expect(node.text).to eq 'completed' }
+      end
+
+      it 'should render step 3 of 3' do
+        expected_text = %w[Step 3 of 3 Step Three]
+        node = page.find('.usa-step-indicator__heading')
+        result_text = node.text.split.map(&:strip)
+        expect(result_text).to eq expected_text
+      end
+    end
+    context 'index 3' do
+      let(:index) { 3 }
+      it 'should render step content in order' do
+        expected_text = ['Step One completed', 'Step Two completed', 'Step Three completed']
+        nodes = page.all('.usa-step-indicator__segment')
+        expect(nodes.map { |node| node.text.strip }).to eq expected_text
+      end
+
+      it 'should render two not completed' do
+        nodes = page.all('.usa-step-indicator__segments .usa-sr-only')
+        expect(nodes.length).to eq 3
+        nodes.each { |node| expect(node.text).to eq 'completed' }
+      end
+
+      it 'should not render step indicator' do
+        page.assert_no_selector('.usa-step-indicator__heading')
+      end
+    end
+  end
+end

--- a/dpc-portal/spec/components/page/invitations/accept_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/accept_invitation_component_spec.rb
@@ -23,17 +23,6 @@ RSpec.describe Page::Invitations::AcceptInvitationComponent, type: :component do
       let(:component) { described_class.new(org, cd_invite) }
 
       context 'New form' do
-        it 'should match header' do
-          header = <<~HTML
-            <h1>Accept organization invite</h1>
-              <div class="usa-alert usa-alert--info margin-bottom-4">
-                <div class="usa-alert__body">
-                  <h4 class="usa-alert__heading">Key information</h4>
-                  <p class="usa-alert__text">
-          HTML
-          is_expected.to include(normalize_space(header))
-        end
-
         it 'should match form tag' do
           form_url = "/portal/organizations/#{org.path_id}/invitations/#{cd_invite.id}/confirm"
           form_tag = ['<form class="usa-form" id="cd-accept-form"',
@@ -86,6 +75,12 @@ RSpec.describe Page::Invitations::AcceptInvitationComponent, type: :component do
         form_method_action = %(method="post" action="#{form_url}")
         is_expected.to include(form_method_action)
       end
+
+      it 'should have step component at step 2' do
+        expect(page).to have_selector('.usa-step-indicator__current-step')
+        expect(page.find('.usa-step-indicator__current-step').text).to eq '2'
+      end
+
       it 'should not have verification_code stanza' do
         verification_code = <<~HTML
           <div class="margin-bottom-4">

--- a/dpc-portal/spec/components/page/invitations/register_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/register_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page::Invitations::RegisterComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end

--- a/dpc-portal/spec/components/page/invitations/register_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/register_component_spec.rb
@@ -3,13 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe Page::Invitations::RegisterComponent, type: :component do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:component) { described_class.new(invitation.provider_organization, invitation) }
+  before { render_inline(component) }
 
-  # it "renders something useful" do
-  #   expect(
-  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
-  #   ).to include(
-  #     "Hello, components!"
-  #   )
-  # end
+  describe 'cd' do
+    let(:invitation) { create(:invitation, :cd) }
+    it 'should post to register' do
+      expected = "/portal/organizations/#{invitation.provider_organization.id}/invitations/#{invitation.id}/register"
+      form = page.find('form')
+      expect(form[:action]).to eq expected
+    end
+  end
+  describe 'ao' do
+    let(:invitation) { create(:invitation, :ao) }
+    it 'should have step component at step 3' do
+      expect(page).to have_selector('.usa-step-indicator__current-step')
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '3'
+    end
+
+    it 'should post to register' do
+      expected = "/portal/organizations/#{invitation.provider_organization.id}/invitations/#{invitation.id}/register"
+      form = page.find('form')
+      expect(form[:action]).to eq expected
+    end
+  end
 end

--- a/dpc-portal/spec/components/page/invitations/start_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/start_component_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page::Invitations::StartComponent, type: :component do
+  let(:ao_invite) { create(:invitation, invitation_type: :authorized_official) }
+  let(:component) { described_class.new(ao_invite.provider_organization, ao_invite) }
+  before { render_inline(component) }
+
+  describe 'basic page' do
+    it 'should show start button' do
+      button = page.find('.usa-button')
+      expect(button.text).to eq 'Start'
+    end
+
+    it 'should go to accept page' do
+      expected = "/portal/organizations/#{ao_invite.provider_organization.id}/invitations/#{ao_invite.id}/accept"
+      form = page.find('form')
+      expect(form[:action]).to eq expected
+    end
+  end
+end

--- a/dpc-portal/spec/components/page/invitations/success_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/success_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Page::Invitations::SuccessComponent, type: :component do
+  let(:component) { described_class.new(invitation.provider_organization, invitation) }
+  before { render_inline(component) }
+  describe 'ao' do
+    let(:invitation) { create(:invitation, :ao) }
+    it 'should have step component at step 4' do
+      expect(page).to have_selector('.usa-step-indicator__current-step')
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '4'
+    end
+  end
+end

--- a/dpc-portal/spec/components/page/session/invitation_login_component_spec.rb
+++ b/dpc-portal/spec/components/page/session/invitation_login_component_spec.rb
@@ -27,4 +27,14 @@ RSpec.describe Page::Session::InvitationLoginComponent, type: :component do
       expect(page.find('form')[:method]).to eq 'post'
     end
   end
+
+  describe 'ao' do
+    let(:invitation) { create(:invitation, :ao) }
+    let(:component) { described_class.new(invitation) }
+    before { render_inline(component) }
+    it 'should have step component at step 1' do
+      expect(page).to have_selector('.usa-step-indicator__current-step')
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '1'
+    end
+  end
 end

--- a/dpc-portal/spec/mailers/invitation_spec.rb
+++ b/dpc-portal/spec/mailers/invitation_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       invitation = build(:invitation, id: 4, provider_organization:)
       given_name = family_name = ''
       mailer = InvitationMailer.with(invitation:, given_name:, family_name:).invite_ao
-      expected_url = 'http://localhost:3100/portal/organizations/2/invitations/4/accept'
+      expected_url = 'http://localhost:3100/portal/organizations/2/invitations/4'
       expect(mailer.body).to match(expected_url)
     end
   end

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -473,4 +473,15 @@ RSpec.describe Invitation, type: :model do
       end
     end
   end
+
+  describe :expires_in do
+    after { Timecop.return }
+    let!(:invitation) { create(:invitation, :cd, created_at: 24.hours.ago) }
+    it 'should expire in 23 hours 10 minutes' do
+      Timecop.travel(2999.seconds.from_now)
+      hours, minutes = invitation.expires_in
+      expect(hours).to eq 23
+      expect(minutes).to eq 10
+    end
+  end
 end

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -372,16 +372,18 @@ RSpec.describe Invitation, type: :model do
     end
 
     describe :match_user do
-      let(:ao_invite) { build(:invitation, :ao) }
-      it 'should match user if ssn correct' do
-        user_info = { 'social_security_number' => '900111111' }
+      let(:ao_invite) { build(:invitation, :ao, invited_email: 'bob@example.com') }
+      it 'should match user if email match' do
+        user_info = { 'all_emails' => [
+          'bob@testy.com',
+          'bob@example.com'
+        ] }
+
         expect(ao_invite.match_user?(user_info)).to eq true
       end
-      it 'should not match user if ssn not correct' do
-        user_info = { 'social_security_number' => '900111112' }
-        expect do
-          ao_invite.match_user?(user_info)
-        end.to raise_error(InvitationError, 'user_not_authorized_official')
+      it 'should not match user if no email match' do
+        user_info = { 'all_emails' => ['tim@example.com'] }
+        expect(ao_invite.match_user?(user_info)).to eq false
       end
     end
   end

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -3,6 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe 'Invitations', type: :request do
+  describe 'GET /' do
+    context :ao do
+      let!(:ao_invite) { create(:invitation, :ao) }
+      let(:user) do
+        create(:user, given_name: 'Herman',
+                      family_name: 'Wouk',
+                      email: ao_invite.invited_email)
+      end
+      let(:org) { ao_invite.provider_organization }
+
+      it 'should show button to accept' do
+        get "/organizations/#{org.id}/invitations/#{ao_invite.id}"
+        expect(response).to be_ok
+        expect(response.body).to include(accept_organization_invitation_path(org, ao_invite))
+      end
+    end
+  end
+
   describe 'GET /accept' do
     context :ao do
       context 'not logged in' do

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -262,6 +262,11 @@ RSpec.describe 'Invitations', type: :request do
           post "/organizations/#{org.id}/invitations/#{invitation.id}/register"
           expect(request.session["invitation_status_#{invitation.id}"]).to be_nil
         end
+        it 'should show success page' do
+          post "/organizations/#{org.id}/invitations/#{invitation.id}/register"
+          expect(response).to be_ok
+          expect(response.body).to include('Registration completed')
+        end
       end
       context 'failure' do
         before do
@@ -284,29 +289,6 @@ RSpec.describe 'Invitations', type: :request do
         let(:invitation) { create(:invitation, :cd, verification_code:) }
         let(:success_params) { { verification_code: } }
       end
-      let(:verification_code) { 'ABC123' }
-      let(:cd_invite) { create(:invitation, :cd, verification_code:) }
-      let(:org) { cd_invite.provider_organization }
-
-      let(:success_params) { { verification_code: } }
-
-      context :logged_in do
-        before { sign_in create(:user) }
-
-        context 'success' do
-          before do
-            stub_user_info
-            get "/organizations/#{org.id}/invitations/#{cd_invite.id}/accept"
-            post "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm", params: success_params
-          end
-          it 'should redirect to organization page with notice' do
-            post "/organizations/#{org.id}/invitations/#{cd_invite.id}/register"
-            expect(response).to redirect_to(organization_path(org))
-            expected_message =  "Invitation accepted. You can now manage this organization's credentials. Learn more."
-            expect(flash[:notice]).to eq expected_message
-          end
-        end
-      end
     end
     context :ao do
       it_behaves_like 'an invitation endpoint', :post, 'register' do
@@ -315,24 +297,6 @@ RSpec.describe 'Invitations', type: :request do
       it_behaves_like 'a register endpoint' do
         let(:invitation) { create(:invitation, :ao) }
         let(:success_params) { {} }
-      end
-      let(:ao_invite) { create(:invitation, :ao) }
-      let(:org) { ao_invite.provider_organization }
-      context :logged_in do
-        before { sign_in create(:user) }
-        context 'success' do
-          before do
-            stub_user_info
-            get "/organizations/#{org.id}/invitations/#{ao_invite.id}/accept"
-            post "/organizations/#{org.id}/invitations/#{ao_invite.id}/confirm"
-          end
-          it 'should redirect to organization page with notice' do
-            post "/organizations/#{org.id}/invitations/#{ao_invite.id}/register"
-            expect(response).to redirect_to(organization_path(org))
-            expected_message =  'Invitation accepted.'
-            expect(flash[:notice]).to eq expected_message
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4129

## 🛠 Changes

- Added components to support flow: Step, Start, Register Success
- Registration checks split between identity and other validation
- Invitations spec uses shared examples for endpoints, same behavior for cd and ao invitations

## ℹ️ Context

We are expanding the registration process.

## 🧪 Validation

Automated and manual testing of both authorized official and credential delegate flows.
