### PR TITLE
DPC-4132 Only create user on connecting to org

### DIFF
--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -43,7 +43,7 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
   end
 
   def path(user, auth)
-    if auth.extra.raw_info.ial == 'http://idmanagement.gov/ns/assurance/ial/1' && user.blank?
+    if user.blank? && auth.extra.raw_info.ial == 'http://idmanagement.gov/ns/assurance/ial/1'
       flash[:alert] = 'You must have an account to sign in.'
       return new_user_session_url
     end

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -20,40 +20,51 @@ RSpec.describe 'LoginDotGov', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
       end
 
-      it 'signs in a user' do
-        post '/users/auth/openid_connect'
-        follow_redirect!
-        expect(response.location).to eq organizations_url
-      end
-
-      it 'persists user if not exist' do
-        expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 0
-        expect do
+      context :user_exists do
+        before { create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com') }
+        it 'signs in a user' do
           post '/users/auth/openid_connect'
           follow_redirect!
-        end.to change { User.count }.by(1)
-        expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                          family_name: 'Hoskins').count).to eq 1
-      end
-
-      it 'does not persist user if exists' do
-        create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com')
-        expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 1
-        expect do
+          expect(response.location).to eq organizations_url
+        end
+        it 'does not add another user' do
+          expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 1
+          expect do
+            post '/users/auth/openid_connect'
+            follow_redirect!
+          end.to change { User.count }.by(0)
+        end
+        it 'adds user names' do
+          expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
+                            family_name: 'Hoskins').count).to eq 0
           post '/users/auth/openid_connect'
           follow_redirect!
-        end.to change { User.count }.by(0)
-      end
+          expect(response.location).to eq organizations_url
+          expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
+                            family_name: 'Hoskins').count).to eq 1
+        end
 
-      it 'adds user names' do
-        create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com')
-        expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                          family_name: 'Hoskins').count).to eq 0
-        post '/users/auth/openid_connect'
-        follow_redirect!
-        expect(response.location).to eq organizations_url
-        expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                          family_name: 'Hoskins').count).to eq 1
+        it 'sets authentication token' do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+          expect(request.session[:login_dot_gov_token]).to eq token
+          expect(request.session[:login_dot_gov_token_exp]).to_not be_nil
+          expect(request.session[:login_dot_gov_token_exp]).to be_within(1.second).of 899.seconds.from_now
+        end
+      end
+      context :user_does_not_exist do
+        it 'does not persist user' do
+          expect do
+            post '/users/auth/openid_connect'
+            follow_redirect!
+          end.to change { User.count }.by(0)
+        end
+        it 'does not sign in user if not exist' do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+          expect(response.location).to eq organizations_url
+          expect(response).to be_redirect
+        end
       end
 
       it 'sets authentication token' do
@@ -75,52 +86,67 @@ RSpec.describe 'LoginDotGov', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
       end
 
-      it 'signs in a user' do
-        post '/users/auth/openid_connect'
-        follow_redirect!
-        expect(response.location).to eq organizations_url
-      end
-
-      it 'persists user if not exist' do
-        expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 0
-        expect do
+      context :user_exists do
+        before do
+          create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
+                        family_name: 'Hoskins')
+        end
+        it 'signs in a user' do
           post '/users/auth/openid_connect'
           follow_redirect!
-        end.to change { User.count }.by(1)
-        expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: nil,
-                          family_name: nil).count).to eq 1
-      end
+          expect(response.location).to eq organizations_url
+        end
 
-      it 'does not persist user if exists' do
-        create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com')
-        expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 1
-        expect do
+        it 'does not add another user' do
+          expect do
+            post '/users/auth/openid_connect'
+            follow_redirect!
+          end.to change { User.count }.by(0)
+        end
+
+        it 'does not update user names' do
+          expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
+                            family_name: 'Hoskins').count).to eq 1
           post '/users/auth/openid_connect'
           follow_redirect!
-        end.to change { User.count }.by(0)
+          expect(response.location).to eq organizations_url
+          expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
+                            family_name: 'Hoskins').count).to eq 1
+        end
+
+        it 'does not set authentication token' do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+          expect(request.session[:login_dot_gov_token]).to be_nil
+          expect(request.session[:login_dot_gov_token_exp]).to be_nil
+        end
       end
 
-      it 'does not update user names' do
-        create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                      family_name: 'Hoskins')
-        expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                          family_name: 'Hoskins').count).to eq 1
-        post '/users/auth/openid_connect'
-        follow_redirect!
-        expect(response.location).to eq organizations_url
-        expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                          family_name: 'Hoskins').count).to eq 1
-      end
+      context 'user does not exist' do
+        it 'does not sign in user' do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+          expect(response.location).to eq new_user_session_url
+          expect(flash[:alert]).to eq('You must have an account to sign in.')
+          expect(response).to be_redirect
+        end
 
-      it 'does not set authentication token' do
-        post '/users/auth/openid_connect'
-        follow_redirect!
-        expect(request.session[:login_dot_gov_token]).to be_nil
-        expect(request.session[:login_dot_gov_token_exp]).to be_nil
+        it 'does not persist user' do
+          expect do
+            post '/users/auth/openid_connect'
+            follow_redirect!
+          end.to change { User.count }.by(0)
+        end
+
+        it 'does not set authentication token' do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+          expect(request.session[:login_dot_gov_token]).to be_nil
+          expect(request.session[:login_dot_gov_token_exp]).to be_nil
+        end
       end
     end
   end
