### PR TITLE
DPC-4172: Upgrade tika-parsers

### DIFF
--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -81,10 +81,10 @@
         </dependency>
         <!-- tika parser explicit upgrade to something that doesn't break snyk -->
         <dependency>
-	  <groupId>org.apache.tika</groupId>
-	  <artifactId>tika-parsers</artifactId>
-	  <version>2.9.2</version>
-	  <type>pom</type>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-parsers</artifactId>
+            <version>2.9.2</version>
+            <type>pom</type>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>

--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -81,20 +81,10 @@
         </dependency>
         <!-- tika parser explicit upgrade to something that doesn't break snyk -->
         <dependency>
-            <groupId>org.apache.tika</groupId>
-            <artifactId>tika-parsers</artifactId>
-            <version>1.28.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.26.1</version>
+	  <groupId>org.apache.tika</groupId>
+	  <artifactId>tika-parsers</artifactId>
+	  <version>2.9.2</version>
+	  <type>pom</type>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4172

## 🛠 Changes

- tika-parsers upgraded to 2.9.2
- removed explicit upgrade of apache commons - compress to 1.26.1 because that is what 2.9.2 uses

## ℹ️ Context

Snyk was complaining about a vulnerability in a dependency of tika-parsers 1.28.5 (org.apache.cxf 3.5.3) and tika 2.9.2 uses org.apache.cxf 3.5.8, which does not have this vulnerability.

## 🧪 Validation

[Smoke test](https://management.dpc.cms.gov/job/DPC%20-%20Smoke%20Test/5491/) with this upgrade passes