### PR TITLE
DPC-4355 Special redirect url for sandbox

### DIFF
--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require 'dpc_portal_utils'
+
 # Handles acceptance of invitations
 class InvitationsController < ApplicationController
+  include DpcPortalUtils
+
   before_action :load_organization
   before_action :load_invitation
   before_action :validate_invitation, except: %i[renew]
@@ -71,7 +75,7 @@ class InvitationsController < ApplicationController
                            path: '/openid_connect/authorize',
                            query: { acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
                                     client_id: IDP_CLIENT_ID,
-                                    redirect_uri: "#{redirect_host}/portal/users/auth/openid_connect/callback",
+                                    redirect_uri: "#{my_protocol_host}/portal/users/auth/openid_connect/callback",
                                     response_type: 'code',
                                     scope: 'openid email all_emails profile social_security_number',
                                     nonce: @nonce,
@@ -283,16 +287,5 @@ class InvitationsController < ApplicationController
                        { actionContext: LoggingConstants::ActionContext::Registration,
                          actionType: LoggingConstants::ActionType::AoHasWaiver,
                          invitation: @invitation.id }])
-  end
-end
-
-def redirect_host
-  case ENV.fetch('ENV', nil)
-  when 'local'
-    'http://localhost:3100'
-  when 'prod'
-    'https://dpc.cms.gov'
-  else
-    "https://#{ENV.fetch('ENV', nil)}.dpc.cms.gov"
   end
 end

--- a/dpc-portal/config/initializers/devise.rb
+++ b/dpc-portal/config/initializers/devise.rb
@@ -8,21 +8,17 @@
 #
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
+
+require "dpc_portal_utils"
+
 Devise.setup do |config|
+  include DpcPortalUtils
   begin
     private_key = OpenSSL::PKey::RSA.new(ENV['LOGIN_GOV_PRIVATE_KEY'])
   rescue TypeError, OpenSSL::PKey::RSAError => e
     Rails.logger.error("Unable to create private key for omniauth: #{e}")
     private_key = OpenSSL::PKey::RSA.new(1024)
   end
-  host = case ENV['ENV']
-         when 'local'
-           'http://localhost:3100'
-         when 'prod'
-           'https://dpc.cms.gov'
-         else
-           "https://#{ENV['ENV']}.dpc.cms.gov"
-         end
   idp_host = ENV.fetch('IDP_HOST', 'idp.int.identitysandbox.gov')
   config.omniauth :openid_connect, {
                     name: :openid_connect,
@@ -38,7 +34,7 @@ Devise.setup do |config|
                       host: idp_host,
                       identifier: "urn:gov:cms:openidconnect.profiles:sp:sso:cms:dpc:#{ENV['ENV']}",
                       private_key: private_key,
-                      redirect_uri: "#{host}/portal/users/auth/openid_connect/callback"
+                      redirect_uri: "#{my_protocol_host}/portal/users/auth/openid_connect/callback"
                     }
                   }
   # The secret key used by Devise. Devise uses this key to generate

--- a/dpc-portal/lib/dpc_portal_utils.rb
+++ b/dpc-portal/lib/dpc_portal_utils.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Shared functionality
+module DpcPortalUtils
+  def my_protocol_host
+    env = ENV.fetch('ENV', nil)
+    case env
+    when 'local'
+      'http://localhost:3100'
+    when 'prod-sbx'
+      'https://sandbox.dpc.cms.gov'
+    else
+      "https://#{env}.dpc.cms.gov"
+    end
+  end
+end

--- a/dpc-portal/spec/lib/dpc_portal_utils_spec.rb
+++ b/dpc-portal/spec/lib/dpc_portal_utils_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'dpc_portal_utils'
+RSpec.describe DpcPortalUtils do
+  before { allow(ENV).to receive(:fetch).and_call_original }
+  it 'should return localhost' do
+    expect(my_protocol_host).to eq 'http://localhost:3100'
+  end
+  it 'should return sandbox.dpc.cms.gov if prod-sbx' do
+    expect(ENV).to receive(:fetch).with('ENV', nil).and_return('prod-sbx')
+    expect(my_protocol_host).to eq 'https://sandbox.dpc.cms.gov'
+  end
+  it 'should return {env}.dpc.cms.gov unless prod-sbx' do
+    expect(ENV).to receive(:fetch).with('ENV', nil).and_return('fake_env')
+    expect(my_protocol_host).to eq 'https://fake_env.dpc.cms.gov'
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4355

## 🛠 Changes

- Host resolution moved to shared file
- Host resolution for prod-sbx becomes sandbox

## ℹ️ Context

Unlike other environments, the host for the sandbox is "sandbox.dpc.cms.gov" rather than "{env}.dpc.cms.gov", so the redirect requests to login.gov where not working

## 🧪 Validation

Automated testing
