### PR TITLE
[DPC-4402] Add Expired Invitations list to Organization view for AO

### DIFF
--- a/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
@@ -27,5 +27,18 @@
         <p>There are no pending credential delegates.</p>
       <% end %>
     </div>
+    <div>
+      <h2>Expired invitations</h2>
+      <p>These invites expired. You can resend the invite to give them more time to accept.</p>
+      <% if @expired_invitations.present? %>
+        <%= render(Core::Table::TableComponent.new(id: 'expired-invitation-table', additional_classes: ['width-full'], sortable: false)) do %>
+          <%= render(Core::Table::HeaderComponent.new(caption: 'Expired Invitation Table',
+                                                      columns: ['Name', 'Email', 'Expired on'])) %>
+          <%= render(Core::Table::RowComponent.with_collection(@expired_invitations, keys: ['full_name', 'email', 'expired_at'], obj_name: 'expired invitation')) %>
+        <% end %>
+      <% else %>
+        <p>You have no expired invitations.</p>
+      <% end %>
+    </div>
   <% end %>
 </div>

--- a/dpc-portal/app/components/page/credential_delegate/list_component.rb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component.rb
@@ -6,11 +6,12 @@ module Page
     class ListComponent < ViewComponent::Base
       attr_reader :organization, :active_credential_delegates, :pending_credential_delegates
 
-      def initialize(organization, cd_invitations, credential_delegates)
+      def initialize(organization, pending_invitations, expired_invitations, credential_delegates)
         super
         @organization = organization
         @active_credential_delegates = credential_delegates.map(&:show_attributes)
-        @pending_credential_delegates = cd_invitations.map(&:show_attributes)
+        @pending_credential_delegates = pending_invitations.map(&:show_attributes)
+        @expired_invitations = expired_invitations.map(&:show_attributes)
       end
     end
   end

--- a/dpc-portal/app/components/page/credential_delegate/list_component_preview.rb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component_preview.rb
@@ -11,24 +11,34 @@ module Page
     #
     class ListComponentPreview < ViewComponent::Preview
       def empty
-        render(Page::CredentialDelegate::ListComponent.new(org, [], []))
+        render(Page::CredentialDelegate::ListComponent.new(org, [], [], []))
       end
 
       def active
         user1 = User.new(given_name: 'Bob', family_name: 'Hodges', email: 'bob@example.com')
         user2 = User.new(given_name: 'Lisa', family_name: 'Franklin', email: 'lisa@example.com')
         cds = [CdOrgLink.new(user: user1, created_at: 1.week.ago), CdOrgLink.new(user: user2, created_at: 2.weeks.ago)]
-        render(Page::CredentialDelegate::ListComponent.new(org, [], cds))
+        render(Page::CredentialDelegate::ListComponent.new(org, [], [], cds))
       end
 
       def pending
         cds = [
           Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com',
-                         id: 2),
+                         id: 2, created_at: 1.day.ago),
           Invitation.new(invited_given_name: 'Lisa', invited_family_name: 'Franklin',
-                         invited_email: 'lisa@example.com', id: 3)
+                         invited_email: 'lisa@example.com', id: 3, created_at: 1.day.ago)
         ]
-        render(Page::CredentialDelegate::ListComponent.new(org, cds, []))
+        render(Page::CredentialDelegate::ListComponent.new(org, cds, [], []))
+      end
+
+      def expired
+        expired_invites = [
+          Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com',
+                         id: 2, created_at: 3.days.ago),
+          Invitation.new(invited_given_name: 'Lisa', invited_family_name: 'Franklin',
+                         invited_email: 'lisa@example.com', id: 3, created_at: 3.days.ago)
+        ]
+        render(Page::CredentialDelegate::ListComponent.new(org, [], expired_invites, []))
       end
 
       private

--- a/dpc-portal/app/components/page/organization/compound_show_component.html.erb
+++ b/dpc-portal/app/components/page/organization/compound_show_component.html.erb
@@ -2,6 +2,6 @@
   <h1><%= @organization.name %></h1>
   <div class="margin-bottom-5">NPI: <%= @organization.npi %></div>
   <%= render(Core::Navigation::TabbedComponent.new('organization_nav', @links)) if @show_cds %>
