### PR TITLE
Me/dpc 4443 log gzip

### DIFF
--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -62,7 +62,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>gov.cms.dpc</groupId>

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
@@ -19,6 +19,7 @@ import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateModule;
 import gov.cms.dpc.common.hibernate.queue.DPCQueueHibernateBundle;
 import gov.cms.dpc.common.hibernate.queue.DPCQueueHibernateModule;
 import gov.cms.dpc.common.logging.filters.GenerateRequestIdFilter;
+import gov.cms.dpc.common.logging.filters.LogHeaderFilter;
 import gov.cms.dpc.common.logging.filters.LogResponseFilter;
 import gov.cms.dpc.common.utils.EnvironmentParser;
 import gov.cms.dpc.common.utils.UrlGenerator;
@@ -34,6 +35,7 @@ import io.dropwizard.core.setup.Environment;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.health.check.http.HttpHealthCheck;
 import io.dropwizard.migrations.MigrationsBundle;
+import org.apache.http.HttpHeaders;
 import ru.vyarus.dropwizard.guice.GuiceBundle;
 import ru.vyarus.dropwizard.guice.injector.lookup.InjectorLookup;
 
@@ -95,6 +97,7 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
         environment.jersey().register(new JsonParseExceptionMapper());
         environment.jersey().register(new GenerateRequestIdFilter(false));
         environment.jersey().register(new LogResponseFilter());
+        environment.jersey().register(new LogHeaderFilter(HttpHeaders.ACCEPT_ENCODING));
 
         // Find Guice-aware validator and swap in for Dropwizard's default hk2 validator.
         Optional<Injector> injector = InjectorLookup.getInjector(this);

--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -41,7 +41,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>${hapi.fhir.groupID}</groupId>

