### PR TITLE
[NO TICKET] Update new relic api key secret name

### DIFF
--- a/.github/workflows/dpc-load-test.yml
+++ b/.github/workflows/dpc-load-test.yml
@@ -19,7 +19,7 @@ jobs:
           docker run -d \
             --name newrelic-statsd \
             -e NR_ACCOUNT_ID=${{ secrets.NEW_RELIC_ACCOUNT_ID }} \
-            -e NR_API_KEY=${{ secrets.NEW_RELIC_API_KEY }} \
+            -e NR_API_KEY=${{ secrets.LOAD_TEST_NEW_RELIC_API_KEY }} \
             -p 8125:8125/udp \
             newrelic/nri-statsd:latest
 


### PR DESCRIPTION
## 🎫 Ticket

None

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
This changes the name of the NEW_RELIC_API_KEY secret to LOAD_TEST_NEW_RELIC_API_KEY.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
The original name was too generic. For the Load Test use case, we specifically need an INGEST key, and as such, it is likely not useful for other use cases. By specifying the use case, others can create and add keys of their own for their own use cases.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
- [ ] DPC Load Test GH Actions workflow succeeds when run against this branch - https://github.com/CMSgov/dpc-app/actions/runs/12716246054/job/35450142766