### PR TITLE
[DPC-3951] POC: Unit test for ExpireAttributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ If you want to run and debug integration tests through IntelliJ there are a few 
   - This will recompile dpc with debug extensions included and start containers for dpc-attribution, dpc-aggregation, dpc-consent and a db.
 - Now you should be able to run any of the integration tests under dpc-api by clicking on the little green arrow next to their implementation.
   - Need to debug a test?  Right click on the triangle and select debug.
+  - If running ExpirationJobTest results in a port collision error, you can stop the attribution service in Docker and try running the test again. 
 - If you have to debug one of the dependant services, for instance because an IT is calling dpc-attribution and getting a 500, and you can't figure out why, follow the instructions under [Local Debugging](#local-debugging) to open up the dependant service's debugger port in docker-compose, then rerun `make start-it-debug`.
   - Now you can attach your debugger to that service and still run integration tests as described above.
   - You'll have one debugger tab open on an IT in dpc-api and another on the dependant service, allowing you to set break points in either and examine the test end to end.

--- a/dpc-attribution/pom.xml
+++ b/dpc-attribution/pom.xml
@@ -117,6 +117,16 @@
             <artifactId>gson</artifactId>
             <version>2.10.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest_Unit.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/jobs/ExpirationJobTest_Unit.java
@@ -1,0 +1,109 @@
+package gov.cms.dpc.attribution.jobs;
+
+import io.dropwizard.db.ManagedDataSource;
+import io.dropwizard.jobs.Job;
+import org.jooq.conf.Settings;
+import org.junit.Before;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+import gov.cms.dpc.attribution.DPCAttributionConfiguration;
+import gov.cms.dpc.attribution.DPCAttributionService;
+import gov.cms.dpc.testing.BufferedLoggerHandler;
+import gov.cms.dpc.testing.JobTestUtils;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.DropwizardTestSupport;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.Group;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.postgresql.jdbc3.Jdbc3ConnectionPool;
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.quartz.JobExecutionContext;
+import ru.vyarus.dropwizard.guice.module.context.SharedConfigurationState;
+
+import javax.ws.rs.client.Client;
+
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static gov.cms.dpc.attribution.AttributionTestHelpers.DEFAULT_ORG_ID;
+import static gov.cms.dpc.attribution.SharedMethods.createAttributionBundle;
+import static gov.cms.dpc.attribution.SharedMethods.submitAttributionBundle;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+/**
+ * Integration test for verifying that the expiration jobs runs correctly.
+ * We currently don't have a way of verifying that the job runs when expected, since we can't really override Dropwizard's time source.
+ * In the future, we might consider using something like ByteBuddy to intercept all system time calls and see if the job still gets run.
+ * <p>
+ * Disabled until made effective
+ */
+@ExtendWith(BufferedLoggerHandler.class)
+@ExtendWith(MockitoExtension.class)
+class ExpirationJobTestUnit {
+
+    @Mock
+    private ManagedDataSource dataSource;
+    @Mock
+    private Settings settings;
+    @Mock
+    private Connection connection;
+    @Mock
+    private JobExecutionContext jobContext;
+    private FhirContext ctx = FhirContext.forDstu3();
+    private static final String PROVIDER_ID = "2322222227";
+    @InjectMocks
+    private ExpireAttributions expireAttributions;
+
+    @BeforeEach
+    public void setUp() throws SQLException, NoSuchFieldException, IllegalAccessException {
+        MockitoAnnotations.openMocks(this);
+
+        JdbcConnectionPool cp = JdbcConnectionPool.create("jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1", "sa", "");
+        this.connection = cp.getConnection();
+        when(this.dataSource.getConnection()).thenReturn(this.connection);
+
+        Field dataSourceField = ExpireAttributions.class.getDeclaredField("dataSource");
+        dataSourceField.setAccessible(true);
+        dataSourceField.set(expireAttributions, dataSource);
+
+        try (Statement stmt = this.connection.createStatement()) {
+            stmt.execute("CREATE TABLE attribution (id BIGINT PRIMARY KEY, period_begin TIMESTAMP WITH TIME ZONE, period_end TIMESTAMP WITH TIME ZONE DEFAULT (now()), inactive BOOLEAN DEFAULT (false))");
+            stmt.execute("INSERT INTO attribution (id, period_begin, period_end) VALUES (1, now(), DATEADD('DAY', -1, now()))");
+        }
+    }
+
+    @Test
+    void testDoJob() throws NoSuchFieldException, SQLException {
+        assertEquals(this.expireAttributions.getClass(), ExpireAttributions.class);
+
+        // Create and submit mock attribution bundle
+        // Need to experiment more with how this works
+        // final Bundle updateBundle = createAttributionBundle(PROVIDER_ID, "0L00L00LL00", DEFAULT_ORG_ID);
+        // final Group group = submitAttributionBundle(client, updateBundle);
+        // Mock attributions for testing
+        // Run job and check that attributions are expired or deleted as appropriate
+        this.expireAttributions.doJob(this.jobContext);
+        try (Statement smt = this.connection.createStatement()) {
+            ResultSet result = smt.executeQuery("SELECT inactive FROM attribution WHERE id = 1");
+            if (result.next()) {
+                String isInactive = result.getString("inactive");
+                assertEquals(isInactive, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/3951

## 🛠 Changes

This serves as a proof of concept for effectively unit testing ExpireAttributions. While this version doesn't run completely, it does prove the following:

1. We can mock attributions for testing.
2. We can mock all the necessary dependencies for ExpireAttributions
3. Instantiating `ExpireAttributions` and calling `doJob` on it causes the method to execute -- in other words, we don't need run an integration test and run the job via Quartz in order to get test coverage.

Future changes will need to complete the run, work out the `Settings` dependency, and test multiple test cases.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
