### PR TITLE
[DPC-4329] Update content for new invitation confirmation modal

### DIFF
--- a/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/new_invitation_component.html.erb
@@ -35,10 +35,12 @@
     <%= link_to 'Go Back', organization_path(organization.path_id), class: ['usa-button', 'usa-button--outline'] %>
     <a href="#verify-modal" aria-controls="verify-modal" class="usa-button" data-open-modal>Send invite</a>
     <%= render(Core::Modal::ModalComponent.new(
-        'Are you sure?',
-        'Messaging for AO Invite agreement',
-        submit_tag("Yes, assign CD", class: "usa-button", form: "cd-form"),
-        'No, go back',
+        'Acknowledgement',
+        "<p>By assigning this user as a delegate, you are providing them with access to private health information. This means you assume responsibility for their compliance with the Health Insurance Portability and Accountability Act (HIPAA).</p>
+        <p>Do you acknowledge your responsibility for your delegate's compliance with HIPAA regulations?</p>
+        <p>Upon your acknowledgement they will receive an invitation to sign up for access to the DPC Portal. This invitation will expire in 48 hours.</p>",
+        submit_tag("Yes, I acknowledge", class: "usa-button", form: "cd-form"),
+        'Cancel',
         'verify-modal')) %>
   </div>
 </div>

--- a/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
@@ -92,6 +92,41 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
                         '</a>'].join
         is_expected.to include(modal_prompt)
       end
+
+      it 'should render a modal with the correct content' do
+        modal = <<~HTML
+                <div class="usa-modal" id="verify-modal" aria-labelledby="verify-modal-heading" aria-describedby="verify-modal-description">
+          <div class="usa-modal__content">
+              <div class="usa-modal__main">
+                  <h2 class="usa-modal__heading" id="verify-modal-heading">Acknowledgement</h2>
+                  <div class="usa-prose">
+                      <p id="verify-modal-description">
+                          <p>By assigning this user as a delegate, you are providing them with access to private health information. This means you assume responsibility for their compliance with the Health Insurance Portability and Accountability Act (HIPAA).</p>
+                          <p>Do you acknowledge your responsibility for your delegate's compliance with HIPAA regulations?</p>
+                          <p>Upon your acknowledgement they will receive an invitation to sign up for access to the DPC Portal. This invitation will expire in 48 hours.</p>
+                      </p>
+                  </div>
+                  <div class="usa-modal__footer">
+                      <ul class="usa-button-group">
+                          <li class="usa-button-group__item">
+                              <input type="submit" name="commit" value="Yes, I acknowledge" class="usa-button" form="cd-form" data-disable-with="Yes, I acknowledge" />
+                          </li>
+                          <li class="usa-button-group__item">
+                              <button type="button" class="usa-button usa-button--unstyled padding-105 text-center" data-close-modal>Cancel</button>
+                          </li>
+                      </ul>
+                  </div>
+              </div>
+              <button type="button" class="usa-button usa-modal__close" aria-label="Close this window" data-close-modal>
+                  <svg class="usa-icon" aria-hidden="true" focusable="false" role="img">
+                      <use xlink:href="/assets/img/sprite.svg#close"></use>
+                  </svg>
+              </button>
+          </div></div></div></div>
+        HTML
+
+        is_expected.to include(normalize_space(modal))
+      end
     end
 
     context 'Errors' do


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4329

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Adds real content for the new invitation confirmation modal

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
We need to display a message explaining the ramifications of inviting a new credential delegate.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
- [ ] Manual testing
- [ ] Updated unit test


<img width="901" alt="Screenshot 2024-10-24 at 11 41 09 AM" src="https://github.com/user-attachments/assets/105f6dc6-4744-4136-9b5b-c0bff03c8e5e">