--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.15.1</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>${hapi.fhir.groupID}</groupId>
@@ -126,6 +126,11 @@
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
             <version>1.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.12.0</version>
         </dependency>
         <!-- required by HAPI FHIR; specifying non-vulnerable version -->
         <dependency>

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/DPCJsonLayout.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/DPCJsonLayout.java
@@ -73,8 +73,8 @@ public class DPCJsonLayout extends EventJsonLayout {
         return StreamSupport.stream(Spliterators.spliteratorUnknownSize(rec.iterator(), 0), false)
             .map(field -> field.split(KEY_VALUE_SEPARATOR))
             .collect(Collectors.toMap(
-                array -> StringUtils.strip(array[0]),                 // Key
-                array -> StringUtils.strip(array[1])                  // Value
+                array -> StringUtils.strip(array[0]),   // Key
+                array -> StringUtils.strip(array[1])    // Value
             ));
     }
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/DPCJsonLayout.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/DPCJsonLayout.java
@@ -19,7 +19,10 @@ public class DPCJsonLayout extends EventJsonLayout {
     private static final String MESSAGE = "message";
     private static final String EXCEPTION = "exception";
     private static final String KEY_VALUE_SEPARATOR = "=";
-    private static final String ENTRY_SEPARATOR = ",";
+
+    // This says search for commas only when there is 0, or an even number of double quotes after it.
+    // Essentially, find commas that aren't in quotes.
+    private static final String ENTRY_SEPARATOR_REGEX = ",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)";
     private static final Pattern MBI_PATTERN = Pattern.compile("\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z][a-zA-Z0-9]\\d[a-zA-Z]{2}\\d{2}");
     private static final String MBI_MASK = "***MBI?***";
     private static final String DATABASE_INFO_MASK = "**********";
@@ -57,11 +60,12 @@ public class DPCJsonLayout extends EventJsonLayout {
     }
 
     private Map<String, String> splitToMap(String in) {
-        return Arrays.stream(in.split(ENTRY_SEPARATOR))
+        return Arrays.stream(in.split(ENTRY_SEPARATOR_REGEX))
                 .map(s -> s.split(KEY_VALUE_SEPARATOR))
                 .collect(Collectors.toMap(
-                        a -> StringUtils.strip(a[0]),  //key
-                        a -> StringUtils.strip(a[1])   //value
+                        a -> StringUtils.strip(a[0]),   // key
+                        a -> StringUtils.strip(a[1])    // value
+                            .replaceAll("^\"|\"$", "") // Remove start and end quotes
                 ));
     }
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/DPCJsonLayout.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/DPCJsonLayout.java
@@ -75,7 +75,6 @@ public class DPCJsonLayout extends EventJsonLayout {
             .collect(Collectors.toMap(
                 array -> StringUtils.strip(array[0]),                 // Key
                 array -> StringUtils.strip(array[1])                  // Value
-                    .replaceAll("(^\")|(\"$)", "")   // Remove start and end quotes
             ));
     }
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
@@ -15,11 +15,11 @@ public class LogHeaderFilter implements ContainerRequestFilter {
 
 	@Override
 	public void filter(ContainerRequestContext requestContext) throws IOException {
-		// If we have a value, wrap it in quotes.  Some headers can have commas in them, and if we don't add quotes
-		// it breaks our logging layout.
 		String headerValue = requestContext.getHeaderString(headerKey);
-		if (headerValue != null) {
-			headerValue = "\"" + headerValue + "\"";
+
+		// Escape commas so they don't get confused with field separators
+		if(headerValue != null) {
+			headerValue = headerValue.replace(",", "\\,");
 		}
 
 		logger.info("{}={}", headerKey, headerValue);

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
@@ -15,6 +15,13 @@ public class LogHeaderFilter implements ContainerRequestFilter {
 
 	@Override
 	public void filter(ContainerRequestContext requestContext) throws IOException {
-		logger.info("{}=\"{}\"", headerKey, requestContext.getHeaderString(headerKey));
+		// If we have a value, wrap it in quotes.  Some headers can have commas in them, and if we don't add quotes
+		// it breaks our logging layout.
+		String headerValue = requestContext.getHeaderString(headerKey);
+		if (headerValue != null) {
+			headerValue = "\"" + headerValue + "\"";
+		}
+
+		logger.info("{}={}", headerKey, headerValue);
 	}
 }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
@@ -1,0 +1,20 @@
+package gov.cms.dpc.common.logging.filters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import java.io.IOException;
+
+public class LogHeaderFilter implements ContainerRequestFilter {
+	private static final Logger logger = LoggerFactory.getLogger(LogHeaderFilter.class);
+	final String headerKey;
+
+	public LogHeaderFilter(String headerKey) { this.headerKey = headerKey; }
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) throws IOException {
+		logger.info("{}={}", headerKey, requestContext.getHeaderString(headerKey));
+	}
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
@@ -15,6 +15,6 @@ public class LogHeaderFilter implements ContainerRequestFilter {
 
 	@Override
 	public void filter(ContainerRequestContext requestContext) throws IOException {
-		logger.info("{}={}", headerKey, requestContext.getHeaderString(headerKey));
+		logger.info("{}=\"{}\"", headerKey, requestContext.getHeaderString(headerKey));
 	}
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/DPCJsonLayoutUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/DPCJsonLayoutUnitTest.java
@@ -188,8 +188,8 @@ public class DPCJsonLayoutUnitTest {
     }
 
     @Test
-    public void testQuotedValues() {
-        String message = "key1=value1, key2=\"value2a,value2b\"";
+    void testEscapedValues() {
+        String message = "key1=value1, key2=value2a\\,value2b";
 
         when(loggingEvent.getFormattedMessage()).thenReturn(message);
         Map<String, Object> map = dpcJsonLayout.toJsonMap(loggingEvent);

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/DPCJsonLayoutUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/DPCJsonLayoutUnitTest.java
@@ -186,4 +186,15 @@ public class DPCJsonLayoutUnitTest {
         Map<String, Object> map = dpcJsonLayout.toJsonMap(loggingEvent);
         assertEquals(expectedLogMessage, map.get("exception"));
     }
+
+    @Test
+    public void testQuotedValues() {
+        String message = "key1=value1, key2=\"value2a,value2b\"";
+
+        when(loggingEvent.getFormattedMessage()).thenReturn(message);
+        Map<String, Object> map = dpcJsonLayout.toJsonMap(loggingEvent);
+        assertFalse(map.containsKey("message"));
+        assertEquals("value1", map.get("key1"));
+        assertEquals("value2a,value2b", map.get("key2"));
+    }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
@@ -1,0 +1,36 @@
+package gov.cms.dpc.common.logging.filters;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+class LogHeaderFilterUnitTest {
+	@Test
+	public void testLogsHeader() throws IOException {
+		final String headerKey = "fakeHeader";
+		final String headerValue = "fakeValue";
+
+		Logger logger = mock(Logger.class);
+
+		ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+		when(requestContext.getHeaderString(headerKey)).thenReturn(headerValue);
+
+		try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+			loggerFactory.when(() -> LoggerFactory.getLogger(LogHeaderFilter.class))
+				.thenReturn(logger);
+
+			LogHeaderFilter logHeaderFilter = new LogHeaderFilter(headerKey);
+			logHeaderFilter.filter(requestContext);
+
+			// Verify that our mock logger was called with the correct values
+			verify(logger).info(Mockito.anyString(), eq(headerKey), eq(headerValue));
+		}
+	}
+}

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
@@ -15,7 +15,7 @@ class LogHeaderFilterUnitTest {
 	@Test
 	public void testLogsHeader() throws IOException {
 		final String headerKey = "fakeHeader";
-		final String headerValue = "fakeValue";
+		final String headerValue = "fakeValue,fakervalue";
 
 		Logger logger = mock(Logger.class);
 

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
@@ -39,9 +39,9 @@ class LogHeaderFilterUnitTest {
 	}
 
 	@Test
-	public void testLogsHeader() throws IOException {
+	void testLogsHeader() throws IOException {
 		final String headerValue = "fakeValue,fakervalue";
-		final String headerValueLogged = "\"fakeValue,fakervalue\"";
+		final String headerValueLogged = "fakeValue\\,fakervalue";
 
 		ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
 		when(requestContext.getHeaderString(headerKey)).thenReturn(headerValue);
@@ -53,7 +53,7 @@ class LogHeaderFilterUnitTest {
 	}
 
 	@Test
-	public void testLogsNull() throws IOException {
+	void testLogsNull() throws IOException {
 		ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
 		when(requestContext.getHeaderString(headerKey)).thenReturn(null);
 

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
@@ -1,36 +1,65 @@
 package gov.cms.dpc.common.logging.filters;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 import static org.mockito.Mockito.*;
 
 class LogHeaderFilterUnitTest {
+
+	private final Logger logger = mock(Logger.class);
+
+	private LogHeaderFilter logHeaderFilter;
+
+	private final String headerKey = "fakeHeader";
+	private final String logFormat = "{}={}";
+
+	@BeforeEach
+	public void setup() throws NoSuchFieldException, IllegalAccessException {
+		// There isn't really a non-hacky way to mock a static final field, but this
+		// feels like the best of a bunch of bad options.
+
+		// Grab the logger field in LogHeaderFilter and make it accessible
+		Field field = LogHeaderFilter.class.getDeclaredField("logger");
+		field.setAccessible(true);
+
+		Field modifiersField = Field.class.getDeclaredField("modifiers");
+		modifiersField.setAccessible(true);
+		modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+		// Set the logger to our mock
+		field.set(null, logger);
+		logHeaderFilter = new LogHeaderFilter("fakeHeader");
+	}
+
 	@Test
 	public void testLogsHeader() throws IOException {
-		final String headerKey = "fakeHeader";
 		final String headerValue = "fakeValue,fakervalue";
-
-		Logger logger = mock(Logger.class);
+		final String headerValueLogged = "\"fakeValue,fakervalue\"";
 
 		ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
 		when(requestContext.getHeaderString(headerKey)).thenReturn(headerValue);
 
-		try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
-			loggerFactory.when(() -> LoggerFactory.getLogger(LogHeaderFilter.class))
-				.thenReturn(logger);
+		logHeaderFilter.filter(requestContext);
 
-			LogHeaderFilter logHeaderFilter = new LogHeaderFilter(headerKey);
-			logHeaderFilter.filter(requestContext);
+		// Verify that our mock logger was called with the correct values
+		verify(logger).info(logFormat, headerKey, headerValueLogged);
+	}
 
-			// Verify that our mock logger was called with the correct values
-			verify(logger).info(Mockito.anyString(), eq(headerKey), eq(headerValue));
-		}
+	@Test
+	public void testLogsNull() throws IOException {
+		ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+		when(requestContext.getHeaderString(headerKey)).thenReturn(null);
+
+		logHeaderFilter.filter(requestContext);
+
+		// Verify that our mock logger was called with the correct values
+		verify(logger).info(logFormat, headerKey, null);
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,11 @@
                 <version>3.7.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.18.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4443

## 🛠 Changes

- Added `LogHeaderFilter` and set it to log the _Accept-Encoding_ header of each incoming request, or null if there isn't one.
- Updated _DPCJsonLayout_ to ignore commas in values if they are escaped with a '\'.

## ℹ️ Context

The ask was to log whether or not requests asked for gzip encoding.  The eventual goal is to figure out what percentage of requests ask for gzip, and decide if it makes sense to pre-compress our export files.

The changes to DPCJsonLayout were necessary because logging "gzip,deflate" was breaking our ability to create a structured log due to the embedded ",".

## 🧪 Validation

Header set to "gzip":
```
{"timestamp":"2024-12-26T17:28:04.300+0000","level":"INFO","thread":"dw-52","logger":"gov.cms.dpc.common.logging.filters.LogHeaderFilter","mdc":{"request_id":"b41a5786-c82c-44fb-b48e-09ea87e06c58"},"environment":"local","application":"dpc-api","version":"unknown_version","Accept-Encoding":"gzip"}
```

Header set to "gzip,deflate":
```
{"timestamp":"2024-12-26T17:27:40.205+0000","level":"INFO","thread":"dw-56","logger":"gov.cms.dpc.common.logging.filters.LogHeaderFilter","mdc":{"request_id":"54854c63-e8ca-4b94-afbc-c3af9fa922d8"},"environment":"local","application":"dpc-api","version":"unknown_version","Accept-Encoding":"gzip,deflate"}
```

Header set to null:
```
{"timestamp":"2024-12-26T17:28:26.243+0000","level":"INFO","thread":"dw-53","logger":"gov.cms.dpc.common.logging.filters.LogHeaderFilter","mdc":{"request_id":"8e53929a-cf31-405c-a639-1bf8e975c90d"},"environment":"local","application":"dpc-api","version":"unknown_version","Accept-Encoding":"null"}
```