### PR TITLE
Use ssl to connect to databases in lambdas

### DIFF
--- a/lambda/opt-out-export/db.go
+++ b/lambda/opt-out-export/db.go
@@ -11,7 +11,11 @@ import (
 var createConnection = func(dbName string, dbUser string, dbPassword string) (*sql.DB, error) {
 	var dbHost string = os.Getenv("DB_HOST")
 	var dbPort int = 5432
-	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", dbHost, dbPort, dbUser, dbPassword, dbName)
+	var sslmode string = "require"
+	if isTesting {
+		sslmode = "disable"
+	}
+	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", dbHost, dbPort, dbUser, dbPassword, dbName, sslmode)
 
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {

--- a/lambda/opt-out-import/db.go
+++ b/lambda/opt-out-import/db.go
@@ -194,7 +194,11 @@ func createConnection(dbUser string, dbPassword string) (*sql.DB, error) {
 	var dbName string = "dpc_consent"
 	var dbHost string = os.Getenv("DB_HOST")
 	var dbPort int = 5432
-	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", dbHost, dbPort, dbUser, dbPassword, dbName)
+	var sslmode string = "require"
+	if isTesting {
+		sslmode = "disable"
+	}
+	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s", dbHost, dbPort, dbUser, dbPassword, dbName, sslmode)
 
 	db, err := sql.Open("postgres", psqlInfo)
 	if err != nil {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4415

## 🛠 Changes

Conditionally force sslmode depending on environment

## ℹ️ Context
In our upgrade to postgres 16, we have to use ssl. We had ssl turned off for our lambdas so they could run against our local database (for testing), which are not set up for ssl. New code runs in sslmode except when 'testing' (which includes running locally)

## 🧪 Validation
Tested both locally (test and run-local)
Uploaded export to test and it worked.
Uploaded import to test but unsure how to test?
