### PR TITLE
DPC-4204 AO fails email check

### DIFF
--- a/dpc-portal/app/components/page/invitations/bad_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/bad_invitation_component.html.erb
@@ -20,5 +20,9 @@
         <%= render Core::Button::ButtonComponent.new(label: "Go to DPC home",
             destination: 'https://dpc.cms.gov/',
             method: :get) %>
+      <% when :pii_mismatch %>
+        <%= render Core::Button::ButtonComponent.new(label: "Sign out of Login.gov",
+            destination: login_dot_gov_logout_path(invitation_id: @invitation.id),
+            method: :delete) %>
     <% end %>
 </div>

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -29,6 +29,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def url_for_login_dot_gov_logout
+    state = SecureRandom.hex(16)
+    session['omniauth.state'] = state
+    URI::HTTPS.build(host: IDP_HOST,
+                     path: '/openid_connect/logout',
+                     query: { client_id: IDP_CLIENT_ID,
+                              post_logout_redirect_uri: "#{root_url}users/auth/logged_out",
+                              state: }.to_query)
+  end
+
   def block_prod_sbx
     redirect_to root_url if ENV.fetch('ENV', nil) == 'prod-sbx'
   end

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@
 
 # Parent class of all controllers
 class ApplicationController < ActionController::Base
+  IDP_HOST = ENV.fetch('IDP_HOST')
+  IDP_CLIENT_ID = "urn:gov:cms:openidconnect.profiles:sp:sso:cms:dpc:#{ENV.fetch('ENV')}".freeze
   before_action :block_prod_sbx
   before_action :check_session_length
   before_action :set_current_request_attributes

--- a/dpc-portal/app/controllers/application_controller.rb
+++ b/dpc-portal/app/controllers/application_controller.rb
@@ -29,6 +29,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Documentation at https://developers.login.gov/oidc/logout/
   def url_for_login_dot_gov_logout
     state = SecureRandom.hex(16)
     session['omniauth.state'] = state

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -34,6 +34,20 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
     end
   end
 
+  def logout
+      if params[:invitation_id].present?
+        invitation = Invitation.find(params[:invitation_id])
+        session[:user_return_to] = organization_invitation_url(invitation.provider_organization.id, invitation.id)
+      end
+      session['omniauth.state'] = @state = SecureRandom.hex(16)
+      url = URI::HTTPS.build(host: IDP_HOST,
+                             path: '/openid_connect/logout',
+                             query: { client_id: IDP_CLIENT_ID,
+                                      post_logout_redirect_uri: "#{root_url}users/auth/logged_out",
+                                      state: @state }.to_query)
+      redirect_to url, allow_other_host: true
+  end
+
   private
 
   def handle_invitation_flow_failure(invitation_id)

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -37,10 +37,10 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
   # Documentation at https://developers.login.gov/oidc/logout/
   def logout
     if params[:invitation_id].present?
-
       invitation = Invitation.find(params[:invitation_id])
       session[:user_return_to] = organization_invitation_url(invitation.provider_organization.id, invitation.id)
     end
+
     redirect_to url_for_login_dot_gov_logout, allow_other_host: true
   end
 

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -34,6 +34,7 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
     end
   end
 
+  # Documentation at https://developers.login.gov/oidc/logout/
   def logout
     set_invitation_return_to
     session['omniauth.state'] = @state = SecureRandom.hex(16)

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -45,6 +45,11 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
     redirect_to url, allow_other_host: true
   end
 
+  # Return from login.gov
+  def logged_out
+    redirect_to session.delete(:user_return_to) || new_user_session_path
+  end
+
   private
 
   def handle_invitation_flow_failure(invitation_id)

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -34,7 +34,6 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
     end
   end
 
-  # Documentation at https://developers.login.gov/oidc/logout/
   def logout
     if params[:invitation_id].present?
       invitation = Invitation.find(params[:invitation_id])

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -36,7 +36,11 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
 
   # Documentation at https://developers.login.gov/oidc/logout/
   def logout
