### PR TITLE
[DPC-4273] Added troubleshooting tip to manual dpc-app build steps.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.1
+    rev: v8.18.4
     hooks:
       - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Then, run `mvn clean install` to build and test the application. Dependencies wi
 
 Running `mvn clean install` will also construct the Docker images for the individual services. To skip the Docker build, pass `-Djib.skip=True`.
 
+If a build failure is encountered, try running `make api`, followed by `mvn install` which may resolve the cause of the build failure.
+
 Note that the `dpc-base` image produced by `make docker-base` is not stored in a remote repository. The `mvn clean install` process relies on the base image being available via the local Docker daemon.
 
 ## Running the DPC API


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

- documentation change, only.
- added alternate steps to README.md for s/w build if build failures are encountered.

## ℹ️ Context

- Encountered build failure following steps in README.md, on a brand new system during company/project onboarding.
- Verified recommended alternative steps provided by M. Esposito.
- Using the ticket as an opportunity to walk through dev methodology and tools prior to being assigned development work
- Documentation only

## 🧪 Validation

- validated alternative steps work to resolve build failure
- verified commands described in README.md 