### PR TITLE
DPC-4525 Github Actions Promote Build

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -93,14 +93,14 @@ jobs:
       - name: Set Deployed Image Tag
         id: image-tag
         env:
-          EXPLICIT_TAG: ${{ inputs.tag }}
+          EXPLICIT_TAG: ${{ intputs.ecr_image_tag }}
         run: |
           if [ -z $EXPLICIT_TAG ] || [ $EXPLICIT_TAG = 'latest' ]; then
             image_tag=`aws --region us-east-1 ecr describe-images --repository-name dpc-api --image-ids 'imageTag=latest' '--query=imageDetails[].imageTags[] | [?contains(@, \`rls-\`)] | [0]' --output text`
             echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
           else
           # Note: this will fail if the image doesn't exist
-            aws --region us-east-1 ecr describe-images --repository-name dpc-api --image-ids 'imageTag=${{ inputs.tag }}' > /dev/null
+            aws --region us-east-1 ecr describe-images --repository-name dpc-api --image-ids 'imageTag=${{ intputs.ecr_image_tag }}' > /dev/null
             echo "image_tag=$EXPLICIT_TAG" >> "$GITHUB_OUTPUT"
           fi
           echo $image_tag

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -93,14 +93,14 @@ jobs:
       - name: Set Deployed Image Tag
         id: image-tag
         env:
-          EXPLICIT_TAG: ${{ intputs.ecr_image_tag }}
+          EXPLICIT_TAG: ${{ inputs.ecr_image_tag }}
         run: |
           if [ -z $EXPLICIT_TAG ] || [ $EXPLICIT_TAG = 'latest' ]; then
             image_tag=`aws --region us-east-1 ecr describe-images --repository-name dpc-api --image-ids 'imageTag=latest' '--query=imageDetails[].imageTags[] | [?contains(@, \`rls-\`)] | [0]' --output text`
             echo "image_tag=$image_tag" >> "$GITHUB_OUTPUT"
           else
           # Note: this will fail if the image doesn't exist
-            aws --region us-east-1 ecr describe-images --repository-name dpc-api --image-ids 'imageTag=${{ intputs.ecr_image_tag }}' > /dev/null
+            aws --region us-east-1 ecr describe-images --repository-name dpc-api --image-ids 'imageTag=${{ inputs.ecr_image_tag }}' > /dev/null
             echo "image_tag=$EXPLICIT_TAG" >> "$GITHUB_OUTPUT"
           fi
           echo $image_tag

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -46,7 +46,8 @@ jobs:
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |
-          TASK_DEFINITION=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq -r '.taskDefinition | split(":")[-1]'`
+          DEPLOY_INFO=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]"`
+          TASK_DEFINITION=`jq -r '.taskDefinition | split(":")[-1]' <<< $DEPLOY_INFO`
           INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
           IMAGE=`jq '.Image | split(":")[1]' <<< $INFO`
           echo $IMAGE

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -30,8 +30,8 @@ jobs:
     name: "Set Parameters"
     runs-on: self-hosted
     outputs:
-      version: ${{ steps.fetch-info.outputs.version }}
-      image: ${{ steps.fetch-info.outputs.image }}
+      app_version: ${{ steps.fetch-info.outputs.app_version }}
+      ecr_image_tag: ${{ steps.fetch-info.outputs.ecr_image_tag }}
     steps:
       - name: "Validate Environment"
         if: ${{ inputs.to_env != inputs.confirm_env }}
@@ -49,8 +49,20 @@ jobs:
           SERVICE_INFO=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
           TASK_DEFINITION=`echo $SERVICE_INFO | jq -r '.taskDefinition | split(":")[-1]'`
           TASK_INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
-          IMAGE=`echo $TASK_INFO | jq '.Image | split(":")[1]'`
-          echo $IMAGE
-          VERSION=`echo $TASK_INFO | jq '.Version'`
-          echo $VERSION
+          IMAGE_TAG=`echo $TASK_INFO | jq '.Image | split(":")[1]'`
+          echo $IMAGE_TAG
+          echo "ecr_image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          APP_VERSION=`echo $TASK_INFO | jq '.Version'`
+          echo $APP_VERSION
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
 
+  deploy:
+    needs: set-parameters
+    uses: ./.github/workflows/ecs-deploy.yml
+    with:
+      env: ${{ inputs.to_env || 'test'  }}
+      confirm_env: ${{ inputs.to_env || 'test' }}
+      ecr_image_tag: ${{ needs.set-parameters.outputs.ecr_image_tag }}
+      app-version: ${{ needs.set-parameters.outputs.app_version }}
+    secrets: inherit
+      

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -48,5 +48,5 @@ jobs:
         run: |
           SERVICE_INFO=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
           TASK_DEFINITION=`echo $SERVICE_INFO | jq -r '.taskDefinition | split(":")[-1]'`
