### PR TITLE
Add required node version for postman tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ If you want to build applications locally, you'll need the following tools:
 In addition, it's helpful to have the following installed for more specific scenarios:
 
 - Running [smoke tests](#smoke-tests): Python 3 (includes `pip`)
-- Running [postman tests](#postman-collection): Node.js (includes `npm`)
+- Running [postman tests](#postman-collection): Node.js (includes `npm`; note: a [known issue](https://github.com/postmanlabs/newman/issues/3267) means you should not install node > 22.2.0)
 
 ### Recommended tools
 


### PR DESCRIPTION
## 🎫 Ticket

no ticket

## 🛠 Changes

README.md updated

## ℹ️ Context

Currently `make ci-app` fails if run on node greater than 22.2.0 (current version is 23.6.1). This gives a heads up to developers, both for local testing and in case ci starts failing.

Optional fix is to downgrade newman (the test runner) to 6.13.1, which works with the latest node but screams warnings.

Note: brew install node@22 fails, as this is version 22.13.?

## 🧪 Validation

Installed node 20 locally and tests worked fine.
