### PR TITLE
docs: Add some API architecture docs and fix dpc-queue label

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ The DPC application is split into multiple services.
 | [dpc-api](/dpc-api)                 |Public API| Asynchronous FHIR API for managing organizations and requesting or retrieving data     |Java (Dropwizard)|
 | [dpc-attribution](/dpc-attribution) |Internal API| Provides and updates data about attribution                                            |Java (Dropwizard)|
 | [dpc-consent](/dpc-consent)         |Internal API| Provides and updates information about data-sharing consent for individuals            |Java (Dropwizard)|
-| [dpc-queue](/dpc-queue)             |Internal API| Provides and updates data about export jobs and batches                                |Java (Dropwizard)|
 | [dpc-aggregation](/dpc-aggregation) |Internal Worker Service| Polls for job batches and exports data for singular batches                            |Java (Dropwizard + RxJava)|
 
 #### Shared Modules
@@ -78,6 +77,7 @@ In addition to services, several modules are shared across components.
 |---|---|---|
 |[dpc-bluebutton](/dpc-bluebutton)|Bluebutton API Client|Java|
 |[dpc-macaroons](/dpc-macaroons)|Implementation of macaroons for authentication|Java|
+|[dpc-queue](/dpc-queue)| Provides an interface for managing export jobs and batches|Java|
 |[dpc-common](/dpc-common)|Shared utilities for components|Java|
 |[dpc-testing](/dpc-testing)|Shared utilities for testing|Java|
 |[dpc-smoketest](/dpc-smoketest)|Smoke test suite|Java|

--- a/docs/api/logging.md
+++ b/docs/api/logging.md
@@ -1,0 +1,11 @@
+# API Logging
+
+The API services log in JSON format, customized using the [DPCJsonLayoutBaseFactory](/dpc-common/src/main/java/gov/cms/dpc/common/logging/DPCJsonLayoutBaseFactory.java). The application.yml files configure certain globally-logged fields using the `additionalFields` key.
+
+Note that each API configuration file sets two loggers, one for access logs and one for general usage in the Dropwizard application. Therefore, they may differ slightly in which keys are being logged.
+
+## Request-local values
+
+The Mapped Diagnostic Context (MDC) is an slf4j construct which allows us to store key-value pairs that are maintained for the lifetime of the request. Dropwizard automatically includes these values in all logs under the `mdc` object.
+
+The [MDCConstants](/dpc-common/src/main/java/gov/cms/dpc/common/MDCConstants.java) class maintains a centralized list of all MDC global keys we are utilizing for logging. These are set at various points within the applications (using `MDC.put`) to include as much context as possible about the request and make debugging and data investigations easier.

--- a/docs/api/service-initialization.md
+++ b/docs/api/service-initialization.md
@@ -1,0 +1,58 @@
+# API Service Initialization
+
+All Dropwizard APIs are initialized through the relevant io.dropwizard.core `Application` and `Configuration` instances, e.g. `DPCAPIService` and `DPCAPIConfiguration`.
+
+## Configuration
+
+Configuration instances are loaded from the `src/main/resources/application.yml` file, which use a `SubstitutingSourceProvider` to utilize environment variables. Environment variables are configured through one of the following means:
+
+-   The docker-compose file (local development)
+-   Parameter Store (configured and loaded via the ECS task definition)
+-   The `{env}.application.env` file, which stores some non-sensitive variables.
+
+## Database Initialization
+
+We utilize [Hibernate](https://hibernate.org/orm/) as our Object Relational Mapping (ORM) library to map database tables to our Java classes.
+
+Each service manages their own database schema and ensures that migrations are up to date during service initialization. This is done using the Dropwizard `MigrationsBundle`.
+
+To create new migrations, look for the relevant `*.migrations.yml` file and follow the [Dropwizard manual here](https://www.dropwizard.io/en/stable/manual/migrations.html).
+
+## Dependency Injection
+
+The Dropwizard APIs are built around the idea of dependency injection. Dependency injection is the process of passing (injecting) dependencies for a class instance, typically through annotated constructor parameters.
+
+For example, if our Dropwizard service is initialized with a Dropwizard module like this:
+
+```java
+public class DPCAPIModule extends DropwizardAwareModule<DPCAPIConfiguration> {
+    @Override
+    public void configure() {
+        Binder binder = binder();
+        // Allows the EndpointResource class to receive dependency injections
+        binder.bind(EndpointResource.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named("attribution")
+    public IGenericClient provideFHIRClient(FhirContext ctx) {
+        // Creates and returns a configured FHIR API client for the attribution service
+    }
+}
+```
+
+The Endpoint Resource can utilize the attribution client provider:
+
+```java
+public class EndpointResource {
+    private final IGenericClient client;
+
+    @Inject
+    EndpointResource(@Named("attribution") IGenericClient client) {
+        this.client = client;
+    }
+}
+```
+
+The default injector is HK2, but we utilize [dropwizard-guicey](https://github.com/xvik/dropwizard-guicey) for more advanced configuration support.


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🛠 Changes

- Moved `dpc-queue` to the shared modules section, since it's not an API/service.
- Added some docs about logging and API service initialization

## ℹ️ Context

Adding some docs to make onboarding a little easier and help with understanding the Dropwizard services.

## 🧪 Validation

N/A