### PR TITLE
DPC-4478 self hosted ci workflow

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,6 +6,9 @@ on:
       - .github/workflows/opt-out-*
       - lambda/**
   workflow_dispatch: # Allow manual trigger
+  push:
+    paths:
+      - .github/workflows/ci-workflow.yml
 
 env:
   VAULT_PW: ${{ secrets.VAULT_PW }}
@@ -65,6 +68,23 @@ jobs:
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-app
+      - name: Consent Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-consent-1
+      - name: Attribution Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-attribution-1
+      - name: Aggregation Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-aggregation-1
+      - name: Api Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-api-1
+      - name: Down
+        if: ${{ always() }}
+        run: |
+          docker compose -p start-v1-app down
+          docker volume rm start-v1-app_pgdata16
       - name: "Move jacoco reports"
         run: |
           sudo mkdir jacoco-reports

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,7 +14,7 @@ env:
   ENV: "github-ci"
 
 jobs:
-  test-api:
+  build-api:
     name: "Build and Test API"
     runs-on: self-hosted
     steps:
@@ -24,11 +24,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
-      - name: Setup Java
+      - name: "Set up JDK 11"
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
-          distribution: 'corretto'
+          distribution: "corretto"
+          java-version: "11"
       - name: Install Maven 3.6.3
         run: |
           export PATH="$PATH:/opt/maven/bin"
@@ -84,13 +84,13 @@ jobs:
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh
 
-  test-portal:
-    name: "Build and Test Portal"
+  build-dpc-web:
+    name: "Build and Test DPC Web"
     runs-on: self-hosted
     steps:
       - name: Assert Ownership
         run: sudo chmod -R 777 .
-      - name: Checkout Code
+      - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
@@ -104,77 +104,7 @@ jobs:
           curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
           chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-      - name: "Test portal"
-        run: |
-          export PATH=$PATH:~/.local/bin
-          make ci-portal
-      - name: "Copy test results"
-        run: sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report-dpc-portal
-          path: ./portal-resultset-raw.json
-      - name: Cleanup
-        if: ${{ always() }}
-        run: ./scripts/cleanup-docker.sh
-
-  test-admin:
-    name: "Build and Test Admin"
-    runs-on: self-hosted
-    steps:
-      - name: Assert Ownership
-        run: sudo chmod -R 777 .
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Cleanup Runner
-        run: ./scripts/cleanup-docker.sh
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
-      - name: Install docker compose manually
-        run: |
-          mkdir -p /usr/local/lib/docker/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-      - name: "Test Admin"
-        run: |
-          export PATH=$PATH:~/.local/bin
-          make ci-admin-portal
-      - name: "Copy test results"
-        run: sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report-dpc-admin
-          path: ./admin-resultset-raw.json
-      - name: Cleanup
-        if: ${{ always() }}
-        run: ./scripts/cleanup-docker.sh
-
-  test-web:
-    name: "Build and Test Web"
-    runs-on: self-hosted
-    steps:
-      - name: Assert Ownership
-        run: sudo chmod -R 777 .
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Cleanup Runner
-        run: ./scripts/cleanup-docker.sh
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
-      - name: Install docker compose manually
-        run: |
-          mkdir -p /usr/local/lib/docker/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-      - name: "Test Web"
+      - name: "DPC Web Build"
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-web-portal
@@ -189,7 +119,77 @@ jobs:
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh
 
-  test-dpc-client:
+  build-dpc-admin:
+    name: "Build and Test DPC Admin Portal"
+    runs-on: self-hosted
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "DPC Admin Portal Build"
+        run: |
+          export PATH=$PATH:~/.local/bin
+          make ci-admin-portal
+      - name: "Copy test results"
+        run: sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-admin
+          path: ./admin-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  build-dpc-portal:
+    name: "Build and Test DPC Portal"
+    runs-on: self-hosted
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "DPC Portal Build"
+        run: |
+          export PATH=$PATH:~/.local/bin
+          make ci-portal
+      - name: "Copy test results"
+        run: sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-portal
+          path: ./portal-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  build-dpc-client:
     name: "Build and Test DPC Client"
     runs-on: self-hosted
     steps:
@@ -200,14 +200,15 @@ jobs:
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
       - name: "DPC Client Build"
-        run: make ci-api-client
+        run: |
+          make ci-api-client
       - name: Cleanup
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh
 
   sonar-quality-gate-dpc-web-and-admin:
     name: Sonarqube Quality Gate for dpc-web and dpc-admin
-    needs: [test-admin, test-web]
+    needs: [build-dpc-admin, build-dpc-web]
     runs-on: self-hosted
     env:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
@@ -215,7 +216,7 @@ jobs:
     steps:
       - name: Assert Ownership
         run: sudo chmod -R 777 .
-      - name: Checkout Code
+      - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
@@ -256,7 +257,7 @@ jobs:
 
   sonar-quality-gate-dpc-portal:
     name: Sonarqube Quality Gate for dpc-portal
-    needs: test-portal
+    needs: build-dpc-portal
     runs-on: self-hosted
     env:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
@@ -264,7 +265,7 @@ jobs:
     steps:
       - name: Assert Ownership
         run: sudo chmod -R 777 .
-      - name: Checkout Code
+      - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
@@ -301,7 +302,7 @@ jobs:
 
   sonar-quality-gate-dpc-api:
     name: Sonarqube Quality Gate for dpc-api
-    needs: test-api
+    needs: build-api
     runs-on: self-hosted
     env:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
@@ -337,16 +338,19 @@ jobs:
           sudo rm -rf /opt/maven
           sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
       - name: Clean maven
-        run: mvn -ntp -U clean
+        run: |
+          mvn -ntp -U clean
       - name: Compile Project
-        run: mvn clean compile -Perror-prone -B -V -ntp
+        run: |
+          mvn clean compile -Perror-prone -B -V -ntp
       - name: Download code coverage
         uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-api
           path: jacoco-reports
       - name: Verify download
-        run: find . -name dpc-api-jacoco.xml
+        run: |
+          find . -name dpc-api-jacoco.xml
       - name: Run quality gate scan
         run: |
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
-          docker system prune --volumes -f
+          docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Setup Java
@@ -89,7 +89,7 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
-          docker system prune --volumes -f
+          docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: "Set up Ansible"
@@ -123,7 +123,7 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
-          docker system prune --volumes -f
+          docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: "Set up Ansible"
@@ -157,7 +157,7 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
-          docker system prune --volumes -f
+          docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: "Set up Ansible"
@@ -205,7 +205,7 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
-          docker system prune --volumes -f
+          docker system prune -a --volumes -f
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download web code coverage
@@ -247,7 +247,7 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
-          docker system prune --volumes -f
+          docker system prune -a --volumes -f
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download code coverage
@@ -286,7 +286,7 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
-          docker system prune --volumes -f
+          docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Setup Java

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo chmod -R 777 .
           RUNNING=`docker ps -q`
-          if [ ! -z ${RUNNING} ]; then
+          if [ -n "$RUNNING" ]; then
             docker stop $(docker ps -q)
           fi
           docker system prune -a --volumes -f
@@ -68,6 +68,9 @@ jobs:
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-app
+      - name: Posgres Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-db-1
       - name: Consent Logs
         if: ${{ failure() && steps.api-build.outcome == 'failure' }}
         run: docker logs start-v1-app-consent-1
@@ -114,7 +117,7 @@ jobs:
         run: |
           sudo chmod -R 777 .
           RUNNING=`docker ps -q`
-          if [ ! -z ${RUNNING} ]; then
+          if [ -n "$RUNNING" ]; then
             docker stop $(docker ps -q)
           fi
           docker system prune -a --volumes -f
@@ -151,7 +154,7 @@ jobs:
         run: |
           sudo chmod -R 777 .
           RUNNING=`docker ps -q`
-          if [ ! -z ${RUNNING} ]; then
+          if [ -n "$RUNNING" ]; then
             docker stop $(docker ps -q)
           fi
           docker system prune -a --volumes -f
@@ -188,7 +191,7 @@ jobs:
         run: |
           sudo chmod -R 777 .
           RUNNING=`docker ps -q`
-          if [ ! -z ${RUNNING} ]; then
+          if [ -n "$RUNNING" ]; then
             docker stop $(docker ps -q)
           fi
           docker system prune -a --volumes -f
@@ -239,7 +242,7 @@ jobs:
         run: |
           sudo chmod -R 777 .
           RUNNING=`docker ps -q`
-          if [ ! -z ${RUNNING} ]; then
+          if [ -n "$RUNNING" ]; then
             docker stop $(docker ps -q)
           fi
           docker system prune -a --volumes -f
@@ -289,7 +292,7 @@ jobs:
         run: |
           sudo chmod -R 777 .
           RUNNING=`docker ps -q`
-          if [ ! -z ${RUNNING} ]; then
+          if [ -n "$RUNNING" ]; then
             docker stop $(docker ps -q)
           fi
           docker system prune -a --volumes -f
@@ -335,7 +338,7 @@ jobs:
         run: |
           sudo chmod -R 777 .
           RUNNING=`docker ps -q`
-          if [ ! -z ${RUNNING} ]; then
+          if [ -n "$RUNNING" ]; then
             docker stop $(docker ps -q)
           fi
           docker system prune -a --volumes -f

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,16 +21,12 @@ jobs:
     name: "Build and Test API"
     runs-on: self-hosted
     steps:
-      - name: Cleanup Runner
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -46,8 +42,7 @@ jobs:
           sudo rm -rf /opt/maven
           sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
       - name: Clean maven
-        run: |
-          mvn -ntp -U clean
+        run: mvn -ntp -U clean
       - name: Install npm
         run: |
           sudo dnf -y install nodejs
@@ -90,28 +85,18 @@ jobs:
           path: ./jacoco-reports
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh
 
   test-portal:
     name: "Build and Test Portal"
     runs-on: self-hosted
     steps:
-      - name: Cleanup Runner
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: "Set up Ansible"
         run: |
           sudo dnf -y install python3 python3-pip
@@ -127,8 +112,7 @@ jobs:
           export PATH=$PATH:~/.local/bin
           make ci-portal
       - name: "Copy test results"
-        run: |
-          sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json
+        run: sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
@@ -136,28 +120,18 @@ jobs:
           path: ./portal-resultset-raw.json
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh
 
   test-admin:
     name: "Build and Test Admin"
     runs-on: self-hosted
     steps:
-      - name: Cleanup Runner
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: "Set up Ansible"
         run: |
           sudo dnf -y install python3 python3-pip
@@ -173,8 +147,7 @@ jobs:
           export PATH=$PATH:~/.local/bin
           make ci-admin-portal
       - name: "Copy test results"
-        run: |
-          sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
+        run: sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
@@ -182,28 +155,18 @@ jobs:
           path: ./admin-resultset-raw.json
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh
 
   test-web:
     name: "Build and Test Web"
     runs-on: self-hosted
     steps:
-      - name: Cleanup Runner
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: "Set up Ansible"
         run: |
           sudo dnf -y install python3 python3-pip
@@ -219,8 +182,7 @@ jobs:
           export PATH=$PATH:~/.local/bin
           make ci-web-portal
       - name: "Copy test results"
-        run: |
-          sudo cp dpc-web/coverage/.resultset.json web-resultset-raw.json
+        run: sudo cp dpc-web/coverage/.resultset.json web-resultset-raw.json
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
@@ -228,32 +190,23 @@ jobs:
           path: ./web-resultset-raw.json
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh
 
   test-dpc-client:
     name: "Build and Test DPC Client"
     runs-on: self-hosted
     steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
       - name: "Checkout code"
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: "DPC Client Build"
-        run: |
-          make ci-api-client
+        run: make ci-api-client
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh
 
   sonar-quality-gate-dpc-web-and-admin:
     name: Sonarqube Quality Gate for dpc-web and dpc-admin
@@ -263,16 +216,12 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
-      - name: Cleanup Runner
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
-      - name: "Checkout code"
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: Download web code coverage
         uses: actions/download-artifact@v4
         with:
@@ -306,13 +255,7 @@ jobs:
             -Dsonar.qualitygate.wait=true
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh
 
   sonar-quality-gate-dpc-portal:
     name: Sonarqube Quality Gate for dpc-portal
@@ -322,16 +265,12 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
-      - name: Cleanup Runner
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
-      - name: "Checkout code"
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: Download code coverage
         uses: actions/download-artifact@v4
         with:
@@ -361,13 +300,7 @@ jobs:
             -Dsonar.qualitygate.wait=true
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh
 
   sonar-quality-gate-dpc-api:
     name: Sonarqube Quality Gate for dpc-api
@@ -377,16 +310,12 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-      - name: Cleanup Runner
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -411,28 +340,19 @@ jobs:
           sudo rm -rf /opt/maven
           sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
       - name: Clean maven
-        run: |
-          mvn -ntp -U clean
+        run: mvn -ntp -U clean
       - name: Compile Project
-        run: |
-          mvn clean compile -Perror-prone -B -V -ntp
+        run: mvn clean compile -Perror-prone -B -V -ntp
       - name: Download code coverage
         uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-api
           path: jacoco-reports
       - name: Verify download
-        run: |
-          find . -name dpc-api-jacoco.xml
+        run: find . -name dpc-api-jacoco.xml
       - name: Run quality gate scan
         run: |
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"
       - name: Cleanup
         if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
+        run: ./scripts/cleanup-docker.sh

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -130,8 +130,7 @@ jobs:
           curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
           chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-      - name: "Test webapps"
-        id: api-build
+      - name: "Test portal"
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-portal
@@ -168,8 +167,7 @@ jobs:
           curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
           chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-      - name: "Test webapps"
-        id: api-build
+      - name: "Test Admin"
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-admin-portal
@@ -206,8 +204,7 @@ jobs:
           curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
           chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-      - name: "Test webapps"
-        id: api-build
+      - name: "Test Web"
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-web-portal

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,9 +6,6 @@ on:
       - .github/workflows/opt-out-*
       - lambda/**
   workflow_dispatch: # Allow manual trigger
-  push:
-    paths:
-      - .github/workflows/ci-workflow.yml
 
 env:
   VAULT_PW: ${{ secrets.VAULT_PW }}
@@ -21,9 +18,10 @@ jobs:
     name: "Build and Test API"
     runs-on: self-hosted
     steps:
-      - name: chmod working directory
+      - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          docker system prune --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Setup Java
@@ -88,9 +86,10 @@ jobs:
     name: "Build and Test Portal"
     runs-on: self-hosted
     steps:
-      - name: chmod working directory
+      - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          docker system prune --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: "Set up Ansible"
@@ -121,9 +120,10 @@ jobs:
     name: "Build and Test Admin"
     runs-on: self-hosted
     steps:
-      - name: chmod working directory
+      - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          docker system prune --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: "Set up Ansible"
@@ -154,9 +154,10 @@ jobs:
     name: "Build and Test Web"
     runs-on: self-hosted
     steps:
-      - name: chmod working directory
+      - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          docker system prune --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: "Set up Ansible"
@@ -201,9 +202,10 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
-      - name: chmod working directory
+      - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          docker system prune --volumes -f
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download web code coverage
@@ -242,9 +244,10 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
-      - name: chmod working directory
+      - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          docker system prune --volumes -f
       - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Download code coverage
@@ -280,9 +283,10 @@ jobs:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
-      - name: chmod working directory
+      - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          docker system prune --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Setup Java

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           distribution: "corretto"
           java-version: "11"
-      - name: "Set up Ansible"
+      - name: "Set up Python and install Ansible"
         run: |
           sudo dnf -y install python3 python3-pip
           pip install ansible

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,6 +21,11 @@ jobs:
     name: "Build and Test API"
     runs-on: self-hosted
     steps:
+      - name: Install npm
+        run: |
+          sudo dnf install nodjs
+          npm --version
+          node --version
       - name: chmod working directory
         run: |
           sudo chmod -R 777 .

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,11 +21,6 @@ jobs:
     name: "Build and Test API"
     runs-on: self-hosted
     steps:
-      - name: Install npm
-        run: |
-          sudo dnf -y install nodejs
-          npm --version
-          node --version
       - name: chmod working directory
         run: |
           sudo chmod -R 777 .
@@ -35,8 +30,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: temurin
-          cache: maven
+          distribution: 'corretto'
       - name: Install Maven 3.6.3
         run: |
           export PATH="$PATH:/opt/maven/bin"
@@ -49,6 +43,11 @@ jobs:
       - name: Clean maven
         run: |
           mvn -ntp -U clean
+      - name: Install npm
+        run: |
+          sudo dnf -y install nodejs
+          npm --version
+          node --version
       - name: "Set up Ansible"
         run: |
           sudo dnf -y install python3 python3-pip
@@ -84,8 +83,8 @@ jobs:
         with:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
+
   test-portal:
-    if: ${{ false }}
     name: "Build and Test Portal"
     runs-on: self-hosted
     steps:
@@ -117,8 +116,8 @@ jobs:
         with:
           name: code-coverage-report-dpc-portal
           path: ./portal-resultset.json
+
   test-admin:
-    if: ${{ false }}
     name: "Build and Test Admin"
     runs-on: self-hosted
     steps:
@@ -150,8 +149,8 @@ jobs:
         with:
           name: code-coverage-report-dpc-admin
           path: ./admin-resultset.json
+
   test-web:
-    if: ${{ false }}
     name: "Build and Test Web"
     runs-on: self-hosted
     steps:
@@ -185,7 +184,6 @@ jobs:
           path: ./web-resultset.json
 
   test-dpc-client:
-    if: ${{ false }}
     name: "Build and Test DPC Client"
     runs-on: self-hosted
     steps:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -83,11 +83,15 @@ jobs:
       - name: Api Logs
         if: ${{ failure() && steps.api-build.outcome == 'failure' }}
         run: docker logs start-v1-app-api-1
-      - name: Down
+      - name: Cleanup
         if: ${{ always() }}
         run: |
-          docker compose -p start-v1-app down
-          docker volume rm start-v1-app_pgdata16
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
       - name: "Move jacoco reports"
         run: |
           sudo mkdir jacoco-reports
@@ -145,6 +149,15 @@ jobs:
         with:
           name: code-coverage-report-dpc-portal
           path: ./portal-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
 
   test-admin:
     name: "Build and Test Admin"
@@ -182,6 +195,15 @@ jobs:
         with:
           name: code-coverage-report-dpc-admin
           path: ./admin-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
 
   test-web:
     name: "Build and Test Web"
@@ -219,6 +241,15 @@ jobs:
         with:
           name: code-coverage-report-dpc-web
           path: ./web-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
 
   test-dpc-client:
     name: "Build and Test DPC Client"
@@ -229,6 +260,15 @@ jobs:
       - name: "DPC Client Build"
         run: |
           make ci-api-client
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
 
   sonar-quality-gate-dpc-web-and-admin:
     name: Sonarqube Quality Gate for dpc-web and dpc-admin
@@ -279,6 +319,15 @@ jobs:
             -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
             -Dsonar.qualitygate.wait=true
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
 
   sonar-quality-gate-dpc-portal:
     name: Sonarqube Quality Gate for dpc-portal
@@ -325,6 +374,15 @@ jobs:
             -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
             -Dsonar.qualitygate.wait=true
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
 
   sonar-quality-gate-dpc-api:
     name: Sonarqube Quality Gate for dpc-api
@@ -384,3 +442,12 @@ jobs:
       - name: Run quality gate scan
         run: |
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Install npm
         run: |
-          sudo dnf install nodejs
+          sudo dnf -y install nodejs
           npm --version
           node --version
       - name: chmod working directory

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -94,10 +94,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
       - name: Install docker compose manually
         run: |
           mkdir -p /usr/local/lib/docker/cli-plugins
@@ -106,7 +102,6 @@ jobs:
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
       - name: "DPC Web Build"
         run: |
-          export PATH=$PATH:~/.local/bin
           make ci-web-portal
       - name: "Copy test results"
         run: sudo cp dpc-web/coverage/.resultset.json web-resultset-raw.json
@@ -129,10 +124,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
       - name: Install docker compose manually
         run: |
           mkdir -p /usr/local/lib/docker/cli-plugins
@@ -141,7 +132,6 @@ jobs:
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
       - name: "DPC Admin Portal Build"
         run: |
-          export PATH=$PATH:~/.local/bin
           make ci-admin-portal
       - name: "Copy test results"
         run: sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
@@ -164,10 +154,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
       - name: Install docker compose manually
         run: |
           mkdir -p /usr/local/lib/docker/cli-plugins
@@ -176,7 +162,6 @@ jobs:
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
       - name: "DPC Portal Build"
         run: |
-          export PATH=$PATH:~/.local/bin
           make ci-portal
       - name: "Copy test results"
         run: sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,6 +6,9 @@ on:
       - .github/workflows/opt-out-*
       - lambda/**
   workflow_dispatch: # Allow manual trigger
+  push:
+    paths:
+      - .github/workflows/ci-workflow.yml
 
 env:
   VAULT_PW: ${{ secrets.VAULT_PW }}
@@ -15,22 +18,62 @@ env:
 
 jobs:
   build-api:
+    if: ${{ false }}
     name: "Build and Test API"
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Set up JDK 11"
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-      - name: "Set up Python 3.8.1"
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.8.1"
-      - name: "API Build"
+      - name: chmod working directory
         run: |
+          sudo chmod -R 777 .
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: temurin
+          cache: maven
+      - name: Install Maven 3.6.3
+        run: |
+          export PATH="$PATH:/opt/maven/bin"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+          tmpdir="$(mktemp -d)"
+          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+          sudo rm -rf /opt/maven
+          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
+      - name: Clean maven
+        run: |
+          mvn -ntp -U clean
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "Test API"
+        id: api-build
+        run: |
+          export PATH=$PATH:~/.local/bin
           make ci-app
+      - name: "Get Docker logs"
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: |
+          mkdir -p appLogs
+          docker logs start-v1-app-aggregation-1 > appLogs/api.log
+          docker logs start-v1-app-attribution-1 > appLogs/api.log
+          docker logs start-v1-app-consent-1 > appLogs/api.log
+          docker logs start-v1-app-api-1 > appLogs/api.log
+      - name: "Upload Docker logs"
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-logs
+          path: ./appLogs
       - name: "Move jacoco reports"
         run: |
           sudo mkdir jacoco-reports
@@ -51,200 +94,27 @@ jobs:
         with:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
-
-  build-dpc-web:
-    name: "Build and Test DPC Web"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "DPC Web Build"
-        run: |
-          make ci-web-portal
-      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
-        run: |
-          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-web") then .key |= sub("/dpc-web"; "/github/workspace/dpc-web") else . end)' dpc-web/coverage/.resultset.json > web-resultset.json
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report-dpc-web
-          path: ./web-resultset.json
-
-  build-dpc-admin:
-    name: "Build and Test DPC Admin Portal"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "DPC Admin Portal Build"
-        run: |
-          make ci-admin-portal
-      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
-        run: |
-          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-admin") then .key |= sub("/dpc-admin"; "/github/workspace/dpc-admin") else . end)' dpc-admin/coverage/.resultset.json > admin-resultset.json
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report-dpc-admin
-          path: ./admin-resultset.json
-
-  build-dpc-portal:
-    name: "Build and Test DPC Portal"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "DPC Portal Build"
-        run: |
-          make ci-portal
-      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
-        run: |
-          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-portal") then .key |= sub("/dpc-portal"; "/github/workspace/dpc-portal") else . end)' dpc-portal/coverage/.resultset.json > portal-resultset.json
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-coverage-report-dpc-portal
-          path: ./portal-resultset.json
-
-  build-dpc-client:
-    name: "Build and Test DPC Client"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "DPC Client Build"
-        run: |
-          make ci-api-client
-
-  sonar-quality-gate-dpc-web-and-admin:
-    name: Sonarqube Quality Gate for dpc-web and dpc-admin
-    needs: [build-dpc-admin, build-dpc-web]
+  build-api:
+    name: "Build and Test Webapps"
     runs-on: self-hosted
-    env:
-      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-    steps:
-      - name: chmod working directory
-        run: |
-          sudo chmod -R 777 .
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: Download web code coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage-report-dpc-web
-      - name: Download admin code coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage-report-dpc-admin
-      - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-        with:
-          params: |
-            SONAR_HOST_URL=/sonarqube/url
-            SONAR_TOKEN=/sonarqube/token
-      - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@master
-        with:
-          args:
-            -Dsonar.projectKey=bcda-dpc-web
-            -Dsonar.sources=./dpc-web/app,./dpc-web/lib,./dpc-admin/app,./dpc-admin/lib
-            -Dsonar.ruby.coverage.reportPaths=./web-resultset.json,./admin-resultset.json
-            -Dsonar.working.directory=./sonar_workspace
-            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
-            -Dsonar.qualitygate.wait=true
-
-  sonar-quality-gate-dpc-portal:
-    name: Sonarqube Quality Gate for dpc-portal
-    needs: build-dpc-portal
-    runs-on: self-hosted
-    env:
-      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
-    steps:
-      - name: chmod working directory
-        run: |
-          sudo chmod -R 777 .
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: Download code coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage-report-dpc-portal
-      - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-        with:
-          params: |
-            SONAR_HOST_URL=/sonarqube/url
-            SONAR_TOKEN=/sonarqube/token
-      - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@master
-        with:
-          args:
-            -Dsonar.projectKey=bcda-dpc-portal
-            -Dsonar.sources=./dpc-portal/app,./dpc-portal/lib
-            -Dsonar.coverage.exclusions=**/*_preview.rb,**/*html.erb,**/application_*
-            -Dsonar.ruby.coverage.reportPaths=./portal-resultset.json
-            -Dsonar.working.directory=./sonar_workspace
-            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
-            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
-            -Dsonar.qualitygate.wait=true
-
-  sonar-quality-gate-dpc-api:
-    name: Sonarqube Quality Gate for dpc-api
-    needs: build-api
-    runs-on: self-hosted
-    env:
-      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: chmod working directory
         run: |
           sudo chmod -R 777 .
       - name: Checkout Code
         uses: actions/checkout@v4
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: temurin
-          cache: maven
-      - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-        with:
-          params: |
-            SONAR_HOST_URL=/sonarqube/url
-            SONAR_TOKEN=/sonarqube/token
-      - name: Install Maven 3.6.3
+      - name: "Set up Ansible"
         run: |
