### PR TITLE
[DPC-4432] Add org ID to details page

### DIFF
--- a/dpc-portal/app/components/page/organization/compound_show_component.html.erb
+++ b/dpc-portal/app/components/page/organization/compound_show_component.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h1><%= @organization.name %></h1>
   <div class="margin-bottom-3">NPI: <%= @organization.npi %></div>
-  <div class="margin-bottom-5">Organization ID: <%= @organization.id %></div>
+  <div class="margin-bottom-5">Organization ID: <%= @organization.dpc_api_organization_id %></div>
   <%= render(Core::Navigation::TabbedComponent.new('organization_nav', @links)) if @show_cds %>
   <%= render(Page::CredentialDelegate::ListComponent.new(@organization, @pending_credential_delegates, @expired_cd_invitations, @active_credential_delegates,)) if @show_cds %>
   <%= render(Page::Organization::CredentialsComponent.new(@organization)) %>

--- a/dpc-portal/app/components/page/organization/compound_show_component.html.erb
+++ b/dpc-portal/app/components/page/organization/compound_show_component.html.erb
@@ -1,6 +1,7 @@
 <div>
   <h1><%= @organization.name %></h1>
-  <div class="margin-bottom-5">NPI: <%= @organization.npi %></div>
+  <div class="margin-bottom-3">NPI: <%= @organization.npi %></div>
+  <div class="margin-bottom-5">Organization ID: <%= @organization.id %></div>
   <%= render(Core::Navigation::TabbedComponent.new('organization_nav', @links)) if @show_cds %>
   <%= render(Page::CredentialDelegate::ListComponent.new(@organization, @pending_credential_delegates, @expired_cd_invitations, @active_credential_delegates,)) if @show_cds %>
   <%= render(Page::Organization::CredentialsComponent.new(@organization)) %>

--- a/dpc-portal/app/components/page/organization/compound_show_component_preview.rb
+++ b/dpc-portal/app/components/page/organization/compound_show_component_preview.rb
@@ -6,12 +6,12 @@ module Page
     class CompoundShowComponentPreview < ViewComponent::Preview
       def authorized_official
         org = ProviderOrganization.new(name: 'Health Hut', npi: '1111111111', id: 2)
-        render(Page::Organization::CompoundShowComponent.new(org, { active: [], pending: [], expired: [] }))
+        render(Page::Organization::CompoundShowComponent.new(org, { active: [], pending: [], expired: [] }, true))
       end
 
       def credential_delegate
         org = ProviderOrganization.new(name: 'Health Hut', npi: '1111111111', id: 2)
-        render(Page::Organization::CompoundShowComponent.new(org, {}))
+        render(Page::Organization::CompoundShowComponent.new(org, {}, true))
       end
     end
   end

--- a/dpc-portal/spec/components/page/organization/compound_show_component_spec.rb
+++ b/dpc-portal/spec/components/page/organization/compound_show_component_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Page::Organization::CompoundShowComponent, type: :component do
           is_expected.to include("NPI: #{org.npi}")
         end
         it 'Should have org id' do
-          is_expected.to include("Organization ID: #{org.id}")
+          is_expected.to include("Organization ID: #{org.dpc_api_organization_id}")
         end
         it 'Should have script tag' do
           is_expected.to include('<script')
@@ -65,7 +65,7 @@ RSpec.describe Page::Organization::CompoundShowComponent, type: :component do
         is_expected.to include("NPI: #{org.npi}")
       end
       it 'Should have org id' do
-        is_expected.to include("Organization ID: #{org.id}")
+        is_expected.to include("Organization ID: #{org.dpc_api_organization_id}")
       end
       it 'Should not have script tag' do
         is_expected.to_not include('<script')

--- a/dpc-portal/spec/components/page/organization/compound_show_component_spec.rb
+++ b/dpc-portal/spec/components/page/organization/compound_show_component_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe Page::Organization::CompoundShowComponent, type: :component do
           is_expected.to include("<h1>#{org.name}</h1>")
         end
         it 'Should have npi' do
-          is_expected.to include(%(<div class="margin-bottom-5">NPI: #{org.npi}</div>))
+          is_expected.to include("NPI: #{org.npi}")
+        end
+        it 'Should have org id' do
+          is_expected.to include("Organization ID: #{org.id}")
         end
         it 'Should have script tag' do
           is_expected.to include('<script')
@@ -59,7 +62,10 @@ RSpec.describe Page::Organization::CompoundShowComponent, type: :component do
         is_expected.to include("<h1>#{org.name}</h1>")
       end
       it 'Should have npi' do
-        is_expected.to include(%(<div class="margin-bottom-5">NPI: #{org.npi}</div>))
+        is_expected.to include("NPI: #{org.npi}")
+      end
+      it 'Should have org id' do
+        is_expected.to include("Organization ID: #{org.id}")
       end
       it 'Should not have script tag' do
         is_expected.to_not include('<script')


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4432

## 🛠 Changes

Adds org id to details page.

## ℹ️ Context

As any portal user
I want to see org ID below the org name/NPI on the org details page 
so that I can use it as a reference for API setup

## 🧪 Validation

![image](https://github.com/user-attachments/assets/b48531c5-b915-471d-97ce-e19d2f54be3d)
![image](https://github.com/user-attachments/assets/06fe74ea-38d4-4560-8153-ec176ac326c8)

Spec updated.
