### PR TITLE
[DPC-3785] update dpc-attribution application.yml logging

### DIFF
--- a/dpc-attribution/src/main/resources/application.yml
+++ b/dpc-attribution/src/main/resources/application.yml
@@ -66,6 +66,7 @@ logging:
     "org.hibernate.SQL": ERROR
     "org.hibernate.engine.jdbc": "OFF"
     io.dropwizard.jersey: "OFF"
+    "org.postgresql": "OFF"
     # Turn this on to verify updates/inserts are getting batched
     #"org.hibernate.engine.jdbc.batch.internal.BatchingBatch": DEBUG
     "gov.cms.dpc.api.auth": INFO

--- a/dpc-attribution/src/main/resources/application.yml
+++ b/dpc-attribution/src/main/resources/application.yml
@@ -64,6 +64,8 @@ logging:
     "gov.cms.dpc.queue.DistributedBatchQueue": DEBUG
     "org.hibernate": ERROR
     "org.hibernate.SQL": ERROR
+    "org.hibernate.engine.jdbc": "OFF"
+    io.dropwizard.jersey: "OFF"
     # Turn this on to verify updates/inserts are getting batched
     #"org.hibernate.engine.jdbc.batch.internal.BatchingBatch": DEBUG
     "gov.cms.dpc.api.auth": INFO


### PR DESCRIPTION
## 🎫 Ticket
[DPC-3875](https://jira.cms.gov/browse/DPC-3785)


## 🛠 Changes
Update configuration file for dpc-attribution

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context
Even when database entities (i.e. [OrganizationEntity](https://github.com/CMSgov/dpc-app/blob/99f63fd7ccbdf603c246f6c062eb874f4053cd0f/dpc-common/src/main/java/gov/cms/dpc/common/entities/OrganizationEntity.java)) are not explicitly logged,  if an exception is raised, information from the database may show up in system logs. (See validation section below for example)

This PR aims to disable specific pieces of library code from emitting logs in order to mitigate risk of database information showing up in the dpc-attribution app.

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
One database exception that can be trigged manually and repeatably is a Unique Constraint violation.

Invoking the Organization `$submit` operation from the dpc-attribution app repeatedly results in a long stack trace which includes...

```
2024-10-29 21:54:15 {"timestamp":"2024-10-30T04:54:14.991+0000","level":"ERROR","thread":"pool-3-thread-7","logger":"io.dropwizard.jersey.errors.LoggingExceptionMapper","message":"Error handling a request: 644c9bd1725092c5","exception":"org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint \"organization_idx\"\n  Detail: Key (id_system, id_value)=(1, 1111111112) already exists.\n\tat org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2725)\n\tat org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2412)\n\t... 98 common frames omitted\nWrapped by: java.sql.BatchUpdateException: Batch entry 0 /* insert gov.cms.dpc.common.entities.OrganizationEntity */ insert into organizations (city, country, district, line1, line2, postal_code, state, address_type, address_use, id_system, id_value, organization_name, id) values (('Akron'), ('US'), (NULL), ('111 Main ST'), ('STE 5'), ('22222'), ('OH'), ('2'::int4), ('1'::int4), ('1'::int4), ('1111111112'), ('Org'), ('6f101cee-e286-4d0d-a8cf-26ce526b14ce'::uuid)) was aborted: ERROR: duplicate key value violates unique constraint \"organization_idx\"\n  Detail: Key (id_system, id_value)=(1, 1111111112) already exists.  Call getNextException to see other errors in the batch.\n\tat org.postgresql.jdbc.BatchResultHandler.handleError(BatchResultHandler.java:165)
```

making the same API call with the log config updates results in the following output...
```
2024-10-29 22:23:19 {"timestamp":"2024-10-30T05:23:19.600+0000","level":"INFO","thread":"pool-3-thread-7","logger":"gov.cms.dpc.common.logging.filters.GenerateRequestIdFilter","mdc":{"request_id":"d03e20d4-27c5-4e6c-be08-ccfadf78e1b7"},"environment":"local","application":"dpc-attribution","version":"unknown_version","method":"POST","media_type":"application/fhir+json;charset","use_provided_request_id":"true","resource_requested":"v1/Organization/$submit","request_id":"d03e20d4-27c5-4e6c-be08-ccfadf78e1b7"}
2024-10-29 22:23:23 {"timestamp":"2024-10-30T05:23:23.236+0000","level":"INFO","thread":"pool-3-thread-7","logger":"gov.cms.dpc.common.logging.filters.LogResponseFilter","mdc":{"request_id":"d03e20d4-27c5-4e6c-be08-ccfadf78e1b7"},"environment":"local","application":"dpc-attribution","version":"unknown_version","method":"POST","media_type":"application/fhir+json;charset","resource_requested":"v1/Organization/$submit","status":"400"}
2024-10-29 22:23:23 {"timestamp":"2024-10-30T05:23:23.428+0000","contentLength":750,"method":"POST","protocol":"HTTP/1.1","remoteAddress":"172.26.0.6","requestTime":4807,"uri":"/v1/Organization/$submit","status":400,"userAgent":"HAPI-FHIR/7.2.1 (FHIR Client; FHIR 3.0.2/DSTU3; apache)","environment":"local","application":"dpc-attribution","version":"unknown_version"}
```