### PR TITLE
DPC-4078 automate sandbox approval

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -46,12 +46,19 @@ services:
       context: .
       dockerfile: dpc-web/Dockerfile
     command: sidekiq
-    image: dpc-web-sidekiq:latest
+    image: dpc-web:latest
     environment:
       - REDIS_URL=redis://redis
       - DATABASE_URL=postgresql://db/dpc-website_development
+      - TEST_DATABASE_URL=postgresql://db/dpc-website_test
+      - API_METADATA_URL=http://api:3002/v1
+      - API_ADMIN_URL=http://api:9900
+      - GOLDEN_MACAROON=${GOLDEN_MACAROON}
       - DB_USER=postgres
       - DB_PASS=dpc-safe
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
+      - DPC_CA_CERT=${DPC_CA_CERT}
+      - RUBY_YJIT_ENABLE=1
       - DISABLE_JSON_LOGGER=true
     depends_on:
       - redis
@@ -92,12 +99,18 @@ services:
       context: .
       dockerfile: dpc-admin/Dockerfile
     command: sidekiq
-    image: dpc-admin-sidekiq:latest
+    image: dpc-web-admin:latest
     environment:
       - REDIS_URL=redis://redis
+      - GOLDEN_MACAROON=${GOLDEN_MACAROON}
+      - API_METADATA_URL=http://api:3002/v1
+      - API_ADMIN_URL=http://api:9900
       - DATABASE_URL=postgresql://db/dpc-website_development
+      - TEST_DATABASE_URL=postgresql://db/dpc-website_test
       - DB_USER=postgres
       - DB_PASS=dpc-safe
+      - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
+      - RUBY_YJIT_ENABLE=1
       - DISABLE_JSON_LOGGER=true
     depends_on:
       - redis

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -16,6 +16,8 @@ services:
       - "./dpc-web/coverage:/dpc-web/coverage"
       - ./tmp/letter_opener/web:/dpc-web/tmp/letter_opener
       - "./dpc-web/Gemfile.lock:/dpc-web/Gemfile.lock"
+      - "./dpc-web/app:/dpc-web/app"
+      - "./dpc-web/spec:/dpc-web/spec"
 
     environment:
       - REDIS_URL=redis://redis

--- a/dpc-web/app/jobs/grant_access_job.rb
+++ b/dpc-web/app/jobs/grant_access_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class GrantAccessJob < ApplicationJob
+  def perform(user_id)
+    # Get user
+    # Check if registered
+    # Check if organization exists (by name)
+    # Make org
+    # Make registered org
+    user = User.find user_id
+
+    organization = Organization.find_or_create_by(name: user.requested_organization) do |org|
+      org.organization_type = user.requested_organization_type
+      org.num_providers = user.requested_num_providers
+      org.assign_id
+      org.build_address street: user.address_1,
+                        'street_2' => user.address_2,
+                        city: user.city,
+                        state: user.state,
+                        zip: user.zip
+    end
+
+    unless organization.registered_organization.present?
+      registered_organization = organization.build_registered_organization
+      registered_organization.build_default_fhir_endpoint
+      registered_organization.save
+    end
+    # Add the user at the end to make sure email is sent
+    organization.users << user
+    organization
+  end
+end

--- a/dpc-web/app/jobs/grant_access_job.rb
+++ b/dpc-web/app/jobs/grant_access_job.rb
@@ -24,6 +24,9 @@ class GrantAccessJob < ApplicationJob
   end
 
   def find_or_create_org(user)
+    orgs = Organization.where('name ~* ?', user.requested_organization)
+    return orgs.first if orgs.one?
+
     Organization.find_or_create_by!(name: user.requested_organization) do |org|
       org.organization_type = user.requested_organization_type
       org.num_providers = user.requested_num_providers

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -146,8 +146,8 @@ class User < ApplicationRecord
   end
 
   def grant_access_on_confirmed
-    return unless confirmed_at && confirmed_at_changed?
+    return unless confirmed_at_changed?(from: nil)
 
-    GrantAccessJob.perform_later(self.id)
+    GrantAccessJob.perform_later(id)
   end
 end

--- a/dpc-web/app/models/user.rb
+++ b/dpc-web/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
 
   before_save :requested_num_providers_to_zero_if_blank
 
+  before_update :grant_access_on_confirmed
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable,
   # :trackable, and :omniauthable, :recoverable,
@@ -141,5 +143,11 @@ class User < ApplicationRecord
 
   def requested_num_providers_to_zero_if_blank
     self.requested_num_providers = 0 if requested_num_providers.blank?
+  end
+
+  def grant_access_on_confirmed
+    return unless confirmed_at && confirmed_at_changed?
+
+    GrantAccessJob.perform_later(self.id)
   end
 end

