### PR TITLE
DPC-4204: use https for link to invitation

### DIFF
--- a/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
+++ b/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
@@ -6,10 +6,10 @@
   </head>
   <body>
     <h1>Register <%= @invitation.provider_organization.name %> to access API claims data.</h1>
-
     <p>You've been identified as an Authorized Official (AO) of <%= @invitation.provider_organization.name %>. As an AO, you must register the organization so that it can access beneficiary claims data through Data at the Point of Care (DPC). You also must sign program Terms of Service.</p>
 
-    <p><%= link_to 'Use this link to register your organization in the DPC Portal.', organization_invitation_url(@invitation.provider_organization, @invitation) %></p>
+    <p><%= link_to 'Use this link to register your organization in the DPC Portal.',
+	   organization_invitation_url(@invitation.provider_organization, @invitation, protocol: Rails.env.production? ? 'https' : 'http') %></p>
 
     <p>This link will expire in 48 hours.</p>
 

--- a/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
+++ b/dpc-portal/app/views/invitation_mailer/invite_ao.html.erb
@@ -6,6 +6,7 @@
   </head>
   <body>
     <h1>Register <%= @invitation.provider_organization.name %> to access API claims data.</h1>
+
     <p>You've been identified as an Authorized Official (AO) of <%= @invitation.provider_organization.name %>. As an AO, you must register the organization so that it can access beneficiary claims data through Data at the Point of Care (DPC). You also must sign program Terms of Service.</p>
 
     <p><%= link_to 'Use this link to register your organization in the DPC Portal.',

--- a/dpc-portal/app/views/invitation_mailer/invite_cd.html.erb
+++ b/dpc-portal/app/views/invitation_mailer/invite_cd.html.erb
@@ -8,7 +8,8 @@
     <h1>Dear <%= @invitation.invited_given_name %> <%= @invitation.invited_family_name %>,</h1>
     <p><%= @invitation.invited_by.given_name %> <%= @invitation.invited_by.family_name %> has invited you to manage
       the credentials for <%= @invitation.provider_organization.name %> within Data at the Point of Care.</p>
-    <p><%= link_to 'Accept this invitation', accept_organization_invitation_url(@invitation.provider_organization, @invitation) %></p>
+    <p><%= link_to 'Accept this invitation',
+	   accept_organization_invitation_url(@invitation.provider_organization, @invitation, protocol: Rails.env.production? ? 'https' : 'http') %></p>	   
     <p>Sincerely,</p>
 
     <p>The Data at the Point of Care Team</p>

--- a/dpc-portal/spec/mailers/invitation_spec.rb
+++ b/dpc-portal/spec/mailers/invitation_spec.rb
@@ -4,12 +4,20 @@ require 'rails_helper'
 
 RSpec.describe InvitationMailer, type: :mailer do
   describe :invite_cd do
+    let(:invited_by) { build(:user) }
+    let(:provider_organization) { build(:provider_organization, id: 2) }
+    let(:invitation) { build(:invitation, id: 4, invited_by:, provider_organization:) }
     it 'has link to invitation' do
-      invited_by = build(:user)
-      provider_organization = build(:provider_organization, id: 2)
-      invitation = build(:invitation, id: 4, invited_by:, provider_organization:)
-      mailer = InvitationMailer.with(invitation:).invite_cd
       expected_url = 'http://localhost:3100/portal/organizations/2/invitations/4/accept'
+
+      mailer = InvitationMailer.with(invitation:).invite_cd
+      expect(mailer.body).to match(expected_url)
+    end
+    it 'has https link to invitation in prod' do
+      expect(Rails.env).to receive(:production?).and_return true
+      expected_url = 'https://localhost:3100/portal/organizations/2/invitations/4/accept'
+
+      mailer = InvitationMailer.with(invitation:).invite_cd
       expect(mailer.body).to match(expected_url)
     end
   end

--- a/dpc-portal/spec/mailers/invitation_spec.rb
+++ b/dpc-portal/spec/mailers/invitation_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       mailer = InvitationMailer.with(invitation:).invite_cd
       expect(mailer.body).to match(expected_url)
     end
-    it 'has https link to invitation in prod' do
+    it 'uses https for invitation link if it thinks it is prod' do
       expect(Rails.env).to receive(:production?).and_return true
       expected_url = 'https://localhost:3100/portal/organizations/2/invitations/4/accept'
 
@@ -33,7 +33,7 @@ RSpec.describe InvitationMailer, type: :mailer do
       html = mailer.body.parts.select { |part| part.content_type.match 'text/html' }.first
       expect(html.body).to match(expected_url)
     end
-    it 'has uses https if it thinks it is prod' do
+    it 'uses https for invitation link if it thinks it is prod' do
       expect(Rails.env).to receive(:production?).and_return true
       expected_url = 'https://localhost:3100/portal/organizations/2/invitations/4'
 

--- a/dpc-portal/spec/mailers/invitation_spec.rb
+++ b/dpc-portal/spec/mailers/invitation_spec.rb
@@ -14,12 +14,22 @@ RSpec.describe InvitationMailer, type: :mailer do
     end
   end
   describe :invite_ao do
+    let(:provider_organization) { build(:provider_organization, id: 2) }
+    let(:invitation) { build(:invitation, id: 4, provider_organization:) }
+    let(:given_name) { '' }
+    let(:family_name) { '' }
     it 'has link to invitation' do
-      provider_organization = build(:provider_organization, id: 2)
-      invitation = build(:invitation, id: 4, provider_organization:)
-      given_name = family_name = ''
-      mailer = InvitationMailer.with(invitation:, given_name:, family_name:).invite_ao
       expected_url = 'http://localhost:3100/portal/organizations/2/invitations/4'
+
+      mailer = InvitationMailer.with(invitation:, given_name:, family_name:).invite_ao
+      html = mailer.body.parts.select { |part| part.content_type.match 'text/html' }.first
+      expect(html.body).to match(expected_url)
+    end
+    it 'has uses https if it thinks it is prod' do
+      expect(Rails.env).to receive(:production?).and_return true
+      expected_url = 'https://localhost:3100/portal/organizations/2/invitations/4'
+
+      mailer = InvitationMailer.with(invitation:, given_name:, family_name:).invite_ao
       html = mailer.body.parts.select { |part| part.content_type.match 'text/html' }.first
       expect(html.body).to match(expected_url)
     end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4204

## 🛠 Changes

- Templates for cd and ao invites explicitly use https if Rails.env.production? == true

## ℹ️ Context

- Link to invitation in production should be https protocol
- Rails.env just means not running in development or test mode. It should be 'production' for dev and test (and eventually prod) servers

## 🧪 Validation

Automated testing