### PR TITLE
Me/dpc 4119 track long lived jobs

### DIFF
--- a/dpc-aggregation/src/main/resources/application.yml
+++ b/dpc-aggregation/src/main/resources/application.yml
@@ -50,6 +50,7 @@ logging:
     "org.hibernate.SQL": ERROR
     "gov.cms.dpc.api.auth": INFO
     "gov.cms.dpc.common.logging.filters": INFO
+    "metrics": INFO
   appenders:
     - type: console
       timeZone: UTC
@@ -89,8 +90,10 @@ bbclient:
 awsQueue:
   emitAwsMetrics: ${EMIT_AWS_METRICS:-true}
   queueSizeMetricName: ${QUEUE_SIZE_METRIC_NAME:-"JobQueueBatchCount"}
+  queueAgeMetricName: ${QUEUE_AGE_METRIC_NAME:-"JobQueueBatchAgeHours"}
   awsRegion: ${AWS_REGION:-"us-east-1"}
-  awsReportingInterval: ${AWS_REPORTING_INTERVAL:-60}
+  awsSizeReportingInterval: ${AWS_SIZE_REPORTING_INTERVAL:-60}
+  awsAgeReportingInterval: ${AWS_AGE_REPORTING_INTERVAL:-600}
   environment: ${ENV:-"unknown_env"}
   awsNamespace: ${NAMESPACE:-"DPC"}
 

--- a/dpc-aggregation/src/test/resources/test.application.yml
+++ b/dpc-aggregation/src/test/resources/test.application.yml
@@ -88,9 +88,11 @@ bbclient:
 
 awsQueue:
   emitAwsMetrics: ${EMIT_AWS_METRICS:-false}
-  queueSizeMetricName: ${QUEUE_SIZE_METRIC_NAME:-"JobQueueBatchSize"}
+  queueSizeMetricName: ${QUEUE_SIZE_METRIC_NAME:-"JobQueueBatchCount"}
+  queueAgeMetricName: ${QUEUE_AGE_METRIC_NAME:-"JobQueueBatchAgeHours"}
   awsRegion: ${AWS_REGION:-"us-east-1"}
-  awsReportingInterval: ${AWS_REPORTING_INTERVAL:-60}
+  awsSizeReportingInterval: ${AWS_SIZE_REPORTING_INTERVAL:-60}
+  awsAgeReportingInterval: ${AWS_AGE_REPORTING_INTERVAL:-600}
   environment: ${ENV:-"unknown_env"}
   awsNamespace: ${NAMESPACE:-"DPC"}
 

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/AwsDistributedBatchQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/AwsDistributedBatchQueue.java
@@ -3,6 +3,7 @@ package gov.cms.dpc.queue;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
+import com.google.inject.name.Named;
 import gov.cms.dpc.common.hibernate.queue.DPCQueueManagedSessionFactory;
 import gov.cms.dpc.queue.annotations.QueueBatchSize;
 import gov.cms.dpc.queue.config.DPCAwsQueueConfiguration;
@@ -20,21 +21,33 @@ public class AwsDistributedBatchQueue extends DistributedBatchQueue {
 		DPCQueueManagedSessionFactory factory,
 		@QueueBatchSize int batchSize,
 		MetricRegistry metricRegistry,
-		ScheduledReporter reporter,
+		@Named("QueueAge") ScheduledReporter ageReporter,
+		@Named("QueueSize") ScheduledReporter sizeReporter,
 		DPCAwsQueueConfiguration awsConfig
 	) {
 		super(factory, batchSize, metricRegistry);
 
+		// Setup queue size metric
 		DimensionedName queueSizeName = DimensionedName
 			.withName(awsConfig.getQueueSizeMetricName())
 			.withDimension("environment", awsConfig.getEnvironment())
 			.build();
-
 		metricRegistry.register(
 			queueSizeName.encode(),
 			(Gauge<Long>) this::queueSize
 		);
 
-		reporter.start(awsConfig.getAwsReportingInterval(), TimeUnit.SECONDS);
+		// Setup queue age metric
+		DimensionedName queueAgeName = DimensionedName
+			.withName(awsConfig.getQueueAgeMetricName())
+			.withDimension("environment", awsConfig.getEnvironment())
+			.build();
+		metricRegistry.register(
+			queueAgeName.encode(),
+			(Gauge<Double>) this::queueAge
+		);
+
+		ageReporter.start(awsConfig.getAwsAgeReportingInterval(), TimeUnit.SECONDS);
+		sizeReporter.start(awsConfig.getAwsSizeReportingInterval(), TimeUnit.SECONDS);
 	}
 }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
