### PR TITLE
DPC-4472 fix workflow names

### DIFF
--- a/.github/workflows/api-waf-sync-deploy.yml
+++ b/.github/workflows/api-waf-sync-deploy.yml
@@ -1,4 +1,4 @@
-name: api-waf-sync dev deploy
+name: API-WAF-SYNC Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/api-waf-sync-deploy.yml
+++ b/.github/workflows/api-waf-sync-deploy.yml
@@ -1,4 +1,4 @@
-name: API-WAF-SYNC Deploy
+name: Api-Waf-Sync Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/api-waf-sync-test-integration.yml
+++ b/.github/workflows/api-waf-sync-test-integration.yml
@@ -1,4 +1,4 @@
-name: api-waf-sync integration tests
+name: Api-Waf-Sync Integration Tests
 
 on:
   pull_request:

--- a/.github/workflows/check_healthy.yml
+++ b/.github/workflows/check_healthy.yml
@@ -1,4 +1,4 @@
-name: Utility for validating that services are up
+name: utility-check-healthy
 
 on:
   workflow_call:

--- a/.github/workflows/deploy_go_lambda.yml
+++ b/.github/workflows/deploy_go_lambda.yml
@@ -1,4 +1,4 @@
-name: Deploy go lambda
+name: utility-deploy-go-lambda
 
 on:
   workflow_call:

--- a/.github/workflows/dpc-portal-accessibility-test.yml
+++ b/.github/workflows/dpc-portal-accessibility-test.yml
@@ -1,4 +1,4 @@
-name: dpc-portal accessibility test
+name: Dpc-Portal Accessibility Tests
 
 on:
   workflow_dispatch:

--- a/.github/workflows/opt-out-export-deploy.yml
+++ b/.github/workflows/opt-out-export-deploy.yml
@@ -1,4 +1,4 @@
-name: opt-out-export deploy
+name: Opt-Out-Export Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/opt-out-export-test-integration.yml
+++ b/.github/workflows/opt-out-export-test-integration.yml
@@ -1,4 +1,4 @@
-name: opt-out-export integration tests
+name: Opt-Out-Export Integration Tests
 
 on:
   pull_request:

--- a/.github/workflows/opt-out-import-deploy.yml
+++ b/.github/workflows/opt-out-import-deploy.yml
@@ -1,4 +1,4 @@
-name: opt-out-import dev deploy
+name: Opt-Out-Import Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/opt-out-import-test-integration.yml
+++ b/.github/workflows/opt-out-import-test-integration.yml
@@ -1,4 +1,4 @@
-name: opt-out-import test integration
+name: Opt-Out-Import Integration Tests
 
 on:
   pull_request:

--- a/.github/workflows/opt-out-import-unit.yml
+++ b/.github/workflows/opt-out-import-unit.yml
@@ -1,4 +1,4 @@
-name: opt-out-import unit tests
+name: Opt-Out-Import Unit Tests
 
 on:
   pull_request:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,4 +1,4 @@
-name: 'Tag Repo Utility'
+name: utility-tag-repo
 
 on:
   workflow_call:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4472

## 🛠 Changes

Top-level names changed for multiple workflows.

## ℹ️ Context

I had left 'dev' in some workflow names, and thought standardizing naming would be useful.

## 🧪 Validation

After merge, will verify names in Actions look better.
