### PR TITLE
Add exception handling to LogOrganizationsApiCredentialStatusJob

### DIFF
--- a/dpc-portal/app/jobs/log_organizations_api_credential_status_job.rb
+++ b/dpc-portal/app/jobs/log_organizations_api_credential_status_job.rb
@@ -14,7 +14,14 @@ class LogOrganizationsApiCredentialStatusJob < ApplicationJob
       have_incomplete_or_no_credentials: 0
     }
     ProviderOrganization.where.not(terms_of_service_accepted_by: nil).find_each do |organization|
-      credential_status = fetch_credential_status(organization.dpc_api_organization_id)
+      begin
+        credential_status = fetch_credential_status(organization.dpc_api_organization_id)
+      rescue StandardError
+        Rails.logger.error(['Failed to fetch api credential status for organization',
+                            {  name: organization.name,
+                               dpc_api_org_id: organization.dpc_api_organization_id }])
+        next
+      end
       Rails.logger.info(['Credential status for organization',
                          { name: organization.name,
                            dpc_api_org_id: organization.dpc_api_organization_id,

--- a/dpc-portal/app/jobs/log_organizations_api_credential_status_job.rb
+++ b/dpc-portal/app/jobs/log_organizations_api_credential_status_job.rb
@@ -14,21 +14,24 @@ class LogOrganizationsApiCredentialStatusJob < ApplicationJob
       have_incomplete_or_no_credentials: 0
     }
     ProviderOrganization.where.not(terms_of_service_accepted_by: nil).find_each do |organization|
-      begin
-        credential_status = fetch_credential_status(organization.dpc_api_organization_id)
-      rescue StandardError
-        Rails.logger.error(['Failed to fetch api credential status for organization',
-                            {  name: organization.name,
-                               dpc_api_org_id: organization.dpc_api_organization_id }])
-        next
-      end
-      Rails.logger.info(['Credential status for organization',
-                         { name: organization.name,
-                           dpc_api_org_id: organization.dpc_api_organization_id,
-                           credential_status: }])
-      update_organization_aggregate_hash(organizations_credential_aggregate_status, credential_status)
+      process_organization_credentials(organizations_credential_aggregate_status, organization.name,
+                                       organization.dpc_api_organization_id)
     end
     Rails.logger.info(['Organizations API credential status', organizations_credential_aggregate_status])
+  end
+
+  def process_organization_credentials(organizations_credential_aggregate_status, organization_name,
+                                       organization_id)
+    credential_status = fetch_credential_status(organization_id)
+    Rails.logger.info(['Credential status for organization',
+                       { name: organization_name,
+                         dpc_api_org_id: organization_id,
+                         credential_status: }])
+    update_organization_aggregate_hash(organizations_credential_aggregate_status, credential_status)
+  rescue StandardError
+    Rails.logger.error(['Failed to fetch api credential status for organization',
+                        {  name: organization_name,
+                           dpc_api_org_id: organization_id }])
   end
 
   def update_organization_aggregate_hash(aggregate_stats, credential_status)

--- a/dpc-portal/spec/jobs/log_organizations_api_credential_status_spec.rb
+++ b/dpc-portal/spec/jobs/log_organizations_api_credential_status_spec.rb
@@ -104,6 +104,10 @@ RSpec.describe LogOrganizationsApiCredentialStatusJob, type: :job do
         StandardError.new('something failed inside fetch_credential_status!')
       )
 
+      allow(Rails.logger).to receive(:error)
+      expect(Rails.logger).to receive(:error).with(['Failed to fetch api credential status for organization',
+                                                    {  name: 'Test2',
+                                                       dpc_api_org_id: 'bar' }])
       allow(Rails.logger).to receive(:info)
       expect(Rails.logger).to receive(:info).with(['Organizations API credential status',
                                                    { have_active_credentials: 1,

--- a/dpc-portal/spec/jobs/log_organizations_api_credential_status_spec.rb
+++ b/dpc-portal/spec/jobs/log_organizations_api_credential_status_spec.rb
@@ -60,31 +60,31 @@ RSpec.describe LogOrganizationsApiCredentialStatusJob, type: :job do
 
       described_class.perform_now
     end
-  end
-  it 'updates log with 1 organization that has all 3 credentials' do
-    provider_organization.save!
+    it 'updates log with 1 organization that has all 3 credentials' do
+      provider_organization.save!
 
-    expect(mock_dpc_client).to receive(:get_client_tokens).and_return(mock_one_token_response).once
-    expect(mock_dpc_client).to receive(:get_public_keys).and_return({ 'count' => 2 }).once
-    expect(mock_dpc_client).to receive(:get_ip_addresses).and_return({ 'count' => 3 }).once
-    allow(Rails.logger).to receive(:info)
-    expect(Rails.logger).to receive(:info).with(['Organizations API credential status',
-                                                 { have_active_credentials: 1,
-                                                   have_incomplete_or_no_credentials: 0 }])
+      expect(mock_dpc_client).to receive(:get_client_tokens).and_return(mock_one_token_response).once
+      expect(mock_dpc_client).to receive(:get_public_keys).and_return({ 'count' => 2 }).once
+      expect(mock_dpc_client).to receive(:get_ip_addresses).and_return({ 'count' => 3 }).once
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with(['Organizations API credential status',
+                                                   { have_active_credentials: 1,
+                                                     have_incomplete_or_no_credentials: 0 }])
 
-    described_class.perform_now
-  end
-  it 'updates log with 1 organization that has partial credentials' do
-    provider_organization.save!
+      described_class.perform_now
+    end
+    it 'updates log with 1 organization that has partial credentials' do
+      provider_organization.save!
 
-    expect(mock_dpc_client).to receive(:get_client_tokens).and_return(mock_one_token_response).once
-    expect(mock_dpc_client).to receive(:get_public_keys).and_return({ 'count' => 2 }).once
-    expect(mock_dpc_client).to receive(:get_ip_addresses).and_return({ 'count' => 0 }).once
-    allow(Rails.logger).to receive(:info)
-    expect(Rails.logger).to receive(:info).with(['Organizations API credential status',
-                                                 { have_active_credentials: 0,
-                                                   have_incomplete_or_no_credentials: 1 }])
+      expect(mock_dpc_client).to receive(:get_client_tokens).and_return(mock_one_token_response).once
+      expect(mock_dpc_client).to receive(:get_public_keys).and_return({ 'count' => 2 }).once
+      expect(mock_dpc_client).to receive(:get_ip_addresses).and_return({ 'count' => 0 }).once
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with(['Organizations API credential status',
+                                                   { have_active_credentials: 0,
+                                                     have_incomplete_or_no_credentials: 1 }])
 
-    described_class.perform_now
+      described_class.perform_now
+    end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

This is a follow-up to https://github.com/CMSgov/dpc-app/pull/2327 for [DPC-4390](https://jira.cms.gov/browse/DPC-4390).


## 🛠 Changes
 - wrap DpcApiClient calls so if an exception is raised, the sidekiq job can continue to run for organizations with successful API calls (see context below)

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context
 - following the automatic deployment to the dev environment, I observed that the sidekiq job was not emitting the expected message in the logs.
  - it appears that one of the organizations on the dev environment has an invalid UUID, causing get_client_tokens() to fail
 
![Screenshot 2024-11-19 at 5 58 44 PM](https://github.com/user-attachments/assets/0f26ca74-e819-4716-8cea-aef44ca78119)
![Screenshot 2024-11-19 at 5 58 47 PM](https://github.com/user-attachments/assets/6f24917e-db44-4eef-a66b-76747f30b612)

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