-  <%= render(Page::CredentialDelegate::ListComponent.new(@organization, @active_credential_delegates, @pending_credential_delegates)) if @show_cds %>
+  <%= render(Page::CredentialDelegate::ListComponent.new(@organization, @pending_credential_delegates, @expired_cd_invitations, @active_credential_delegates,)) if @show_cds %>
   <%= render(Page::Organization::CredentialsComponent.new(@organization)) %>
 </div>

--- a/dpc-portal/app/components/page/organization/compound_show_component.rb
+++ b/dpc-portal/app/components/page/organization/compound_show_component.rb
@@ -4,13 +4,14 @@ module Page
   module Organization
     # Shows tabbed credential delegates and credentials
     class CompoundShowComponent < ViewComponent::Base
-      def initialize(organization, cd_invitations, credential_delegates, show_cds)
+      def initialize(organization, cd_invitations, expired_cd_invitations, credential_delegates, show_cds)
         super
         @links = [['User Access', '#credential_delegates', true],
                   ['Credentials', '#credentials', false]]
         @organization = organization
         @active_credential_delegates = credential_delegates
         @pending_credential_delegates = cd_invitations
+        @expired_cd_invitations = expired_cd_invitations
         @show_cds = show_cds
       end
     end

--- a/dpc-portal/app/components/page/organization/compound_show_component_preview.rb
+++ b/dpc-portal/app/components/page/organization/compound_show_component_preview.rb
@@ -6,12 +6,12 @@ module Page
     class CompoundShowComponentPreview < ViewComponent::Preview
       def authorized_official
         org = ProviderOrganization.new(name: 'Health Hut', npi: '1111111111', id: 2)
-        render(Page::Organization::CompoundShowComponent.new(org, [], [], true))
+        render(Page::Organization::CompoundShowComponent.new(org, [], [], [], true))
       end
 
       def credential_delegate
         org = ProviderOrganization.new(name: 'Health Hut', npi: '1111111111', id: 2)
-        render(Page::Organization::CompoundShowComponent.new(org, [], [], false))
+        render(Page::Organization::CompoundShowComponent.new(org, [], [], [], false))
       end
     end
   end

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -22,6 +22,8 @@ class OrganizationsController < ApplicationController
       @invitations = Invitation.where(provider_organization: @organization,
                                       invited_by: current_user,
                                       status: :pending)
+      @expired_invitations = Invitation.where(provider_organization: @organization,
+                                              invited_by: current_user).select {|inv| inv.expired? }
       @cds = CdOrgLink.where(provider_organization: @organization, disabled_at: nil)
     end
     render(Page::Organization::CompoundShowComponent.new(@organization, @cds, @invitations, show_cds))

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -23,10 +23,11 @@ class OrganizationsController < ApplicationController
                                       invited_by: current_user,
                                       status: :pending)
       @expired_invitations = Invitation.where(provider_organization: @organization,
-                                              invited_by: current_user).select {|inv| inv.expired? }
+                                              invited_by: current_user).select(&:expired?)
       @cds = CdOrgLink.where(provider_organization: @organization, disabled_at: nil)
     end
-    render(Page::Organization::CompoundShowComponent.new(@organization, @cds, @invitations, show_cds))
+    render(Page::Organization::CompoundShowComponent.new(@organization, @invitations, @expired_invitations, @cds,
+                                                         show_cds))
   end
 
   def new

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -19,9 +19,11 @@ class OrganizationsController < ApplicationController
   def show
     show_cds = current_user.ao?(@organization)
     if show_cds
+      # Invitation expiration is determined in relation to the `created_at` field; the `status` field will
+      # never be `'expired'`. Therefore, we need to further filter out expired invitations from this query.
       @invitations = Invitation.where(provider_organization: @organization,
                                       invited_by: current_user,
-                                      status: :pending)
+                                      status: :pending).select { |inv| inv.expired? == false }
       @expired_invitations = Invitation.where(provider_organization: @organization,
                                               invited_by: current_user).select(&:expired?)
       @cds = CdOrgLink.where(provider_organization: @organization, disabled_at: nil)

