### PR TITLE
[DPC-4299] - Update AO job so sanctions don't affect org API access

### DIFF
--- a/dpc-portal/app/jobs/verify_ao_job.rb
+++ b/dpc-portal/app/jobs/verify_ao_job.rb
@@ -57,7 +57,7 @@ class VerifyAoJob < ApplicationJob
 
   def update_ao_sanctions(link, message)
     link.user.update!(entity_error_attributes(message))
-    link.provider_organization.update!(entity_error_attributes(message))
+#     link.provider_organization.update!(entity_error_attributes(message))
     unverify_all_links_and_orgs(link.user, message)
   end
 
@@ -69,7 +69,7 @@ class VerifyAoJob < ApplicationJob
   def unverify_all_links_and_orgs(user, message)
     AoOrgLink.where(user:, verification_status: true).each do |link|
       link.update!(link_error_attributes(message))
-      link.provider_organization.update!(entity_error_attributes(message))
+#       link.provider_organization.update!(entity_error_attributes(message))
       logger.info(["#{self.class.name} Check Fail",
                    { actionContext: LoggingConstants::ActionContext::BatchVerificationCheck,
                      actionType: LoggingConstants::ActionType::FailCpiApiGwCheck,

--- a/dpc-portal/app/jobs/verify_ao_job.rb
+++ b/dpc-portal/app/jobs/verify_ao_job.rb
@@ -57,7 +57,6 @@ class VerifyAoJob < ApplicationJob
 
   def update_ao_sanctions(link, message)
     link.user.update!(entity_error_attributes(message))
-#     link.provider_organization.update!(entity_error_attributes(message))
     unverify_all_links_and_orgs(link.user, message)
   end
 
@@ -69,7 +68,6 @@ class VerifyAoJob < ApplicationJob
   def unverify_all_links_and_orgs(user, message)
     AoOrgLink.where(user:, verification_status: true).each do |link|
       link.update!(link_error_attributes(message))
-#       link.provider_organization.update!(entity_error_attributes(message))
       logger.info(["#{self.class.name} Check Fail",
                    { actionContext: LoggingConstants::ActionContext::BatchVerificationCheck,
                      actionType: LoggingConstants::ActionType::FailCpiApiGwCheck,

--- a/dpc-portal/spec/jobs/verify_ao_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_ao_job_spec.rb
@@ -198,9 +198,6 @@ RSpec.describe VerifyAoJob, type: :job do
             expect_log_for(link, 'ao_med_sanctions')
           end
           VerifyAoJob.perform_now
-          links.each do |link|
-            expect_audits(link, also: %i[user org])
-          end
         end
         it 'neither former nor current org link updated when ao verification status rejected' do
           user = create(:user, pac_id: '900666666', verification_status: :approved)

--- a/dpc-portal/spec/jobs/verify_ao_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_ao_job_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe VerifyAoJob, type: :job do
           end
         end
         # @@@
-        it "should update user, but not impact ProviderOrganization.verification_status" do
+        it 'should update user, but not impact ProviderOrganization.verification_status' do
           expect(AoOrgLink.where(last_checked_at: ..6.days.ago).count).to eq 1
           VerifyAoJob.perform_now
           links.each do |link|

--- a/dpc-portal/spec/jobs/verify_ao_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_ao_job_spec.rb
@@ -190,6 +190,7 @@ RSpec.describe VerifyAoJob, type: :job do
             expect(link.user.verification_status).to eq 'rejected'
             expect(link.user.verification_reason).to eq 'ao_med_sanctions'
             expect(link.provider_organization.verification_status).to eq 'approved'
+            expect(link.provider_organization.verification_reason).to be nil
           end
         end
         it 'should log user check failed' do
@@ -198,6 +199,9 @@ RSpec.describe VerifyAoJob, type: :job do
             expect_log_for(link, 'ao_med_sanctions')
           end
           VerifyAoJob.perform_now
+          links.each do |link|
+            expect_audits(link, also: %i[user])
+          end
         end
         it 'neither former nor current org link updated when ao verification status rejected' do
           user = create(:user, pac_id: '900666666', verification_status: :approved)

--- a/dpc-portal/spec/jobs/verify_ao_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_ao_job_spec.rb
@@ -179,7 +179,8 @@ RSpec.describe VerifyAoJob, type: :job do
             links << create(:ao_org_link, last_checked_at: (n + 4).days.ago, user:, provider_organization:)
           end
         end
-        it "should update user and all user's orgs and links" do
+        # @@@
+        it "should update user, but not impact ProviderOrganization.verification_status" do
           expect(AoOrgLink.where(last_checked_at: ..6.days.ago).count).to eq 1
           VerifyAoJob.perform_now
           links.each do |link|
@@ -188,8 +189,7 @@ RSpec.describe VerifyAoJob, type: :job do
             expect(link.verification_reason).to eq 'ao_med_sanctions'
             expect(link.user.verification_status).to eq 'rejected'
             expect(link.user.verification_reason).to eq 'ao_med_sanctions'
-            expect(link.provider_organization.verification_status).to eq 'rejected'
-            expect(link.provider_organization.verification_reason).to eq 'ao_med_sanctions'
+            expect(link.provider_organization.verification_status).to eq 'approved'
           end
         end
         it 'should log user check failed' do
@@ -202,7 +202,7 @@ RSpec.describe VerifyAoJob, type: :job do
             expect_audits(link, also: %i[user org])
           end
         end
-        it 'should not update former org/link' do
+        it 'neither former nor current org link updated when ao verification status rejected' do
           user = create(:user, pac_id: '900666666', verification_status: :approved)
           provider_organization = create(:provider_organization, verification_status: :approved)
           link = create(:ao_org_link, last_checked_at: 8.days.ago, user:, provider_organization:)
@@ -216,8 +216,8 @@ RSpec.describe VerifyAoJob, type: :job do
           expect(link.verification_reason).to eq 'ao_med_sanctions'
           expect(link.user.verification_status).to eq 'rejected'
           expect(link.user.verification_reason).to eq 'ao_med_sanctions'
-          expect(link.provider_organization.verification_status).to eq 'rejected'
-          expect(link.provider_organization.verification_reason).to eq 'ao_med_sanctions'
+          expect(link.provider_organization.verification_status).to eq 'approved'
+          expect(link.provider_organization.verification_reason).to be nil
           expect(link.verification_status).to be false
           former_link.reload
           expect(former_link.verification_reason).to eq 'user_not_authorized_official'


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4299](https://jira.cms.gov/browse/DPC-4299)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
- remove code that updates ProviderOrganization verification status in [verify_ao_job.rb](https://github.com/CMSgov/dpc-app/blob/acb5c1a19f3274afbdd8aad2ce3cff4be93d0c08/dpc-portal/app/jobs/verify_ao_job.rb#L7)

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - an AO failing med sanction check would cause an entire organization to also be rejected. [disable_rejected()](https://github.com/CMSgov/dpc-app/blob/ca55c2499cdc2503929c10f00245ea65e76adb1d/dpc-portal/app/models/provider_organization.rb#L64) would delete the api tokens for the organization
 - We no longer want this behavior, so now only the AO user is rejected

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
- existing test cases already cover this sidekiq job in [verify_ao_job_spec.rb](erify_ao_job_spec.rb)
- failing test cases updated to reflect changes
