### PR TITLE
[DPC-4191] emit logs when cpi api gateway calls fail in sidekiq job

### DIFF
--- a/dpc-portal/app/jobs/verify_ao_job.rb
+++ b/dpc-portal/app/jobs/verify_ao_job.rb
@@ -26,7 +26,12 @@ class VerifyAoJob < ApplicationJob
   end
 
   def check_link(service, link)
-    response = service.check_ao_eligibility(link.provider_organization.npi, :pac_id, link.user.pac_id)
+    begin
+      response = service.check_ao_eligibility(link.provider_organization.npi, :pac_id, link.user.pac_id)
+    rescue OAuth2::Error => e
+      service.handle_oauth_error(e)
+      raise
+    end
     log_batch_verification_waivers(response)
   end
 

--- a/dpc-portal/spec/jobs/verify_ao_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_ao_job_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe VerifyAoJob, type: :job do
   describe :perform do
     context :cpi_gateway_client_error do
       before do
-          user = create(:user, pac_id: '900111111', verification_status: :approved)
-          create(:ao_org_link, user:, last_checked_at: 6.days.ago)
-          cpi_api_gateway_client_class = class_double(CpiApiGatewayClient).as_stubbed_const
-          cpi_api_gateway_client = double(CpiApiGatewayClient)
-          expect(cpi_api_gateway_client_class).to receive(:new).at_least(:once).and_return(cpi_api_gateway_client)
-          expect(cpi_api_gateway_client).to receive(:fetch_profile).and_raise(
-            OAuth2::Error, Faraday::Response.new(status: 500)
-          )
+        user = create(:user, pac_id: '900111111', verification_status: :approved)
+        create(:ao_org_link, user:, last_checked_at: 6.days.ago)
+        cpi_api_gateway_client_class = class_double(CpiApiGatewayClient).as_stubbed_const
+        cpi_api_gateway_client = double(CpiApiGatewayClient)
+        expect(cpi_api_gateway_client_class).to receive(:new).at_least(:once).and_return(cpi_api_gateway_client)
+        expect(cpi_api_gateway_client).to receive(:fetch_profile).and_raise(
+          OAuth2::Error, Faraday::Response.new(status: 500)
+        )
       end
       it 'handles OAuth2::Error raised by service.check_ao_eligibility in the perform method' do
-          expect(Rails.logger).to receive(:error).with(['API Gateway Error during AO Verification'])
-          VerifyAoJob.perform_now
+        expect(Rails.logger).to receive(:error).with(['API Gateway Error during AO Verification'])
+        VerifyAoJob.perform_now
       end
     end
 


### PR DESCRIPTION
## 🎫 Ticket
- https://jira.cms.gov/projects/DPC/issues/DPC-4191


## 🛠 Changes
 - updates to `dpc-portal/app/jobs/verify_ao_job.rb` to log failed cpi api gateway calls
 - covered in rspec `dpc-portal/spec/jobs/verify_ao_job_spec.rb`

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context
  - calls to third party services may fail and even if DPC is not responsible for 3rd party liveliness, we should know about it
  - alerts to be created on splunk to capture these error messages

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - `dpc-portal/spec/jobs/verify_ao_job_spec.rb`
