### PR TITLE
DPC-4453  - revert fetch optimization

### DIFF
--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tag-dpc-app:
     name: "Tag dpc-app"
-    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
+    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@jd/permissions-issue
     with:
       repo_ref: ${{ inputs.repo_ref }}
     secrets: inherit

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tag-dpc-app:
     name: "Tag dpc-app"
-    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@jd/permissions-issue
+    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
     with:
       repo_ref: ${{ inputs.repo_ref }}
     secrets: inherit

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -24,9 +24,6 @@ jobs:
     outputs:
       next_rev: ${{ steps.set_revs.outputs.next_rev }}
     steps:
-      - name: Assert Ownership
-        run: |
-          sudo chmod -R 777 .
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
@@ -35,12 +32,14 @@ jobs:
       - name: "Calculate Next Revision"
         id: set_revs
         run: |
+          git tag -l 'r*' --sort=v:refname
           prev_rev=`git tag -l 'r*' --sort=v:refname | tail -n 1`
           echo "prev_rev=$prev_rev" >> "$GITHUB_OUTPUT"
           prev_rev_num=${prev_rev/r}
           next_rev_num=$((prev_rev_num + 1))
           next_rev=r$next_rev_num
           echo "next_rev=$next_rev" >> "$GITHUB_OUTPUT"
+          echo "Prev Revision: $prev_rev"
           echo "Next Revision: $next_rev"
       - name: "Set Body"
         id: set_body
@@ -53,6 +52,7 @@ jobs:
           fi
           echo "body=$BODY" >> "$GITHUB_OUTPUT"
       - name: Release
+        if: ${{ false }}
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.set_body.outputs.body }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -28,21 +28,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.repo_ref || 'main' }}
-          fetch-tags: true
       - name: "Fetch git info"
         run: |
           git fetch --quiet
       - name: "Calculate Next Revision"
         id: set_revs
         run: |
-          git tag -l 'r*' --sort=v:refname
           prev_rev=`git tag -l 'r*' --sort=v:refname | tail -n 1`
           echo "prev_rev=$prev_rev" >> "$GITHUB_OUTPUT"
           prev_rev_num=${prev_rev/r}
           next_rev_num=$((prev_rev_num + 1))
           next_rev=r$next_rev_num
           echo "next_rev=$next_rev" >> "$GITHUB_OUTPUT"
-          echo "Prev Revision: $prev_rev"
           echo "Next Revision: $next_rev"
       - name: "Set Body"
         id: set_body
@@ -55,7 +52,6 @@ jobs:
           fi
           echo "body=$BODY" >> "$GITHUB_OUTPUT"
       - name: Release
-        if: ${{ false }}
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.set_body.outputs.body }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Assert Ownership
         run: |
-          sudo chmod -R u+rwX .
+          sudo chmod -R 777 .
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           ref: ${{ inputs.repo_ref || 'main' }}
           fetch-tags: true
+      - name: "Fetch git info"
+        run: |
+          git fetch --quiet
       - name: "Calculate Next Revision"
         id: set_revs
         run: |

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Assert Ownership
         run: |
-          chmod -R u+rwX .
+          sudo chmod -R u+rwX .
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -24,6 +24,9 @@ jobs:
     outputs:
       next_rev: ${{ steps.set_revs.outputs.next_rev }}
     steps:
+      - name: Assert Ownership
+        run: |
+          chmod -R u+rwX .
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4453

## 🛠 Changes

Go back to fetching everything as separate step.

## ℹ️ Context

Previous fix tried to optimize fetching tags. Turns out, it doesn't work.
Runners try to do the least work possible, so it was saving previously-fetched tags. Running a different workflow forced a complete clean of the directory, so the next time this workflow was run, it didn't have any tags.

## 🧪 Validation

Successful run: https://github.com/CMSgov/dpc-app/actions/runs/12601770911/job/35123530838