-          export PATH="$PATH:/opt/maven/bin"
-          echo "PATH=$PATH" >> $GITHUB_ENV
-          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
-          tmpdir="$(mktemp -d)"
-          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
-          sudo rm -rf /opt/maven
-          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
-      - name: Clean maven
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+      - name: Install docker compose manually
         run: |
-          mvn -ntp -U clean
-      - name: Compile Project
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "Test webapps"
+        id: api-build
         run: |
-          mvn clean compile -Perror-prone -B -V -ntp
-      - name: Download code coverage
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage-report-dpc-api
-          path: jacoco-reports
-      - name: Verify download
-        run: |
-          find . -name dpc-api-jacoco.xml
-      - name: Run quality gate scan
-        run: |
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"
+          export PATH=$PATH:~/.local/bin
+          make ci-portals

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -95,7 +95,7 @@ jobs:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
   test-portal:
-    name: "Build and Test Webapps"
+    name: "Build and Test Portal"
     runs-on: self-hosted
     steps:
       - name: chmod working directory
@@ -127,7 +127,7 @@ jobs:
           name: code-coverage-report-dpc-portal
           path: ./portal-resultset.json
   test-admin:
-    name: "Build and Test Webapps"
+    name: "Build and Test Admin"
     runs-on: self-hosted
     steps:
       - name: chmod working directory
