### PR TITLE
upgrade fugit

### DIFF
--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     cgi (0.4.1)
     climate_control (1.2.0)
     coderay (1.1.3)
-    concurrent-ruby (1.3.1)
+    concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crack (1.0.0)
       bigdecimal
@@ -189,7 +189,7 @@ GEM
       date_time_precision (>= 0.8)
       mime-types (>= 3.0)
       nokogiri (>= 1.11.4)
-    fugit (1.11.0)
+    fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     globalid (1.2.1)


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Fugit in Gemfile.lock updated

## ℹ️ Context

Build failing on GHSA-2m96-52r3-2f3g
Need to upgrade to 1.11.1
We don't request fugit directly, but via sidekiq-cron. Updated by disabling check, then running `bundle update fugit` in the docker container.

## 🧪 Validation

Builds and passes tests
