### PR TITLE
[DPC-4196] - Episode II - fix replaceRoster() response

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -176,9 +176,9 @@ public class GroupResource extends AbstractGroupResource {
                 })
             .forEach(relationshipDAO::addAttributionRelationship);
 
-        // TODO: Force commit before making this call (DPC-4196)
         final RosterEntity rosterEntity1 = rosterDAO.getEntity(rosterID)
                 .orElseThrow(() -> NOT_FOUND_EXCEPTION);
+        this.rosterDAO.refresh(rosterEntity1);
 
         return converter.toFHIR(Group.class, rosterEntity1);
     }


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4196](https://jira.cms.gov/browse/DPC-4196)

## 🛠 Changes

- fixes replaceRoster() response to include the data for the newly updated roster (e.g. the members that are `PUT` in there)
- integration test covers this scenario
- uses same refresh method from DAO class in previous PR (linked below)

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context
This is a follow-up to #2241 


<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
Before:
![broken_roster_replace](https://github.com/user-attachments/assets/c8068691-672e-4b51-8ff9-beeb2bca2823)


After:
![fixed_roster_replace](https://github.com/user-attachments/assets/796b9912-f27d-4f3a-99c8-5766abc1cd3d)


See also `dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/GroupResourceTest.java`

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
