### PR TITLE
[DPC-4229] Removed given name and phone matching on cd invite

### DIFF
--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -107,11 +107,7 @@ class Invitation < ApplicationRecord
 
   def cd_match?(user_info)
     cd_info_present?(user_info)
-
-    return false unless invited_given_name.downcase == user_info['given_name'].downcase &&
-                        invited_family_name.downcase == user_info['family_name'].downcase
-
-    phone_match(user_info)
+    invited_family_name.downcase == user_info['family_name'].downcase
   end
 
   def email_match?(user_info)
@@ -134,20 +130,6 @@ class Invitation < ApplicationRecord
     Rails.logger.error("User Info Missing: #{key}")
     raise UserInfoServiceError, 'missing_info'
   end
-
-  # rubocop:disable Metrics/AbcSize
-  # Go ahead and pass if one or the other starts with US country code (1)
-  def phone_match(user_info)
-    user_phone = user_info['phone'].tr('^0-9', '')
-    if user_phone.length == invited_phone.length
-      user_phone == invited_phone
-    elsif user_phone.length > invited_phone.length && user_phone[0] == '1'
-      user_phone[1..] == invited_phone
-    elsif user_phone.length < invited_phone.length && invited_phone[0] == '1'
-      user_phone == invited_phone[1..]
-    end
-  end
-  # rubocop:enable Metrics/AbcSize
 
   def cannot_cancel_accepted
     return unless status_was == 'accepted' && cancelled?

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -185,32 +185,27 @@ RSpec.describe Invitation, type: :model do
           'family_name' => 'Hodges',
           'phone' => '+111-111-1111' }
       end
-      it 'should match user if names, email, and phone correct' do
+      it 'should match user if last name and email correct' do
         expect(cd_invite.cd_match?(user_info)).to eq true
         expect(cd_invite.email_match?(user_info)).to eq true
       end
       it 'should match user if names and email different case' do
-        cd_invite.invited_given_name.upcase!
         cd_invite.invited_family_name.downcase!
         cd_invite.invited_email = cd_invite.invited_email.upcase_first
         expect(cd_invite.cd_match?(user_info)).to eq true
         expect(cd_invite.email_match?(user_info)).to eq true
       end
+      it 'should match user if given name different' do
+        cd_invite.invited_given_name = 'fake'
+        expect(cd_invite.cd_match?(user_info)).to eq true
+      end
+      it 'should match user if phone different' do
+        cd_invite.invited_phone = '11234567890'
+        expect(cd_invite.cd_match?(user_info)).to eq true
+      end
       it 'should match if invited email eq email' do
         cd_invite.invited_email = user_info['email']
         expect(cd_invite.email_match?(user_info)).to eq true
-      end
-      it 'should match if user info phone starts with 1' do
-        plus_phone = user_info.merge('phone' => '+1-111-111-1111')
-        expect(cd_invite.cd_match?(plus_phone)).to eq true
-      end
-      it 'should match if invited phone starts with 1' do
-        cd_invite.phone_raw = '+1-111-111-1111'
-        expect(cd_invite.cd_match?(user_info)).to eq true
-      end
-      it 'should not match user if given name not correct' do
-        cd_invite.invited_given_name = "not #{cd_invite.invited_given_name}"
-        expect(cd_invite.cd_match?(user_info)).to eq false
       end
       it 'should not match user if family name not correct' do
         cd_invite.invited_family_name = "not #{cd_invite.invited_family_name}"
@@ -219,10 +214,6 @@ RSpec.describe Invitation, type: :model do
       it 'should not match user if email not correct' do
         cd_invite.invited_email = "not #{cd_invite.invited_email}"
         expect(cd_invite.email_match?(user_info)).to eq false
-      end
-      it 'should not match user if phone not correct' do
-        cd_invite.invited_phone = 'not number'
-        expect(cd_invite.cd_match?(user_info)).to eq false
       end
       it 'should raise error if user_info missing given name' do
         missing_info = user_info.merge({ 'given_name' => '' })


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4229

## 🛠 Changes

In the CD invitation flow we no longer match on given name and phone number.  

## ℹ️ Context

These changes were made in an attempt to streamline the CD invitation process.

## 🧪 Validation

Tests updated to verify that first name and phone number are no longer required to match.  

**Note**: We still require that the invitation has a given name and phone number, we just don't match on them.
