### PR TITLE
[DPC-4278] Content updates for default welcome page

### DIFF
--- a/dpc-portal/app/assets/stylesheets/login.scss
+++ b/dpc-portal/app/assets/stylesheets/login.scss
@@ -5,3 +5,13 @@
     margin-left: 2px;
     font-size: 1.45rem
 }
+
+.line-separator {
+    border-top: 1px solid #e6e6e6;
+}
+
+.sign-in-instructions {
+    li {
+        line-height: 1.8;
+    }
+}

--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -35,7 +35,9 @@
           <p>
             You don't need an invite to sign up for the DPC Sandbox. This publicly available resource gives you access to test data.
           </p>
-          <button class="usa-button--outline usa-button" type="do_nothing">Sign up to use test data</button>
+          <form class="button_to" method="get" action="https://sandbox.dpc.cms.gov/">
+            <button class="usa-button--outline usa-button" type="submit">Sign up to use test data</button>
+          </form>
         </div>
       </div>
     </div>

--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -2,46 +2,38 @@
   <div class="grid-row margin-x-neg-205 flex-justify-center">
     <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205 margin-bottom-4">
       <h1 class="desktop:display-none font-sans-lg margin-bottom-4 tablet:margin-top-neg-3">
-	Welcome to the production portal for the  Data at the Point of Care (DPC) API
+        Welcome to the DPC API Portal.
       </h1>
       <div class="bg-white padding-y-3 padding-x-5 border border-base-lighter">
-        <h1 class="margin-bottom-0">Sign in to your account</h1>
-        <p>You can access or create your account by signing in below.</p>
+        <h1 class="margin-bottom-0">DPC Portal sign in</h1>
+        <p>Sign in with your DPC Portal Login.gov account</p>
         <%= button_to @login_path, class: 'usa-button width-full margin-bottom-3', data: { turbo: false } do %>
           Sign in with <span class="login-button__logo">Login.gov</span>
         <% end %>
+        <p>
+          <strong>You must use your unique DPC Portal username and password to sign in.</strong>
+        </p>
+        <p>
+          You will have received an invite to set up these credentials.
+        </p>
       </div>
     </div>
     <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205">
       <div class="border-top border-base-lighter padding-top-4 desktop:border-0 desktop:padding-top-0">
         <h2 class="display-none desktop:display-block margin-top-0">
-	  Welcome to the production portal for the  Data at the Point of Care (DPC) API
+	  Welcome to the DPC API Portal.
 	</h2>
         <div class="usa-prose">
-          <p>Use this portal to get production credentials, manage X, and do X. If you're an
-            Authorized Official, you'll need to take the following steps:</p>
-          <section class="usa-graphic-list">
-            <div class="usa-graphic-list__row">
-              <div class="usa-media-block margin-y-2">
-                <%= image_tag 'circle-gray-20.svg', class: ['usa-media-block__img', 'height-7', 'width-7'], alt: '' %>
-                <div class="usa-media-block__body">
-                  <p><strong>Add an organization.</strong> Vivavmus nec velit sed leo scelerisque laoreet vestibulum.</p>
-                </div>
-              </div>
-              <div class="usa-media-block margin-y-2">
-                <%= image_tag 'circle-gray-20.svg', class: ['usa-media-block__img', 'height-7', 'width-7'], alt: '' %>
-                <div class="usa-media-block__body">
-                  <p><strong>Invite a credential delegate.</strong> Vivavmus nec velit sed leo scelerisque laoreet vestibulum.</p>
-                </div>
-              </div>
-              <div class="usa-media-block margin-y-2">
-                <%= image_tag 'circle-gray-20.svg', class: ['usa-media-block__img', 'height-7', 'width-7'], alt: '' %>
-                <div class="usa-media-block__body">
-                  <p><strong>Lorem ipsum.</strong> Vivavmus nec velit sed leo scelerisque laoreet</p>
-                </div>
-              </div>
-            </div>
-          </section>
+          <p>To sign in, you must:</p>
+          <ul>
+            <li>Have a unique DPC Portal Login.gov account</li>
+            <li>Have received an invite to create that account</li>
+            <li>Used the email address identified in your invite</li>
+          </ul>
+          <p>
+            You don't need an invite to sign up for the DPC Sandbox. This publicly available resource gives you access to test data.
+          </p>
+          <button class="usa-button--outline usa-button" type="do_nothing">Sign up to use test data</button>
         </div>
       </div>
     </div>

--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -10,7 +10,7 @@
         <%= button_to @login_path, class: 'usa-button width-full margin-bottom-3', data: { turbo: false } do %>
           Sign in with <span class="login-button__logo">Login.gov</span>
         <% end %>
-        <div style="border-top: 1px solid #e6e6e6;"></div>
+        <div class="line-separator"></div>
         <p>
           <strong>You must use your unique DPC Portal username and password to sign in.</strong>
         </p>
