### PR TITLE
Add PII Fail logging

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: "Set up JDK 11"
         uses: actions/setup-java@v1
         with:
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: "DPC Web Build"
         run: |
           make ci-web-portal
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: "DPC Admin Portal Build"
         run: |
           make ci-admin-portal
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: "DPC Portal Build"
         run: |
           make ci-portal
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: "DPC Client Build"
         run: |
           make ci-api-client
@@ -128,7 +128,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Download web code coverage
         uses: actions/download-artifact@v3
         with:
@@ -166,7 +166,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Download code coverage
         uses: actions/download-artifact@v3
         with:
@@ -201,7 +201,7 @@ jobs:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -114,18 +114,11 @@ class InvitationsController < ApplicationController
 
   def render_bad_invitation?(user_info)
     if @invitation.credential_delegate? && !@invitation.cd_match?(user_info)
-      logger.info(['CD PII Check Fail',
-                   { actionContext: LoggingConstants::ActionContext::Registration,
-                     actionType: LoggingConstants::ActionType::FailCdPiiCheck,
-                     invitation: @invitation.id }])
-
+      log_pii_mismatch
       render(Page::Invitations::BadInvitationComponent.new(@invitation, 'pii_mismatch'),
              status: :forbidden)
     elsif !@invitation.email_match?(user_info)
-      logger.info(['AO PII Check Fail',
-                   { actionContext: LoggingConstants::ActionContext::Registration,
-                     actionType: LoggingConstants::ActionType::FailAoPiiCheck,
-                     invitation: @invitation.id }])
+      log_pii_mismatch
       render(Page::Invitations::BadInvitationComponent.new(@invitation, 'email_mismatch'),
              status: :forbidden)
     end
@@ -292,6 +285,20 @@ class InvitationsController < ApplicationController
       Rails.logger.info(['Authorized Official user created,',
                          { actionContext: LoggingConstants::ActionContext::Registration,
                            actionType: LoggingConstants::ActionType::AoCreated }])
+    end
+  end
+
+  def log_pii_mismatch
+    if @invitation.credential_delegate?
+      Rails.logger.info(['CD PII Check Fail',
+                         { actionContext: LoggingConstants::ActionContext::Registration,
+                           actionType: LoggingConstants::ActionType::FailCdPiiCheck,
+                           invitation: @invitation.id }])
+    else
+      logger.info(['AO PII Check Fail',
+                   { actionContext: LoggingConstants::ActionContext::Registration,
+                     actionType: LoggingConstants::ActionType::FailAoPiiCheck,
+                     invitation: @invitation.id }])
     end
   end
 

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -31,7 +31,9 @@ module LoggingConstants
     FailedLogin = 'FailedLogin'
     UserLoginWithoutAccount = 'UserLoginWithoutAccount'
 
-    FailCpiApiGwCheck = 'FailCpiApiGatewwayCheck'
+    FailAoPiiCheck = 'FailAoPiiCheck'
+    FailCdPiiCheck = 'FailCdPiiCheck'
+    FailCpiApiGwCheck = 'FailCpiApiGatewayCheck'
     ApiBlocked = 'ApiBlocked'
     AoHasWaiver = 'AoHasWaiver'
     OrgHasWaiver = 'OrgHasWaiver'

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -227,6 +227,7 @@ RSpec.describe 'Invitations', type: :request do
         it 'should show error page if email not match' do
           stub_user_info(overrides: { 'email' => 'another@example.com' })
           get "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
+          expect(assigns(:given_name)).to be_nil
           expect(response).to be_forbidden
           expect(response.body).to include(CGI.escapeHTML(I18n.t('verification.email_mismatch_status')))
         end
@@ -470,6 +471,7 @@ RSpec.describe 'Invitations', type: :request do
           it 'should render error page if email not match' do
             stub_user_info(overrides: { 'email' => 'another@example.com' })
             get "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm_cd"
+            expect(assigns(:given_name)).to be_nil
             expect(response).to be_forbidden
             expect(response.body).to include(CGI.escapeHTML(I18n.t('verification.email_mismatch_status')))
             expect(response.body).to_not include(confirm_organization_invitation_path(org, cd_invite))

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -225,6 +225,13 @@ RSpec.describe 'Invitations', type: :request do
           expect(response).to redirect_to(organization_invitation_path(org, cd_invite))
         end
         it 'should show error page if email not match' do
+          allow(Rails.logger).to receive(:info)
+          expect(Rails.logger).to receive(:info).with(
+            ['AO PII Check Fail',
+             { actionContext: LoggingConstants::ActionContext::Registration,
+               actionType: LoggingConstants::ActionType::FailAoPiiCheck,
+               invitation: invitation.id }]
+          )
           stub_user_info(overrides: { 'email' => 'another@example.com' })
           get "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
           expect(assigns(:given_name)).to be_nil
@@ -469,6 +476,13 @@ RSpec.describe 'Invitations', type: :request do
         end
         context :failure do
           it 'should render error page if email not match' do
+            allow(Rails.logger).to receive(:info)
+            expect(Rails.logger).to receive(:info).with(
+              ['CD PII Check Fail',
+               { actionContext: LoggingConstants::ActionContext::Registration,
+                 actionType: LoggingConstants::ActionType::FailCdPiiCheck,
+                 invitation: cd_invite.id }]
+            )
             stub_user_info(overrides: { 'email' => 'another@example.com' })
             get "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm_cd"
             expect(assigns(:given_name)).to be_nil
@@ -477,6 +491,13 @@ RSpec.describe 'Invitations', type: :request do
             expect(response.body).to_not include(confirm_organization_invitation_path(org, cd_invite))
           end
           it 'should render error page if family_name not match' do
+            allow(Rails.logger).to receive(:info)
+            expect(Rails.logger).to receive(:info).with(
+              ['CD PII Check Fail',
+               { actionContext: LoggingConstants::ActionContext::Registration,
+                 actionType: LoggingConstants::ActionType::FailCdPiiCheck,
+                 invitation: cd_invite.id }]
+            )
             stub_user_info(overrides: { 'family_name' => 'Something Else' })
             get "/organizations/#{org.id}/invitations/#{cd_invite.id}/confirm_cd"
             expect(response).to be_forbidden


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4389

## 🛠 Changes
- FailAo/CdPiiCheck added to logging constants
- log when AO or CD fails PII check

## ℹ️ Context
We need these events logged for our Registration Failure Dashboard ([DPC-4371](https://jira.cms.gov/browse/DPC-4371))
## 🧪 Validation

Automated testing with log/test.log verification
