### PR TITLE
[dpc-4461] Make sure local smoke tests are initialized correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,9 @@ smoke:
 
 .PHONY: smoke/local
 smoke/local: export USE_BFD_MOCK=false
-smoke/local: venv smoke start-portals start-api-dependencies start-api
+smoke/local: export AUTH_DISABLED=false
+smoke/local: venv smoke start-dpc
 	@echo "Running Smoke Tests against Local env"
-	@read -p "`echo '\n=====\nThe Smoke Tests require an authenticated environment!\nVerify your local API environment has \"authenticationDisabled = false\" or these tests will fail.\n=====\n\nPress ENTER to run the tests...'`"
 	. venv/bin/activate; pip install -Ur requirements.txt; bzt src/test/local.smoke_test.yml
 
 .PHONY: smoke/remote

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,10 @@ smoke:
 
 .PHONY: smoke/local
 smoke/local: venv smoke
+smoke/local: start-portals
 	@echo "Running Smoke Tests against Local env"
 	@read -p "`echo '\n=====\nThe Smoke Tests require an authenticated environment!\nVerify your local API environment has \"authenticationDisabled = false\" or these tests will fail.\n=====\n\nPress ENTER to run the tests...'`"
+	@USE_BFD_MOCK=false docker compose up aggregation api --wait
 	. venv/bin/activate; pip install -Ur requirements.txt; bzt src/test/local.smoke_test.yml
 
 .PHONY: smoke/remote

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,10 @@ smoke:
 	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local
-smoke/local: venv smoke
-smoke/local: start-portals
+smoke/local: export USE_BFD_MOCK = false
+smoke/local: venv smoke start-portals start-api-dependencies start-api
 	@echo "Running Smoke Tests against Local env"
 	@read -p "`echo '\n=====\nThe Smoke Tests require an authenticated environment!\nVerify your local API environment has \"authenticationDisabled = false\" or these tests will fail.\n=====\n\nPress ENTER to run the tests...'`"
-	@USE_BFD_MOCK=false docker compose up aggregation api --wait
 	. venv/bin/activate; pip install -Ur requirements.txt; bzt src/test/local.smoke_test.yml
 
 .PHONY: smoke/remote

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ smoke:
 	@mvn clean package -DskipTests -Djib.skip=True -pl dpc-smoketest -am -ntp
 
 .PHONY: smoke/local
-smoke/local: export USE_BFD_MOCK = false
+smoke/local: export USE_BFD_MOCK=false
 smoke/local: venv smoke start-portals start-api-dependencies start-api
 	@echo "Running Smoke Tests against Local env"
 	@read -p "`echo '\n=====\nThe Smoke Tests require an authenticated environment!\nVerify your local API environment has \"authenticationDisabled = false\" or these tests will fail.\n=====\n\nPress ENTER to run the tests...'`"

--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/ClientUtils.java
@@ -64,10 +64,10 @@ public class ClientUtils {
                 .map(search -> (Group) search.getEntryFirstRep().getResource())
                 .map(group -> jobCompletionLambda(exportClient, httpClient, group, overrideURL))
                 .peek(jobResponse -> {
-                    if (jobResponse.getError().size() > 0) {
+                    if (! jobResponse.getError().isEmpty()) {
                         ObjectMapper mapper = new ObjectMapper();
                         try {
-                            logger.error(mapper.writeValueAsString(jobResponse));
+                            logger.error(mapper.writerWithDefaultPrettyPrinter().writeValueAsString(jobResponse));
                         } catch (JsonProcessingException e) {
                             throw new IllegalStateException("Export job completed, but with unserializable errors");
                         }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4461

## 🛠 Changes

Ensures that when running local smoke tests dpc-api is up and connected to the real BFD.

## ℹ️ Context

Local smoke tests were sometimes failing because we recently defaulted to using our mockBfdClient when running for most processes, and the smoke tests need a connection to the real BFD. If you had previously ran dpc with `USE_BFD_MOCK` set to true and then ran the smoke tests they would fail.

## 🧪 Validation

Run `make smoke/local` and everything should pass.