@@ -149,7 +149,7 @@ jobs:
         id: api-build
         run: |
           export PATH=$PATH:~/.local/bin
-          make ci-admin
+          make ci-admin-portal
       - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
         run: |
           sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-admin") then .key |= sub("/dpc-admin"; "/github/workspace/dpc-admin") else . end)' dpc-admin/coverage/.resultset.json > admin-resultset.json
@@ -159,7 +159,7 @@ jobs:
           name: code-coverage-report-dpc-admin
           path: ./admin-resultset.json
   test-web:
-    name: "Build and Test Webapps"
+    name: "Build and Test Web"
     runs-on: self-hosted
     steps:
       - name: chmod working directory

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Install npm
         run: |
-          sudo dnf install nodjs
+          sudo dnf install nodejs
           npm --version
           node --version
       - name: chmod working directory
@@ -85,6 +85,7 @@ jobs:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
   test-portal:
+    if: ${{ false }}
     name: "Build and Test Portal"
     runs-on: self-hosted
     steps:
@@ -117,6 +118,7 @@ jobs:
           name: code-coverage-report-dpc-portal
           path: ./portal-resultset.json
   test-admin:
+    if: ${{ false }}
     name: "Build and Test Admin"
     runs-on: self-hosted
     steps:
@@ -149,6 +151,7 @@ jobs:
           name: code-coverage-report-dpc-admin
           path: ./admin-resultset.json
   test-web:
+    if: ${{ false }}
     name: "Build and Test Web"
     runs-on: self-hosted
     steps:
@@ -182,6 +185,7 @@ jobs:
           path: ./web-resultset.json
 
   test-dpc-client:
+    if: ${{ false }}
     name: "Build and Test DPC Client"
     runs-on: self-hosted
     steps:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -18,7 +18,6 @@ env:
 
 jobs:
   test-api:
-    if: ${{ false }}
     name: "Build and Test API"
     runs-on: self-hosted
     steps:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ ! -z ${RUNNING} ]; then
+            docker stop $(docker ps -q)
+          fi
           docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -89,6 +93,10 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ ! -z ${RUNNING} ]; then
+            docker stop $(docker ps -q)
+          fi
           docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -123,6 +131,10 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ ! -z ${RUNNING} ]; then
+            docker stop $(docker ps -q)
+          fi
           docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -157,6 +169,10 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ ! -z ${RUNNING} ]; then
+            docker stop $(docker ps -q)
+          fi
           docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -205,6 +221,10 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ ! -z ${RUNNING} ]; then
+            docker stop $(docker ps -q)
+          fi
           docker system prune -a --volumes -f
       - name: "Checkout code"
         uses: actions/checkout@v4
@@ -247,6 +267,10 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ ! -z ${RUNNING} ]; then
+            docker stop $(docker ps -q)
+          fi
           docker system prune -a --volumes -f
       - name: "Checkout code"
         uses: actions/checkout@v4
