### PR TITLE
Me/dpc 4409 snyk vunlerabilities

### DIFF
--- a/dpc-bluebutton/pom.xml
+++ b/dpc-bluebutton/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.14.2</version>
+            <version>2.18.1</version>
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>

--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -151,6 +151,12 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/dpc-queue/pom.xml
+++ b/dpc-queue/pom.xml
@@ -13,7 +13,7 @@
     <name>DPC Java Job Queue</name>
 
     <properties>
-        <aws.java.sdk.version>2.26.7</aws.java.sdk.version>
+        <aws.java.sdk.version>2.29.20</aws.java.sdk.version>
     </properties>
 
     <dependencyManagement>

--- a/dpc-smoketest/pom.xml
+++ b/dpc-smoketest/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.20</version>
+            <version>1.4.21</version>
         </dependency>
         <dependency>
             <groupId>org.apache.pdfbox</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>3.0.7</dropwizard.version>
+        <dropwizard.version>3.0.10</dropwizard.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <slf4j.version>2.0.12</slf4j.version>
         <hapi.fhir.groupID>ca.uhn.hapi.fhir</hapi.fhir.groupID>
-        <hapi.fhir.version>7.2.1</hapi.fhir.version>
+        <hapi.fhir.version>7.4.5</hapi.fhir.version>
         <pgsql.version>42.7.3</pgsql.version>
         <java.version>11</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <slf4j.version>2.0.12</slf4j.version>
         <hapi.fhir.groupID>ca.uhn.hapi.fhir</hapi.fhir.groupID>
-        <hapi.fhir.version>7.4.5</hapi.fhir.version>
+        <hapi.fhir.version>7.6.0</hapi.fhir.version>
         <pgsql.version>42.7.3</pgsql.version>
         <java.version>11</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4409

## 🛠 Changes

Bumped dependency versions to reduce Snyk vulnerabilities.  

- hapi-fhir  7.2.1 -> 7.6.0
- software.amazon.awssdk 2.26.7 -> 2.29.20
- io.dropwizard 3.0.7 -> 3.0.10
- com.fasterxml.jackson.core 2.14.2 -> 2.18.1
- com.thoughtworks.xstream 1.4.20 -> 1.4.21

## ℹ️ Context

Snyk was flagging a number of vulnerabilities in dpc-api, and this update fixes a handful of them.

## 🧪 Validation

Snyk before:
![image](https://github.com/user-attachments/assets/7f9a7805-6f8d-4d06-9acc-b6151915fef5)

Snyk after:
![image](https://github.com/user-attachments/assets/30f32453-642c-4bc0-85e9-eb352a90415a)