@@ -333,7 +333,7 @@ public class DistributedBatchQueue extends JobQueueCommon {
                 if(submitTime.isPresent()) {
                     Long now = Timestamp.from(Instant.now()).getTime(); // Now in milliseconds from Unix epoch
                     Long then = submitTime.get().getTime();             // Submit time in milliseconds from Unix epoch
-                    return ((double) (now - then)) / (1000 * 60 * 60);  // millisec difference / millisec in an hour
+                    return ((double) (now - then)) / (1000 * 60 * 60);  // msec difference / msec in an hour
                 } else {
                     return 0;
                 }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
@@ -115,6 +115,7 @@ public class JobQueueModule<T extends Configuration & DPCQueueConfig> extends Dr
                 configuration().getDpcAwsQueueConfiguration().getAwsNamespace()
             )
             .withReportRawCountValue()
+            .withZeroValuesSubmission()
             .filter(MetricFilter.contains(metricName))
             .build();
     }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/JobQueueModule.java
@@ -1,13 +1,14 @@
 package gov.cms.dpc.queue;
 
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.Slf4jReporter;
+import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Slf4jReporter;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import com.google.inject.name.Named;
 import gov.cms.dpc.queue.annotations.AggregatorID;
 import gov.cms.dpc.queue.annotations.QueueBatchSize;
 import gov.cms.dpc.queue.config.DPCAwsQueueConfiguration;
@@ -79,43 +80,49 @@ public class JobQueueModule<T extends Configuration & DPCQueueConfig> extends Dr
     DPCAwsQueueConfiguration provideDpcAwsQueueConfiguration() { return configuration().getDpcAwsQueueConfiguration(); }
 
     @Provides
-    CloudWatchAsyncClient provideCloudWatchAsyncClient() {
+    @Named("QueueSize")
+    @Inject
+    ScheduledReporter provideSizeScheduledReporter(MetricRegistry metricRegistry) {
+        DPCAwsQueueConfiguration awsConfig = configuration().getDpcAwsQueueConfiguration();
+        String metricName = awsConfig.getQueueSizeMetricName();
+
+        // If AwsMetrics are turned off, use a reporter that writes metrics to our logs instead.
+        if( awsConfig.getEmitAwsMetrics() ) {
+            return provideCloudWatchReporter(metricRegistry, metricName, provideCloudWatchAsyncClient());
+        } else {
+            return provideSlf4jReporter(metricRegistry, metricName);
+        }
+    }
+
+    @Provides
+    @Named("QueueAge")
+    @Inject
+    ScheduledReporter provideAgeScheduledReporter(MetricRegistry metricRegistry) {
+        return provideSlf4jReporter(metricRegistry, configuration().getDpcAwsQueueConfiguration().getQueueAgeMetricName());
+    }
+
+    private Slf4jReporter provideSlf4jReporter(MetricRegistry metricRegistry, String metricName) {
+        return Slf4jReporter.forRegistry(metricRegistry)
+            .filter(MetricFilter.contains(metricName))
+            .withLoggingLevel(Slf4jReporter.LoggingLevel.INFO)
+            .build();
+    }
+
+    private CloudWatchReporter provideCloudWatchReporter(MetricRegistry metricRegistry, String metricName, CloudWatchAsyncClient cloudWatchAsyncClient) {
+        return CloudWatchReporter.forRegistry(
+                metricRegistry,
+                cloudWatchAsyncClient,
+                configuration().getDpcAwsQueueConfiguration().getAwsNamespace()
+            )
+            .withReportRawCountValue()
+            .filter(MetricFilter.contains(metricName))
+            .build();
+    }
+
+    private CloudWatchAsyncClient provideCloudWatchAsyncClient() {
         return CloudWatchAsyncClient
             .builder()
             .region(Region.of(configuration().getDpcAwsQueueConfiguration().getAwsRegion()))
             .build();
-    }
-
-    @Provides
-    @Inject
-    CloudWatchReporter provideCloudWatchReporter(MetricRegistry metricRegistry, CloudWatchAsyncClient cloudWatchAsyncClient) {
-       return CloudWatchReporter.forRegistry(
-            metricRegistry,
-            cloudWatchAsyncClient,
-            configuration().getDpcAwsQueueConfiguration().getAwsNamespace()
-        )
-        .withReportRawCountValue()
-        .filter(MetricFilter.contains(configuration().getDpcAwsQueueConfiguration().getQueueSizeMetricName()))
-        .build();
-    }
-
-    @Provides
-    @Inject
-    Slf4jReporter provideSlf4jReporter(MetricRegistry metricRegistry) {
-        return Slf4jReporter.forRegistry(metricRegistry)
-            .filter(MetricFilter.contains(configuration().getDpcAwsQueueConfiguration().getQueueSizeMetricName()))
-            .withLoggingLevel(Slf4jReporter.LoggingLevel.DEBUG)
-            .build();
-    }
-
-    @Provides
-    @Inject
-    ScheduledReporter provideScheduledReporter(MetricRegistry metricRegistry, CloudWatchAsyncClient cloudWatchAsyncClient) {
-        // If AwsMetrics are turned off, use a reporter that writes metrics to our logs instead.
-        if( configuration().getDpcAwsQueueConfiguration().getEmitAwsMetrics() ) {
-            return provideCloudWatchReporter(metricRegistry, cloudWatchAsyncClient);
-        } else {
-            return provideSlf4jReporter(metricRegistry);
-        }
     }
 }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/config/DPCAwsQueueConfiguration.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/config/DPCAwsQueueConfiguration.java
