### PR TITLE
[DPC-4496] use upload/download artifacts for rails docker builds

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -42,14 +42,13 @@ jobs:
         run: |
           make ci-portal
 
-#        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz
       - name: gzip the image
         run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:
           name: dpc-$REPOSITORY
-          path: ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+          path: ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz.tar
 
   docker_push_rails_web_portal_image:
     runs-on: self-hosted
@@ -62,18 +61,6 @@ jobs:
         with:
           name: dpc-$REPOSITORY
           path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/myimage.tar
-          docker image ls -a
-      - name: gzip the image
-        run: docker save dpc-$REPOSITORY:latest | gzip > $REPOSITORY_latest.tar.gz
-      - name: upload tar artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: dpc-$REPOSITORY
-          path: ${{ runner.temp }}/$REPOSITORY_latest.tar.gz.tar
 
       - name: Load image
         run: |

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        repository: [ web-portal, web-admin, web ]
+        ecr_repository: [ web-portal, web-admin, web ]
         include:
           # note this is confusing, but make ci-web-portal points to dpc-web-portal-test.sh which runs
           # docker compose -p ... dpc_web
-          - repository: web-portal
+          - ecr_repository: web-portal
             make_command: make ci-portal
-          - repository: web-admin
+          - ecr_repository: web-admin
             make_command: make ci-admin-portal
-          - repository: web
+          - ecr_repository: web
             make_command: make ci-web-portal
     steps:
       - name: Install python3
@@ -46,30 +46,30 @@ jobs:
         run: ${{ matrix.make_command }}
 
       - name: gzip the image
