### PR TITLE
Remove check for CVE-2024-21510

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -124,6 +124,9 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
+      - name: chmod working directory
+        run: |
+          chmod -R 777 .
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download web code coverage
@@ -162,6 +165,9 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
+      - name: chmod working directory
+        run: |
+          chmod -R 777 .
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download code coverage
@@ -197,6 +203,9 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
+      - name: chmod working directory
+        run: |
+          chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Setup Java

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -126,7 +126,7 @@ jobs:
     steps:
       - name: chmod working directory
         run: |
-          chmod -R 777 .
+          sudo chmod -R 777 .
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download web code coverage
@@ -167,7 +167,7 @@ jobs:
     steps:
       - name: chmod working directory
         run: |
-          chmod -R 777 .
+          sudo chmod -R 777 .
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download code coverage
@@ -205,7 +205,7 @@ jobs:
     steps:
       - name: chmod working directory
         run: |
-          chmod -R 777 .
+          sudo chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Setup Java

--- a/dpc-portal/Dockerfile
+++ b/dpc-portal/Dockerfile
@@ -29,7 +29,7 @@ RUN gem install bundler --no-document && \
 
 # Run bundler audit
 # ignoring CVE-2024-21510 as it affects Sinatra, which is only used internally
-RUN bundle exec bundle audit update && bundle exec bundle audit check --ignore CVE-2024-21510
+RUN bundle exec bundle audit update && bundle exec bundle audit check
 
 # Copy the code, test the app, and build the assets pipeline
 COPY /dpc-portal /dpc-portal


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4359

## 🛠 Changes

Removed ignore flag in dpc-portal/Dockerfile

## ℹ️ Context

CVE-2024-21510 is a vulnerability in Sinatra that was fixed in 4.1.0, which we had already upgraded to.

## 🧪 Validation

Removed ignore flag and everything still worked
