### PR TITLE
[DPC-4476] Enable AttributionFHIRTest.java

### DIFF
--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
@@ -128,15 +128,14 @@ class AttributionFHIRTest extends AbstractAttributionTest {
         // Try to create roster for provider with existing one
         // Re-add the meta, because it gets stripped
         FHIRBuilders.addOrganizationTag(createdGroup, UUID.fromString(organizationID));
-        try {
-            client
-                    .create()
-                    .resource(createdGroup)
-                    .encodedJson().execute();
-        } catch (WebApplicationException e) {
-            assertEquals(Response.Status.FORBIDDEN.getStatusCode(), e.getResponse().getStatus());
-            assertTrue(e.getMessage().contains("Could not create a roster for this provider as they already have one."));
-        }
+        WebApplicationException e = assertThrows(WebApplicationException.class,
+                () -> client
+                        .create()
+                        .resource(createdGroup)
+                        .encodedJson().execute()
+        );
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), e.getResponse().getStatus());
+        assertTrue(e.getMessage().contains("Could not create a roster for this provider as they already have one."));
 
         // Try to get attributed patients
         final Bundle attributed = client

--- a/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
+++ b/dpc-attribution/src/test/java/gov/cms/dpc/attribution/AttributionFHIRTest.java
@@ -13,14 +13,11 @@ import gov.cms.dpc.fhir.FHIRExtractors;
 import gov.cms.dpc.testing.BufferedLoggerHandler;
 import gov.cms.dpc.testing.IntegrationTest;
 import gov.cms.dpc.testing.OrganizationHelpers;
-import io.dropwizard.testing.ConfigOverride;
-import io.dropwizard.testing.DropwizardTestSupport;
 import org.apache.commons.lang3.tuple.Pair;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import ru.vyarus.dropwizard.guice.module.context.SharedConfigurationState;
 
 import java.io.InputStream;
 import java.time.Instant;
@@ -36,12 +33,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(BufferedLoggerHandler.class)
 @IntegrationTest
-class AttributionFHIRTest {
+class AttributionFHIRTest extends AbstractAttributionTest {
 
-    private static final String CONFIG_PATH = "src/test/resources/test.application.yml";
-    private static final DropwizardTestSupport<DPCAttributionConfiguration> APPLICATION =
-            new DropwizardTestSupport<>(DPCAttributionService.class, CONFIG_PATH,
-                    ConfigOverride.config("server.applicationConnectors[0].port", "3727"));
     private static final FhirContext ctx = FhirContext.forDstu3();
     private static final String CSV = "test_associations-dpr.csv";
     private static Map<String, List<Pair<String, String>>> groupedPairs = new HashMap<>();
@@ -49,12 +42,6 @@ class AttributionFHIRTest {
 
     @BeforeAll
     static void setup() throws Exception {
-        APPLICATION.before();
-        SharedConfigurationState.clear();
-        APPLICATION.getApplication().run("db", "drop-all", "--confirm-delete-everything", CONFIG_PATH);
-        SharedConfigurationState.clear();
-        APPLICATION.getApplication().run("db", "migrate", CONFIG_PATH);
-
         // Get the test seeds
         final InputStream resource = AttributionFHIRTest.class.getClassLoader().getResourceAsStream(CSV);
         if (resource == null) {
@@ -66,11 +53,6 @@ class AttributionFHIRTest {
 
         // Create the Organization
         organization = OrganizationHelpers.createOrganization(ctx, AttributionTestHelpers.createFHIRClient(ctx, String.format("http://localhost:%s/v1/", APPLICATION.getLocalPort())));
-    }
-
-    @AfterAll
-    static void shutdown() {
-        APPLICATION.after();
     }
 
     @TestFactory


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4476

## 🛠 Changes

Removes erroneous creation of roster in tests.

## ℹ️ Context

AttributionFHIRTest was disabled because of a failure in the SUBMIT tests. This PR removes the additional call to `create`.

## 🧪 Validation

Tests updated.
