### PR TITLE
DPC-4221: Remove unnecessary hashing

### DIFF
--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -71,7 +71,7 @@ class Invitation < ApplicationRecord
 
     service = AoVerificationService.new
     result = service.check_eligibility(provider_organization.npi,
-                                       Digest::SHA2.new(256).hexdigest(user_info['social_security_number'].tr('-', '')))
+                                       user_info['social_security_number'].tr('-', ''))
     raise InvitationError, result[:failure_reason] unless result[:success]
 
     result

--- a/dpc-portal/app/services/ao_verification_service.rb
+++ b/dpc-portal/app/services/ao_verification_service.rb
@@ -8,8 +8,8 @@ class AoVerificationService
     @cpi_api_gw_client = CpiApiGatewayClient.new
   end
 
-  def check_eligibility(organization_npi, hashed_ao_ssn)
-    ao_role = check_ao_eligibility(organization_npi, :ssn, hashed_ao_ssn)
+  def check_eligibility(organization_npi, ssn)
+    ao_role = check_ao_eligibility(organization_npi, :ssn, ssn)
 
     { success: true, ao_role: }
   rescue OAuth2::Error => e
@@ -101,7 +101,7 @@ class AoVerificationService
   def role_matches(role, identifier_type, identifier)
     case identifier_type
     when :ssn
-      role['roleCode'] == '10' && Digest::SHA2.new(256).hexdigest(role['ssn']) == identifier
+      role['roleCode'] == '10' && role['ssn'] == identifier
     when :pac_id
       role['roleCode'] == '10' && role['pacId'] == identifier
     end

--- a/dpc-portal/db/schema.rb
+++ b/dpc-portal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_20_201824) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_08_140452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,28 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_20_201824) do
     t.datetime "last_checked_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["invitation_id"], name: "index_ao_org_links_on_invitation_id"
     t.index ["user_id", "provider_organization_id"], name: "index_ao_org_links_on_user_id_and_provider_organization_id", unique: true
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "cd_org_links", force: :cascade do |t|

--- a/dpc-portal/db/schema.rb
+++ b/dpc-portal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_08_140452) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_20_201824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,28 +25,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_08_140452) do
     t.datetime "last_checked_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.index ["invitation_id"], name: "index_ao_org_links_on_invitation_id"
     t.index ["user_id", "provider_organization_id"], name: "index_ao_org_links_on_user_id_and_provider_organization_id", unique: true
-  end
-
-  create_table "audits", force: :cascade do |t|
-    t.integer "auditable_id"
-    t.string "auditable_type"
-    t.integer "associated_id"
-    t.string "associated_type"
-    t.integer "user_id"
-    t.string "user_type"
-    t.string "username"
-    t.string "action"
-    t.text "audited_changes"
-    t.integer "version", default: 0
-    t.string "comment"
-    t.string "remote_address"
-    t.string "request_uuid"
-    t.datetime "created_at"
-    t.index ["associated_type", "associated_id"], name: "associated_index"
-    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
-    t.index ["created_at"], name: "index_audits_on_created_at"
-    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
-    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "cd_org_links", force: :cascade do |t|

--- a/dpc-portal/spec/services/ao_verification_service_spec.rb
+++ b/dpc-portal/spec/services/ao_verification_service_spec.rb
@@ -6,99 +6,95 @@ require 'rails_helper'
 describe AoVerificationService do
   let(:service) { AoVerificationService.new }
   let(:good_org_npi) { '3077494235' }
-  let(:hashed_ao_ssn) { Digest::SHA2.new(256).hexdigest('900111111') }
+  let(:valid_ao_ssn) { '900111111' }
 
   describe '.check_eligibility' do
     it 'succeeds with good input' do
-      response = service.check_eligibility(good_org_npi, hashed_ao_ssn)
+      response = service.check_eligibility(good_org_npi, valid_ao_ssn)
       expect(response).to include({ success: true })
       expect(response[:ao_role]).to be_present
     end
 
     it 'returns an error if looking up enrollments for the NPI returns a 404' do
       organization_npi = '3299073577'
-      response = service.check_eligibility(organization_npi, hashed_ao_ssn)
+      response = service.check_eligibility(organization_npi, valid_ao_ssn)
       expect(response).to include({ success: false, failure_reason: 'bad_npi' })
     end
 
     it 'returns an error if there are no approved enrollments' do
       organization_npi = '3782297014'
-      response = service.check_eligibility(organization_npi, hashed_ao_ssn)
+      response = service.check_eligibility(organization_npi, valid_ao_ssn)
       expect(response).to include({ success: false, failure_reason: 'no_approved_enrollment' })
     end
 
     it 'returns an error if the authorized official is only in an inactive enrollment' do
       not_ao_ssn = '900222222'
