### PR TITLE
Expired should not include accepted, cancelled, or renewed invitations

### DIFF
--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -31,7 +31,7 @@ class Invitation < ApplicationRecord
   end
 
   def expired?
-    Time.now > expiration_date
+    pending? && Time.now > expiration_date
   end
 
   def expired_at

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -155,6 +155,10 @@ RSpec.describe Invitation, type: :model do
         invitation = create(:invitation, :cd, created_at: 2.days.ago)
         expect(invitation.expired?).to eq true
       end
+      it 'should not be expired if acccepted and more than 2 days old' do
+        invitation = create(:invitation, :cd, created_at: 49.hours.ago, status: :accepted)
+        expect(invitation.expired?).to eq false
+      end
     end
 
     describe :accept! do


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Filter was added to Invitation#expired?

## ℹ️ Context

Accepted CD invitations were showing up in the expired invitations block. They shouldn't.

## 🧪 Validation

Manual and automated testing
### Before
![before](https://github.com/user-attachments/assets/4c9f6be0-563f-41a8-98ca-54ccecebff2d)
### After
![after](https://github.com/user-attachments/assets/0ef97d79-96e0-42bb-bbc9-cfb5bc51a9f0)