--- a/dpc-portal/app/controllers/organizations_controller.rb
+++ b/dpc-portal/app/controllers/organizations_controller.rb
@@ -21,15 +21,15 @@ class OrganizationsController < ApplicationController
     if show_cds
       # Invitation expiration is determined in relation to the `created_at` field; the `status` field will
       # never be `'expired'`. Therefore, we need to further filter out expired invitations from this query.
-      @invitations = Invitation.where(provider_organization: @organization,
-                                      invited_by: current_user,
-                                      status: :pending).select { |inv| inv.expired? == false }
+      @pending_invitations = Invitation.where(provider_organization: @organization,
+                                              invited_by: current_user,
+                                              status: :pending).reject(&:expired?)
       @expired_invitations = Invitation.where(provider_organization: @organization,
                                               invited_by: current_user).select(&:expired?)
       @cds = CdOrgLink.where(provider_organization: @organization, disabled_at: nil)
     end
-    render(Page::Organization::CompoundShowComponent.new(@organization, @invitations, @expired_invitations, @cds,
-                                                         show_cds))
+    render(Page::Organization::CompoundShowComponent.new(@organization, @pending_invitations, @expired_invitations,
+                                                         @cds, show_cds))
   end
 
   def new

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -31,12 +31,16 @@ class Invitation < ApplicationRecord
   end
 
   def expired?
-    created_at < 2.days.ago
+    Time.now > expiration_date
   end
 
   def expired_at
     return unless expired?
 
+    expiration_date
+  end
+
+  def expiration_date
     created_at + 2.days
   end
 

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -35,9 +35,9 @@ class Invitation < ApplicationRecord
   end
 
   def expired_at
-    if expired?
-      created_at + 2.days
-    end
+    return unless expired?
+
+    created_at + 2.days
   end
 
   def accept!

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -22,6 +22,7 @@ class Invitation < ApplicationRecord
   def show_attributes
     { full_name: "#{invited_given_name} #{invited_family_name}",
       email: invited_email,
+      expired_at: expired_at.to_s,
       id: }.with_indifferent_access
   end
 
@@ -31,6 +32,12 @@ class Invitation < ApplicationRecord
 
   def expired?
     created_at < 2.days.ago
+  end
+
+  def expired_at
+    if expired?
+      created_at + 2.days
+    end
   end
 
   def accept!

--- a/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
 
     let(:org) { ComponentSupport::MockOrg.new }
 
-    let(:component) { described_class.new(org, invitations, credential_delegates) }
+    let(:component) { described_class.new(org, invitations, expired_invitations, credential_delegates) }
 
     before do
       render_inline(component)
@@ -20,6 +20,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
 
     context 'No credential delegates' do
       let(:invitations) { [] }
+      let(:expired_invitations) { [] }
       let(:credential_delegates) { [] }
 
       let(:expected_html) do
@@ -45,6 +46,11 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
                   <h2>Pending invitations</h2>
                   <p>There are no pending credential delegates.</p>
                 </div>
+                <div>
+                  <h2>Expired invitations</h2>
+                  <p>These invites expired. You can resend the invite to give them more time to accept.</p>
+                  <p>You have no expired invitations.</p>
+                </div>
               </div>
             </div>
           </div>
@@ -60,6 +66,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
         Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com')
       end
       let(:invitations) { [] }
+      let(:expired_invitations) { [] }
       let(:credential_delegates) { [CdOrgLink.new(user:, invitation:)] }
 
       it 'has a table' do
@@ -104,8 +111,9 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
     context 'Pending credential delegate' do
       let(:invitations) do
         [Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com',
-                        id: 3)]
+                        id: 3, created_at: 1.day.ago)]
       end
+      let(:expired_invitations) { [] }
       let(:credential_delegates) { [] }
 
       it 'has a table' do
@@ -146,6 +154,61 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
 
       it 'has no active credential delegates' do
         expected_html = '<p>There are no active credential delegates.</p>'
