### PR TITLE
Remove id elements from prod smoketest test data

### DIFF
--- a/src/main/resources/prod_patient_bundle-dpr.json
+++ b/src/main/resources/prod_patient_bundle-dpr.json
@@ -11,7 +11,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "728b270d-d7de-4143-82fe-d3ccd92cebe4",
               "meta": {
                 "versionId": "MTU1NDgxMjczNTM5MjYwMDAwMA",
                 "lastUpdated": "2019-04-09T12:25:35.392600+00:00",
@@ -234,7 +233,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "6f7acde5-db81-4361-82cf-886893a3280c",
               "meta": {
                 "versionId": "MTU1NDgxMjczNjQ1MTMxNjAwMA",
                 "lastUpdated": "2019-04-09T12:25:36.451316+00:00",
@@ -457,7 +455,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "78b28fcd-c455-4da1-81c5-ba94c1f3f5b6",
               "meta": {
                 "versionId": "MTU1NDgxMjczMjE4MzkxMTAwMA",
                 "lastUpdated": "2019-04-09T12:25:32.183911+00:00",
@@ -649,7 +646,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "5acc8bb4-2d14-4461-a560-228d96459cc3",
               "meta": {
                 "versionId": "MTU1NDgxMjczMzI3NTg1MTAwMA",
                 "lastUpdated": "2019-04-09T12:25:33.275851+00:00",
@@ -882,7 +878,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "933c5ad6-11aa-4228-a5ae-72f075aa4681",
               "meta": {
                 "versionId": "MTU1NDgxMjczMDA0OTU4NDAwMA",
                 "lastUpdated": "2019-04-09T12:25:30.049584+00:00",
@@ -1115,7 +1110,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "d819cfa2-c349-4920-94ab-dc244da43c50",
               "meta": {
                 "versionId": "MTU1NDgxMjcyODk3Nzk3MTAwMA",
                 "lastUpdated": "2019-04-09T12:25:28.977971+00:00",
@@ -1307,7 +1301,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "0cd47600-e7d5-426a-9320-b1d817e8a73a",
               "meta": {
                 "versionId": "MTU1NDgxMjcyODM2NTY2MjAwMA",
                 "lastUpdated": "2019-04-09T12:25:28.365662+00:00",
@@ -1540,7 +1533,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "b24efd46-fae3-47e5-97a5-a1545da053fe",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNzg2ODQwMTAwMA",
                 "lastUpdated": "2019-04-09T12:25:27.868401+00:00",
@@ -1763,7 +1755,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "7e38c1b6-0b23-486c-b497-08902390a31d",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNzg5MDgwMDAwMA",
                 "lastUpdated": "2019-04-09T12:25:27.890800+00:00",
@@ -1996,7 +1987,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "db252ad1-7748-4b86-bac7-61184decb0ae",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNjI1OTA3MjAwMA",
                 "lastUpdated": "2019-04-09T12:25:26.259072+00:00",
@@ -2219,7 +2209,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "f6d2bf6d-5c91-40b6-ba88-9bcbca6ebfbd",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNjI4MzI0NDAwMA",
                 "lastUpdated": "2019-04-09T12:25:26.283244+00:00",
@@ -2452,7 +2441,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "f9501d43-81e0-4c40-8306-9f9cb1769b3d",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNTczMzQ3NTAwMA",
                 "lastUpdated": "2019-04-09T12:25:25.733475+00:00",
@@ -2685,7 +2673,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "570cbad5-a727-4720-9a97-b46088196cd7",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNDY2NzAzMDAwMA",
                 "lastUpdated": "2019-04-09T12:25:24.667030+00:00",
@@ -2877,7 +2864,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "69639ae1-8cf3-4112-9097-6ad93a5997dc",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNTc1MzcwNTAwMA",
                 "lastUpdated": "2019-04-09T12:25:25.753705+00:00",
@@ -3110,7 +3096,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "580625f2-cb5f-4d81-87d2-0f1e66862969",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNDE1MjU4OTAwMA",
                 "lastUpdated": "2019-04-09T12:25:24.152589+00:00",
@@ -3343,7 +3328,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "167d8dd6-7ecd-4ad5-8e7a-63a6d6f077da",
               "meta": {
                 "versionId": "MTU1NDgxMjcyNDE0NzUzNTAwMA",
                 "lastUpdated": "2019-04-09T12:25:24.147535+00:00",
@@ -3566,7 +3550,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "b83daa26-3eea-41a0-be57-74beb42f6504",
               "meta": {
                 "versionId": "MTU1NDgxMjcyMzYwNTMwMzAwMA",
                 "lastUpdated": "2019-04-09T12:25:23.605303+00:00",
@@ -3789,7 +3772,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "05306f3b-c7c3-4f9a-a441-87feb2ec6a66",
               "meta": {
                 "versionId": "MTU1NDgxMjcyMzA5Nzg2OTAwMA",
                 "lastUpdated": "2019-04-09T12:25:23.097869+00:00",
@@ -4013,7 +3995,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "871c83f5-5674-450b-a3b6-be3bbcf8a095",
               "meta": {
                 "versionId": "MTU1NDgxMjcyMjUxODIzMDAwMA",
                 "lastUpdated": "2019-04-09T12:25:22.518230+00:00",
@@ -4237,7 +4218,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "995a1c0f-b6bc-4d16-b6b0-b8a6597c6e1d",
               "meta": {
                 "versionId": "MTU1NDgxMjcyMTQ0Njg0OTAwMA",
                 "lastUpdated": "2019-04-09T12:25:21.446849+00:00",
@@ -4460,7 +4440,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "b6ab974a-0cd3-4a45-9c8f-0543b79a007d",
               "meta": {
                 "versionId": "MTU1NDgxMjcxOTM0MjkxMjAwMA",
                 "lastUpdated": "2019-04-09T12:25:19.342912+00:00",
@@ -4693,7 +4672,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "b2360a02-ec1b-4463-b5e8-0996f7b6a4ac",
               "meta": {
                 "versionId": "MTU1NDgxMjcxODI1MDI4NjAwMA",
                 "lastUpdated": "2019-04-09T12:25:18.250286+00:00",
@@ -4885,7 +4863,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "81471da3-aaab-458a-bae3-c71525fe7415",
               "meta": {
                 "versionId": "MTU1NDgxMjcxNzE4MTc2NjAwMA",
                 "lastUpdated": "2019-04-09T12:25:17.181766+00:00",
@@ -5118,7 +5095,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "615c67c5-5ac0-4538-84ae-bd8d4e19dc5d",
               "meta": {
                 "versionId": "MTU1NDgxMjcxNzIwNjQ0MjAwMA",
                 "lastUpdated": "2019-04-09T12:25:17.206442+00:00",
@@ -5352,7 +5328,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "789fce0b-d5a5-4d8b-9fa9-070ccfb7d474",
               "meta": {
                 "versionId": "MTU1NDgxMjcxNjE0MjEzNTAwMA",
                 "lastUpdated": "2019-04-09T12:25:16.142135+00:00",
@@ -5545,7 +5520,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "6c1c89d0-27fc-4289-ba21-ed79a200ebe6",
               "meta": {
                 "versionId": "MTU1NDgxMjcxNjE2MTQ2OTAwMA",
                 "lastUpdated": "2019-04-09T12:25:16.161469+00:00",
@@ -5768,7 +5742,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "326299d1-23d8-46bf-8266-e58efe60c0ea",
               "meta": {
                 "versionId": "MTU1NDgxMjcxNTA3Mjk4ODAwMA",
                 "lastUpdated": "2019-04-09T12:25:15.072988+00:00",
@@ -5960,7 +5933,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "c0c6a188-d377-413e-8dc7-6ded539c96d9",
               "meta": {
                 "versionId": "MTU1NDgxMjcxNDAyODg5NTAwMA",
                 "lastUpdated": "2019-04-09T12:25:14.028895+00:00",
@@ -6193,7 +6165,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "155835fd-7f1d-414b-94d2-41d44adcf250",
               "meta": {
                 "versionId": "MTU1NDgxMjcxMjk0MTEzMjAwMA",
                 "lastUpdated": "2019-04-09T12:25:12.941132+00:00",
@@ -6416,7 +6387,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "ef25ddf1-615e-43d5-b539-6af200ae7da4",
               "meta": {
                 "versionId": "MTU1NDgxMjcxMTg3MDQ4OTAwMA",
                 "lastUpdated": "2019-04-09T12:25:11.870489+00:00",
@@ -6639,7 +6609,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "d41ef714-15e0-44d3-afe3-3be47689f873",
               "meta": {
                 "versionId": "MTU1NDgxMjcwOTc0MzMzMTAwMA",
                 "lastUpdated": "2019-04-09T12:25:09.743331+00:00",
@@ -6865,7 +6834,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "fde02360-8b61-40c1-b5c9-e686627d8207",
               "meta": {
                 "versionId": "MTU1NDgxMjcwOTc3MTYwNDAwMA",
                 "lastUpdated": "2019-04-09T12:25:09.771604+00:00",
@@ -7088,7 +7056,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "0d28e708-12c0-4282-ab1f-831599e61792",
               "meta": {
                 "versionId": "MTU1NDgxMjcwODY3NDIxODAwMA",
                 "lastUpdated": "2019-04-09T12:25:08.674218+00:00",
@@ -7311,7 +7278,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "89645076-a956-485d-9de0-bef62b10daa6",
               "meta": {
                 "versionId": "MTU1NDgxMjcwODcwMDIzNTAwMA",
                 "lastUpdated": "2019-04-09T12:25:08.700235+00:00",
@@ -7534,7 +7500,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "c3e58176-8e84-4721-a6b9-0d7eea88d109",
               "meta": {
                 "versionId": "MTU1NDgxMjcwNzYwMjg1MjAwMA",
                 "lastUpdated": "2019-04-09T12:25:07.602852+00:00",
@@ -7757,7 +7722,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "03a27898-d209-48aa-a2ec-a03f6fdaf1fe",
               "meta": {
                 "versionId": "MTU1NDgxMjcwNTUwMTU3NTAwMA",
                 "lastUpdated": "2019-04-09T12:25:05.501575+00:00",
@@ -7966,7 +7930,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "47fc4fcb-2862-406c-9931-929fc1892ca2",
               "meta": {
                 "versionId": "MTU1NDgxMjcwNTQ3MzEzNTAwMA",
                 "lastUpdated": "2019-04-09T12:25:05.473135+00:00",
@@ -8189,7 +8152,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "d02546e8-aa0a-4b24-97a4-b6147a599478",
               "meta": {
                 "versionId": "MTU1NDgxMjcwMjI5NTY1MDAwMA",
                 "lastUpdated": "2019-04-09T12:25:02.295650+00:00",
@@ -8422,7 +8384,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "fd71330e-ebd7-4e86-a43c-39ea210caf5c",
               "meta": {
                 "versionId": "MTU1NDgxMjcwMTIxNjkwODAwMA",
                 "lastUpdated": "2019-04-09T12:25:01.216908+00:00",
@@ -8645,7 +8606,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "c784b280-c6e9-4205-975e-b89057e23a2e",
               "meta": {
                 "versionId": "MTU1NDgxMjY5OTEzODU2NjAwMA",
                 "lastUpdated": "2019-04-09T12:24:59.138566+00:00",
@@ -8837,7 +8797,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "326c4936-086b-4967-9970-4db1d7a169c9",
               "meta": {
                 "versionId": "MTU1NDgxMjY5ODA2Nzc1ODAwMA",
                 "lastUpdated": "2019-04-09T12:24:58.067758+00:00",
@@ -9029,7 +8988,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "57091303-30fb-4bcc-a4e6-1f76dc7993a7",
               "meta": {
                 "versionId": "MTU1NDgxMjY5Njk3MTg5NjAwMA",
                 "lastUpdated": "2019-04-09T12:24:56.971896+00:00",
@@ -9262,7 +9220,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "245c115e-eeba-4d79-88fb-9ff7029cc662",
               "meta": {
                 "versionId": "MTU1NDgxMjY5NjkwNTA4OTAwMA",
                 "lastUpdated": "2019-04-09T12:24:56.905089+00:00",
@@ -9495,7 +9452,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "a29211ce-0014-43f5-a103-6368fa664749",
               "meta": {
                 "versionId": "MTU1NDgxMjY5NDgxNTQ1MjAwMA",
                 "lastUpdated": "2019-04-09T12:24:54.815452+00:00",
@@ -9687,7 +9643,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "2cd701bf-b781-493c-ab3c-30a8603015df",
               "meta": {
                 "versionId": "MTU1NDgxMjY5NDg0MjI1OTAwMA",
                 "lastUpdated": "2019-04-09T12:24:54.842259+00:00",
@@ -9910,7 +9865,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "a28cfad3-f1da-421e-91e2-0f16f1d7253d",
               "meta": {
                 "versionId": "MTU1NDgxMjY5MzcyMTQzNDAwMA",
                 "lastUpdated": "2019-04-09T12:24:53.721434+00:00",
@@ -10133,7 +10087,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "78226741-3095-42a9-87e2-9a18604edb7d",
               "meta": {
                 "versionId": "MTU1NDgxMjY5MTY0ODA1NDAwMA",
                 "lastUpdated": "2019-04-09T12:24:51.648054+00:00",
@@ -10356,7 +10309,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "5294faca-cba1-4606-a079-23539a3e26e2",
               "meta": {
                 "versionId": "MTU1NDgxMjY5MjY1NzYyNjAwMA",
                 "lastUpdated": "2019-04-09T12:24:52.657626+00:00",
@@ -10548,7 +10500,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "bbb2ec77-c5cf-408f-aab8-3f1496334617",
               "meta": {
                 "versionId": "MTU1NDgxMjY4OTQ5MDk1NDAwMA",
                 "lastUpdated": "2019-04-09T12:24:49.490954+00:00",
@@ -10781,7 +10732,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "aaae7cd0-c632-4b28-8aa7-c5ae41e4753d",
               "meta": {
                 "versionId": "MTU1NDgxMjY4ODQyNDEyNTAwMA",
                 "lastUpdated": "2019-04-09T12:24:48.424125+00:00",
@@ -11004,7 +10954,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "770a1931-b6d8-485e-8da8-9256f3208c27",
               "meta": {
                 "versionId": "MTU1NDgxMjY4ODQyOTA5MjAwMA",
                 "lastUpdated": "2019-04-09T12:24:48.429092+00:00",
@@ -11228,7 +11177,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "fe8a77cd-facf-471d-97ad-6a7a7cf6561d",
               "meta": {
                 "versionId": "MTU1NDgxMjY4NjI5OTQyNjAwMA",
                 "lastUpdated": "2019-04-09T12:24:46.299426+00:00",
@@ -11451,7 +11399,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "4fdb156f-e87a-4f69-bca2-d8d61e595ce9",
               "meta": {
                 "versionId": "MTU1NDgxMjY4NjI4NjYzNjAwMA",
                 "lastUpdated": "2019-04-09T12:24:46.286636+00:00",
@@ -11684,7 +11631,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "ef59d34d-e132-4bca-9246-d2efc1df73da",
               "meta": {
                 "versionId": "MTU1NDgxMjY4NTIxMDM0NjAwMA",
                 "lastUpdated": "2019-04-09T12:24:45.210346+00:00",
@@ -11917,7 +11863,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "dcf240d2-ad7d-4bd2-8952-cebd9ebc6003",
               "meta": {
                 "versionId": "MTU1NDgxMjY4NDExNzI5NjAwMA",
                 "lastUpdated": "2019-04-09T12:24:44.117296+00:00",
@@ -12150,7 +12095,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "41d0b3e0-264a-41d7-9370-84a1521ec505",
               "meta": {
                 "versionId": "MTU1NDgxMjY4MzA0OTExMTAwMA",
                 "lastUpdated": "2019-04-09T12:24:43.049111+00:00",
@@ -12383,7 +12327,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "81fdf5bf-e03f-4662-a727-6804a7870021",
               "meta": {
                 "versionId": "MTU1NDgxMjY4MDkzODk5MDAwMA",
                 "lastUpdated": "2019-04-09T12:24:40.938990+00:00",
@@ -12575,7 +12518,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "9b84f3aa-1ac8-4a74-b07b-f5853a365494",
               "meta": {
                 "versionId": "MTU1NDgxMjY3OTg1ODA0NDAwMA",
                 "lastUpdated": "2019-04-09T12:24:39.858044+00:00",
@@ -12808,7 +12750,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "ed011cc9-cf28-4234-bc62-e96ad02d06bf",
               "meta": {
                 "versionId": "MTU1NDgxMjY3NzczMzU3NzAwMA",
                 "lastUpdated": "2019-04-09T12:24:37.733577+00:00",
@@ -13031,7 +12972,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "fc0b3924-0ca8-424f-81b0-08f7f37b6e9b",
               "meta": {
                 "versionId": "MTU1NDgxMjY3NjY2MTkyMjAwMA",
                 "lastUpdated": "2019-04-09T12:24:36.661922+00:00",
@@ -13264,7 +13204,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "4dafccb6-7548-43f4-b394-39170367f1ef",
               "meta": {
                 "versionId": "MTU1NDgxMjY3NTYwNTU1NTAwMA",
                 "lastUpdated": "2019-04-09T12:24:35.605555+00:00",
@@ -13487,7 +13426,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "772fe3d7-c13c-4f24-bf0f-fc714cbf98b1",
               "meta": {
                 "versionId": "MTU1NDgxMjY3NDU1MzM5NjAwMA",
                 "lastUpdated": "2019-04-09T12:24:34.553396+00:00",
@@ -13710,7 +13648,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "9958eb49-ff3b-4797-b720-52a32d0fc7d0",
               "meta": {
                 "versionId": "MTU1NDgxMjY3MzQ4MDgxOTAwMA",
                 "lastUpdated": "2019-04-09T12:24:33.480819+00:00",
@@ -13933,7 +13870,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "a490a01b-4d69-4498-8ef3-caa8ed5ea3ba",
               "meta": {
                 "versionId": "MTU1NDgxMjY3MTMzMDg1MDAwMA",
                 "lastUpdated": "2019-04-09T12:24:31.330850+00:00",
@@ -14166,7 +14102,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "9e87ed0a-d759-4407-a0dc-c629fc102c89",
               "meta": {
                 "versionId": "MTU1NDgxMjY3MjQ0ODA0MzAwMA",
                 "lastUpdated": "2019-04-09T12:24:32.448043+00:00",
@@ -14389,7 +14324,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "3ee3e7f0-bfeb-476b-abc2-eb6517d2d0b2",
               "meta": {
                 "versionId": "MTU1NDgxMjY3MDI5MTEyMzAwMA",
                 "lastUpdated": "2019-04-09T12:24:30.291123+00:00",
@@ -14622,7 +14556,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "9bcf15aa-c5cc-4d5d-b16b-325eef407f9f",
               "meta": {
                 "versionId": "MTU1NDgxMTYyNjk5MDczMzAwMA",
                 "lastUpdated": "2019-04-09T12:07:06.990733+00:00",
@@ -14845,7 +14778,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "d82dd97f-b76e-4d49-bae7-38f3d3bef190",
               "meta": {
                 "versionId": "MTU1NDgxMTYyNDkwNTM0NTAwMA",
                 "lastUpdated": "2019-04-09T12:07:04.905345+00:00",
@@ -15037,7 +14969,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "8e43e552-17d9-406d-9a5b-250c3c33ce83",
               "meta": {
                 "versionId": "MTU1NDgxMTYyMzc4NzMzNTAwMA",
                 "lastUpdated": "2019-04-09T12:07:03.787335+00:00",
@@ -15260,7 +15191,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "46b6a07a-2e13-4460-85a5-cc9c63747c73",
               "meta": {
                 "versionId": "MTU1NDgxMTYyMzgzMTY3NTAwMA",
                 "lastUpdated": "2019-04-09T12:07:03.831675+00:00",
@@ -15484,7 +15414,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "818cf547-5821-46eb-b2f2-14e2a46fccbb",
               "meta": {
                 "versionId": "MTU1NDgxMTYxNjMyNjczOTAwMA",
                 "lastUpdated": "2019-04-09T12:06:56.326739+00:00",
@@ -15707,7 +15636,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "67cf4015-f9fc-4e22-bc90-b40e17442039",
               "meta": {
                 "versionId": "MTU1NDgxMTYwOTQ0NjM1MTAwMA",
                 "lastUpdated": "2019-04-09T12:06:49.446351+00:00",
@@ -15930,7 +15858,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "9ee5abef-b073-4926-8cf1-6b0c7caf31ac",
               "meta": {
                 "versionId": "MTU1NDgxMTYwODM3ODE4NjAwMA",
                 "lastUpdated": "2019-04-09T12:06:48.378186+00:00",
@@ -16154,7 +16081,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "67fc74cc-7e9b-4eb8-9ad6-47dfe73121e1",
               "meta": {
                 "versionId": "MTU1NDgxMTYwNzMzNDU4NDAwMA",
                 "lastUpdated": "2019-04-09T12:06:47.334584+00:00",
@@ -16377,7 +16303,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "b93f0e35-b955-49f2-807d-187788137edf",
               "meta": {
                 "versionId": "MTU1NDgxMTYwNDEwMjAzNjAwMA",
                 "lastUpdated": "2019-04-09T12:06:44.102036+00:00",
@@ -16583,7 +16508,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "ffdaff70-25f4-419b-a55e-f718a8c3efc3",
               "meta": {
                 "versionId": "MTU1NDgxMTYwNTE1NDk5ODAwMA",
                 "lastUpdated": "2019-04-09T12:06:45.154998+00:00",
@@ -16806,7 +16730,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "dbef14f5-f48e-458e-9a2a-5479db87db38",
               "meta": {
                 "versionId": "MTU1NDgxMTYwNTE2MzA1NDAwMA",
                 "lastUpdated": "2019-04-09T12:06:45.163054+00:00",
@@ -17039,7 +16962,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "142149fa-b73b-4466-9eb8-d88af9eb5448",
               "meta": {
                 "versionId": "MTU1NDgxMTYwMzI4ODg2MTAwMA",
                 "lastUpdated": "2019-04-09T12:06:43.288861+00:00",
@@ -17263,7 +17185,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "80c54830-4add-48fd-b9f6-a76020b0570a",
               "meta": {
                 "versionId": "MTU1NDgxMTYwMTgxMzExNDAwMA",
                 "lastUpdated": "2019-04-09T12:06:41.813114+00:00",
@@ -17486,7 +17407,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "474a5860-bbac-4101-8890-10ad29351845",
               "meta": {
                 "versionId": "MTU1NDgxMTYwMDc0NjUwMTAwMA",
                 "lastUpdated": "2019-04-09T12:06:40.746501+00:00",
@@ -17678,7 +17598,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "b6e5a598-87a8-43f7-9677-dc51ca76b72a",
               "meta": {
                 "versionId": "MTU1NDgxMTU5ODYxNTA2MzAwMA",
                 "lastUpdated": "2019-04-09T12:06:38.615063+00:00",
@@ -17911,7 +17830,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "07605caa-9b62-4c90-a939-5fb630cab028",
               "meta": {
                 "versionId": "MTU1NDgxMTU5OTcwNzIyNDAwMA",
                 "lastUpdated": "2019-04-09T12:06:39.707224+00:00",
@@ -18134,7 +18052,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "e7190189-9c85-497d-a7b5-3972ca3c0ecb",
               "meta": {
                 "versionId": "MTU1NDgxMTU5ODMzMzU2MTAwMA",
                 "lastUpdated": "2019-04-09T12:06:38.333561+00:00",
@@ -18367,7 +18284,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "a91c0655-0f40-4253-864e-2f9a77d37667",
               "meta": {
                 "versionId": "MTU1NDgxMTU5NzU0NTgzNzAwMA",
                 "lastUpdated": "2019-04-09T12:06:37.545837+00:00",
@@ -18590,7 +18506,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "673c9383-9b88-4a28-a4d0-4c6df1190690",
               "meta": {
                 "versionId": "MTU1NDgxMTU5NzI2Nzg2MDAwMA",
                 "lastUpdated": "2019-04-09T12:06:37.267860+00:00",
@@ -18782,7 +18697,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "4323f5df-289a-4aa5-8795-b048f8c8fdf8",
               "meta": {
                 "versionId": "MTU1NDgxMTU5NjQ2OTkyNDAwMA",
                 "lastUpdated": "2019-04-09T12:06:36.469924+00:00",
@@ -19008,7 +18922,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "46f99b9f-ab88-40d6-a3a2-24adec933bb3",
               "meta": {
                 "versionId": "MTU1NDgxMTU5NjIzOTk1ODAwMA",
                 "lastUpdated": "2019-04-09T12:06:36.239958+00:00",
@@ -19231,7 +19144,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "6064dd35-f93a-4fba-902b-2f92191554c3",
               "meta": {
                 "versionId": "MTU1NDgxMTU5NjE4ODc4NTAwMA",
                 "lastUpdated": "2019-04-09T12:06:36.188785+00:00",
@@ -19437,7 +19349,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "7e866b75-a36d-4531-b1e3-57aae634ae04",
               "meta": {
                 "versionId": "MTU1NDgxMTU5NTM5MDU0NDAwMA",
                 "lastUpdated": "2019-04-09T12:06:35.390544+00:00",
@@ -19660,7 +19571,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "6a49d9e8-6c8b-4326-80dc-bb54856b07f2",
               "meta": {
                 "versionId": "MTU1NDgxMTU5NDMyMDA2MDAwMA",
                 "lastUpdated": "2019-04-09T12:06:34.320060+00:00",
@@ -19883,7 +19793,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "f7b6050c-2986-4175-8026-688ca4062543",
               "meta": {
                 "versionId": "MTU1NDgxMTU5Mjk5Mjc4MDAwMA",
                 "lastUpdated": "2019-04-09T12:06:32.992780+00:00",
@@ -20116,7 +20025,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "6f526a1e-eae2-4583-bb15-856d7b2d9289",
               "meta": {
                 "versionId": "MTU1NDgxMTU5MzI1MzUwMzAwMA",
                 "lastUpdated": "2019-04-09T12:06:33.253503+00:00",
@@ -20339,7 +20247,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "7da4a2c2-144f-46a6-bba0-78c384efae03",
               "meta": {
                 "versionId": "MTU1NDgxMTU5MTExNjQwNjAwMA",
                 "lastUpdated": "2019-04-09T12:06:31.116406+00:00",
@@ -20562,7 +20469,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "088828a0-7ef6-43a5-aa4e-0c6292e59389",
               "meta": {
                 "versionId": "MTU1NDgxMTU5MTE0NzIwNDAwMA",
                 "lastUpdated": "2019-04-09T12:06:31.147204+00:00",
@@ -20754,7 +20660,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "fda8df83-a8d9-4c5c-bc5b-e7b294889414",
               "meta": {
                 "versionId": "MTU1NDgxMTU4OTc3MjIyMTAwMA",
                 "lastUpdated": "2019-04-09T12:06:29.772221+00:00",
@@ -20977,7 +20882,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "22b0e94a-c395-4c38-ab65-7b34084e15dc",
               "meta": {
                 "versionId": "MTU1NDgxMTU4ODk4MzU0NjAwMA",
                 "lastUpdated": "2019-04-09T12:06:28.983546+00:00",
@@ -21210,7 +21114,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "d59c197a-0115-47c0-ad90-01799d32e01e",
               "meta": {
                 "versionId": "MTU1NDgxMTU4NzYxMzAyMDAwMA",
                 "lastUpdated": "2019-04-09T12:06:27.613020+00:00",
@@ -21444,7 +21347,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "ea39dc3c-1e38-484f-b6db-c03d5e96347a",
               "meta": {
                 "versionId": "MTU1NDgxMTU4NTc3NTAyOTAwMA",
                 "lastUpdated": "2019-04-09T12:06:25.775029+00:00",
@@ -21677,7 +21579,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "0e0d36f4-6653-4ae0-b83d-2530f90deff5",
               "meta": {
                 "versionId": "MTU1NDgxMTU4NDQxODI3NjAwMA",
                 "lastUpdated": "2019-04-09T12:06:24.418276+00:00",
@@ -21900,7 +21801,6 @@
           {
             "resource": {
               "resourceType": "Patient",
-              "id": "52e68ec6-3662-4d7a-b612-dff264d7f071",
               "meta": {
                 "versionId": "MTU1NDgxMTU4NDM5MDIyMjAwMA",
                 "lastUpdated": "2019-04-09T12:06:24.390222+00:00",

--- a/src/main/resources/prod_provider_bundle.json
+++ b/src/main/resources/prod_provider_bundle.json
@@ -20,7 +20,6 @@
                 }
               ],
               "gender": "female",
-              "id": "3461C774-B48F-11E8-96F8-529269fb1459",
               "identifier": [
                 {
                   "system": "http://hl7.org/fhir/sid/us-npi",
@@ -68,7 +67,6 @@
                 }
               ],
               "gender": "female",
-              "id": "C74C008D-42F8-4ED9-BF88-CEE659C7F692",
               "identifier": [
                 {
                   "system": "http://hl7.org/fhir/sid/us-npi",


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4302

## 🛠 Changes

Removed `id` elements from prod smoke test resource files.

## ℹ️ Context

When the smoke tests run they load the resources from these files, and then remove them when they're finished.  If the first smoke test takes a long time, then the second will sometimes start before the first is finished and try to insert the same resources.  This leads to a primary key collision and the tests fail.  Removing the ids allows the system to generate random ones on insert so the tests can run in parallel without problems.

Note: This was already done on the test files used in the other environments.

## 🧪 Validation

Smoke tests ran successfully in prod [here](https://management.dpc.cms.gov/job/DPC%20-%20Smoke%20Test/5774/).
