### PR TITLE
[DPC-4307] Add log message for confirm_cd action #2287

### DIFF
--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -67,6 +67,9 @@ class InvitationsController < ApplicationController
     return if performed?
 
     session["invitation_status_#{@invitation.id}"] = 'verification_complete'
+    Rails.logger.info(['Approved access authorization occurred for the Credential Delegate',
+                       { actionContext: LoggingConstants::ActionContext::Registration,
+                         actionType: LoggingConstants::ActionType::CdConfirmed }])
     render(Page::Invitations::AcceptInvitationComponent.new(@organization, @invitation, @given_name, @family_name))
   end
 

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -24,6 +24,7 @@ module LoggingConstants
     BeginLogin = 'BeginLogin'
     UserLoggedIn = 'UserLoggedIn'
     UserLoggedOut = 'UserLoggedOut'
+    CdConfirmed = 'CdConfirmed'
     SessionTimedOut = 'SessionTimedOut'
     UserCancelledLogin = 'UserCancelledLogin'
     FailedLogin = 'FailedLogin'

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -531,6 +531,17 @@ RSpec.describe 'Invitations', type: :request do
             get "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm_cd"
             expect(request.session["invitation_status_#{cd_invite.id}"]).to eq 'verification_complete'
           end
+          it 'should log approved access for CD' do
+            stub_user_info
+            allow(Rails.logger).to receive(:info)
+            approved_access_log_message = [
+                'Approved access authorization occurred for the Credential Delegate',
+                { actionContext: LoggingConstants::ActionContext::Registration,
+                actionType: LoggingConstants::ActionType::CdConfirmed }
+            ]
+            expect(Rails.logger).to receive(:info).with(approved_access_log_message)
+            get "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm_cd"
+          end
           it 'should ignore given name and phone' do
             stub_user_info(overrides: { 'given_name' => 'Something Else', 'phone' => '9999999999' })
             get "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm_cd"


### PR DESCRIPTION
## 🎫 Ticket
[DPC-4307](https://jira.cms.gov/browse/DPC-4307)


## 🛠 Changes
 - adds additional rails.logger call for when a CD is verified and can confirm access (just before step 3 of 4)

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context
 - 

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - manual testing conducted in `test` env. By inviting a new CD and logging in via login.gov See screenshot attached:
<img width="1304" alt="Screenshot 2024-10-15 at 12 37 09 PM" src="https://github.com/user-attachments/assets/bcfce876-e859-4d4e-a797-e941bf126a11">
 - see also changes to `dpc-portal/spec/requests/invitations_spec.rb`