-
   describe 'Get /users/auth/failure' do
     it 'succeeds' do
       get '/users/auth/failure'

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -3,6 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe 'LoginDotGov', type: :request do
+  RSpec.shared_examples 'an openid client' do
+    context 'user exists' do
+      before { create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com') }
+      it 'should sign in a user' do
+        post '/users/auth/openid_connect'
+        follow_redirect!
+        expect(response.location).to eq organizations_url
+        expect(response).to be_redirect
+        follow_redirect!
+        expect(response).to be_ok
+      end
+      it 'should not add another user' do
+        expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 1
+        expect do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+        end.to change { User.count }.by(0)
+      end
+    end
+
+    context 'user does not exist' do
+      it 'should not persist user' do
+        expect do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+        end.to change { User.count }.by(0)
+      end
+    end
+  end
+
   describe 'POST /users/auth/openid_connect' do
     let(:token) { 'bearer-token' }
     context 'IAL/2' do
@@ -20,28 +50,19 @@ RSpec.describe 'LoginDotGov', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
       end
 
+      it_behaves_like 'an openid client'
+
       context :user_exists do
         before { create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com') }
-        it 'signs in a user' do
-          post '/users/auth/openid_connect'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-        end
-        it 'does not add another user' do
-          expect(User.where(uid: '12345', provider: 'openid_connect').count).to eq 1
+        it 'updates user names' do
           expect do
             post '/users/auth/openid_connect'
             follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-        it 'adds user names' do
-          expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                            family_name: 'Hoskins').count).to eq 0
-          post '/users/auth/openid_connect'
-          follow_redirect!
+          end.to change {
+                   User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
+                              family_name: 'Hoskins').count
+                 }.by 1
           expect(response.location).to eq organizations_url
-          expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
-                            family_name: 'Hoskins').count).to eq 1
         end
 
         it 'sets authentication token' do
@@ -52,27 +73,24 @@ RSpec.describe 'LoginDotGov', type: :request do
           expect(request.session[:login_dot_gov_token_exp]).to be_within(1.second).of 899.seconds.from_now
         end
       end
+
       context :user_does_not_exist do
-        it 'does not persist user' do
-          expect do
-            post '/users/auth/openid_connect'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-        it 'does not sign in user if not exist' do
+        it 'does not sign in user' do
           post '/users/auth/openid_connect'
           follow_redirect!
           expect(response.location).to eq organizations_url
           expect(response).to be_redirect
+          follow_redirect!
+          expect(response).to be_redirect
         end
-      end
 
-      it 'sets authentication token' do
-        post '/users/auth/openid_connect'
-        follow_redirect!
-        expect(request.session[:login_dot_gov_token]).to eq token
-        expect(request.session[:login_dot_gov_token_exp]).to_not be_nil
-        expect(request.session[:login_dot_gov_token_exp]).to be_within(1.second).of 899.seconds.from_now
+        it 'sets authentication token' do
+          post '/users/auth/openid_connect'
+          follow_redirect!
+          expect(request.session[:login_dot_gov_token]).to eq token
+          expect(request.session[:login_dot_gov_token_exp]).to_not be_nil
+          expect(request.session[:login_dot_gov_token_exp]).to be_within(1.second).of 899.seconds.from_now
+        end
       end
     end
 
@@ -86,24 +104,13 @@ RSpec.describe 'LoginDotGov', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
       end
 
+      it_behaves_like 'an openid client'
+
       context :user_exists do
         before do
           create(:user, uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
                         family_name: 'Hoskins')
         end
-        it 'signs in a user' do
-          post '/users/auth/openid_connect'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-        end
-
-        it 'does not add another user' do
-          expect do
-            post '/users/auth/openid_connect'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-
         it 'does not update user names' do
           expect(User.where(uid: '12345', provider: 'openid_connect', email: 'bob@example.com', given_name: 'Bob',
                             family_name: 'Hoskins').count).to eq 1
@@ -131,13 +138,6 @@ RSpec.describe 'LoginDotGov', type: :request do
           expect(response).to be_redirect
         end
 
-        it 'does not persist user' do
-          expect do
-            post '/users/auth/openid_connect'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-
         it 'does not set authentication token' do
           post '/users/auth/openid_connect'
           follow_redirect!
@@ -147,10 +147,11 @@ RSpec.describe 'LoginDotGov', type: :request do
       end
     end
   end
+
   describe 'Get /users/auth/failure' do
-    it 'succeeds' do
+    it 'should succeed' do
       get '/users/auth/failure'
-      expect(response).to have_http_status(200)
+      expect(response).to be_ok
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4132

## 🛠 Changes

- login controller no longer creates user
- invitations controller requires login dot gov tokens instead of sign in
- invitations controller upserts user on confirm registration

## ℹ️ Context

We don't want the users table full of people unrelated to DPC, so we are only creating users after a successful invitation acceptance.

## 🧪 Validation

Automated and manual testing.