@@ -26,12 +26,12 @@
 	</h2>
         <div class="usa-prose">
           <p>To sign in, you must:</p>
-          <ul>
-            <li style="line-height: 1.8;">Have a unique DPC Portal Login.gov account</li>
-            <li style="line-height: 1.8;">Have received an invite to create that account</li>
-            <li style="line-height: 1.8;">Used the email address identified in your invite</li>
+          <ul class="sign-in-instructions">
+            <li>Have a unique DPC Portal Login.gov account</li>
+            <li>Have received an invite to create that account</li>
+            <li>Used the email address identified in your invite</li>
           </ul>
-        <div style="border-top: 1px solid #e6e6e6;"></div>
+        <div class="line-separator"></div>
           <p>
             You don't need an invite to sign up for the DPC Sandbox. This publicly available resource gives you access to test data.
           </p>

--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -35,7 +35,7 @@
           <p>
             You don't need an invite to sign up for the DPC Sandbox. This publicly available resource gives you access to test data.
           </p>
-          <form class="button_to" method="get" action="https://sandbox.dpc.cms.gov/">
+          <form class="button_to sandbox_url" method="get" action="https://sandbox.dpc.cms.gov/">
             <button class="usa-button--outline usa-button" type="submit">Sign up to use test data</button>
           </form>
         </div>

--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -10,6 +10,7 @@
         <%= button_to @login_path, class: 'usa-button width-full margin-bottom-3', data: { turbo: false } do %>
           Sign in with <span class="login-button__logo">Login.gov</span>
         <% end %>
+        <div style="border-top: 1px solid #e6e6e6;"></div>
         <p>
           <strong>You must use your unique DPC Portal username and password to sign in.</strong>
         </p>
@@ -26,10 +27,11 @@
         <div class="usa-prose">
           <p>To sign in, you must:</p>
           <ul>
-            <li>Have a unique DPC Portal Login.gov account</li>
-            <li>Have received an invite to create that account</li>
-            <li>Used the email address identified in your invite</li>
+            <li style="line-height: 1.8;">Have a unique DPC Portal Login.gov account</li>
+            <li style="line-height: 1.8;">Have received an invite to create that account</li>
+            <li style="line-height: 1.8;">Used the email address identified in your invite</li>
           </ul>
+        <div style="border-top: 1px solid #e6e6e6;"></div>
           <p>
             You don't need an invite to sign up for the DPC Sandbox. This publicly available resource gives you access to test data.
           </p>

--- a/dpc-portal/spec/components/page/session/login_component_spec.rb
+++ b/dpc-portal/spec/components/page/session/login_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
   include ComponentSupport
   describe 'login component' do
     let(:url) { '/portal/' }
+    let(:sandbox_url) { 'https://sandbox.dpc.cms.gov/' }
     let(:component) { described_class.new(url) }
     before { render_inline(component) }
     it 'should be a usa section' do
@@ -14,14 +15,19 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
 
     it 'should have a login button' do
       expect(page).to have_selector('button.usa-button')
-      expect(page.find('button.usa-button')).to have_content('Sign in with')
+      expect(page.find('button.usa-button.width-full')).to have_content('Sign in with')
       expect(page).to have_selector('button.usa-button span.login-button__logo')
       expect(page.find('button.usa-button span.login-button__logo')).to have_content('Login.gov')
     end
 
-    it 'should post to appropriate url' do
-      expect(page.find('form')[:action]).to eq url
-      expect(page.find('form')[:method]).to eq 'post'
+    it 'login.gov button should post to appropriate url' do
+      expect(page.find('form', match: :first)[:action]).to eq url
+      expect(page.find('form', match: :first)[:method]).to eq 'post'
+    end
+
+    it 'test data button should post to sandbox url' do
+      expect(page.find('form.sandbox_url')[:action]).to eq sandbox_url
+      expect(page.find('form.sandbox_url')[:method]).to eq 'get'
     end
 
     it 'should have two columns' do


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4278](https://jira.cms.gov/browse/DPC-4278)

## 🛠 Changes

- remove lorem ipsum placeholder text for `/portal/users/sign_in` and use latest content provided by design
- Source of truth for content under "Page for returning users to sign in" on Confluence doc [HERE](https://confluence.cms.gov/display/DAPC/DPC+Portal+MVP+Copy#:~:text=Page%20for%20returning%20users%20to%20sign%20in).
- link to sandbox on the right side of the page

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - Lorem ipsum placeholder text was used beforehand.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - manually verified the content updates by running 
 - `make portal && make start-portal` then navigating to `http://localhost:3100/portal/users/sign_in`
 - see also updates to `dpc-portal/spec/components/page/session/login_component_spec.rb`