### PR TITLE
[DPC-4213] Add error on create existing group

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,8 +1,20 @@
 version: '3'
 
 services:
-
   db:
     ports:
       - "5432:5432"
 
+  # Open up the debugger port on each service
+  api:
+    ports:
+      - "5005:5005"
+  aggregation:
+    ports:
+      - "5006:5005"
+  attribution:
+    ports:
+      - "5007:5005"
+  consent:
+    ports:
+      - "5008:5005"

--- a/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
+++ b/dpc-attribution/src/main/java/gov/cms/dpc/attribution/resources/v1/GroupResource.java
@@ -79,12 +79,11 @@ public class GroupResource extends AbstractGroupResource {
             throw new WebApplicationException("Unable to find attributable provider", Response.Status.NOT_FOUND);
         }
 
-        // TODO: Force commit before making this call (DPC-4196)
-        // Check and see if a roster already exists for the provider, if so, we just return that and ignore what they sent in
+        // Check and see if a roster already exists for the provider
         final List<RosterEntity> entities = this.rosterDAO.findEntities(null, organizationID, providerNPI, null);
         if (!entities.isEmpty()) {
-            final RosterEntity rosterEntity = entities.get(0);
-            return Response.status(Response.Status.OK).entity(this.converter.toFHIR(Group.class, rosterEntity)).build();
+            throw new WebApplicationException("Could not create a roster for this provider as they already have one.  Try updating it instead, or first deleting it.",
+                Response.Status.FORBIDDEN);
         }
 
         // Verify that all patients in the roster exist

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/GroupResourceTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/resources/GroupResourceTest.java
@@ -66,7 +66,6 @@ public class GroupResourceTest extends AbstractAttributionTest {
 
     @Test
     public void testCreateDuplicateRoster() {
-        System.out.println("====== RUNNING TEST!!!! ======");
         final Practitioner practitioner = createPractitioner(NPIUtil.generateNPI());
         final Patient patient = createPatient(MBIUtil.generateMBI(), DEFAULT_ORG_ID);
 


### PR DESCRIPTION
## 🎫 Ticket

https://github.com/CMSgov/dpc-app/compare/me/dpc-4213-create-duplicate-rosters?expand=1

## 🛠 Changes

Attempting to create a roster that already exists for a provider in an org will return an error.  Previously, the request would be ignored, and the already existing roster would be returned with a 200.

## ℹ️ Context

After much [discussion](https://cmsgov.slack.com/archives/CJL0FRN2E/p1722519081409839), I went with the majority and made the error a 403.  If we change our minds before this is merged it's only a two line change.

## 🧪 Validation

Ran locally and verified.