+        is_expected.to include(normalize_space(expected_html))
+      end
+
+      it 'has no expired invitations' do
+        expected_html = '<p>You have no expired invitations.</p>'
+        is_expected.to include(normalize_space(expected_html))
+      end
+    end
+
+    context 'Expired invitations' do
+      let(:invitations) { [] }
+      let(:expired_invitations) do
+        [Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com',
+                        id: 3, created_at: 3.days.ago)]
+      end
+      let(:credential_delegates) { [] }
+
+      it 'has a table' do
+        expired_at = expired_invitations.first.expired_at
+        expected_html = <<~HTML
+          <table id="expired-invitation-table" class="width-full usa-table">
+            <caption aria-hidden="true" hidden>Expired Invitation Table</caption>
+            <thead>
+              <tr>
+                <th scope="row" role="columnheader">Name</th>
+                <th scope="row" role="columnheader">Email</th>
+                <th scope="row" role="columnheader">Expired on</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td data-sort-value="Bob Hodges">Bob Hodges</td>
+                <td data-sort-value="bob@example.com">bob@example.com</td>
+                <td data-sort-value="#{expired_at}">#{expired_at}</td>
+              </tr>
+            </tbody>
+          </table>
+        HTML
+        is_expected.to include(normalize_space(expected_html))
+      end
+
+      it 'has a row' do
+        expired_at = expired_invitations.first.expired_at
+        expected_html = <<~HTML
+          <tr>
+            <td data-sort-value="Bob Hodges">Bob Hodges</td>
+            <td data-sort-value="bob@example.com">bob@example.com</td>
+            <td data-sort-value="#{expired_at}">#{expired_at}</td>
+          </tr>
+        HTML
+        is_expected.to include(normalize_space(expected_html))
+      end
+
+      it 'has no pending credential delegates' do
+        expected_html = '<p>There are no pending credential delegates.</p>'
         is_expected.to include(normalize_space(expected_html))
       end
     end

--- a/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
 
     let(:org) { ComponentSupport::MockOrg.new }
 
-    let(:component) { described_class.new(org, invitations, expired_invitations, credential_delegates) }
+    let(:component) { described_class.new(org, pending_invitations, expired_invitations, credential_delegates) }
 
     before do
       render_inline(component)
     end
 
     context 'No credential delegates' do
-      let(:invitations) { [] }
+      let(:pending_invitations) { [] }
       let(:expired_invitations) { [] }
       let(:credential_delegates) { [] }
 
@@ -65,7 +65,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
       let(:invitation) do
         Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com')
       end
-      let(:invitations) { [] }
+      let(:pending_invitations) { [] }
       let(:expired_invitations) { [] }
       let(:credential_delegates) { [CdOrgLink.new(user:, invitation:)] }
 
@@ -109,7 +109,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
     end
 
     context 'Pending credential delegate' do
-      let(:invitations) do
+      let(:pending_invitations) do
         [Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com',
                         id: 3, created_at: 1.day.ago)]
       end
@@ -164,7 +164,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
     end
 
     context 'Expired invitations' do
-      let(:invitations) { [] }
+      let(:pending_invitations) { [] }
       let(:expired_invitations) do
         [Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com',
                         id: 3, created_at: 3.days.ago)]

--- a/dpc-portal/spec/components/page/organization/compound_show_component_spec.rb
+++ b/dpc-portal/spec/components/page/organization/compound_show_component_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Page::Organization::CompoundShowComponent, type: :component do
       normalize_space(rendered_content)
     end
     let(:org) { build(:provider_organization, name: 'Health Hut', npi: '11111111', id: 2) }
-    let(:component) { described_class.new(org, [], [], show_cds) }
+    let(:component) { described_class.new(org, [], [], [], show_cds) }
 
     before do
       render_inline(component)

--- a/dpc-portal/spec/requests/organizations_spec.rb
+++ b/dpc-portal/spec/requests/organizations_spec.rb
@@ -280,6 +280,31 @@ RSpec.describe 'Organizations', type: :request do
             get "/organizations/#{org.id}"
             expect(assigns(:invitations).size).to eq 0
           end
