### PR TITLE
Update net-imap

### DIFF
--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -233,7 +233,7 @@ GEM
     multi_xml (0.6.0)
     net-http (0.4.1)
       uri
-    net-imap (0.5.1)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -422,7 +422,7 @@ GEM
     stringio (3.1.2)
     thor (1.3.1)
     tilt (2.3.0)
-    timeout (0.4.2)
+    timeout (0.4.3)
     truemail (3.3.1)
       simpleidn (~> 0.2.1)
     turbolinks (5.2.1)

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -163,7 +163,7 @@ GEM
     crass (1.0.6)
     css_parser (1.17.1)
       addressable
-    date (3.3.4)
+    date (3.4.1)
     date_time_precision (0.8.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -311,7 +311,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     net-http (0.4.1)
       uri
-    net-imap (0.4.14)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -536,7 +536,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.4.0)
     timecop (0.9.10)
-    timeout (0.4.1)
+    timeout (0.4.3)
     truemail (3.3.1)
       simpleidn (~> 0.2.1)
     tzinfo (2.0.6)

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -251,7 +251,7 @@ GEM
     multi_xml (0.6.0)
     net-http (0.4.1)
       uri
-    net-imap (0.5.1)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -413,7 +413,7 @@ GEM
     stringio (3.1.2)
     thor (1.3.1)
     tilt (2.3.0)
-    timeout (0.4.2)
+    timeout (0.4.3)
     truemail (3.3.1)
       simpleidn (~> 0.2.1)
     tzinfo (2.0.6)

--- a/dpc-web/db/schema.rb
+++ b/dpc-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_28_130628) do
+ActiveRecord::Schema[7.2].define(version: 2020_09_09_153523) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_28_130628) do
     t.integer "address_use", default: 0, null: false
     t.integer "address_type", default: 0, null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
+  end
+
+  create_table "fhir_endpoints", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "status", null: false
+    t.string "uri", null: false
+    t.integer "organization_id"
+    t.integer "registered_organization_id"
+    t.index ["registered_organization_id"], name: "index_fhir_endpoints_on_registered_organization_id"
   end
 
   create_table "internal_users", force: :cascade do |t|

--- a/dpc-web/db/schema.rb
+++ b/dpc-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2020_09_09_153523) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_28_130628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,15 +27,6 @@ ActiveRecord::Schema[7.2].define(version: 2020_09_09_153523) do
     t.integer "address_use", default: 0, null: false
     t.integer "address_type", default: 0, null: false
     t.index ["addressable_type", "addressable_id"], name: "index_addresses_on_addressable_type_and_addressable_id"
-  end
-
-  create_table "fhir_endpoints", force: :cascade do |t|
-    t.string "name", null: false
-    t.integer "status", null: false
-    t.string "uri", null: false
-    t.integer "organization_id"
-    t.integer "registered_organization_id"
-    t.index ["registered_organization_id"], name: "index_fhir_endpoints_on_registered_organization_id"
   end
 
   create_table "internal_users", force: :cascade do |t|


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Gemfile.lock for each webapp updated to lated net-imap

## ℹ️ Context

CVE-2025-25186 made the current version of this gem (which is a deep dependency of other gems we use) necessary to upgrade.

## 🧪 Validation

Apps, build, ci passes