@@ -11,7 +11,10 @@ public class DPCAwsQueueConfiguration {
 	private String awsRegion;
 
 	@NotNull
-	private int awsReportingInterval;
+	private int awsSizeReportingInterval;
+
+	@NotNull
+	private int awsAgeReportingInterval;
 
 	@NotNull
 	private String environment;
@@ -22,39 +25,70 @@ public class DPCAwsQueueConfiguration {
 	@NotNull
 	private String queueSizeMetricName;
 
-	public boolean getEmitAwsMetrics() { return emitAwsMetrics; }
+	@NotNull
+	private String queueAgeMetricName;
+
+	public boolean getEmitAwsMetrics() {
+		return emitAwsMetrics;
+	}
 	public DPCAwsQueueConfiguration setEmitAwsMetrics(boolean emitAwsMetrics) {
 		this.emitAwsMetrics = emitAwsMetrics;
 		return this;
 	}
 
-	public String getAwsRegion() { return awsRegion; }
+	public String getAwsRegion() {
+		return awsRegion;
+	}
 	public DPCAwsQueueConfiguration setAwsRegion(String awsRegion) {
 		this.awsRegion = awsRegion;
 		return this;
 	}
 
-	public int getAwsReportingInterval() { return awsReportingInterval; }
-	public DPCAwsQueueConfiguration setAwsReporitingInterval(int awsReporitingInterval) {
-		this.awsReportingInterval = awsReporitingInterval;
+	public int getAwsSizeReportingInterval() {
+		return awsSizeReportingInterval;
+	}
+	public DPCAwsQueueConfiguration setAwsSizeReportingInterval(int awsSizeReportingInterval) {
+		this.awsSizeReportingInterval = awsSizeReportingInterval;
 		return this;
 	}
 
-	public String getEnvironment() { return environment; }
+	public int getAwsAgeReportingInterval() {
+		return awsAgeReportingInterval;
+	}
+	public DPCAwsQueueConfiguration setAwsAgeReportingInterval(int awsAgeReportingInterval) {
+		this.awsAgeReportingInterval = awsAgeReportingInterval;
+		return this;
+	}
+
+	public String getEnvironment() {
+		return environment;
+	}
 	public DPCAwsQueueConfiguration setEnvironment(String environment) {
 		this.environment = environment;
 		return this;
 	}
 
-	public String getAwsNamespace() { return awsNamespace; }
+	public String getAwsNamespace() {
+		return awsNamespace;
+	}
 	public DPCAwsQueueConfiguration setAwsNameSpace(String awsNamespace) {
 		this.awsNamespace = awsNamespace;
 		return this;
 	}
 
-	public String getQueueSizeMetricName() { return queueSizeMetricName; }
+	public String getQueueSizeMetricName() {
+		return queueSizeMetricName;
+	}
 	public DPCAwsQueueConfiguration setQueueSizeMetricName(String queueSizeMetricName) {
 		this.queueSizeMetricName = queueSizeMetricName;
+		return this;
+	}
+
+	public String getQueueAgeMetricName() {
+		return queueAgeMetricName;
+	}
+	public DPCAwsQueueConfiguration setQueueAgeMetricName(String queueAgeMetricName) {
+		this.queueAgeMetricName = queueAgeMetricName;
 		return this;
 	}
 }

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/AwsDistributedBatchQueueUnitTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/AwsDistributedBatchQueueUnitTest.java
@@ -1,7 +1,7 @@
 package gov.cms.dpc.queue;
 
-import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
 import gov.cms.dpc.common.hibernate.queue.DPCQueueManagedSessionFactory;
 import gov.cms.dpc.queue.config.DPCAwsQueueConfiguration;
 import org.hibernate.Session;
@@ -18,15 +18,18 @@ class AwsDistributedBatchQueueUnitTest {
 	private DPCAwsQueueConfiguration config;
 	private final Session session = mock(Session.class);
 	private final SessionFactory sessionFactory = mock(SessionFactory.class);
-	private final ConsoleReporter consoleReporter = mock(ConsoleReporter.class);
+	private final Slf4jReporter ageReporter = mock(Slf4jReporter.class);
+	private final Slf4jReporter sizeReporter = mock(Slf4jReporter.class);
 
 	@Test
 	void testReporterStarted() {
 		metricRegistry = new MetricRegistry();
 		config = new DPCAwsQueueConfiguration()
-			.setQueueSizeMetricName("name")
+			.setQueueSizeMetricName("sizeMetricName")
+			.setQueueAgeMetricName("ageMetricName")
 			.setEnvironment("env")
-			.setAwsReporitingInterval(60);
+			.setAwsAgeReportingInterval(60)
+			.setAwsSizeReportingInterval(60);
 
 		when(sessionFactory.openSession()).thenReturn(session);
 
@@ -34,11 +37,13 @@ class AwsDistributedBatchQueueUnitTest {
 			new DPCQueueManagedSessionFactory(sessionFactory),
 			100,
 			metricRegistry,
-			consoleReporter,
+			ageReporter,
+			sizeReporter,
 			config
 			);
 
-		verify(consoleReporter, times(1)).start(60, TimeUnit.SECONDS);
+		verify(ageReporter, times(1)).start(60, TimeUnit.SECONDS);
+		verify(sizeReporter, times(1)).start(60, TimeUnit.SECONDS);
 	}
 
 }

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueUnitTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueUnitTest.java
@@ -1,0 +1,76 @@
+package gov.cms.dpc.queue;
+
+import com.codahale.metrics.MetricRegistry;
+import gov.cms.dpc.common.hibernate.queue.DPCQueueManagedSessionFactory;
+import gov.cms.dpc.queue.models.JobQueueBatch;
+import gov.cms.dpc.queue.models.JobQueueBatchFile;
+import gov.cms.dpc.testing.AbstractMultipleDAOTest;
+import org.hibernate.Session;
+import org.hibernate.Transaction;
+import org.hibernate.query.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+
+class DistributedBatchQueueUnitTest extends AbstractMultipleDAOTest {
+	DistributedBatchQueueUnitTest() {
+		super(JobQueueBatch.class, JobQueueBatchFile.class);
+	}
+
+	private DPCQueueManagedSessionFactory sessionFactory;
+	private DistributedBatchQueue queue;
+	private Session session;
+
+	@BeforeEach
+	void setup() {
+		sessionFactory = spy(new DPCQueueManagedSessionFactory(db.getSessionFactory()));
+		queue = new DistributedBatchQueue(sessionFactory, 100, new MetricRegistry());
+		session = sessionFactory.getSessionFactory().openSession();
+	}
+
+	@Test
+	void test_queueAge_returns_0_on_empty() {
+		Transaction transaction = session.beginTransaction();
+		Query query = session.createQuery("DELETE from job_queue_batch");
+		query.executeUpdate();
+		transaction.commit();
+
+		assertEquals(0, queue.queueAge());
+	}
+
+	@Test
+	void test_queueAge_works() {
+		Transaction transaction = session.beginTransaction();
+
+		JobQueueBatch jobQueueBatch = new JobQueueBatch(
+			UUID.randomUUID(),
+			UUID.randomUUID(),
+			"orgNpi",
+			"providerNpi",
+			List.of(),
+			List.of(),
+			OffsetDateTime.now(),
+			OffsetDateTime.now(),
+			"reqIp",
+			"reqUrl",
+			true
+		);
+
+		session.persist(jobQueueBatch);
+		transaction.commit();
+
+		Double age = queue.queueAge();
+
+		// Check that our submitted job is between 0 and 0.001 hours old (about 3.6 seconds).
+		// We could probably mock the system time and the results coming back from Hibernate, but this is enough to
+		// prove it works.
+		assertTrue(age > 0 && age < .001);
+	}
+}

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueUnitTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/DistributedBatchQueueUnitTest.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.spy;
 
 class DistributedBatchQueueUnitTest extends AbstractMultipleDAOTest {
 	DistributedBatchQueueUnitTest() {
@@ -30,7 +29,7 @@ class DistributedBatchQueueUnitTest extends AbstractMultipleDAOTest {
 
 	@BeforeEach
 	void setup() {
-		sessionFactory = spy(new DPCQueueManagedSessionFactory(db.getSessionFactory()));
+		sessionFactory = new DPCQueueManagedSessionFactory(db.getSessionFactory());
 		queue = new DistributedBatchQueue(sessionFactory, 100, new MetricRegistry());
 		session = sessionFactory.getSessionFactory().openSession();
 	}

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/QueueTest.java
@@ -62,16 +62,22 @@ class QueueTest {
                     } else if(queueName.equals("aws")) {
                         MetricRegistry metricRegistry = new MetricRegistry();
 
-                        ScheduledReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
+                        ScheduledReporter reporter1 = Slf4jReporter.forRegistry(metricRegistry)
+                            .filter(MetricFilter.contains("metricName"))
+                            .withLoggingLevel(Slf4jReporter.LoggingLevel.DEBUG)
+                            .build();
+                        ScheduledReporter reporter2 = Slf4jReporter.forRegistry(metricRegistry)
                             .filter(MetricFilter.contains("metricName"))
                             .withLoggingLevel(Slf4jReporter.LoggingLevel.DEBUG)
                             .build();
 
                         DPCAwsQueueConfiguration awsConfig = new DPCAwsQueueConfiguration();
                         awsConfig
-                            .setQueueSizeMetricName("metricName")
+                            .setQueueSizeMetricName("sizeMetricName")
+                            .setQueueAgeMetricName("ageMetricName")
                             .setEnvironment("test")
-                            .setAwsReporitingInterval(10);
+                            .setAwsAgeReportingInterval(10)
+                            .setAwsSizeReportingInterval(10);
 
                         final Configuration conf = new Configuration();
                         sessionFactory = conf.configure().buildSessionFactory();
@@ -80,7 +86,8 @@ class QueueTest {
                             new DPCQueueManagedSessionFactory(sessionFactory),
                             100,
                             metricRegistry,
-                            reporter,
+                            reporter1,
+                            reporter2,
                             awsConfig
                         );
                     } else {

--- a/dpc-queue/src/test/java/gov/cms/dpc/queue/config/DPCAwsQueueConfigurationUnitTest.java
+++ b/dpc-queue/src/test/java/gov/cms/dpc/queue/config/DPCAwsQueueConfigurationUnitTest.java
@@ -15,8 +15,11 @@ class DPCAwsQueueConfigurationUnitTest {
 		config.setAwsRegion("region");
 		assertEquals("region", config.getAwsRegion());
 
-		config.setAwsReporitingInterval(60);
-		assertEquals(60, config.getAwsReportingInterval());
+		config.setAwsSizeReportingInterval(60);
+		assertEquals(60, config.getAwsSizeReportingInterval());
+
+		config.setAwsAgeReportingInterval(60);
+		assertEquals(60, config.getAwsAgeReportingInterval());
 
 		config.setEnvironment("env");
 		assertEquals("env", config.getEnvironment());
@@ -24,7 +27,10 @@ class DPCAwsQueueConfigurationUnitTest {
 		config.setAwsNameSpace("namespace");
 		assertEquals("namespace", config.getAwsNamespace());
 
-		config.setQueueSizeMetricName("metric");
-		assertEquals("metric", config.getQueueSizeMetricName());
+		config.setQueueSizeMetricName("size");
+		assertEquals("size", config.getQueueSizeMetricName());
+
+		config.setQueueAgeMetricName("age");
+		assertEquals("age", config.getQueueAgeMetricName());
 	}
 }

--- a/dpc-testing/src/main/java/gov/cms/dpc/testing/AbstractMultipleDAOTest.java
+++ b/dpc-testing/src/main/java/gov/cms/dpc/testing/AbstractMultipleDAOTest.java
@@ -1,0 +1,49 @@
+package gov.cms.dpc.testing;
+
+import io.dropwizard.testing.junit5.DAOTestExtension;
+import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.dialect.PostgreSQL10Dialect;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * This is based around the DAOTestExtension that DropWizard already supports, except instead of using an H2 database
+ * it uses PostgreSql in a test container.  It will provide each test with a fresh copy of the DB and take care of setting
+ * it up and tearing it down.
+ *
+ * Note: If you only need to support one Entity, use the {@link AbstractDAOTest}, the syntax is much cleaner for the
+ * implementing classes.
+ *
+ * @see <a href="https://www.dropwizard.io/en/latest/manual/testing.html#testing-database-interactions">DropWizard DB Testing</a>
+ * @see <a href="https://testcontainers.com">TestContainers</a>
+ */
+@ExtendWith(DropwizardExtensionsSupport.class)
+@Testcontainers
+public abstract class AbstractMultipleDAOTest {
+    @Container
+    private final PostgreSQLContainer postgreSql = new PostgreSQLContainer(DockerImageName.parse("postgres:14.7"));
+
+    protected DAOTestExtension db;
+
+    // Constructor takes a list of Entity classes that represent the tables we need Hibernate to support for testing.
+    protected AbstractMultipleDAOTest(Class<?>... clazzes) {
+        postgreSql.start();
+
+        DAOTestExtension.Builder builder = DAOTestExtension.newBuilder()
+            .customizeConfiguration(c -> c.setProperty(AvailableSettings.DIALECT, PostgreSQL10Dialect.class.getName()))
+            .setDriver(postgreSql.getDriverClassName())
+            .setUrl(postgreSql.getJdbcUrl())
+            .setUsername(postgreSql.getUsername())
+            .setPassword(postgreSql.getPassword());
+
+        for (Class clazz : clazzes ) {
+            builder.addEntityClass(clazz);
+        }
+
+        db = builder.build();
+    }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4119

## 🛠 Changes

- Updated `AwsDistributedBatchQueue` so that in addition to emitting a queue size metric to AWS, it also logs queue age for Splunk to pick up an alert on.  Queue age is defined as the age in hours of the oldest job in queued status.
- Also updated so that 0 queue size metrics are now emitted to AWS.  Before, 0's weren't sent.

## ℹ️ Context

In the past, we've had jobs get stuck in the queue without ever knowing about it.  By writing the queue age to the logs, a Splunk alert can be configured that will let us know if a job gets stuck in the queue for too long.

Splunk alert can be found [here](https://splunk.cloud.cms.gov/en-US/app/Office_of_Enterprise_Data_Analytics/alert?s=%2FservicesNS%2Fnobody%2FOffice_of_Enterprise_Data_Analytics%2Fsaved%2Fsearches%2FDPC%2520Prod%2520-%2520Long%2520Lived%2520Jobs).  The alert currently looks for jobs that have been queued for more than 20 hours, but that will probably have to be adjusted once we're done making performance improvements to `dpc-aggregation` and we have a better idea what our baseline looks like.

Run book for handling an alert can be found [here](https://confluence.cms.gov/display/DAPC/Splunk+Alerts%3A+Long+Lived+Jobs).

## 🧪 Validation

- Ran locally and made sure logs were written with the correct queue age.
- Deployed to dev and made sure Splunk alert was triggered.
<img width="416" alt="Screenshot 2024-07-02 at 4 19 04 PM" src="https://github.com/CMSgov/dpc-app/assets/133133846/a853e4e0-2f10-45ec-a83e-644caa57a83f">

