### PR TITLE
DPC-4457 Add assertDoesNotThrow to tests without assertions

### DIFF
--- a/dpc-api/src/test/java/gov/cms/dpc/api/auth/PublicKeyHandlerTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/auth/PublicKeyHandlerTest.java
@@ -46,7 +46,7 @@ class PublicKeyHandlerTest {
         void testValidKey(KeyType keyType) throws NoSuchAlgorithmException {
             final String encoded = generatePublicKey(keyType);
             final String key = String.format("-----BEGIN PUBLIC KEY-----\n%s\n-----END PUBLIC KEY-----\n", encoded);
-            PublicKeyHandler.parsePEMString(key);
+            assertDoesNotThrow(() -> PublicKeyHandler.parsePEMString(key));
         }
 
         @ParameterizedTest

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRAsyncRequestFilterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRAsyncRequestFilterTest.java
@@ -17,8 +17,7 @@ import java.util.List;
 import static gov.cms.dpc.fhir.FHIRHeaders.PREFER_HEADER;
 import static gov.cms.dpc.fhir.FHIRHeaders.PREFER_RESPOND_ASYNC;
 import static gov.cms.dpc.fhir.FHIRMediaTypes.FHIR_JSON;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(BufferedLoggerHandler.class)
 public class FHIRAsyncRequestFilterTest {
@@ -49,7 +48,7 @@ public class FHIRAsyncRequestFilterTest {
             map.put(HttpHeaders.ACCEPT, List.of(FHIR_JSON));
             map.put(PREFER_HEADER, List.of(PREFER_RESPOND_ASYNC));
             Mockito.when(context.getHeaders()).thenReturn(map);
-            filter.filter(context);
+            assertDoesNotThrow(() -> filter.filter(context));
         }
 
         @Test
@@ -58,7 +57,7 @@ public class FHIRAsyncRequestFilterTest {
             map.put(HttpHeaders.ACCEPT, List.of("wrong", FHIR_JSON));
             map.put(PREFER_HEADER, List.of(PREFER_RESPOND_ASYNC));
             Mockito.when(context.getHeaders()).thenReturn(map);
-            filter.filter(context);
+            assertDoesNotThrow(() -> filter.filter(context));
         }
 
         @Test
@@ -89,7 +88,7 @@ public class FHIRAsyncRequestFilterTest {
             map.put(HttpHeaders.ACCEPT, List.of(FHIR_JSON));
             map.put(PREFER_HEADER, List.of(PREFER_RESPOND_ASYNC));
             Mockito.when(context.getHeaders()).thenReturn(map);
-            filter.filter(context);
+            assertDoesNotThrow(() -> filter.filter(context));
         }
 
         @Test

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/dropwizard/filters/FHIRRequestFilterTest.java
@@ -16,8 +16,7 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class FHIRRequestFilterTest {
@@ -32,7 +31,7 @@ public class FHIRRequestFilterTest {
         setAcceptHeader(request, FHIRMediaTypes.FHIR_JSON);
         Mockito.when(request.getHeaders()).thenReturn(headerMap);
 
-        filter.filter(request);
+        assertDoesNotThrow(() -> filter.filter(request));
     }
 
     @Test
@@ -80,7 +79,7 @@ public class FHIRRequestFilterTest {
         Mockito.when(request.getAcceptableMediaTypes()).thenReturn(List.of(MediaType.APPLICATION_JSON_TYPE, MediaType.valueOf(FHIRMediaTypes.FHIR_JSON)));
         Mockito.when(request.getHeaders()).thenReturn(headerMap);
 
-        filter.filter(request);
+        assertDoesNotThrow(() -> filter.filter(request));
     }
 
     @Test
@@ -116,7 +115,7 @@ public class FHIRRequestFilterTest {
         setAcceptHeader(request, FHIRMediaTypes.FHIR_JSON);
         Mockito.when(request.getHeaders()).thenReturn(headerMap);
 
-        filter.filter(request);
+        assertDoesNotThrow(() -> filter.filter(request));
     }
 
     @Test
@@ -127,7 +126,7 @@ public class FHIRRequestFilterTest {
         setAcceptHeader(request, FHIRMediaTypes.FHIR_JSON);
         Mockito.when(request.getHeaders()).thenReturn(headerMap);
 
-        filter.filter(request);
+        assertDoesNotThrow(() -> filter.filter(request));
 
     }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4457

## 🛠 Changes

assertDoesNotThrow added to tests without assertions:

- FHIRRequestFilterTest: testSuccess, testNestedAcceptsHeader, testNullContentHeader, testTestedContentHeader
- FHIRAsyncRequestFilterTest: testCorrectAcceptsHeader, testMultipleAcceptsHeader, testCorrectPreferHeader
- PublicKeyHandlerTest: testValidKey

## ℹ️ Context

Although any exception will cause a test to fail, Sonarqube complains about [tests without assertions](https://sonarqube.cloud.cms.gov/project/issues?resolved=false&scopes=TEST&severities=BLOCKER&id=bcda-dpc-api): Add at least one assertion to this test case.

## 🧪 Validation
Ran ci-workflow against this branch; [sonarqube no longer complains about this issue](https://sonarqube.cloud.cms.gov/project/issues?resolved=false&severities=BLOCKER&branch=jd%2Fdpc-4457-test-assertions&id=bcda-dpc-api).