### PR TITLE
Remove console logging when running rspec

### DIFF
--- a/dpc-portal/app/jobs/verify_resource_health_job.rb
+++ b/dpc-portal/app/jobs/verify_resource_health_job.rb
@@ -25,8 +25,8 @@ class VerifyResourceHealthJob
     dpc_client = DpcClient.new
     dpc_client.healthcheck
     unless dpc_client.response_successful?
-      logger.warn([dpc_client.response_body.to_s,
-                   { actionContext: LoggingConstants::ActionContext::HealthCheck }])
+      Rails.logger.warn([dpc_client.response_body.to_s,
+                         { actionContext: LoggingConstants::ActionContext::HealthCheck }])
     end
 
     log_healthcheck(
@@ -52,12 +52,12 @@ class VerifyResourceHealthJob
     api_health = cpi_client.healthy_api?
 
     unless auth_health
-      logger.warn(['CPI API gateway auth endpoint is currently down',
-                   { actionContext: LoggingConstants::ActionContext::HealthCheck }])
+      Rails.logger.warn(['CPI API gateway auth endpoint is currently down',
+                         { actionContext: LoggingConstants::ActionContext::HealthCheck }])
     end
     unless api_health
-      logger.warn(['CPI API gateway api endpoints are currently down',
-                   { actionContext: LoggingConstants::ActionContext::HealthCheck }])
+      Rails.logger.warn(['CPI API gateway api endpoints are currently down',
+                         { actionContext: LoggingConstants::ActionContext::HealthCheck }])
     end
 
     log_healthcheck(
@@ -72,9 +72,9 @@ class VerifyResourceHealthJob
                   else
                     LoggingConstants::ActionType::HealthCheckFailed
                   end
-    logger.info(["Healthcheck #{check_name}",
-                 { actionContext: LoggingConstants::ActionContext::HealthCheck,
-                   actionType: action_type }])
+    Rails.logger.info(["Healthcheck #{check_name}",
+                       { actionContext: LoggingConstants::ActionContext::HealthCheck,
+                         actionType: action_type }])
     emit_cloudwatch_metric(check_name, healthy)
   end
 
@@ -108,7 +108,7 @@ class VerifyResourceHealthJob
   rescue StandardError
     # If we're not running on AWS, or don't have the AWS CLI configured, we'll get an error.
     # This is normal when running locally, so only logging in debug mode.
-    logger.debug(["Could not emit metric #{check_name} to AWS",
-                  { actionContext: LoggingConstants::ActionContext::HealthCheck }])
+    Rails.logger.debug(["Could not emit metric #{check_name} to AWS",
+                        { actionContext: LoggingConstants::ActionContext::HealthCheck }])
   end
 end

--- a/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
@@ -72,20 +72,13 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
     end
 
     describe 'idp is not configured' do
-      let!(:previous_idp) { VerifyResourceHealthJob::IDP_HOST }
-      before do
-        VerifyResourceHealthJob::IDP_HOST = nil
-      end
-      after do
-        VerifyResourceHealthJob::IDP_HOST = previous_idp
-      end
-
       it 'should emit an unhealthy metric when url is not configured' do
+        stub_const('VerifyResourceHealthJob::IDP_HOST', nil)
         expect_dpc_api
         expect_cpi
         expect_idp(metric: 0)
 
-        job.perform
+        VerifyResourceHealthJob.new.perform
       end
     end
   end


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

- VerifyResourceHealthJob use Rails.logger instead of logger
- Stub IDP_HOST in spec

## ℹ️ Context

Sidekiq:Job has its own logger that pushes to STDOUT, so it logs to console when running tests. And setting the constant manually was writing warnings to the console.


## 🧪 Validation
All tests pass without writing anything to the console
