### PR TITLE
[DPC-4273] Added tip with alternative steps to resolve build failures in manual dpc-app build steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,8 @@ Then, run `mvn clean install` to build and test the application. Dependencies wi
 
 Running `mvn clean install` will also construct the Docker images for the individual services. To skip the Docker build, pass `-Djib.skip=True`.
 
+If a build failure is encountered when running `mvn clean install`, attempt to resolve this by separating the build process into two steps by running `make api` followed by `mvn install`.
+
 Note that the `dpc-base` image produced by `make docker-base` is not stored in a remote repository. The `mvn clean install` process relies on the base image being available via the local Docker daemon.
 
 ## Running the DPC API


### PR DESCRIPTION
## 🎫 Ticket

[[DPC-4273] ](https://jira.cms.gov/browse/DPC-4273)

## 🛠 Changes

- Updated README.md to include alternative steps for building the api if a build failure is encountered when following the existing procedure.

## ℹ️ Context

- Following README.md steps on a new laptop as part of corporate/project onboarding, a build failure was encountered running `mvn clean install`.
- [M. Esposito](https://github.com/MEspositoE14s) suggested alternative steps to resolve build failure.
- Steps were verified and build was successful.
- Revising README.md as basic intro/test of dev methodology and tools, as well as to include useful tip in README.md

## 🧪 Validation

- Re-tested alternative steps and verified build is successful.