### PR TITLE
Ignore sinatra vulnerability

### DIFF
--- a/dpc-portal/Dockerfile
+++ b/dpc-portal/Dockerfile
@@ -28,7 +28,8 @@ RUN gem install bundler --no-document && \
     npm install
 
 # Run bundler audit
-RUN bundle exec bundle audit update && bundle exec bundle audit check
+# ignoring CVE-2024-21510 as it affects Sinatra, which is only used internally
+RUN bundle exec bundle audit update && bundle exec bundle audit check --ignore CVE-2024-21510
 
 # Copy the code, test the app, and build the assets pipeline
 COPY /dpc-portal /dpc-portal


### PR DESCRIPTION
## 🎫 Ticket
No ticket

## 🛠 Changes

Ignoring CVE-2024-2151 added to bundle audit in dpc-portal Dockerfile

## ℹ️ Context

[CVE-2024-2151](https://nvd.nist.gov/vuln/detail/CVE-2024-21510) is a security error in Sinatra that does not have a fix. As we use Sinatra internally for testing and as a mock CPI API Gateway (whose port is not exposed to the public internet), ignoring the warning for now seems permissible.

[DPC-4359](https://jira.cms.gov/browse/DPC-4359) removes the ignore flag when a fix becomes available.

## 🧪 Validation

Portal builds and passes CI.
