### PR TITLE
Disable cgo in opt out lambdas because does not work

### DIFF
--- a/.github/workflows/opt-out-export-dev-deploy.yml
+++ b/.github/workflows/opt-out-export-dev-deploy.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
       - name: Build opt-out-export zip file
+        env:
+          CGO_ENABLED: 0
         run: |
           go build -o bootstrap main.go db.go
           zip function.zip bootstrap

--- a/.github/workflows/opt-out-import-dev-deploy.yml
+++ b/.github/workflows/opt-out-import-dev-deploy.yml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
       - name: Build opt-out-import zip file
+        env:
+          CGO_ENABLED: 0
         run: |
           go build -o bootstrap main.go parsers.go utils.go models.go db.go
           zip function.zip bootstrap


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Build in github actions changed to disable using CGO

## ℹ️ Context

CGO is disabled in the builds for other environments and they work. It was not enabled in dev builds, and they had 'GLIBC not found' errors when run.

## 🧪 Validation

Pushed to dev with branch github actions and export worked.
