### PR TITLE
Pass AO check of login.gov sends ssn with dashes

### DIFF
--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -66,7 +66,7 @@ class Invitation < ApplicationRecord
   def ao_match?(user_info)
     service = AoVerificationService.new
     result = service.check_eligibility(provider_organization.npi,
-                                       Digest::SHA2.new(256).hexdigest(user_info['social_security_number']))
+                                       Digest::SHA2.new(256).hexdigest(user_info['social_security_number'].tr('-', '')))
     raise InvitationError, result[:failure_reason] unless result[:success]
 
     result

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -386,6 +386,24 @@ RSpec.describe Invitation, type: :model do
         expect(ao_invite.match_user?(user_info)).to eq false
       end
     end
+
+    describe :ao_match do
+      let(:ao_invite) { create(:invitation, :ao) }
+      it 'should pass with good ssn' do
+        user_info = { 'social_security_number' => '900111111' }
+        expect(ao_invite.ao_match?(user_info)).to be_truthy
+      end
+      it 'should pass with good ssn with dashes' do
+        user_info = { 'social_security_number' => '900-11-1111' }
+        expect(ao_invite.ao_match?(user_info)).to be_truthy
+      end
+      it 'should raise with bad ssn' do
+        user_info = { 'social_security_number' => '900666666' }
+        expect do
+          ao_invite.ao_match?(user_info)
+        end.to raise_error(InvitationError, 'ao_med_sanctions')
+      end
+    end
   end
 
   describe :unacceptable_reason do


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Remove dashes from SSN from IdP before hashing

## ℹ️ Context

Our IdP started sending the ssn with dashes, which messes up our comparison logic

## 🧪 Validation

Manual and automated testing
