### PR TITLE
DPC-4252 Credential Delegate name missing

### DIFF
--- a/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
@@ -8,8 +8,8 @@
         <% if @active_credential_delegates.present? %>
           <%= render(Core::Table::TableComponent.new(id: 'active-cd-table', additional_classes: ['width-full'], sortable: false)) do %>
             <%= render(Core::Table::HeaderComponent.new(caption: 'Active Credential Delegate Table',
-                                                    columns: ['Name', 'Email', 'Active since', ''])) %>
-            <%= render(Core::Table::RowComponent.with_collection(@active_credential_delegates, keys: ['full_name', 'email', 'activated_at', 'X'])) %>
+                                                    columns: ['Name', 'Email', 'Active since'])) %>
+            <%= render(Core::Table::RowComponent.with_collection(@active_credential_delegates, keys: ['full_name', 'email', 'activated_at'])) %>
           <% end %>
         <% else %>
           <p>There are no active credential delegates.</p>

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -112,6 +112,8 @@ class InvitationsController < ApplicationController
                              actionType: LoggingConstants::ActionType::AoCreated }])
       end
       user_to_create.email = @invitation.invited_email
+      user_to_create.given_name = user_info['given_name']
+      user_to_create.family_name = user_info['family_name']
       user_to_create.pac_id = session.delete(:user_pac_id)
     end
     @user.update(pac_id: session.delete(:user_pac_id)) unless @user.pac_id

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -98,28 +98,29 @@ class InvitationsController < ApplicationController
     @organization.update(verification_status: 'approved')
   end
 
-  # rubocop:disable Metrics/AbcSize
   def user
     user_info = UserInfoService.new.user_info(session)
     @user = User.find_or_create_by!(provider: :openid_connect, uid: user_info['sub']) do |user_to_create|
-      if @invitation.credential_delegate?
-        Rails.logger.info(['Credential Delegate user created,',
-                           { actionContext: LoggingConstants::ActionContext::Registration,
-                             actionType: LoggingConstants::ActionType::CdCreated }])
-      elsif @invitation.authorized_official?
-        Rails.logger.info(['Authorized Official user created,',
-                           { actionContext: LoggingConstants::ActionContext::Registration,
-                             actionType: LoggingConstants::ActionType::AoCreated }])
-      end
-      user_to_create.email = @invitation.invited_email
-      user_to_create.given_name = user_info['given_name']
-      user_to_create.family_name = user_info['family_name']
-      user_to_create.pac_id = session.delete(:user_pac_id)
+      assign_user_attributes(user_to_create)
+      log_user_create
     end
-    @user.update(pac_id: session.delete(:user_pac_id)) unless @user.pac_id
+    update_user(user_info)
     @user
   end
-  # rubocop:enable Metrics/AbcSize
+
+  def assign_user_attributes(user_to_create)
+    user_to_create.email = @invitation.invited_email
+    user_to_create.given_name = user_info['given_name']
+    user_to_create.family_name = user_info['family_name']
+    user_to_create.pac_id = session.delete(:user_pac_id)
+  end
+
+  def update_user(user_info)
+    @user.pac_id = session.delete(:user_pac_id) unless @user.pac_id
+    @user.given_name = user_info['given_name']
+    @user.family_name = user_info['family_name']
+    @user.save
+  end
 
   def check_for_token
     if session[:login_dot_gov_token].present? &&
@@ -233,6 +234,18 @@ class InvitationsController < ApplicationController
     session[:user_return_to] = accept_organization_invitation_url(@organization, params[:id])
     session['omniauth.nonce'] = @nonce = SecureRandom.hex(16)
     session['omniauth.state'] = @state = SecureRandom.hex(16)
