### PR TITLE
Me/dpc 4219 update org and ao status

### DIFF
--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -36,8 +36,6 @@ class InvitationsController < ApplicationController
     Rails.logger.info(['User logged in',
                        { actionContext: LoggingConstants::ActionContext::Registration,
                          actionType: LoggingConstants::ActionType::UserLoggedIn }])
-
-    verify_ao
     render(Page::Invitations::SuccessComponent.new(@organization, @invitation))
   end
 
@@ -96,6 +94,8 @@ class InvitationsController < ApplicationController
                        { actionContext: LoggingConstants::ActionContext::Registration,
                          actionType: LoggingConstants::ActionType::AoLinkedToOrg }])
     @invitation.accept!
+    @user.update(verification_status: 'approved')
+    @organization.update(verification_status: 'approved')
   end
 
   # rubocop:disable Metrics/AbcSize
@@ -241,11 +241,4 @@ def redirect_host
   else
     "https://#{ENV.fetch('ENV', nil)}.dpc.cms.gov"
   end
-end
-
-def verify_ao
-  return unless @invitation.authorized_official?
-
-  @user.update(verification_status: 'approved')
-  @organization.update(verification_status: 'approved')
 end

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -36,6 +36,11 @@ class InvitationsController < ApplicationController
     Rails.logger.info(['User logged in',
                        { actionContext: LoggingConstants::ActionContext::Registration,
                          actionType: LoggingConstants::ActionType::UserLoggedIn }])
+
+    if @invitation.authorized_official?
+      @user.update(verification_status: 'approved')
+      @organization.update(verification_status: 'approved')
+    end
     render(Page::Invitations::SuccessComponent.new(@organization, @invitation))
   end
 

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -37,10 +37,7 @@ class InvitationsController < ApplicationController
                        { actionContext: LoggingConstants::ActionContext::Registration,
                          actionType: LoggingConstants::ActionType::UserLoggedIn }])
 
-    if @invitation.authorized_official?
-      @user.update(verification_status: 'approved')
-      @organization.update(verification_status: 'approved')
-    end
+    verify_ao
     render(Page::Invitations::SuccessComponent.new(@organization, @invitation))
   end
 
@@ -229,4 +226,11 @@ def redirect_host
   else
     "https://#{ENV.fetch('ENV', nil)}.dpc.cms.gov"
   end
+end
+
+def verify_ao
+  return unless @invitation.authorized_official?
+
+  @user.update(verification_status: 'approved')
+  @organization.update(verification_status: 'approved')
 end

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -495,6 +495,23 @@ RSpec.describe 'Invitations', type: :request do
         let(:invitation) { create(:invitation, :cd, verification_code:) }
         let(:success_params) { { verification_code: } }
       end
+      context :success do
+        let(:invitation) { create(:invitation, :cd) }
+        let(:org) { invitation.provider_organization }
+        before do
+          log_in
+          stub_user_info
+          get "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
+          post "/organizations/#{org.id}/invitations/#{invitation.id}/confirm"
+        end
+        it 'should not save verification_status on user and org' do
+          create(:user, provider: :openid_connect, uid: user_info['sub'], pac_id: :foo)
+          post "/organizations/#{org.id}/invitations/#{invitation.id}/register"
+          user = User.find_by(uid: user_info['sub'])
+          expect(user.verification_status).to be_nil
+          expect(org.reload.verification_status).to be_nil
+        end
+      end
     end
     context :ao do
       it_behaves_like 'an invitation endpoint', :post, 'register' do

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -536,6 +536,12 @@ RSpec.describe 'Invitations', type: :request do
           expect(links.size).to eq 1
           expect(links.first.provider_organization).to eq org
         end
+        it 'should save verification_status on user and org' do
+          post "/organizations/#{org.id}/invitations/#{invitation.id}/register"
+          user = User.find_by(uid: user_info['sub'])
+          expect(user.verification_status).to eq('approved')
+          expect(org.reload.verification_status).to eq('approved')
+        end
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4219

## 🛠 Changes

When an AO successfully registers their and the organizations `verification_status` is set to `approved`.

## ℹ️ Context

This is part of the AO registration workflow.

## 🧪 Validation

Added a couple tests to make sure the values are set when an AO registers and not set when a CD registers.
