### PR TITLE
DPC-4237: Allow access to ip address endpoints

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCAuthFilter.java
@@ -15,7 +15,6 @@ import org.slf4j.MDC;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.util.Collections;
 import java.util.List;
@@ -60,11 +59,6 @@ public abstract class DPCAuthFilter extends AuthFilter<DPCAuthCredentials, Organ
         final String orgId = dpcAuthCredentials.getOrganization().getId();
         final String resourceRequested = XSSSanitizerUtil.sanitize(uriInfo.getPath());
         final String method = requestContext.getMethod();
-
-        // TODO Remove this when we want to turn on the IpAddress end point
-        if(resourceRequested.equals("v1/IpAddress")) {
-            throw new WebApplicationException(Response.Status.FORBIDDEN);
-        }
 
         final boolean authenticated = this.authenticate(requestContext, dpcAuthCredentials, null);
         if (!authenticated) {

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/IpAddressResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/IpAddressResourceTest.java
@@ -41,22 +41,7 @@ class IpAddressResourceTest extends AbstractSecureApplicationTest {
         this.fullyAuthedToken = APIAuthHelpers.jwtAuthFlow(getBaseURL(), ORGANIZATION_TOKEN, PUBLIC_KEY_ID, PRIVATE_KEY).accessToken;
     }
 
-    // TODO Once we turn on the IpAddress end point, remove this test and re-enable all of the others.
     @Test
-    public void testForbidden() throws URISyntaxException, IOException {
-        CloseableHttpClient client = HttpClients.createDefault();
-        URIBuilder uriBuilder = new URIBuilder(String.format("%s/IpAddress", getBaseURL()));
-
-        HttpGet get = new HttpGet(uriBuilder.build());
-        get.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
-        get.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + this.fullyAuthedToken);
-
-        CloseableHttpResponse response = client.execute(get);
-        assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusLine().getStatusCode());
-    }
-
-    @Test
-    @Disabled
     @Order(1)
     public void testBadAuth() throws URISyntaxException, IOException {
         CloseableHttpClient client = HttpClients.createDefault();
@@ -71,7 +56,6 @@ class IpAddressResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    @Disabled
     @Order(2)
     public void testNoAuth() throws URISyntaxException, IOException {
         CloseableHttpClient client = HttpClients.createDefault();
@@ -85,7 +69,6 @@ class IpAddressResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    @Disabled
     @Order(3)
     public void testPost_happyPath() throws IOException, URISyntaxException {
         CloseableHttpClient client = HttpClients.createDefault();
@@ -113,7 +96,6 @@ class IpAddressResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    @Disabled
     @Order(4)
     // Force this to run after the POST test
     public void testGet() throws URISyntaxException, IOException {
@@ -140,7 +122,6 @@ class IpAddressResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    @Disabled
     @Order(5)
     public void testDelete_happyPath() throws URISyntaxException, IOException {
         CloseableHttpClient client = HttpClients.createDefault();
@@ -155,7 +136,6 @@ class IpAddressResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    @Disabled
     @Order(6)
     public void testDelete_notFound() throws URISyntaxException, IOException {
         CloseableHttpClient client = HttpClients.createDefault();
@@ -170,7 +150,6 @@ class IpAddressResourceTest extends AbstractSecureApplicationTest {
     }
 
     @Test
-    @Disabled
     @Order(7)
     // Force this test to run last since it's going to max out our Ips for the org
     public void testPost_tooManyIps() throws IOException, URISyntaxException {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4237

## 🛠 Changes

- Forbidden response to access IP Address endpoints removed
- Tests for IP Address endpoints re-enabled

## ℹ️ Context

Revert of [disabling commit](https://github.com/CMSgov/dpc-app/commit/0b07319e3d33007c48ae6d7512d60acbbc692cd6)
We had disabled this endpoint pending [DPC-3768](https://jira.cms.gov/browse/DPC-3768), but we need it for pentesting, so it needs to be enabled for lower environments.

## 🧪 Validation

Manual and automated tests.
Works locally:
![Screenshot 2024-08-21 at 3 56 30 PM](https://github.com/user-attachments/assets/6dbbfcb1-9245-4c82-aa55-d52cde491e4f)