-          echo $TASK_DEFINITION
-
+          TASK_INFO=`aws ecs describe-task-definition --task-definition arn:aws:ecs:us-east-1:755619740999:task-definition/dpc-prod-api:189 --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
+          echo $TASK_INFO

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -46,13 +46,12 @@ jobs:
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |
-          DEPLOY_INFO=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]"`
-          TASK_DEFINITION=`jq -r '.taskDefinition | split(":")[-1]' <<< $DEPLOY_INFO`
-          INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
-          IMAGE=`jq '.Image | split(":")[1]' <<< $INFO`
+          TASK_DEFINITION=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq -r '.taskDefinition | split(":")[-1]')
+          INFO=$(aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}")
+          IMAGE=$(jq '.Image | split(":")[1]' <<< $INFO)
           echo $IMAGE
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-          VERSION=`jq '.Version' <<< $INFO`
+          VERSION=$(jq '.Version' <<< $INFO)
           echo $VERSION
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -48,5 +48,5 @@ jobs:
         run: |
           SERVICE_INFO=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
           TASK_DEFINITION=`echo $SERVICE_INFO | jq -r '.taskDefinition | split(":")[-1]'`
-          TASK_INFO=`aws ecs describe-task-definition --task-definition arn:aws:ecs:us-east-1:755619740999:task-definition/dpc-prod-api:189 --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
+          TASK_INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
           echo $TASK_INFO

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -1,9 +1,6 @@
 name: 'DPC - Promote Build'
 
 on:
-  push:
-    paths:
-      - .github/workflows/promote-build.yml
   workflow_dispatch:
       from_env:
         description: AWS environment to promote FROM

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           echo "Target deployment environment \"${{ inputs.to_env }}\" must be specified and match confirmed deployment environment \"${{ inputs.confirm_env }}\"."
           exit 1
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -49,4 +49,8 @@ jobs:
           SERVICE_INFO=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
           TASK_DEFINITION=`echo $SERVICE_INFO | jq -r '.taskDefinition | split(":")[-1]'`
           TASK_INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
-          echo $TASK_INFO
+          IMAGE=`echo $TASK_INFO | jq '.Image | split(":")[1]'`
+          echo $IMAGE
+          VERSION=`echo $TASK_INFO | jq '.Version'`
+          echo $VERSION
+

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -66,3 +66,9 @@ jobs:
       app-version: ${{ needs.set-parameters.outputs.app_version }}
     secrets: inherit
       
+  smoke-test:
+    needs: deploy
+    uses: ./.github/workflows/smoke-test.yml
+    with:
+      env: ${{ inputs.env || 'test' }}
+    secrets: inherit

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |
-          TASK_DEFINITION=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq '.taskDefinition | split(":")[-1]`
+          TASK_DEFINITION=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq '.taskDefinition | split(":")[-1]'`
           INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
           IMAGE=`jq '.Image | split(":")[1]' <<< $INFO`
           echo $IMAGE

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -46,6 +46,7 @@ jobs:
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |
-          TASK_DEFINITION=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
+          SERVICE_INFO=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
+          TASK_DEFINITION=`echo $SERVICE_INFO | jq -r '.taskDefinition | split(":")[-1]'`
           echo $TASK_DEFINITION
 

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -1,0 +1,53 @@
+name: 'DPC - Promote Build'
+
+on:
+  push:
+    paths:
+      - .github/workflows/promote-build.yml
+  workflow_dispatch:
+      from_env:
+        description: AWS environment to promote FROM
+        required: true
+        type: 'string'
+        default: 'dev'
+      to_env:
+        description: AWS environment to promote TO
+        required: true
+        type: 'string'
+        default: 'dev'
+      confirm_env:
+        description: Double check environment to promote TO
+        required: true
+        type: 'string'
+        default: ''
+    
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.to_env }}
+  cancel-in-progress: false
+
+jobs:
+  set-parameters:
+    name: "Set Parameters"
+    runs-on: self-hosted
+    outputs:
+      version: ${{ steps.fetch-info.outputs.version }}
+      image: ${{ steps.fetch-info.outputs.image }}
+    steps:
+      - name: "Validate Environment"
+        if: ${{ inputs.to_env != inputs.confirm_env }}
+        run: |
+          echo "Target deployment environment \"${{ inputs.to_env }}\" must be specified and match confirmed deployment environment \"${{ inputs.confirm_env }}\"."
+          exit 1
+      - name: "Fetch Image and App Version from AWS"
+        id: fetch-info
+        run: |
+          TASK_DEFINITION=`aws ecs describe-services --services dpc-prod-api-v9 --cluster dpc-prod-frontend --query "services[0].deployments[0].taskDefinition"`          
+          INFO=`aws ecs describe-task-definition --task-definition $TASK_DEFINITION --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
+          IMAGE=`jq '.Image | split(":")[1]' <<< $INFO`
+          echo $IMAGE
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          VERSION=`jq '.Version' <<< $INFO`
+          echo $VERSION
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          
+          

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -46,7 +46,6 @@ jobs:
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |
-          TASK_DEFINITION=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq -r '.taskDefinition | split(":")[-1]')
-          INFO=$(aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}")
-          IMAGE=$(jq '.Image | split(":")[1]' <<< $INFO)
-          echo $IMAGE
+          TASK_DEFINITION=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
+          echo $TASK_DEFINITION
+

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -46,8 +46,8 @@ jobs:
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |
-          TASK_DEFINITION=`aws ecs describe-services --services dpc-prod-api-v9 --cluster dpc-prod-frontend --query "services[0].deployments[0].taskDefinition"`          
-          INFO=`aws ecs describe-task-definition --task-definition $TASK_DEFINITION --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
+          TASK_DEFINITION=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq '.taskDefinition | split(":")[-1]`
+          INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
           IMAGE=`jq '.Image | split(":")[1]' <<< $INFO`
           echo $IMAGE
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |
-          TASK_DEFINITION=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq '.taskDefinition | split(":")[-1]'`
+          TASK_DEFINITION=`aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]" | jq -r '.taskDefinition | split(":")[-1]'`
           INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
           IMAGE=`jq '.Image | split(":")[1]' <<< $INFO`
           echo $IMAGE

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -50,9 +50,3 @@ jobs:
           INFO=$(aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION" --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}")
           IMAGE=$(jq '.Image | split(":")[1]' <<< $INFO)
           echo $IMAGE
