### PR TITLE
remove migrations from check (it does not have a database)

### DIFF
--- a/dpc-admin/config/initializers/health_check.rb
+++ b/dpc-admin/config/initializers/health_check.rb
@@ -25,7 +25,7 @@ HealthCheck.setup do |config|
     #config.buckets = {}
   
     # You can customize which checks happen on a standard health check, eg to set an explicit list use:
-    config.standard_checks = [ 'database', 'migrations', 'site' ]
+    config.standard_checks = [ 'database', 'site' ]
   
     # Or to exclude one check:
     #config.standard_checks -= [ 'emailconf' ]


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes
Removed 'migrations' from admin healthcheck

## ℹ️ Context

Admin does not manage its own database, and for some reason decided to be miffed about this.

## 🧪 Validation

Health check passes.
