### PR TITLE
refresh rosterEntity object w/ latest data before returning api response

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterDAO.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jdbi/RosterDAO.java
@@ -28,6 +28,11 @@ public class RosterDAO extends AbstractDAO<RosterEntity> {
         return Optional.ofNullable(this.get(rosterID));
     }
 
+    public void refresh(RosterEntity roster) {
+        currentSession().flush();
+        currentSession().refresh(roster);
+    }
+
     public List<RosterEntity> findEntities(UUID resourceID, UUID organizationID, String providerNPI, String patientReference) {
 
         // Build a selection query to get records from the database

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -236,8 +236,7 @@ public class GroupResource extends AbstractGroupResource {
         Stream.concat(existingAttributions.stream(), newAttributions.stream())
             .forEach(relationshipDAO::addAttributionRelationship);
 
-        // TODO: Force commit before making this call (DPC-4196)
-        //Getting it again to access the latest updates from above code
+        this.rosterDAO.refresh(rosterEntity);
         final RosterEntity rosterEntity1 = this.rosterDAO.getEntity(rosterID)
                 .orElseThrow(() -> NOT_FOUND_EXCEPTION);
 


### PR DESCRIPTION
## 🎫 Ticket

This is a work-in-progress draft for [DPC-4196](https://jira.cms.gov/browse/DPC-4196). This PR makes an additional call to RosterDAO before returning API response to client

## 🛠 Changes
Call `session.refresh()` in `{{baseUrl}}/v1/Group/{{group_id}}/$add`

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context
I believe `this.rosterDAO.getEntity(rosterID)` is being cached.

> _Whenever you pass an object to save(), update() or saveOrUpdate(), and whenever you retrieve an object using load(), get(), list(), iterate() or scroll(), that object is added to the internal cache of the Session._

from [19.3. Managing the caches](https://docs.jboss.org/hibernate/core/3.3/reference/en/html/performance.html#performance-sessioncache)

> _It is possible to re-load an object and all its collections at any time, using the refresh() method. This is useful when database triggers are used to initialize some of the properties of the object._
> 
> ```
> sess.save(cat);
> sess.flush(); //force the SQL INSERT
> sess.refresh(cat); //re-read the state (after the trigger executes)
> ```
> 
from [11.3 Loading an object](https://docs.jboss.org/hibernate/core/3.6/reference/en-US/html/objectstate.html#objectstate-loading)

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
manually tested in Postman

![Screenshot 2024-08-13 at 12 54 12 PM](https://github.com/user-attachments/assets/1eca7e71-0fa3-4080-8717-8ce339cb13e9)