-          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
-          VERSION=$(jq '.Version' <<< $INFO)
-          echo $VERSION
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          
-          

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -22,8 +22,8 @@ on:
         default: ''
     
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.to_env }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ inputs.from_env }}-${{ inputs.to_env }}
+  cancel-in-progress: true
 
 jobs:
   set-parameters:

--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -22,7 +22,7 @@ on:
         default: ''
     
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.from_env }}-${{ inputs.to_env }}
+  group: ${{ github.workflow }}-${{ inputs.to_env }}
   cancel-in-progress: true
 
 jobs:
@@ -49,10 +49,10 @@ jobs:
           SERVICE_INFO=$(aws ecs describe-services --services dpc-${{ inputs.from_env || 'dev' }}-api-v9 --cluster dpc-${{ inputs.from_env || 'dev' }}-frontend --query "services[0].deployments[0]")
           TASK_DEFINITION=`echo $SERVICE_INFO | jq -r '.taskDefinition | split(":")[-1]'`
           TASK_INFO=`aws ecs describe-task-definition --task-definition dpc-${{ inputs.from_env || 'dev' }}-api:$TASK_DEFINITION --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
-          IMAGE_TAG=`echo $TASK_INFO | jq '.Image | split(":")[1]'`
+          IMAGE_TAG=`echo $TASK_INFO | jq -r '.Image | split(":")[1]'`
           echo $IMAGE_TAG
           echo "ecr_image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
-          APP_VERSION=`echo $TASK_INFO | jq '.Version'`
+          APP_VERSION=`echo $TASK_INFO | jq -r '.Version'`
           echo $APP_VERSION
           echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
 

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.9)
+    rack (3.1.10)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/dpc-portal/Dockerfile
+++ b/dpc-portal/Dockerfile
@@ -30,7 +30,6 @@ RUN gem install bundler --no-document && \
     npm install
 
 # Run bundler audit
-# ignoring CVE-2024-21510 as it affects Sinatra, which is only used internally
 RUN bundle exec bundle audit update && bundle exec bundle audit check
 
 # Copy the code, test the app, and build the assets pipeline

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.9)
+    rack (3.1.10)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.9)
+    rack (3.1.10)
     rack-session (2.0.0)
       rack (>= 3.0.0)
     rack-test (2.1.0)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4525

## 🛠 Changes

- promote-build.yml added
- ecs-deploy.yml fix

## ℹ️ Context

We are migrating from Jenkins to Github Actions. This workflow replaces '[DPC - Promote Build](https://github.com/CMSgov/dpc-ops/blob/main/jenkins_files/Jenkinsfile.promote_build)'.

Note: Jenkins has a feature in which you can look up the parameters of other jobs. This feature is not available in Github Actions. Therefore, this promotion always uses the main branch of dpc-ops. We _could_ add this as a parameter, but I think the cleaner interface is better.

## 🧪 Validation

[Ran](https://github.com/CMSgov/dpc-app/actions/runs/13317487378/job/37194959257) and verified correct image and app_version deployed.