-        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+        run: docker save dpc-${{ matrix.ecr_repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dpc-${{ matrix.repository }}
-          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+          name: dpc-${{ matrix.ecr_repository }}
+          path: ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
 
   docker_push_rails_apps:
     runs-on: self-hosted
     strategy:
       matrix:
-        repository: [ web-portal, web-admin, web ]
+        ecr_repository: [ web-portal, web-admin, web ]
     env:
-      REPOSITORY: ${{ matrix.repository }}
+      ECR_REPOSITORY: ${{ matrix.ecr_repository }}
     needs: docker_build_rails_apps
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: dpc-${{ matrix.repository }}
+          name: dpc-${{ matrix.ecr_repository }}
           path: ${{ runner.temp }}
       - name: Load docker image from artifact download
         run: |
-          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+          docker load --input ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
           docker image ls -a
 
       - name: Configure AWS Credentials
@@ -86,9 +86,9 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
-          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker tag dpc-$ECR_REPOSITORY:latest $REGISTRY/dpc-$ECR_REPOSITORY:latest
+          docker tag dpc-$ECR_REPOSITORY:latest $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
 
 
   docker_build_java:
@@ -167,35 +167,35 @@ jobs:
       - name: ECR (1 of 4) - Push API
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: api
+          ECR_REPOSITORY: api
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/dpc-$ECR_REPOSITORY:latest $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: ECR (2 of 4) - Push Attribution
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: attribution
+          ECR_REPOSITORY: attribution
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/dpc-$ECR_REPOSITORY:latest $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: ECR (3 of 4) - Push Aggregation
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: aggregation
+          ECR_REPOSITORY: aggregation
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/dpc-$ECR_REPOSITORY:latest $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: ECR (4 of 4) - Push Consent
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: consent
+          ECR_REPOSITORY: consent
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker tag $REGISTRY/dpc-$ECR_REPOSITORY:latest $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -17,11 +17,9 @@ env:
 
 jobs:
   docker_build_rails_web_portal:
-    env:
-      REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-      REPOSITORY: web-portal
-      IMAGE_TAG: ${{ github.sha }}
     runs-on: self-hosted
+    env:
+      REPOSITORY: web-portal
     steps:
       - name: check gzip
         run: gzip --version
@@ -54,6 +52,8 @@ jobs:
 
   docker_push_rails_web_portal_image:
     runs-on: self-hosted
+    env:
+      REPOSITORY: web-portal
     needs: docker_build_rails_web_portal
     steps:
       - name: Download artifact
@@ -79,12 +79,12 @@ jobs:
       - name: Push to ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: web-portal
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
           docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
       - name: success
         run: "Did it work???"
       # TODO add additional steps to push dpc-web-admin and dpc-web, see docker_build_all_portals below

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -17,8 +17,15 @@ env:
 
 jobs:
   docker_build_rails_web_portal:
+    env:
+      REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      REPOSITORY: web-portal
+      IMAGE_TAG: ${{ github.sha }}
     runs-on: self-hosted
     steps:
+      - name: check gzip
+        run: gzip --version
+
       - name: Install python3
         run: sudo dnf install python3
 
@@ -37,6 +44,28 @@ jobs:
         run: |
           make ci-portal
 
+      - name: gzip the image
+        run: docker save dpc-$REPOSITORY:latest | gzip > $REPOSITORY_latest.tar.gz
+      - name: upload tar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dpc-$REPOSITORY
+          path: ${{ runner.temp }}/$REPOSITORY_latest.tar.gz.tar
+
+  docker_push_rails_web_portal_image:
+    runs-on: self-hosted
+    needs: docker_build_rails_web_portal
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: $REPOSITORY_latest.tar.gz.tar
+          path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/myimage.tar
+          docker image ls -a
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -56,6 +85,8 @@ jobs:
           docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
           docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+      - name: success
+        run: "Did it work???"
       # TODO add additional steps to push dpc-web-admin and dpc-web, see docker_build_all_portals below
 
 #  docker_build_all_portals:
@@ -134,111 +165,111 @@ jobs:
 #        if: ${{ always() }}
 #        run: ./scripts/cleanup-docker.sh
 
-  docker_build_java:
-    runs-on: self-hosted
-    steps:
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
-
-      - name: "Install npm for Postman tests"
-        run: |
-          sudo dnf -y install nodejs
-          npm --version
-
-      - name: Install docker compose manually
-        run: |
-          sudo mkdir -p /usr/local/lib/docker/cli-plugins
-          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-
-      - name: "Set up JDK 11"
-        uses: actions/setup-java@v3
-        with:
-          java-version: "11"
-          distribution: "corretto"
-          cache: maven
-
-      - name: Install Maven 3.6.3
-        run: |
-          export PATH="$PATH:/opt/maven/bin"
-          echo "PATH=$PATH" >> $GITHUB_ENV
-          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
-          tmpdir="$(mktemp -d)"
-          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
-          sudo rm -rf /opt/maven
-          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
-
-      - name: Clean maven
-        run: mvn -ntp -U clean
-
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-
-      - name: Build ci app
-        id: api-build
-        run: |
-          export PATH=$PATH:~/.local/bin
-          make ci-app
-
-      # add extra commands to log docker containers during failure
-      - name: Consent Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-consent-1
-      - name: Attribution Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-attribution-1
-      - name: Aggregation Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-aggregation-1
-      - name: Api Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-api-1
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: ECR (1 of 4) - Push API
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: api
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-
-      - name: ECR (2 of 4) - Push Attribution
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: attribution
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-
-      - name: ECR (3 of 4) - Push Aggregation
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: aggregation
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-
-      - name: ECR (4 of 4) - Push Consent
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: consent
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#  docker_build_java:
+#    runs-on: self-hosted
+#    steps:
+#      - name: "Set up Ansible"
+#        run: |
+#          sudo dnf -y install python3 python3-pip
+#          pip install ansible
+#
+#      - name: "Install npm for Postman tests"
+#        run: |
+#          sudo dnf -y install nodejs
+#          npm --version
+#
+#      - name: Install docker compose manually
+#        run: |
+#          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+#          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+#          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+#          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+#
+#      - name: "Set up JDK 11"
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: "11"
+#          distribution: "corretto"
+#          cache: maven
+#
+#      - name: Install Maven 3.6.3
+#        run: |
+#          export PATH="$PATH:/opt/maven/bin"
+#          echo "PATH=$PATH" >> $GITHUB_ENV
+#          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+#          tmpdir="$(mktemp -d)"
+#          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+#          sudo rm -rf /opt/maven
+#          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
+#
+#      - name: Clean maven
+#        run: mvn -ntp -U clean
+#
+#      - name: "Checkout code"
+#        uses: actions/checkout@v4
+#
+#      - name: Build ci app
+#        id: api-build
+#        run: |
+#          export PATH=$PATH:~/.local/bin
+#          make ci-app
+#
+#      # add extra commands to log docker containers during failure
+#      - name: Consent Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-consent-1
+#      - name: Attribution Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-attribution-1
+#      - name: Aggregation Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-aggregation-1
+#      - name: Api Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-api-1
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          aws-region: ${{ vars.AWS_REGION }}
+#          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
+#
+#      - name: Login to Amazon ECR
+#        id: login-ecr
+#        uses: aws-actions/amazon-ecr-login@v2
+#
+#      - name: ECR (1 of 4) - Push API
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: api
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#
+#      - name: ECR (2 of 4) - Push Attribution
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: attribution
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#
+#      - name: ECR (3 of 4) - Push Aggregation
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: aggregation
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#
+#      - name: ECR (4 of 4) - Push Consent
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: consent
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -43,7 +43,7 @@ jobs:
           make ci-portal
 
       - name: gzip the image
-        run: docker save dpc-$REPOSITORY:latest | gzip > $REPOSITORY_latest.tar.gz
+        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/$REPOSITORY_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -43,7 +43,7 @@ jobs:
           make ci-portal
 
       - name: gzip the image
-        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/$REPOSITORY_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -35,6 +35,15 @@ jobs:
     steps:
       - name: check disk
         run: lsblk && df -h
+      - name: check docker disk usage (1 of 4)
+        run: docker system df
+      - name: check docker disk usage (2 of 4)
+        run: docker images -f "dangling=true"
+      - name: check docker disk usage (3 of 4)
+        run: docker ps -a --filter "status=exited"
+      - name: check docker disk usage (4 of 4)
+        run: docker volume ls -qf dangling=true
+
 
       - name: Install python3
         run: sudo dnf install python3
@@ -78,6 +87,14 @@ jobs:
     steps:
       - name: check disk
         run: lsblk && df -h
+      - name: check docker disk usage (1 of 4)
+        run: docker system df
+      - name: check docker disk usage (2 of 4)
+        run: docker images -f "dangling=true"
+      - name: check docker disk usage (3 of 4)
+        run: docker ps -a --filter "status=exited"
+      - name: check docker disk usage (4 of 4)
+        run: docker volume ls -qf dangling=true
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -42,8 +42,9 @@ jobs:
         run: |
           make ci-portal
 
+#        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz
       - name: gzip the image
-        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz
+        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -166,111 +166,120 @@ jobs:
 #        if: ${{ always() }}
 #        run: ./scripts/cleanup-docker.sh
 
-#  docker_build_java:
-#    runs-on: self-hosted
-#    steps:
-#      - name: "Set up Ansible"
-#        run: |
-#          sudo dnf -y install python3 python3-pip
-#          pip install ansible
-#
-#      - name: "Install npm for Postman tests"
-#        run: |
-#          sudo dnf -y install nodejs
-#          npm --version
-#
-#      - name: Install docker compose manually
-#        run: |
-#          sudo mkdir -p /usr/local/lib/docker/cli-plugins
-#          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-#
-#      - name: "Set up JDK 11"
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: "11"
-#          distribution: "corretto"
-#          cache: maven
-#
-#      - name: Install Maven 3.6.3
-#        run: |
-#          export PATH="$PATH:/opt/maven/bin"
-#          echo "PATH=$PATH" >> $GITHUB_ENV
-#          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
-#          tmpdir="$(mktemp -d)"
-#          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
-#          sudo rm -rf /opt/maven
-#          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
-#
-#      - name: Clean maven
-#        run: mvn -ntp -U clean
-#
-#      - name: "Checkout code"
-#        uses: actions/checkout@v4
-#
-#      - name: Build ci app
-#        id: api-build
-#        run: |
-#          export PATH=$PATH:~/.local/bin
-#          make ci-app
-#
-#      # add extra commands to log docker containers during failure
-#      - name: Consent Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-consent-1
-#      - name: Attribution Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-attribution-1
-#      - name: Aggregation Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-aggregation-1
-#      - name: Api Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-api-1
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-region: ${{ vars.AWS_REGION }}
-#          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-#
-#      - name: Login to Amazon ECR
-#        id: login-ecr
-#        uses: aws-actions/amazon-ecr-login@v2
-#
-#      - name: ECR (1 of 4) - Push API
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: api
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: ECR (2 of 4) - Push Attribution
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: attribution
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: ECR (3 of 4) - Push Aggregation
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: aggregation
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: ECR (4 of 4) - Push Consent
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: consent
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+  docker_build_java:
+    runs-on: self-hosted
+    steps:
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+
+      - name: "Install npm for Postman tests"
+        run: |
+          sudo dnf -y install nodejs
+          npm --version
+
+      - name: Install docker compose manually
+        run: |
+          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+
+      - name: "Set up JDK 11"
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "corretto"
+          cache: maven
+
+      - name: Install Maven 3.6.3
+        run: |
+          export PATH="$PATH:/opt/maven/bin"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+          tmpdir="$(mktemp -d)"
+          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+          sudo rm -rf /opt/maven
+          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
+
+      - name: Clean maven
+        run: mvn -ntp -U clean
+
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+
+      - name: Build ci app
+        id: api-build
+        run: |
+          export PATH=$PATH:~/.local/bin
+          make ci-app
+
+      # add extra commands to log docker containers during failure
+      - name: Consent Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-consent-1
+      - name: Attribution Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-attribution-1
+      - name: Aggregation Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-aggregation-1
+      - name: Api Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-api-1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: ECR (1 of 4) - Push API
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: api
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
+      - name: ECR (2 of 4) - Push Attribution
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: attribution
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
+      - name: ECR (3 of 4) - Push Aggregation
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: aggregation
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
+      - name: ECR (4 of 4) - Push Consent
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: consent
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
+      - name: Prune docker images and volumes
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -33,6 +33,9 @@ jobs:
     env:
       MAKE_COMMAND: ${{ matrix.make_command }}
     steps:
+      - name: check disk
+        run: lsblk && df -h
+
       - name: Install python3
         run: sudo dnf install python3
 
@@ -49,13 +52,20 @@ jobs:
       - name: Build specified app
         run: $MAKE_COMMAND
 
+#      - name: gzip the image
+#        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+#      - name: upload tar artifact
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: dpc-${{ matrix.repository }}
+#          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
       - name: gzip the image
-        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_hardcoded_str.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:
           name: dpc-${{ matrix.repository }}
-          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_hardcoded_str.tar.gz
 
   docker_push_rails_apps:
     runs-on: self-hosted
@@ -66,14 +76,23 @@ jobs:
       REPOSITORY: ${{ matrix.repository }}
     needs: docker_build_rails_apps
     steps:
+      - name: check disk
+        run: lsblk && df -h
+
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: dpc-${{ matrix.repository }}
           path: ${{ runner.temp }}
+#      - name: Load docker image from artifact download
+#        run: |
+#          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+#          docker image ls -a
+      - name: check disk after download
+        run: lsblk && df -h
       - name: Load docker image from artifact download
         run: |
-          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
+          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_hardcoded_str.tar.gz
           docker image ls -a
 
       - name: Configure AWS Credentials
@@ -85,12 +104,19 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+#      - name: Push to ECR
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
+#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
       - name: Push to ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: hardcoded_str
         run: |
-          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
           docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
 

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        repository: [web-portal, web-admin, web]
+        repository: [ web-portal, web-admin, web ]
         include:
           # note this is confusing, but make ci-web-portal points to dpc-web-portal-test.sh which runs
           # docker compose -p ... dpc_web
@@ -59,7 +59,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        repository: [web-portal, web-admin, web]
+        repository: [ web-portal, web-admin, web ]
     env:
       REPOSITORY: ${{ matrix.repository }}
     needs: docker_build_rails_apps
@@ -93,111 +93,111 @@ jobs:
           docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
 
 
-#  docker_build_java:
-#    runs-on: self-hosted
-#    steps:
-#      - name: "Set up Ansible"
-#        run: |
-#          sudo dnf -y install python3 python3-pip
-#          pip install ansible
-#
-#      - name: "Install npm for Postman tests"
-#        run: |
-#          sudo dnf -y install nodejs
-#          npm --version
-#
-#      - name: Install docker compose manually
-#        run: |
-#          sudo mkdir -p /usr/local/lib/docker/cli-plugins
-#          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-#
-#      - name: "Set up JDK 11"
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: "11"
-#          distribution: "corretto"
-#          cache: maven
-#
-#      - name: Install Maven 3.6.3
-#        run: |
-#          export PATH="$PATH:/opt/maven/bin"
-#          echo "PATH=$PATH" >> $GITHUB_ENV
-#          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
-#          tmpdir="$(mktemp -d)"
-#          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
-#          sudo rm -rf /opt/maven
-#          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
-#
-#      - name: Clean maven
-#        run: mvn -ntp -U clean
-#
-#      - name: "Checkout code"
-#        uses: actions/checkout@v4
-#
-#      - name: Build ci app
-#        id: api-build
-#        run: |
-#          export PATH=$PATH:~/.local/bin
-#          make ci-app
-#
-#      # add extra commands to log docker containers during failure
-#      - name: Consent Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-consent-1
-#      - name: Attribution Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-attribution-1
-#      - name: Aggregation Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-aggregation-1
-#      - name: Api Logs
-#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-#        run: docker logs start-v1-app-api-1
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-region: ${{ vars.AWS_REGION }}
-#          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-#
-#      - name: Login to Amazon ECR
-#        id: login-ecr
-#        uses: aws-actions/amazon-ecr-login@v2
-#
-#      - name: ECR (1 of 4) - Push API
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: api
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: ECR (2 of 4) - Push Attribution
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: attribution
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: ECR (3 of 4) - Push Aggregation
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: aggregation
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: ECR (4 of 4) - Push Consent
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: consent
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+  docker_build_java:
+    runs-on: self-hosted
+    steps:
+      - name: "Set up Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+
+      - name: "Install npm for Postman tests"
+        run: |
+          sudo dnf -y install nodejs
+          npm --version
+
+      - name: Install docker compose manually
+        run: |
+          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+      - name: "Set up JDK 11"
+        uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "corretto"
+          cache: maven
+
+      - name: Install Maven 3.6.3
+        run: |
+          export PATH="$PATH:/opt/maven/bin"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+          tmpdir="$(mktemp -d)"
+          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+          sudo rm -rf /opt/maven
+          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
+
+      - name: Clean maven
+        run: mvn -ntp -U clean
+
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+
+      - name: Build ci app
+        id: api-build
+        run: |
+          export PATH=$PATH:~/.local/bin
+          make ci-app
+
+      # add extra commands to log docker containers during failure
+      - name: Consent Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-consent-1
+      - name: Attribution Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-attribution-1
+      - name: Aggregation Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-aggregation-1
+      - name: Api Logs
+        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+        run: docker logs start-v1-app-api-1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: ECR (1 of 4) - Push API
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: api
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
+      - name: ECR (2 of 4) - Push Attribution
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: attribution
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
+      - name: ECR (3 of 4) - Push Aggregation
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: aggregation
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+
+      - name: ECR (4 of 4) - Push Consent
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: consent
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Load image
         run: |
-          docker load --input ${{ runner.temp }}/myimage.tar
+          docker load --input ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
           docker image ls -a
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,9 +1,7 @@
 name: Docker Build
 
 on:
-#  workflow_dispatch:
-  push:
-
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -33,18 +31,6 @@ jobs:
     env:
       MAKE_COMMAND: ${{ matrix.make_command }}
     steps:
-      - name: check disk
-        run: lsblk && df -h
-      - name: check docker disk usage (1 of 4)
-        run: docker system df
-      - name: check docker disk usage (2 of 4)
-        run: docker images -f "dangling=true"
-      - name: check docker disk usage (3 of 4)
-        run: docker ps -a --filter "status=exited"
-      - name: check docker disk usage (4 of 4)
-        run: docker volume ls -qf dangling=true
-
-
       - name: Install python3
         run: sudo dnf install python3
 
@@ -61,20 +47,13 @@ jobs:
       - name: Build specified app
         run: $MAKE_COMMAND
 
-#      - name: gzip the image
-#        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
-#      - name: upload tar artifact
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: dpc-${{ matrix.repository }}
-#          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
       - name: gzip the image
-        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_hardcoded_str.tar.gz
+        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:
           name: dpc-${{ matrix.repository }}
-          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_hardcoded_str.tar.gz
+          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
 
   docker_push_rails_apps:
     runs-on: self-hosted
@@ -85,31 +64,14 @@ jobs:
       REPOSITORY: ${{ matrix.repository }}
     needs: docker_build_rails_apps
     steps:
-      - name: check disk
-        run: lsblk && df -h
-      - name: check docker disk usage (1 of 4)
-        run: docker system df
-      - name: check docker disk usage (2 of 4)
-        run: docker images -f "dangling=true"
-      - name: check docker disk usage (3 of 4)
-        run: docker ps -a --filter "status=exited"
-      - name: check docker disk usage (4 of 4)
-        run: docker volume ls -qf dangling=true
-
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: dpc-${{ matrix.repository }}
           path: ${{ runner.temp }}
-#      - name: Load docker image from artifact download
-#        run: |
-#          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
-#          docker image ls -a
-      - name: check disk after download
-        run: lsblk && df -h
       - name: Load docker image from artifact download
         run: |
-          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_hardcoded_str.tar.gz
+          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
           docker image ls -a
 
       - name: Configure AWS Credentials
@@ -121,174 +83,15 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-#      - name: Push to ECR
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
-#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
       - name: Push to ECR
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          IMAGE_TAG: hardcoded_str
+          IMAGE_TAG: ${{ github.sha }}
         run: |
+          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
           docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
 
-      - name: success
-        run: echo "success?"
-
-
-  #  docker_build_web_portal:
-#    runs-on: self-hosted
-#    env:
-#      REPOSITORY: web-portal
-#      MAKE_COMMAND: make ci-portal
-#    steps:
-#      - name: check gzip
-#        run: gzip --version
-#
-#      - name: Install python3
-#        run: sudo dnf install python3
-#
-#      - name: "Checkout code"
-#        uses: actions/checkout@v4
-#
-#      - name: Install docker compose manually
-#        run: |
-#          sudo mkdir -p /usr/local/lib/docker/cli-plugins
-#          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-#
-#      - name: Build portal
-#        run: |
-#          $MAKE_COMMAND
-#
-#      - name: gzip the image
-#        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
-#      - name: upload tar artifact
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: dpc-$REPOSITORY
-#          path: ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
-#
-#  docker_push_rails_web_portal_image:
-#    runs-on: self-hosted
-#    env:
-#      REPOSITORY: web-portal
-#    needs: docker_build_rails_web_portal
-#    steps:
-#      - name: Download artifact
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: dpc-$REPOSITORY
-#          path: ${{ runner.temp }}
-#
-#      - name: Load image
-#        run: |
-#          docker load --input ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
-#          docker image ls -a
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-region: ${{ vars.AWS_REGION }}
-#          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-#
-#      - name: Login to Amazon ECR
-#        id: login-ecr
-#        uses: aws-actions/amazon-ecr-login@v2
-#
-#      - name: Push to ECR
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          IMAGE_TAG: ${{ github.sha }}
-#        run: |
-#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
-#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: success
-#        run: "Did it work???"
-#      # TODO add additional steps to push dpc-web-admin and dpc-web, see docker_build_all_portals below
-
-#  docker_build_all_portals:
-#    runs-on: self-hosted
-#    steps:
-#      - name: Install python3
-#        run: sudo dnf install python3
-#
-#      - name: "Checkout code"
-#        uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.ref_name }}
-#
-#      - name: Install docker compose manually
-#        run: |
-#          sudo mkdir -p /usr/local/lib/docker/cli-plugins
-#          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-#          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-#
-#      - name: Assert Ownership
-#        run: sudo chmod -R 777 .
-#      - name: Cleanup Runner
-#        run: ./scripts/cleanup-docker.sh
-#
-#      - name: Configure AWS Credentials
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-region: ${{ vars.AWS_REGION }}
-#          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-#
-#      - name: Login to Amazon ECR
-#        id: login-ecr
-#        uses: aws-actions/amazon-ecr-login@v2
-#
-#      - name: "Set up Ansible"
-#        run: |
-#          sudo dnf -y install python3 python3-pip
-#          pip install ansible
-#
-#      - name: Build portals
-#        run: |
-#          make ci-portals-v1
-#
-#      - name: Push Rails Web Portal to ECR
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: web-portal
-#          IMAGE_TAG: hardcodedstringfornow
-#        run: |
-#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: Push Rails Admin Portal to ECR
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: web-admin
-#          IMAGE_TAG: hardcodedstringfornow
-#        run: |
-#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: Push Web to ECR
-#        env:
-#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#          REPOSITORY: web
-#          IMAGE_TAG: hardcodedstringfornow
-#        run: |
-#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-#
-#      - name: echo hello
-#        run: echo "pushed portal images"
-#
-#      - name: Cleanup at the end too??
-#        if: ${{ always() }}
-#        run: ./scripts/cleanup-docker.sh
 
 #  docker_build_java:
 #    runs-on: self-hosted

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dpc-$REPOSITORY
-          path: ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz.tar
+          path: ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
 
   docker_push_rails_web_portal_image:
     runs-on: self-hosted

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -17,10 +17,6 @@ env:
 
 jobs:
   docker_build_rails_web_portal:
-    env:
-      REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-      REPOSITORY: web-portal
-      IMAGE_TAG: ${{ github.sha }}
     runs-on: self-hosted
     env:
       REPOSITORY: web-portal

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -282,4 +282,4 @@ jobs:
 
       - name: Prune docker images and volumes
         if: ${{ always() }}
-        run: ./scripts/cleanup-docker.sh
+        run: ls && ls ./scripts && ./scripts/cleanup-docker.sh

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -1,7 +1,8 @@
 name: Docker Build
 
 on:
-  workflow_dispatch:
+#  workflow_dispatch:
+  push:
 
 
 permissions:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -17,6 +17,10 @@ env:
 
 jobs:
   docker_build_rails_web_portal:
+    env:
+      REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+      REPOSITORY: web-portal
+      IMAGE_TAG: ${{ github.sha }}
     runs-on: self-hosted
     env:
       REPOSITORY: web-portal
@@ -62,6 +66,18 @@ jobs:
         with:
           name: dpc-$REPOSITORY
           path: ${{ runner.temp }}
+
+      - name: Load image
+        run: |
+          docker load --input ${{ runner.temp }}/myimage.tar
+          docker image ls -a
+      - name: gzip the image
+        run: docker save dpc-$REPOSITORY:latest | gzip > $REPOSITORY_latest.tar.gz
+      - name: upload tar artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dpc-$REPOSITORY
+          path: ${{ runner.temp }}/$REPOSITORY_latest.tar.gz.tar
 
       - name: Load image
         run: |
@@ -166,111 +182,111 @@ jobs:
 #        if: ${{ always() }}
 #        run: ./scripts/cleanup-docker.sh
 
-  docker_build_java:
-    runs-on: self-hosted
-    steps:
-      - name: "Set up Ansible"
-        run: |
-          sudo dnf -y install python3 python3-pip
-          pip install ansible
-
-      - name: "Install npm for Postman tests"
-        run: |
-          sudo dnf -y install nodejs
-          npm --version
-
-      - name: Install docker compose manually
-        run: |
-          sudo mkdir -p /usr/local/lib/docker/cli-plugins
-          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
-          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
-          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-
-      - name: "Set up JDK 11"
-        uses: actions/setup-java@v3
-        with:
-          java-version: "11"
-          distribution: "corretto"
-          cache: maven
-
-      - name: Install Maven 3.6.3
-        run: |
-          export PATH="$PATH:/opt/maven/bin"
-          echo "PATH=$PATH" >> $GITHUB_ENV
-          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
-          tmpdir="$(mktemp -d)"
-          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
-          sudo rm -rf /opt/maven
-          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
-
-      - name: Clean maven
-        run: mvn -ntp -U clean
-
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-
-      - name: Build ci app
-        id: api-build
-        run: |
-          export PATH=$PATH:~/.local/bin
-          make ci-app
-
-      # add extra commands to log docker containers during failure
-      - name: Consent Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-consent-1
-      - name: Attribution Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-attribution-1
-      - name: Aggregation Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-aggregation-1
-      - name: Api Logs
-        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
-        run: docker logs start-v1-app-api-1
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: ECR (1 of 4) - Push API
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: api
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-
-      - name: ECR (2 of 4) - Push Attribution
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: attribution
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-
-      - name: ECR (3 of 4) - Push Aggregation
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: aggregation
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-
-      - name: ECR (4 of 4) - Push Consent
-        env:
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          REPOSITORY: consent
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#  docker_build_java:
+#    runs-on: self-hosted
+#    steps:
+#      - name: "Set up Ansible"
+#        run: |
+#          sudo dnf -y install python3 python3-pip
+#          pip install ansible
+#
+#      - name: "Install npm for Postman tests"
+#        run: |
+#          sudo dnf -y install nodejs
+#          npm --version
+#
+#      - name: Install docker compose manually
+#        run: |
+#          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+#          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+#          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+#          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+#
+#      - name: "Set up JDK 11"
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: "11"
+#          distribution: "corretto"
+#          cache: maven
+#
+#      - name: Install Maven 3.6.3
+#        run: |
+#          export PATH="$PATH:/opt/maven/bin"
+#          echo "PATH=$PATH" >> $GITHUB_ENV
+#          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+#          tmpdir="$(mktemp -d)"
+#          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+#          sudo rm -rf /opt/maven
+#          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
+#
+#      - name: Clean maven
+#        run: mvn -ntp -U clean
+#
+#      - name: "Checkout code"
+#        uses: actions/checkout@v4
+#
+#      - name: Build ci app
+#        id: api-build
+#        run: |
+#          export PATH=$PATH:~/.local/bin
+#          make ci-app
+#
+#      # add extra commands to log docker containers during failure
+#      - name: Consent Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-consent-1
+#      - name: Attribution Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-attribution-1
+#      - name: Aggregation Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-aggregation-1
+#      - name: Api Logs
+#        if: ${{ failure() && steps.api-build.outcome == 'failure' }}
+#        run: docker logs start-v1-app-api-1
+#
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          aws-region: ${{ vars.AWS_REGION }}
+#          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
+#
+#      - name: Login to Amazon ECR
+#        id: login-ecr
+#        uses: aws-actions/amazon-ecr-login@v2
+#
+#      - name: ECR (1 of 4) - Push API
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: api
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#
+#      - name: ECR (2 of 4) - Push Attribution
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: attribution
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#
+#      - name: ECR (3 of 4) - Push Aggregation
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: aggregation
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#
+#      - name: ECR (4 of 4) - Push Consent
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          REPOSITORY: consent
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -28,8 +28,6 @@ jobs:
             make_command: make ci-admin-portal
           - repository: web
             make_command: make ci-web-portal
-    env:
-      MAKE_COMMAND: ${{ matrix.make_command }}
     steps:
       - name: Install python3
         run: sudo dnf install python3
@@ -45,7 +43,7 @@ jobs:
           sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
       - name: Build specified app
-        run: $MAKE_COMMAND
+        run: ${{ matrix.make_command }}
 
       - name: gzip the image
         run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -43,7 +43,7 @@ jobs:
           make ci-portal
 
       - name: gzip the image
-        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/$REPOSITORY_latest.tar.gz
+        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           name: dpc-${{ matrix.ecr_repository }}
           path: ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
+          retention-days: 1
 
   docker_push_rails_apps:
     runs-on: self-hosted

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -16,14 +16,23 @@ env:
   ENV: "github-ci"
 
 jobs:
-  docker_build_rails_web_portal:
+  docker_build_rails_apps:
     runs-on: self-hosted
+    strategy:
+      matrix:
+        repository: [web-portal, web-admin, web]
+        include:
+          # note this is confusing, but make ci-web-portal points to dpc-web-portal-test.sh which runs
+          # docker compose -p ... dpc_web
+          - repository: web-portal
+            make_command: make ci-portal
+          - repository: web-admin
+            make_command: make ci-admin-portal
+          - repository: web
+            make_command: make ci-web-portal
     env:
-      REPOSITORY: web-portal
+      MAKE_COMMAND: ${{ matrix.make_command }}
     steps:
-      - name: check gzip
-        run: gzip --version
-
       - name: Install python3
         run: sudo dnf install python3
 
@@ -37,42 +46,41 @@ jobs:
           sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
-      # TODO replace w/ make ci-portals-v1 when disk space issue resolved
-      - name: Build portal
-        run: |
-          make ci-portal
+      - name: Build specified app
+        run: $MAKE_COMMAND
 
-#        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz
       - name: gzip the image
-        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+        run: docker save dpc-${{ matrix.repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
       - name: upload tar artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dpc-$REPOSITORY
-          path: ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+          name: dpc-${{ matrix.repository }}
+          path: ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
 
-  docker_push_rails_web_portal_image:
+  docker_push_rails_apps:
     runs-on: self-hosted
+    strategy:
+      matrix:
+        repository: [web-portal, web-admin, web]
     env:
-      REPOSITORY: web-portal
-    needs: docker_build_rails_web_portal
+      REPOSITORY: ${{ matrix.repository }}
+    needs: docker_build_rails_apps
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: dpc-$REPOSITORY
+          name: dpc-${{ matrix.repository }}
           path: ${{ runner.temp }}
-
-      - name: Load image
+      - name: Load docker image from artifact download
         run: |
-          docker load --input ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+          docker load --input ${{ runner.temp }}/dpc_${{ matrix.repository }}_latest.tar.gz
           docker image ls -a
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
@@ -87,8 +95,81 @@ jobs:
           docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
 
       - name: success
-        run: "Did it work???"
-      # TODO add additional steps to push dpc-web-admin and dpc-web, see docker_build_all_portals below
+        run: echo "success?"
+
+
+  #  docker_build_web_portal:
+#    runs-on: self-hosted
+#    env:
+#      REPOSITORY: web-portal
+#      MAKE_COMMAND: make ci-portal
+#    steps:
+#      - name: check gzip
+#        run: gzip --version
+#
+#      - name: Install python3
+#        run: sudo dnf install python3
+#
+#      - name: "Checkout code"
+#        uses: actions/checkout@v4
+#
+#      - name: Install docker compose manually
+#        run: |
+#          sudo mkdir -p /usr/local/lib/docker/cli-plugins
+#          sudo curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+#          sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+#          sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+#
+#      - name: Build portal
+#        run: |
+#          $MAKE_COMMAND
+#
+#      - name: gzip the image
+#        run: docker save dpc-$REPOSITORY:latest | gzip > ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+#      - name: upload tar artifact
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: dpc-$REPOSITORY
+#          path: ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+#
+#  docker_push_rails_web_portal_image:
+#    runs-on: self-hosted
+#    env:
+#      REPOSITORY: web-portal
+#    needs: docker_build_rails_web_portal
+#    steps:
+#      - name: Download artifact
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: dpc-$REPOSITORY
+#          path: ${{ runner.temp }}
+#
+#      - name: Load image
+#        run: |
+#          docker load --input ${{ runner.temp }}/dpc_web-portal_latest.tar.gz
+#          docker image ls -a
+#      - name: Configure AWS Credentials
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          aws-region: ${{ vars.AWS_REGION }}
+#          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
+#
+#      - name: Login to Amazon ECR
+#        id: login-ecr
+#        uses: aws-actions/amazon-ecr-login@v2
+#
+#      - name: Push to ECR
+#        env:
+#          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#          IMAGE_TAG: ${{ github.sha }}
+#        run: |
+#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:latest
+#          docker tag dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#          docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
+#
+#      - name: success
+#        run: "Did it work???"
+#      # TODO add additional steps to push dpc-web-admin and dpc-web, see docker_build_all_portals below
 
 #  docker_build_all_portals:
 #    runs-on: self-hosted

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dpc-$REPOSITORY
-          path: ${{ runner.temp }}/$REPOSITORY_latest.tar.gz.tar
+          path: ${{ runner.temp }}/dpc_$REPOSITORY_latest.tar.gz.tar
 
   docker_push_rails_web_portal_image:
     runs-on: self-hosted
@@ -59,7 +59,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: $REPOSITORY_latest.tar.gz.tar
+          name: dpc-$REPOSITORY
           path: ${{ runner.temp }}
 
       - name: Load image

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -186,11 +186,6 @@ jobs:
           sudo chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
           sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
-      - name: Assert Ownership
-        run: sudo chmod -R 777 .
-      - name: Cleanup Runner
-        run: ./scripts/cleanup-docker.sh
-
       - name: "Set up JDK 11"
         uses: actions/setup-java@v3
         with:
@@ -279,7 +274,3 @@ jobs:
         run: |
           docker tag $REGISTRY/dpc-$REPOSITORY:latest $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
           docker push $REGISTRY/dpc-$REPOSITORY:$IMAGE_TAG
-
-      - name: Prune docker images and volumes
-        if: ${{ always() }}
-        run: ls && ls ./scripts && ./scripts/cleanup-docker.sh


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4496](https://jira.cms.gov/browse/DPC-4496)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - Remove obsolete commented out code
 - remove job for building just web-portal
 - 2 new jobs
   - ea rails app will be built and then uploaded as an artifact
   - the second job will pull down that artifact and push to AWS ECR

## ℹ️ Context
 - currently experiencing issues w/ self-hosted GHA runners running out of disk space, so these jobs were separated out as opposed to a single `make ci-portals-v1` command 
 - in practice, the java apps still take a majority of the time, but this gives feedback to the developer sooner if one of the rails apps fails to build

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation
 - Example CI job [here](https://github.com/CMSgov/dpc-app/actions/runs/13185239034)

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