-      hashed_not_ao_ssn = Digest::SHA2.new(256).hexdigest(not_ao_ssn)
-      response = service.check_eligibility(good_org_npi, hashed_not_ao_ssn)
+      response = service.check_eligibility(good_org_npi, not_ao_ssn)
       expect(response).to include({ success: false, failure_reason: 'user_not_authorized_official' })
     end
 
     it 'returns an error if the user is not an authorized official' do
       not_ao_ssn = '111223456'
-      hashed_not_ao_ssn = Digest::SHA2.new(256).hexdigest(not_ao_ssn)
-      response = service.check_eligibility(good_org_npi, hashed_not_ao_ssn)
+      response = service.check_eligibility(good_org_npi, not_ao_ssn)
       expect(response).to include({ success: false, failure_reason: 'user_not_authorized_official' })
     end
 
     it 'returns an error if the AO has an active med sanction' do
       sanctioned_ao_ssn = '900666666'
-      hashed_sanctioned_ao_ssn = Digest::SHA2.new(256).hexdigest(sanctioned_ao_ssn)
-      response = service.check_eligibility(good_org_npi, hashed_sanctioned_ao_ssn)
+      response = service.check_eligibility(good_org_npi, sanctioned_ao_ssn)
       expect(response).to include({ success: false, failure_reason: 'ao_med_sanctions' })
     end
 
     it 'returns an error if the org has an active med sanction' do
       sanctioned_org_npi = '3598564557'
-      response = service.check_eligibility(sanctioned_org_npi, hashed_ao_ssn)
+      response = service.check_eligibility(sanctioned_org_npi, valid_ao_ssn)
       expect(response).to include({ success: false, failure_reason: 'org_med_sanctions' })
     end
 
     it 'does not return an error if user has a med sanction AND waiver' do
-      ao_ssn = '900777777'
-      hashed_ao_ssn = Digest::SHA2.new(256).hexdigest(ao_ssn)
-      response = service.check_eligibility(good_org_npi, hashed_ao_ssn)
+      waived_ao_ssn = '900777777'
+      response = service.check_eligibility(good_org_npi, waived_ao_ssn)
       expect(response).to include({ success: true })
     end
 
     it 'does not return an error if org has a med sanction AND waiver' do
-      org_npi = '3098168743'
-      response = service.check_eligibility(org_npi, hashed_ao_ssn)
+      waived_org_npi = '3098168743'
+      response = service.check_eligibility(waived_org_npi, valid_ao_ssn)
       expect(response).to include({ success: true })
     end
 
     it 'returns an error on Gateway server error' do
-      org_npi = '3593081045'
-      response = service.check_eligibility(org_npi, hashed_ao_ssn)
+      error_generating_org_npi = '3593081045'
+      response = service.check_eligibility(error_generating_org_npi, valid_ao_ssn)
       expect(response[:success]).to eq false
       expect(response[:failure_reason]).to eq 'api_gateway_error'
     end
 
     it 'returns an error on invalid endpoint' do
-      org_npi = '3746980325'
-      response = service.check_eligibility(org_npi, hashed_ao_ssn)
+      invalid_endpoint_generating_org_npi = '3746980325'
+      response = service.check_eligibility(invalid_endpoint_generating_org_npi, valid_ao_ssn)
       expect(response[:success]).to eq false
       expect(response[:failure_reason]).to eq 'invalid_endpoint_called'
     end
 
     it 'returns an error when any error' do
-      org_npi = '3302763388'
-      response = service.check_eligibility(org_npi, hashed_ao_ssn)
+      unexpected_error_generating_org_npi = '3302763388'
+      response = service.check_eligibility(unexpected_error_generating_org_npi, valid_ao_ssn)
       expect(response[:success]).to eq false
       expect(response[:failure_reason]).to eq 'unexpected_error'
     end
   end
 
   describe '.check_ao_eligibility' do
-    it 'should work with good hashed ssn' do
+    it 'should work with good ssn' do
       expect do
-        service.check_ao_eligibility(good_org_npi, :ssn, hashed_ao_ssn)
+        service.check_ao_eligibility(good_org_npi, :ssn, valid_ao_ssn)
       end.to_not raise_error
     end
 
-    it 'should raise error with bad hashed ssn' do
+    it 'should raise error with bad ssn' do
       expect do
-        service.check_ao_eligibility(good_org_npi, :ssn, 'not even a hash')
+        service.check_ao_eligibility(good_org_npi, :ssn, 'not even ssn-like')
       end.to raise_error(AoException, 'user_not_authorized_official')
     end
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4221

## 🛠 Changes

Hashing of ssn for comparison with ssn in information from CPI API Gateway removed. Now doing straight string matching.

## ℹ️ Context

Original implementation assumed we would be storing the ssn in the session, so we set it up to compare hashes. We are not storing it in the session (we either retrieve it from our IdP for the check, or we use a stored foreign key), so the hashing no longer serves any useful purpose.

## 🧪 Validation

Manual and Automated testing
