### PR TITLE
No Ticket: remove reference to never-existing favicon

### DIFF
--- a/dpc-admin/app/views/shared/_head.html.erb
+++ b/dpc-admin/app/views/shared/_head.html.erb
@@ -24,7 +24,6 @@
 
   <link rel="apple-touch-icon" sizes="180x180" href="/admin/assets/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/admin/assets/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/admin/assets/favicon-16x16.png">
   <link rel="manifest" href="/admin/assets/site.webmanifest">
   <link rel="mask-icon" href="/admin/assets/safari-pinned-tab.svg" color="#5bbad5">
   <meta name="msapplication-TileColor" content="#da532c">


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Removed reference to 16x16 favicon from dpc-admin shared header, as this asset does not (and never had) existed.

## ℹ️ Context

When doing the POC for portals smoke tests, the test to admin failed when it attempted its default behavior to download page assets, as this asset is not available.

## 🧪 Validation

[POC smoke tests](https://github.com/CMSgov/dpc-app/pull/2232) passed with page asset verification on dpc-admin.
