### PR TITLE
Show Docker Image Tag on generation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,9 +28,8 @@ jobs:
         id: output_docker_tag
         run: |
           DOCKER_TAG="rls-$(date -u +'%Y%m%d%H%M')-${{ github.run_id }}"
+          echo "$DOCKER_TAG"
           echo "docker_tag=$DOCKER_TAG" >> $GITHUB_OUTPUT
-      - name: print tag to STDOUT
-        run: echo "$DOCKER_TAG"
 
   docker_build_rails_apps:
     runs-on: self-hosted


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

docker-build.yml generate_docker_tag stanza echoes docker tag in same step it generates.

## ℹ️ Context

Echoing in other step did not always work.

## 🧪 Validation

Ran [workflow](https://github.com/CMSgov/dpc-app/actions/runs/13289770580/job/37107324124) and tag in output.