+
+          it 'does not assign if expired' do
+            create(:invitation, :cd, provider_organization: org, invited_by: user, created_at: 3.days.ago)
+            get "/organizations/#{org.id}"
+            expect(assigns(:invitations).size).to eq 0
+          end
+        end
+
+        context :expired_invitations do
+          it 'assigns if exist' do
+            create(:invitation, :cd, provider_organization: org, invited_by: user, created_at: 3.days.ago)
+            get "/organizations/#{org.id}"
+            expect(assigns(:expired_invitations).size).to eq 1
+          end
+
+          it 'does not assign if not exist' do
+            get "/organizations/#{org.id}"
+            expect(assigns(:invitations).size).to eq 0
+          end
+
+          it 'does not assign if invitation is not expired' do
+            create(:invitation, :cd, provider_organization: org, invited_by: user)
+            get "/organizations/#{org.id}"
+            expect(assigns(:expired_invitations).size).to eq 0
+          end
         end
 
         context :credential_delegates do

--- a/dpc-portal/spec/requests/organizations_spec.rb
+++ b/dpc-portal/spec/requests/organizations_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe 'Organizations', type: :request do
         it 'does not assign invitations even if exist' do
           create(:invitation, :cd, provider_organization: org, invited_by: user)
           get "/organizations/#{org.id}"
-          expect(assigns(:invitations)).to be_nil
+          expect(assigns(:pending_invitations)).to be_nil
         end
       end
     end
@@ -263,28 +263,28 @@ RSpec.describe 'Organizations', type: :request do
           expect(response.body).to include('<h2>Expired invitations</h2>')
         end
 
-        context :invitations do
+        context :pending_invitations do
           it 'assigns if exist' do
             create(:invitation, :cd, provider_organization: org, invited_by: user)
             get "/organizations/#{org.id}"
-            expect(assigns(:invitations).size).to eq 1
+            expect(assigns(:pending_invitations).size).to eq 1
           end
 
           it 'does not assign if not exist' do
             get "/organizations/#{org.id}"
-            expect(assigns(:invitations).size).to eq 0
+            expect(assigns(:pending_invitations).size).to eq 0
           end
 
           it 'does not assign if only accepted exists' do
             create(:invitation, :cd, provider_organization: org, invited_by: user, status: :accepted)
             get "/organizations/#{org.id}"
-            expect(assigns(:invitations).size).to eq 0
+            expect(assigns(:pending_invitations).size).to eq 0
           end
 
           it 'does not assign if expired' do
             create(:invitation, :cd, provider_organization: org, invited_by: user, created_at: 3.days.ago)
             get "/organizations/#{org.id}"
-            expect(assigns(:invitations).size).to eq 0
+            expect(assigns(:pending_invitations).size).to eq 0
           end
         end
 
@@ -297,7 +297,7 @@ RSpec.describe 'Organizations', type: :request do
 
           it 'does not assign if not exist' do
             get "/organizations/#{org.id}"
-            expect(assigns(:invitations).size).to eq 0
+            expect(assigns(:pending_invitations).size).to eq 0
           end
 
           it 'does not assign if invitation is not expired' do

--- a/dpc-portal/spec/requests/organizations_spec.rb
+++ b/dpc-portal/spec/requests/organizations_spec.rb
@@ -260,6 +260,7 @@ RSpec.describe 'Organizations', type: :request do
           expect(response.body).to include('<h2>Credential delegates</h2>')
           expect(response.body).to include('<h2>Pending invitations</h2>')
           expect(response.body).to include('<h2>Active</h2>')
+          expect(response.body).to include('<h2>Expired invitations</h2>')
         end
 
         context :invitations do


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4402

## 🛠 Changes

- Added a table to the list view component for expired invitations
- Query for expired invitations during OrganizationsController#show action
- Filter out expired invitations from the pending invitations query in OrganizationsController#show action

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
We want to render a list of expired invitations, so that the AO can keep track and initiate a new invitation if need be.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
- [ ] Unit testing
- [ ] Manual verification -- see screenshot below

<img width="979" alt="Screenshot 2024-11-21 at 12 10 46 PM" src="https://github.com/user-attachments/assets/b7a04198-26c0-4b68-8b38-692fd099c7fc">
