### PR TITLE
[DPC-4456] Update ci to use mock bfd client for all tests

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -10,7 +10,7 @@ services:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   dpc_web:
@@ -53,7 +53,7 @@ services:
       test: curl --fail http://localhost:3500/health_check || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   web_sidekiq:
@@ -86,7 +86,7 @@ services:
       test: curl --fail http://localhost:7433 || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   dpc_admin:
@@ -123,7 +123,7 @@ services:
       test: curl --fail http://localhost:3000/admin/health_check || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   admin_sidekiq:
@@ -155,7 +155,7 @@ services:
       test: curl --fail http://localhost:7434 || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   dpc_portal:
@@ -219,7 +219,7 @@ services:
       test: curl --fail http://localhost:3100/portal/health_check || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   portal_sidekiq:
@@ -254,5 +254,5 @@ services:
       test: curl --fail http://localhost:7435 || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -8,9 +8,9 @@ services:
     image: redis:latest
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   dpc_web:
@@ -51,9 +51,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl --fail http://localhost:3500/health_check || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   web_sidekiq:
@@ -84,9 +84,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl --fail http://localhost:7433 || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   dpc_admin:
@@ -121,9 +121,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl --fail http://localhost:3000/admin/health_check || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   admin_sidekiq:
@@ -153,9 +153,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl --fail http://localhost:7434 || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   dpc_portal:
@@ -217,9 +217,9 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl --fail http://localhost:3100/portal/health_check || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   portal_sidekiq:
@@ -252,7 +252,7 @@ services:
         condition: service_healthy
     healthcheck:
       test: curl --fail http://localhost:7435 || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       - ./tmp:/var/tmp
     healthcheck:
       test: "pg_isready -U $${POSTGRES_USER}"
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   aggregation:
@@ -43,9 +43,9 @@ services:
       - ./jacocoReport/dpc-aggregation:/jacoco-report
     healthcheck:
       test: curl --fail http://localhost:9901/healthcheck || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   attribution:
@@ -64,9 +64,9 @@ services:
       - ./jacocoReport/dpc-attribution:/jacoco-report
     healthcheck:
       test: curl --fail http://localhost:9902/healthcheck || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   api:
@@ -91,9 +91,9 @@ services:
       - ./jacocoReport/dpc-api:/jacoco-report
     healthcheck:
       test: curl --fail http://localhost:9900/healthcheck || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   consent:
@@ -112,9 +112,9 @@ services:
       - ./jacocoReport/dpc-consent:/jacoco-report
     healthcheck:
       test: curl --fail http://localhost:9904/healthcheck || exit 1
-      interval: 5s
+      interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 30s
       retries: 5
 
   tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       test: "pg_isready -U $${POSTGRES_USER}"
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   aggregation:
@@ -45,7 +45,7 @@ services:
       test: curl --fail http://localhost:9901/healthcheck || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   attribution:
@@ -66,7 +66,7 @@ services:
       test: curl --fail http://localhost:9902/healthcheck || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   api:
@@ -93,7 +93,7 @@ services:
       test: curl --fail http://localhost:9900/healthcheck || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   consent:
@@ -114,7 +114,7 @@ services:
       test: curl --fail http://localhost:9904/healthcheck || exit 1
       interval: 5s
       timeout: 5s
-      start_period: 10s
+      start_period: 20s
       retries: 5
 
   tests:

--- a/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
+++ b/dpc-bluebutton/src/main/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClient.java
@@ -157,6 +157,11 @@ public class MockBlueButtonClient implements BlueButtonClient {
 
             // If this is the synthetic bene dpc-api uses to get the BFD transaction time, make sure the time returned
             // is in the past.  If not, dpc-aggregation will fail tests when it checks transaction times.
+            //
+            // Dpc-api loads this particular synthetic patient to get its meta.lastUpdated time to figure out when BFD
+            // data was last loaded.  Dpc-aggregation then compares this date to the meta.lastUpdated of any resource
+            // bundles to make sure the bundle was created after the last data load.  At some point in the past, BFD had
+            // an issue with transaction time regression, and this was how it was dealt with.
             Date lastUpdated = beneId.equals(MBI_BENE_ID_MAP.get(TEST_PATIENT_FOR_API_TRANSACTION_TIME)) ?
                 Date.from(BFD_TRANSACTION_TIME.toInstant().minusSeconds(300)) :
                 Date.from(BFD_TRANSACTION_TIME.toInstant());

--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClientUnitTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClientUnitTest.java
@@ -1,0 +1,104 @@
+package gov.cms.dpc.bluebutton.client;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import org.hl7.fhir.dstu3.model.Bundle;
+import org.hl7.fhir.dstu3.model.CapabilityStatement;
+import org.hl7.fhir.dstu3.model.Patient;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * To be clear, {@link MockBlueButtonClient} is itself only used for testing and probably doesn't need its own set of
+ * tests.  SonarQube is flagging it for code coverage, though, so I'm adding some anyway.
+ */
+class MockBlueButtonClientUnitTest {
+	private MockBlueButtonClient client = new MockBlueButtonClient(FhirContext.forDstu3());
+
+	private String mbi = MockBlueButtonClient.TEST_PATIENT_MBIS.get(0);
+	private String id = MockBlueButtonClient.MBI_BENE_ID_MAP.get(mbi);
+
+	@Test
+	void testRequestPatientFromServerByMbi() {
+		Bundle resultBundle = client.requestPatientFromServerByMbi(mbi, Map.of());
+		assertEquals(1, resultBundle.getTotal());
+
+		Patient pat = (Patient) resultBundle.getEntryFirstRep().getResource();
+		assertEquals(pat.getIdPart(), id);
+	}
+
+	@Test
+	void testRequestPatientFromServer() {
+		DateRangeParam dateRangeParam = new DateRangeParam()
+			.setLowerBound("2000-12-31")
+			.setUpperBound("2100-01-01");
+		Bundle resultBundle = client.requestPatientFromServer(id, dateRangeParam, Map.of());
+		assertEquals(1, resultBundle.getTotal());
+
+		Patient pat = (Patient) resultBundle.getEntryFirstRep().getResource();
+		assertEquals(pat.getIdPart(), id);
+	}
+	@Test
+	void testRequestPatientFromServerOutOfRange() {
+		DateRangeParam dateRangeParam = new DateRangeParam()
+			.setLowerBound("2099-01-01")
+			.setUpperBound("2100-01-01");
+		Bundle resultBundle = client.requestPatientFromServer(id, dateRangeParam, Map.of());
+		assertEquals(0, resultBundle.getTotal());
+	}
+
+	@Test
+	void testRequestEobFromServer() {
+		DateRangeParam dateRangeParam = new DateRangeParam()
+			.setLowerBound("2000-12-31")
+			.setUpperBound("2100-01-01");
+		Bundle resultBundle = client.requestEOBFromServer(id, dateRangeParam, Map.of());
+		assertEquals("c20130ee-5bf9-4c5a-b71b-70e814b67fc0", resultBundle.getIdPart());
+	}
+	@Test
+	void testRequestEobFromServerOutOfRange() {
+		DateRangeParam dateRangeParam = new DateRangeParam()
+			.setLowerBound("2099-01-01")
+			.setUpperBound("2100-01-01");
+		Bundle resultBundle = client.requestEOBFromServer(id, dateRangeParam, Map.of());
+		assertEquals(0, resultBundle.getTotal());
+	}
+
+	@Test
+	void testRequestCoverageFromServer() {
+		DateRangeParam dateRangeParam = new DateRangeParam()
+			.setLowerBound("2000-12-31")
+			.setUpperBound("2100-01-01");
+		Bundle resultBundle = client.requestCoverageFromServer(id, dateRangeParam, Map.of());
+		assertEquals("5f25ebcf-a442-4811-b623-5d73d51e11e2", resultBundle.getIdPart());
+	}
+	@Test
+	void testRequestCoverageFromServerOutOfRange() {
+		DateRangeParam dateRangeParam = new DateRangeParam()
+			.setLowerBound("2099-01-01")
+			.setUpperBound("2100-01-01");
+		Bundle resultBundle = client.requestCoverageFromServer(id, dateRangeParam, Map.of());
+		assertEquals(0, resultBundle.getTotal());
+	}
+
+	@Test
+	void testRequestNextBundle() {
+		DateRangeParam dateRangeParam = new DateRangeParam()
+			.setLowerBound("2000-12-31")
+			.setUpperBound("2100-01-01");
+		Bundle firstBundle = client.requestEOBFromServer(id, dateRangeParam, Map.of());
+
+		Bundle nextBundle = client.requestNextBundleFromServer(firstBundle, Map.of());
+		assertEquals("529877ac-c606-4eb2-a2e7-f64e079414a0", nextBundle.getIdPart());
+	}
+
+	@Test
+	void testRequestCapabilityStatement() {
+		CapabilityStatement capabilityStatement = client.requestCapabilityStatement();
+		assertNotNull(capabilityStatement);
+	}
+}

--- a/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClientUnitTest.java
+++ b/dpc-bluebutton/src/test/java/gov/cms/dpc/bluebutton/client/MockBlueButtonClientUnitTest.java
@@ -17,10 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * tests.  SonarQube is flagging it for code coverage, though, so I'm adding some anyway.
  */
 class MockBlueButtonClientUnitTest {
-	private MockBlueButtonClient client = new MockBlueButtonClient(FhirContext.forDstu3());
+	private final MockBlueButtonClient client = new MockBlueButtonClient(FhirContext.forDstu3());
 
-	private String mbi = MockBlueButtonClient.TEST_PATIENT_MBIS.get(0);
-	private String id = MockBlueButtonClient.MBI_BENE_ID_MAP.get(mbi);
+	private final String mbi = MockBlueButtonClient.TEST_PATIENT_MBIS.get(0);
+	private final String id = MockBlueButtonClient.MBI_BENE_ID_MAP.get(mbi);
 
 	@Test
 	void testRequestPatientFromServerByMbi() {

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -55,8 +55,7 @@ docker compose -p start-v1-app down
 docker volume rm start-v1-app_pgdata16
 
 # Start the API server
-USE_BFD_MOCK=true docker compose -p start-v1-app up db attribution aggregation --wait
-USE_BFD_MOCK=false AUTH_DISABLED=true docker compose -p start-v1-app up api consent --wait
+USE_BFD_MOCK=true AUTH_DISABLED=true docker compose -p start-v1-app up db attribution aggregation consent api --wait
 
 # Run the Postman tests
 npm install

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -46,7 +46,7 @@ fi
 
 docker compose -p start-v1-app down
 docker volume rm start-v1-app_pgdata16
-docker compose -p start-v1-app up db attribution aggregation --wait
+USE_BFD_MOCK=true docker compose -p start-v1-app up db attribution aggregation --wait
 
 # Run the integration tests
 docker compose -p start-v1-app up --exit-code-from tests tests
@@ -54,6 +54,7 @@ docker compose -p start-v1-app up --exit-code-from tests tests
 docker compose -p start-v1-app down
 docker volume rm start-v1-app_pgdata16
 
+echo "Starting Postman tests"
 # Start the API server
 USE_BFD_MOCK=true AUTH_DISABLED=true docker compose -p start-v1-app up db attribution aggregation consent api --wait
 

--- a/src/main/resources/bb-test-data/patient/-19990000000001.json
+++ b/src/main/resources/bb-test-data/patient/-19990000000001.json
@@ -7,7 +7,7 @@
     {
       "resource": {
         "resourceType": "Patient",
-        "id": "-10000010288391",
+        "id": "-19990000000001",
         "meta": {
           "lastUpdated": "2023-04-26T15:19:31.964-04:00"
         },
@@ -68,7 +68,7 @@
         "identifier": [
           {
             "system": "https://bluebutton.cms.gov/resources/variables/bene_id",
-            "value": "-10000010288391"
+            "value": "-19990000000001"
           },
           {
             "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
@@ -86,7 +86,7 @@
               }
             ],
             "system": "http://hl7.org/fhir/sid/us-mbi",
-            "value": "9V99EU8XY91"
+            "value": "9S99EU8XY92"
           },
           {
             "extension": [

--- a/src/test/resources/bb-test-data/empty.json
+++ b/src/test/resources/bb-test-data/empty.json
@@ -1,0 +1,7 @@
+{
+  "resourceType": "Bundle",
+  "id": "2ebd4f66-7907-45fb-b60b-f20871a2c67f",
+  "type": "searchset",
+  "total": 0,
+  "entry": []
+}

--- a/src/test/resources/bb-test-data/patient/-19990000000001.json
+++ b/src/test/resources/bb-test-data/patient/-19990000000001.json
@@ -7,7 +7,7 @@
     {
       "resource": {
         "resourceType": "Patient",
-        "id": "-10000010288391",
+        "id": "-19990000000001",
         "meta": {
           "lastUpdated": "2023-04-26T15:19:31.964-04:00"
         },
@@ -68,7 +68,7 @@
         "identifier": [
           {
             "system": "https://bluebutton.cms.gov/resources/variables/bene_id",
-            "value": "-10000010288391"
+            "value": "-19990000000001"
           },
           {
             "system": "https://bluebutton.cms.gov/resources/identifier/mbi-hash",
@@ -86,7 +86,7 @@
               }
             ],
             "system": "http://hl7.org/fhir/sid/us-mbi",
-            "value": "9V99EU8XY91"
+            "value": "9S99EU8XY92"
           },
           {
             "extension": [


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4456

## 🛠 Changes

- Update ci tests to use the mockBfdClient for dpc-api.
- Update mockBfdClient to support the synthetic patient we search for in prod BFD to load transaction time.

## ℹ️ Context

Our integration tests run as part of `make ci-app` relied on dpc-api being connected to the real production BFD system, and dpc-aggregation using our mockBfdClient.  This PR makes the whole test suite use the mockBfdClient and makes things generally more reliable.

### Note

This fixes the Jenkins build problems due to dpc-api failing its health check because it couldn't connect to BFD.

Example [here](https://management.dpc.cms.gov/job/DPC%20-%20Docker%20Build/4382/)
Passing run [here](https://management.dpc.cms.gov/job/DPC%20-%20Full%20Deploy%20and%20Release/2829/)

## 🧪 Validation

Ran locally and in Jenkins.
