### PR TITLE
Fix create bug in portal

### DIFF
--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -198,14 +198,14 @@ class InvitationsController < ApplicationController
   def user
     user_info = UserInfoService.new.user_info(session)
     @user = User.find_or_create_by!(provider: :openid_connect, uid: user_info['sub']) do |user_to_create|
-      assign_user_attributes(user_to_create)
+      assign_user_attributes(user_to_create, user_info)
       log_create_user
     end
     update_user(user_info)
     @user
   end
 
-  def assign_user_attributes(user_to_create)
+  def assign_user_attributes(user_to_create, user_info)
     user_to_create.email = @invitation.invited_email
     user_to_create.given_name = user_info['given_name']
     user_to_create.family_name = user_info['family_name']


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

- user info passed to create user in invitations controller
- user info method in invitations spec renamed because bled into controller

## ℹ️ Context

Bug in invitations controller was masked by a method in the spec

## 🧪 Validation

Automated and manual testing