+  end
+
+  def log_user_create
+    if @invitation.authorized_official?
+      Rails.logger.info(['Authorized Official user created,',
+                         { actionContext: LoggingConstants::ActionContext::Registration,
+                           actionType: LoggingConstants::ActionType::AoCreated }])
+    elsif @invitation.credential_delegate?
+      Rails.logger.info(['Credential Delegate user created,',
+                         { actionContext: LoggingConstants::ActionContext::Registration,
+                           actionType: LoggingConstants::ActionType::CdCreated }])
+    end
   end
 end
 

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -102,7 +102,7 @@ class InvitationsController < ApplicationController
     user_info = UserInfoService.new.user_info(session)
     @user = User.find_or_create_by!(provider: :openid_connect, uid: user_info['sub']) do |user_to_create|
       assign_user_attributes(user_to_create)
-      log_user_create
+      log_create_user
     end
     update_user(user_info)
     @user
@@ -236,15 +236,15 @@ class InvitationsController < ApplicationController
     session['omniauth.state'] = @state = SecureRandom.hex(16)
   end
 
-  def log_user_create
-    if @invitation.authorized_official?
-      Rails.logger.info(['Authorized Official user created,',
-                         { actionContext: LoggingConstants::ActionContext::Registration,
-                           actionType: LoggingConstants::ActionType::AoCreated }])
-    elsif @invitation.credential_delegate?
+  def log_create_user
+    if @invitation.credential_delegate?
       Rails.logger.info(['Credential Delegate user created,',
                          { actionContext: LoggingConstants::ActionContext::Registration,
                            actionType: LoggingConstants::ActionType::CdCreated }])
+    elsif @invitation.authorized_official?
+      Rails.logger.info(['Authorized Official user created,',
+                         { actionContext: LoggingConstants::ActionContext::Registration,
+                           actionType: LoggingConstants::ActionType::AoCreated }])
     end
   end
 end

--- a/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
@@ -79,8 +79,6 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
                 <th scope="row" role="columnheader">
                   Active since
                 </th>
-                <th scope="row" role="columnheader">
-                </th>
               </tr>
             </thead>
         HTML
@@ -94,7 +92,6 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
             <td data-sort-value="Bob Hodges">Bob Hodges</td>
             <td data-sort-value="bob@example.com">bob@example.com</td>
             <td data-sort-value="#{activated}">#{activated}</td>
-            <td data-sort-value="X">X</td>
           </tr>
         HTML
         is_expected.to include(normalize_space(expected_html))

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -485,6 +485,9 @@ RSpec.describe 'Invitations', type: :request do
           expect do
             post "/organizations/#{org.id}/invitations/#{invitation.id}/register"
           end.to change { User.count }.by 1
+          user = User.last
+          expect(user.given_name).to eq user_info['given_name']
+          expect(user.family_name).to eq user_info['family_name']
         end
         it 'should log when credential delegate user is created' do
           invitation.update!(invitation_type: 0)

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -511,6 +511,15 @@ RSpec.describe 'Invitations', type: :request do
             post "/organizations/#{org.id}/invitations/#{invitation.id}/register"
           end.to change { User.count }.by 0
         end
+        it 'should update name of user if changed' do
+          user = create(:user, provider: :openid_connect, uid: user_info['sub'], given_name: :foo, family_name: :bar)
+          expect do
+            post "/organizations/#{org.id}/invitations/#{invitation.id}/register"
+          end.to change { User.count }.by 0
+          user.reload
+          expect(user.given_name).to eq user_info['given_name']
+          expect(user.family_name).to eq user_info['family_name']
+        end
         it 'should not override pac_id on existing user' do
           create(:user, provider: :openid_connect, uid: user_info['sub'], pac_id: :foo)
           post "/organizations/#{org.id}/invitations/#{invitation.id}/register"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4252

## 🛠 Changes

- User names added/updated when registering
- Column removed from "Active Credential Delegates" table

## ℹ️ Context

Testing revealed we were not showing the Credential Delegate's name in the "Active Credential Delegates" table. It turns out that we had stopped persisting the name on create.
As long as we were in there, we removed a column for deleting a Credential Delegate's access to an organization, as we don't have the functionality and will not be implementing it for MVP.

## 🧪 Validation

Manual and Automated testing.
![Screenshot 2024-09-03 at 1 29 45 PM](https://github.com/user-attachments/assets/551a6090-0051-4a17-b77d-9b91e086ad99)