@@ -286,6 +310,10 @@ jobs:
       - name: Cleanup Runner
         run: |
           sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ ! -z ${RUNNING} ]; then
+            docker stop $(docker ps -q)
+          fi
           docker system prune -a --volumes -f
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -59,20 +59,6 @@ jobs:
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-app
-      - name: "Get Docker logs"
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: |
-          mkdir -p appLogs
-          docker logs start-v1-app-aggregation-1 > appLogs/api.log
-          docker logs start-v1-app-attribution-1 > appLogs/api.log
-          docker logs start-v1-app-consent-1 > appLogs/api.log
-          docker logs start-v1-app-api-1 > appLogs/api.log
-      - name: "Upload Docker logs"
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-logs
-          path: ./appLogs
       - name: "Move jacoco reports"
         run: |
           sudo mkdir jacoco-reports

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -68,30 +68,6 @@ jobs:
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-app
-      - name: Posgres Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-db-1
-      - name: Consent Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-consent-1
-      - name: Attribution Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-attribution-1
-      - name: Aggregation Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-aggregation-1
-      - name: Api Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-api-1
-      - name: Cleanup
-        if: ${{ always() }}
-        run: |
-          sudo chmod -R 777 .
-          RUNNING=`docker ps -q`
-          if [ -n "$RUNNING" ]; then
-            docker stop $(docker ps -q)
-          fi
-          docker system prune -a --volumes -f
       - name: "Move jacoco reports"
         run: |
           sudo mkdir jacoco-reports
