### PR TITLE
Upgrade to Artifacts Actions to v4

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -47,7 +47,7 @@ jobs:
           sudo cp ./dpc-macaroons/target/site/jacoco/jacoco.xml jacoco-reports/dpc-macaroons-jacoco.xml
           sudo cp ./dpc-queue/target/site/jacoco/jacoco.xml jacoco-reports/dpc-queue-jacoco.xml
       - name: Upload jacoco reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
@@ -65,7 +65,7 @@ jobs:
         run: |
           sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-web") then .key |= sub("/dpc-web"; "/github/workspace/dpc-web") else . end)' dpc-web/coverage/.resultset.json > web-resultset.json
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-dpc-web
           path: ./web-resultset.json
@@ -83,7 +83,7 @@ jobs:
         run: |
           sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-admin") then .key |= sub("/dpc-admin"; "/github/workspace/dpc-admin") else . end)' dpc-admin/coverage/.resultset.json > admin-resultset.json
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-dpc-admin
           path: ./admin-resultset.json
@@ -101,7 +101,7 @@ jobs:
         run: |
           sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-portal") then .key |= sub("/dpc-portal"; "/github/workspace/dpc-portal") else . end)' dpc-portal/coverage/.resultset.json > portal-resultset.json
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-dpc-portal
           path: ./portal-resultset.json
@@ -127,11 +127,11 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download web code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-web
       - name: Download admin code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-admin
       - name: Set env vars from AWS params
@@ -165,7 +165,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-portal
       - name: Set env vars from AWS params
@@ -229,7 +229,7 @@ jobs:
         run: |
           mvn clean compile -Perror-prone -B -V -ntp
       - name: Download code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-api
           path: jacoco-reports


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4448

## 🛠 Changes

actions/(upload|download)-artifact updated to v4 in ci-workflow.yml

## ℹ️ Context

We are closing down access to v3 on January 30, 2025. See https://jira.cms.gov/browse/PLT-832

grepped workflows directory and found usage only in ci-workflow.yml

## 🧪 Validation
Upgraded to v4 and still ran successfully