--- a/dpc-web/spec/features/authentication/user_resets_password_spec.rb
+++ b/dpc-web/spec/features/authentication/user_resets_password_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.feature 'user resets password' do
+  include ActiveJob::TestHelper
   let(:user) { create :user }
 
   context 'when successful' do
@@ -13,7 +14,7 @@ RSpec.feature 'user resets password' do
 
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(1)
 
       last_delivery = ActionMailer::Base.deliveries.last
@@ -37,7 +38,7 @@ RSpec.feature 'user resets password' do
 
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(1)
 
       last_delivery = ActionMailer::Base.deliveries.last
@@ -90,7 +91,7 @@ RSpec.feature 'user resets password' do
 
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(1)
 
       visit new_user_password_path
@@ -99,7 +100,7 @@ RSpec.feature 'user resets password' do
 
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(0)
     end
   end

--- a/dpc-web/spec/features/authentication/user_sign_in_spec.rb
+++ b/dpc-web/spec/features/authentication/user_sign_in_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.feature 'user signs in' do
+  include ActiveJob::TestHelper
+
   let!(:user) { create :user, password: '12345ABCDEfghi!', password_confirmation: '12345ABCDEfghi!' }
 
   scenario 'when successful' do
@@ -41,7 +43,7 @@ RSpec.feature 'user signs in' do
 
     expect do
       find('input[data-test="submit"]').click
-      Sidekiq::Worker.drain_all
+      perform_enqueued_jobs
     end.to change(ActionMailer::Base.deliveries, :count).by(2)
 
     last_delivery = ActionMailer::Base.deliveries.last

--- a/dpc-web/spec/features/confirmation/user_confirmation_email_spec.rb
+++ b/dpc-web/spec/features/confirmation/user_confirmation_email_spec.rb
@@ -3,6 +3,7 @@
 require 'rails_helper'
 
 RSpec.feature 'user resends confirmation instructions' do
+  include ActiveJob::TestHelper
   let(:user) { create :user, confirmed_at: nil }
 
   context 'when successful' do
@@ -13,7 +14,7 @@ RSpec.feature 'user resends confirmation instructions' do
 
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(2)
 
       last_delivery = ActionMailer::Base.deliveries.last
@@ -37,7 +38,7 @@ RSpec.feature 'user resends confirmation instructions' do
 
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(0)
 
       expect(page.body).to include('If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.')
@@ -61,7 +62,7 @@ RSpec.feature 'user resends confirmation instructions' do
       # towards the mailing threshold (as this email can only ever be sent once anyways)
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(2)
 
       visit new_user_confirmation_path
@@ -70,7 +71,7 @@ RSpec.feature 'user resends confirmation instructions' do
 
       expect do
         find('input[data-test="submit"]').click
-        Sidekiq::Worker.drain_all
+        perform_enqueued_jobs
       end.to change(ActionMailer::Base.deliveries, :count).by(0)
     end
   end

--- a/dpc-web/spec/jobs/grant_access_job_spec.rb
+++ b/dpc-web/spec/jobs/grant_access_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GrantAccessJob, type: :job do
     let(:user) { create(:user) }
     context :success do
       before { stub_api_client(message: :create_organization, success: true, response: default_org_creation_response) }
-      it 'should create organization' do
+      it 'should create organization', :focus do
         expect do
           GrantAccessJob.perform_now(user.id)
         end.to change { Organization.count }.by 1
@@ -21,12 +21,38 @@ RSpec.describe GrantAccessJob, type: :job do
       end
       it 'should bind user to organization' do
         expect do
-          GrantAccessJob.perform_now(user.id)
-        end.to change { user.organizations.count }.by 1
+          organization = GrantAccessJob.perform_now(user.id)
+          expect(organization.users).to include(user)
+        end.to change { OrganizationUserAssignment.count }.by 1
       end
     end
     context :failure do
-      it 'should fail'
+      before do
+        expect(Rails.logger).to receive(:error).with(/GrantAccessJob failure/)
+      end
+      it 'should fail if no user' do
+        stub_api_client(message: :create_organization, success: true, response: default_org_creation_response)
+        expect do
+          GrantAccessJob.perform_now(:foo)
+        end.to change { Organization.count }.by 0
+      end
+      it 'should fail if cannot save organization' do
+        stub_api_client(message: :create_organization, success: true, response: default_org_creation_response)
+        bad_org = Organization.new
+        bad_org.errors.add(:base, 'bad')
+        org_double = class_double(Organization).as_stubbed_const
+        expect(org_double).to receive(:find_or_create_by!).and_raise(ActiveRecord::RecordInvalid, bad_org)
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { OrganizationUserAssignment.count }.by 0
+      end
+      it 'should fail if cannot save registered organization' do
+        stub_api_client(message: :create_organization, success: false)
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { RegisteredOrganization.count }.by 0
+        expect(user.reload.organizations.length).to eq 0
+      end
     end
   end
   describe 'existing organization' do