@@ -112,6 +88,15 @@ jobs:
         with:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
+      - name: Cleanup
+        if: ${{ always() }}
+        run: |
+          sudo chmod -R 777 .
+          RUNNING=`docker ps -q`
+          if [ -n "$RUNNING" ]; then
+            docker stop $(docker ps -q)
+          fi
+          docker system prune -a --volumes -f
 
   test-portal:
     name: "Build and Test Portal"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Assert Ownership
         run: sudo chmod -R 777 .
-      - name: Checkout Code
+      - name: "Checkout code"
         uses: actions/checkout@v4
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
@@ -29,6 +29,10 @@ jobs:
         with:
           distribution: "corretto"
           java-version: "11"
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
       - name: Install Maven 3.6.3
         run: |
           export PATH="$PATH:/opt/maven/bin"
@@ -39,23 +43,20 @@ jobs:
           sudo rm -rf /opt/maven
           sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
       - name: Clean maven
-        run: mvn -ntp -U clean
+        run: |
+          mvn -ntp -U clean
       - name: Install npm
         run: |
           sudo dnf -y install nodejs
           npm --version
           node --version
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
       - name: Install docker compose manually
         run: |
           mkdir -p /usr/local/lib/docker/cli-plugins
           curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
           chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-      - name: "Test API"
