### PR TITLE
Bug fix

### DIFF
--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jobs/ExpireAttributions.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/jobs/ExpireAttributions.java
@@ -43,6 +43,8 @@ public class ExpireAttributions extends Job {
         logger.debug("Expiring active attribution relationships before {}.", expirationTemporal.format(DateTimeFormatter.ISO_DATE_TIME));
 
         try (final Connection connection = this.dataSource.getConnection(); final DSLContext context = DSL.using(connection, this.settings)) {
+            connection.setAutoCommit(false);
+
             final int updated = context
                     .update(Attributions.ATTRIBUTIONS)
                     .set(Attributions.ATTRIBUTIONS.INACTIVE, true)


### PR DESCRIPTION
## 🎫 Ticket

None

## 🛠 Changes

Explicitly turn off auto commit.

## ℹ️ Context

We were seeing this in the logs:
```
exception:  org.postgresql.util.PSQLException: Cannot commit when autoCommit is enabled.
	at org.postgresql.jdbc.PgConnection.commit(PgConnection.java:998)
	at jdk.internal.reflect.GeneratedMethodAccessor31.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.tomcat.jdbc.pool.ProxyConnection.invoke(ProxyConnection.java:131)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:107)
	at org.apache.tomcat.jdbc.pool.interceptor.AbstractCreateStatementInterceptor.invoke(AbstractCreateStatementInterceptor.java:74)
	at org.apache.tomcat.jdbc.pool.JdbcInterceptor.invoke(JdbcInterceptor.java:107)
	at org.apache.tomcat.jdbc.pool.DisposableConnectionFacade.invoke(DisposableConnectionFacade.java:81)
	at com.sun.proxy.$Proxy78.commit(Unknown Source)
	at gov.cms.dpc.attribution.jobs.ExpireAttributions.doJob(ExpireAttributions.java:61)
	... 3 common frames omitted
Wrapped by: gov.cms.dpc.attribution.exceptions.AttributionException: An error occurred during the database operation.
	at gov.cms.dpc.attribution.jobs.ExpireAttributions.doJob(ExpireAttributions.java:63)
	at io.dropwizard.jobs.Job.execute(Job.java:42)
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
	... 1 common frames omitted
Wrapped by: org.quartz.SchedulerException: Job threw an unhandled exception.
	at org.quartz.core.JobRunShell.run(JobRunShell.java:213)
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

## 🧪 Validation

Pushed to dev, error is gone.