-    set_invitation_return_to
+    if params[:invitation_id].present?
+
+      invitation = Invitation.find(params[:invitation_id])
+      session[:user_return_to] = organization_invitation_url(invitation.provider_organization.id, invitation.id)
+    end
     redirect_to url_for_login_dot_gov_logout, allow_other_host: true
   end
 
@@ -59,13 +63,6 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
       render(Page::Invitations::AoFlowFailComponent.new(invitation, 'fail_to_proof', 1),
              status: :forbidden)
     end
-  end
-
-  def set_invitation_return_to
-    return unless params[:invitation_id].present?
-
-    invitation = Invitation.find(params[:invitation_id])
-    session[:user_return_to] = organization_invitation_url(invitation.provider_organization.id, invitation.id)
   end
 
   def maybe_update_user(user, data)

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -37,13 +37,7 @@ class LoginDotGovController < Devise::OmniauthCallbacksController
   # Documentation at https://developers.login.gov/oidc/logout/
   def logout
     set_invitation_return_to
-    session['omniauth.state'] = @state = SecureRandom.hex(16)
-    url = URI::HTTPS.build(host: IDP_HOST,
-                           path: '/openid_connect/logout',
-                           query: { client_id: IDP_CLIENT_ID,
-                                    post_logout_redirect_uri: "#{root_url}users/auth/logged_out",
-                                    state: @state }.to_query)
-    redirect_to url, allow_other_host: true
+    redirect_to url_for_login_dot_gov_logout, allow_other_host: true
   end
 
   # Return from login.gov

--- a/dpc-portal/app/controllers/users/sessions_controller.rb
+++ b/dpc-portal/app/controllers/users/sessions_controller.rb
@@ -9,14 +9,8 @@ module Users
       Rails.logger.info(['User logged out',
                          { actionContext: LoggingConstants::ActionContext::Authentication,
                            actionType: LoggingConstants::ActionType::UserLoggedOut }])
-      session['omniauth.state'] = @state = SecureRandom.hex(16)
       sign_out(current_user)
-      url = URI::HTTPS.build(host: IDP_HOST,
-                             path: '/openid_connect/logout',
-                             query: { client_id: IDP_CLIENT_ID,
-                                      post_logout_redirect_uri: "#{root_url}users/auth/logged_out",
-                                      state: @state }.to_query)
-      redirect_to url, allow_other_host: true
+      redirect_to url_for_login_dot_gov_logout, allow_other_host: true
     end
   end
 end

--- a/dpc-portal/config/locales/en.yml
+++ b/dpc-portal/config/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   verification:
-    pii_mismatch_status: Invitation denied
-    pii_mismatch_text: Sorry, this invitation is for someone else.
+    pii_mismatch_status: The email you used to sign in doesn't match your invite.
+    pii_mismatch_text: <p>Please <b>sign out</b> of Login.gov and either:<ul><li>Create an account</li><li>Add an alternate email to your current Login.gov account</li></ul></p>
     accepted_status: Organization already registered.
     accepted_text: If you meant to register a different organization, check your inbox for the correct request. Sign in to access details for this organization.
     ao_expired_status:  Your registration link has expired.

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'login_dot_gov' }
   devise_scope :user do
     get '/users/auth/failure', to: 'login_dot_gov#failure', as: 'login_dot_gov_failure'
+    get '/users/auth/logged_out', to: 'login_dot_gov#logged_out'
     delete '/logout', to: 'login_dot_gov#logout', as: 'login_dot_gov_logout'
     get 'active', to: 'users/sessions#active'
     get 'timeout', to: 'users/sessions#timeout'

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { omniauth_callbacks: 'login_dot_gov' }
   devise_scope :user do
     get '/users/auth/failure', to: 'login_dot_gov#failure', as: 'login_dot_gov_failure'