+      - name: "API Build"
         id: api-build
         run: |
           export PATH=$PATH:~/.local/bin

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -6,9 +6,6 @@ on:
       - .github/workflows/opt-out-*
       - lambda/**
   workflow_dispatch: # Allow manual trigger
-  push:
-    paths:
-      - .github/workflows/ci-workflow.yml
 
 env:
   VAULT_PW: ${{ secrets.VAULT_PW }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
-  build-api:
+  build-webapps:
     name: "Build and Test Webapps"
     runs-on: self-hosted
     steps:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -134,14 +134,14 @@ jobs:
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-portal
-      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+      - name: "Copy test results"
         run: |
-          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-portal") then .key |= sub("/dpc-portal"; "/github/workspace/dpc-portal") else . end)' dpc-portal/coverage/.resultset.json > portal-resultset.json
+          sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-dpc-portal
-          path: ./portal-resultset.json
+          path: ./portal-resultset-raw.json
 
   test-admin:
     name: "Build and Test Admin"
@@ -171,14 +171,14 @@ jobs:
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-admin-portal
-      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+      - name: "Copy test results"
         run: |
-          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-admin") then .key |= sub("/dpc-admin"; "/github/workspace/dpc-admin") else . end)' dpc-admin/coverage/.resultset.json > admin-resultset.json
+          sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-dpc-admin
-          path: ./admin-resultset.json
+          path: ./admin-resultset-raw.json
 
   test-web:
     name: "Build and Test Web"
@@ -208,14 +208,14 @@ jobs:
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-web-portal
-      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+      - name: "Copy test results"
         run: |
-          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-web") then .key |= sub("/dpc-web"; "/github/workspace/dpc-web") else . end)' dpc-web/coverage/.resultset.json > web-resultset.json
+          sudo cp dpc-web/coverage/.resultset.json web-resultset-raw.json
       - name: Archive code coverage results
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report-dpc-web
-          path: ./web-resultset.json
+          path: ./web-resultset-raw.json
 
   test-dpc-client:
     name: "Build and Test DPC Client"
@@ -253,6 +253,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-admin
+      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+        run: |
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-web") then .key |= sub("/dpc-web"; "${{ github.workspace }}/dpc-web") else . end)' web-resultset-raw.json > web-resultset.json
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-admin") then .key |= sub("/dpc-admin"; "${{ github.workspace }}/dpc-admin") else . end)' admin-resultset-raw.json > admin-resultset.json
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
@@ -295,6 +299,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: code-coverage-report-dpc-portal
+      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+        run: |
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-portal") then .key |= sub("/dpc-portal"; "${{ github.workspace }}/dpc-portal") else . end)' portal-resultset-raw.json > portal-resultset.json
       - name: Set env vars from AWS params
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -17,7 +17,7 @@ env:
   ENV: "github-ci"
 
 jobs:
-  build-api:
+  test-api:
     if: ${{ false }}
     name: "Build and Test API"
     runs-on: self-hosted
@@ -94,7 +94,7 @@ jobs:
         with:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
-  build-webapps:
+  test-portal:
     name: "Build and Test Webapps"
     runs-on: self-hosted
     steps:
@@ -117,4 +117,219 @@ jobs:
         id: api-build
         run: |
           export PATH=$PATH:~/.local/bin
-          make ci-portals
+          make ci-portal
+      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+        run: |
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-portal") then .key |= sub("/dpc-portal"; "/github/workspace/dpc-portal") else . end)' dpc-portal/coverage/.resultset.json > portal-resultset.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-portal
+          path: ./portal-resultset.json
+  test-admin:
+    name: "Build and Test Webapps"
+    runs-on: self-hosted
+    steps:
+      - name: chmod working directory
+        run: |
+          sudo chmod -R 777 .
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "Test webapps"
+        id: api-build
+        run: |
+          export PATH=$PATH:~/.local/bin
+          make ci-admin
+      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+        run: |
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-admin") then .key |= sub("/dpc-admin"; "/github/workspace/dpc-admin") else . end)' dpc-admin/coverage/.resultset.json > admin-resultset.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-admin
+          path: ./admin-resultset.json
+  test-web:
+    name: "Build and Test Webapps"
+    runs-on: self-hosted
+    steps:
+      - name: chmod working directory
+        run: |
+          sudo chmod -R 777 .
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "Test webapps"
+        id: api-build
+        run: |
+          export PATH=$PATH:~/.local/bin
+          make ci-web-portal
+      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+        run: |
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-web") then .key |= sub("/dpc-web"; "/github/workspace/dpc-web") else . end)' dpc-web/coverage/.resultset.json > web-resultset.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-web
+          path: ./web-resultset.json
+
+  test-dpc-client:
+    name: "Build and Test DPC Client"
+    runs-on: self-hosted
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: "DPC Client Build"
+        run: |
+          make ci-api-client
+
+  sonar-quality-gate-dpc-web-and-admin:
+    name: Sonarqube Quality Gate for dpc-web and dpc-admin
+    needs: [test-admin, test-web]
+    runs-on: self-hosted
+    env:
+      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+    steps:
+      - name: chmod working directory
+        run: |
+          sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Download web code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-web
+      - name: Download admin code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-admin
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+      - name: Run quality gate scan
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args:
+            -Dsonar.projectKey=bcda-dpc-web
+            -Dsonar.sources=./dpc-web/app,./dpc-web/lib,./dpc-admin/app,./dpc-admin/lib
+            -Dsonar.ruby.coverage.reportPaths=./web-resultset.json,./admin-resultset.json
+            -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
+            -Dsonar.qualitygate.wait=true
+
+  sonar-quality-gate-dpc-portal:
+    name: Sonarqube Quality Gate for dpc-portal
+    needs: test-portal
+    runs-on: self-hosted
+    env:
+      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+    steps:
+      - name: chmod working directory
+        run: |
+          sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Download code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-portal
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+      - name: Run quality gate scan
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args:
+            -Dsonar.projectKey=bcda-dpc-portal
+            -Dsonar.sources=./dpc-portal/app,./dpc-portal/lib
+            -Dsonar.coverage.exclusions=**/*_preview.rb,**/*html.erb,**/application_*
+            -Dsonar.ruby.coverage.reportPaths=./portal-resultset.json
+            -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
+            -Dsonar.qualitygate.wait=true
+
+  sonar-quality-gate-dpc-api:
+    name: Sonarqube Quality Gate for dpc-api
+    needs: test-api
+    runs-on: self-hosted
+    env:
+      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    steps:
+      - name: chmod working directory
+        run: |
+          sudo chmod -R 777 .
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: temurin
+          cache: maven
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+      - name: Install Maven 3.6.3
+        run: |
+          export PATH="$PATH:/opt/maven/bin"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+          tmpdir="$(mktemp -d)"
+          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+          sudo rm -rf /opt/maven
+          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
+      - name: Clean maven
+        run: |
+          mvn -ntp -U clean
+      - name: Compile Project
+        run: |
+          mvn clean compile -Perror-prone -B -V -ntp
+      - name: Download code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-api
+          path: jacoco-reports
+      - name: Verify download
+        run: |
+          find . -name dpc-api-jacoco.xml
+      - name: Run quality gate scan
+        run: |
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -57,7 +57,6 @@ jobs:
           chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
       - name: "API Build"
