### PR TITLE
[DPC-4403] Log when invitation already accepted

### DIFF
--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -23,6 +23,8 @@ module LoggingConstants
     CdCreated = 'CdCreated'
     AoLinkedToOrg = 'AoLinkedToOrg'
     CdLinkedToOrg = 'CdLinkedToOrg'
+    AoAlreadyRegistered = 'AoAlreadyRegistered'
+    CdAlreadyRegistered = 'CdAlreadyRegistered'
 
     BeginLogin = 'BeginLogin'
     UserLoggedIn = 'UserLoggedIn'

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe 'Invitations', type: :request do
     end
     it 'should show warning page if accepted' do
       invitation.accept!
+      if invitation.authorized_official?
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(
+          ['Authorized Official Invitation already accepted',
+           { actionContext: LoggingConstants::ActionContext::Registration,
+             actionType: LoggingConstants::ActionType::AoAlreadyRegistered,
+             invitation: invitation.id }]
+        )
+      elsif invitation.credential_delegate?
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(
+          ['Credential Delegate Invitation already accepted',
+           { actionContext: LoggingConstants::ActionContext::Registration,
+             actionType: LoggingConstants::ActionType::CdAlreadyRegistered,
+             invitation: invitation.id }]
+        )
+      end
+
       send(method, "/organizations/#{org.id}/invitations/#{invitation.id}/#{path_suffix}")
       expect(response).to be_forbidden
       if invitation.authorized_official?


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4403

## 🛠 Changes

Updated logging messages for invitation unacceptable errors.

## ℹ️ Context

When hitting a registration endpoint in which the invitation has already been registered, we are logging "AoInvitationExpired" as the actionType; it should be its own thing.

## 🧪 Validation

Spec updated.