+    delete '/logout', to: 'login_dot_gov#logout', as: 'login_dot_gov_logout'
     get 'active', to: 'users/sessions#active'
     get 'timeout', to: 'users/sessions#timeout'
   end

--- a/dpc-portal/spec/components/page/invitations/bad_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/bad_invitation_component_spec.rb
@@ -31,9 +31,13 @@ RSpec.describe Page::Invitations::BadInvitationComponent, type: :component do
       let(:component) { described_class.new(invitation, 'pii_mismatch') }
       it 'should match header' do
         header = <<~HTML
-          <h1>#{I18n.t('verification.pii_mismatch_status')}</h1>
+          <h1>#{CGI.escapeHTML(I18n.t('verification.pii_mismatch_status'))}</h1>
         HTML
         is_expected.to include(normalize_space(header))
+      end
+      it 'should have logout button' do
+        button_url = "/logout?invitation_id=#{invitation.id}"
+        is_expected.to include(button_url)
       end
     end
 

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe 'Invitations', type: :request do
           stub_user_info(overrides: { 'email' => 'another@example.com' })
           get "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
           expect(response).to be_forbidden
-          expect(response.body).to include(I18n.t('verification.pii_mismatch_status'))
+          expect(response.body).to include(CGI.escapeHTML(I18n.t('verification.pii_mismatch_status')))
         end
         context :server_error do
           it 'should show server error page' do
@@ -517,7 +517,7 @@ RSpec.describe 'Invitations', type: :request do
             stub_user_info(overrides: { 'email' => 'another@example.com' })
             get "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm_cd"
             expect(response).to be_forbidden
-            expect(response.body).to include(I18n.t('verification.pii_mismatch_status'))
+            expect(response.body).to include(CGI.escapeHTML(I18n.t('verification.pii_mismatch_status')))
             expect(response.body).to_not include(confirm_organization_invitation_path(org, cd_invite))
           end
           it 'should render error page if given_name not match' do

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -181,4 +181,17 @@ RSpec.describe 'LoginDotGov', type: :request do
       get '/users/auth/failure'
     end
   end
+
+  describe 'Delete /logout' do
+    it 'should redirect to login.gov' do
+      delete '/logout'
+      expect(response.location).to include(ENV.fetch('IDP_HOST'))
+      expect(request.session[:user_return_to]).to be_nil
+    end
+    it 'should set return to invitation flow if invitation sent' do
+      invitation = create(:invitation, :ao)
+      delete "/logout?invitation_id=#{invitation.id}"
+      expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id, invitation.id)
+    end
+  end
 end

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -195,4 +195,18 @@ RSpec.describe 'LoginDotGov', type: :request do
                                                                                  invitation.id)
     end
   end
+
+  describe 'Get /users/auth/logged_out' do
+    it 'should redirect to user_return_to' do
+      get '/organizations'
+      expect(request.session[:user_return_to]).to eq organizations_path
+      get '/users/auth/logged_out'
+      expect(response).to redirect_to(organizations_path)
+    end
+
+    it 'should redirect to new session if no user_return_to set' do
+      get '/users/auth/logged_out'
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
 end

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -191,7 +191,8 @@ RSpec.describe 'LoginDotGov', type: :request do
     it 'should set return to invitation flow if invitation sent' do
       invitation = create(:invitation, :ao)
       delete "/logout?invitation_id=#{invitation.id}"
-      expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id, invitation.id)
+      expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
+                                                                                 invitation.id)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC_4204

## 🛠 Changes

- Logout button added to BadInvitationComponent
- IDP environment variables moved to ApplicationController as used in multiple controllers
- logout and logged_out routes added to LoginDotGovController to handle logout and return from IdP
- Failed PII match text updated

## ℹ️ Context

Matches designs

## 🧪 Validation

Manual and automated testing
![Screenshot 2024-09-09 at 11 04 59 AM](https://github.com/user-attachments/assets/3e232827-a92d-4166-89dd-a0b960777365)