-        id: api-build
         run: |
           export PATH=$PATH:~/.local/bin
           make ci-app

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -12,6 +12,13 @@ set -o allexport
 [[ -f ${DIR}/ops/config/decrypted/local.env ]] && source ${DIR}/ops/config/decrypted/local.env
 set +o allexport
 
+function _finally {
+  docker compose -p start-v1-app down
+  docker volume rm start-v1-app_pgdata16
+}
+
+trap _finally EXIT
+
 if [ -n "$REPORT_COVERAGE" ]; then
   echo "┌──────────────────────────────────────┐"
   echo "│                                      │"

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -12,13 +12,6 @@ set -o allexport
 [[ -f ${DIR}/ops/config/decrypted/local.env ]] && source ${DIR}/ops/config/decrypted/local.env
 set +o allexport
 
-function _finally {
-  docker compose -p start-v1-app down
-  docker volume rm start-v1-app_pgdata16
-}
-
-trap _finally EXIT
-
 if [ -n "$REPORT_COVERAGE" ]; then
   echo "┌──────────────────────────────────────┐"
   echo "│                                      │"

--- a/dpc-test.sh
+++ b/dpc-test.sh
@@ -45,7 +45,6 @@ USE_BFD_MOCK=true docker compose -p start-v1-app up db attribution aggregation -
 docker compose -p start-v1-app up --exit-code-from tests tests
 
 docker compose -p start-v1-app down
-docker volume rm start-v1-app_pgdata16
 
 echo "Starting Postman tests"
 # Start the API server

--- a/engines/api_client/Dockerfile
+++ b/engines/api_client/Dockerfile
@@ -2,12 +2,11 @@ FROM ruby:3.3-alpine AS ruby_builder
 
 # Install build dependencies
 RUN apk update && \
-    apk add --no-cache postgresql-dev && \
     apk add --no-cache libsodium-dev && \
     apk add --no-cache libffi-dev && \
     apk add --no-cache shared-mime-info && \
     apk add --no-cache --virtual build-deps alpine-sdk npm tzdata && \
-    apk add xz && \
+    apk add --no-cache xz && \
     apk add --no-cache gcompat
 
 # Set the working directory

--- a/engines/api_client/Dockerfile
+++ b/engines/api_client/Dockerfile
@@ -2,11 +2,8 @@ FROM ruby:3.3-alpine AS ruby_builder
 
 # Install build dependencies
 RUN apk update && \
-    apk add --no-cache libsodium-dev && \
     apk add --no-cache libffi-dev && \
-    apk add --no-cache shared-mime-info && \
-    apk add --no-cache --virtual build-deps alpine-sdk npm tzdata && \
-    apk add --no-cache xz && \
+    apk add --no-cache --virtual build-deps alpine-sdk tzdata && \
     apk add --no-cache gcompat
 
 # Set the working directory

--- a/scripts/cleanup-docker.sh
+++ b/scripts/cleanup-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+RUNNING=`docker ps -q`
+if [ -n "$RUNNING" ]; then
+    docker stop $(docker ps -q)
+fi
+docker system prune -a --volumes -f


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4478

## 🛠 Changes
- ci-workflow.yml updated to use self hosted runners
- cleanup-docker.sh added to avoid duplication
- dcp-test.sh no longer removes database volume between tests
- api_client dockerfile removed unnecessary packages

## ℹ️ Context

For security reasons, we should be using self-hosted runners instead of github runners. Moving to self-hosted runners required us to manually install python, maven, docker compose, and npm.
We also kept running out of disk space, so cleaning up docker (via the new cleanup-docker.sh) and removing unnecessary packages from the api_client were necessary.
We had to leave the database volume between tests because of some race condition making dpc-consent not start up.
There is also a drive-by fix to sonarqube, which stopped finding tests for the portals.

## 🧪 Validation

CI runs successfully