@@ -49,8 +75,18 @@ RSpec.describe GrantAccessJob, type: :job do
       end
       it 'should bind user to organization' do
         expect do
-          GrantAccessJob.perform_now(user.id)
+          organization = GrantAccessJob.perform_now(user.id)
+          expect(organization.users).to include(user)
         end.to change { user.organizations.count }.by 1
+      end
+    end
+    context :failure do
+      it 'should fail if cannot register registered organization' do
+        stub_api_client(message: :create_organization, success: false)
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { RegisteredOrganization.count }.by 0
+        expect(user.reload.organizations.length).to eq 0
       end
     end
   end
@@ -73,9 +109,8 @@ RSpec.describe GrantAccessJob, type: :job do
         end.to change { RegisteredOrganization.count }.by 0
       end
       it 'should bind user to organization' do
-        expect do
-          GrantAccessJob.perform_now(user.id)
-        end.to change { user.organizations.count }.by 1
+        organization = GrantAccessJob.perform_now(user.id)
+        expect(organization.users).to include(user)
       end
     end
   end

--- a/dpc-web/spec/jobs/grant_access_job_spec.rb
+++ b/dpc-web/spec/jobs/grant_access_job_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GrantAccessJob, type: :job do
+  include DpcClientSupport
+
+  describe 'new organization' do
+    let(:user) { create(:user) }
+    context :success do
+      before { stub_api_client(message: :create_organization, success: true, response: default_org_creation_response) }
+      it 'should create organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { Organization.count }.by 1
+      end
+      it 'should create registered organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { RegisteredOrganization.count }.by 1
+      end
+      it 'should bind user to organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { user.organizations.count }.by 1
+      end
+    end
+    context :failure do
+      it 'should fail'
+    end
+  end
+  describe 'existing organization' do
+    let(:user) { create(:user) }
+
+    context :success do
+      before do
+        stub_api_client(message: :create_organization, success: true, response: default_org_creation_response)
+        create(:organization, name: user.requested_organization)
+      end
+      it 'should not create organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { Organization.count }.by 0
+      end
+      it 'should not create registered organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { RegisteredOrganization.count }.by 1
+      end
+      it 'should bind user to organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { user.organizations.count }.by 1
+      end
+    end
+  end
+  describe 'existing registered organization' do
+    let(:user) { create(:user) }
+
+    context :success do
+      before do
+        stub_api_client(message: :create_organization, success: true, response: default_org_creation_response)
+        create(:organization, :api_enabled, name: user.requested_organization)
+      end
+      it 'should not create organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { Organization.count }.by 0
+      end
+      it 'should not create registered organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { RegisteredOrganization.count }.by 0
+      end
+      it 'should bind user to organization' do
+        expect do
+          GrantAccessJob.perform_now(user.id)
+        end.to change { user.organizations.count }.by 1
+      end
+    end
+  end
+end

--- a/dpc-web/spec/jobs/grant_access_job_spec.rb
+++ b/dpc-web/spec/jobs/grant_access_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe GrantAccessJob, type: :job do
     let(:user) { create(:user) }
     context :success do
       before { stub_api_client(message: :create_organization, success: true, response: default_org_creation_response) }
-      it 'should create organization', :focus do
+      it 'should create organization' do
         expect do
           GrantAccessJob.perform_now(user.id)
         end.to change { Organization.count }.by 1

--- a/dpc-web/spec/models/user_spec.rb
+++ b/dpc-web/spec/models/user_spec.rb
@@ -213,6 +213,18 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe 'grant access' do
+    let!(:job) { class_double(GrantAccessJob).as_stubbed_const }
+    let(:user) { create(:user, confirmed_at: nil) }
+    it 'should perform GrantAccessJob if confirmed_at changed' do
+      expect(job).to receive(:perform_later).with(user.id)
+      user.confirm
+    end
+    it 'should not perform GrantAccessJob if confirmed_at not changed' do
+      user.update!(first_name: 'Bob')
+    end
+  end
+
   describe 'scopes' do
     describe '.assigned' do
       it 'includes only users with an organization' do


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4078

## 🛠 Changes

- GrantAccessJob added
- User performs GrantAccessJob when confirmed_at set to non-nil
- Other specs changed to use ActiveJob::TestHelper because queue polluted by GrantAccessJob

## ℹ️ Context

We are not really vetting access to the sandbox, so this job will grant access automatically. We will need to set a Splunk alert on log failure so we can manually add in case of failure.

## 🧪 Validation

Manual and automated testing
