### PR TITLE
DPC-4533 Add all changes to release documentation

### DIFF
--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tag-dpc-app:
     name: "Tag dpc-app"
-    uses: CMSgov/dpc-app/.github/workflows/tag_release.yml@main
+    uses: ./.github/workflows/tag_release.yml
     with:
       repo_ref: ${{ inputs.repo_ref }}
     secrets: inherit

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -26,8 +26,6 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.repo_ref || 'main' }}
       - name: "Fetch git info"
         run: |
           git fetch --quiet

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -49,7 +49,9 @@ jobs:
             BODY='No changes'
           fi
           echo $BODY
-          echo "body=$BODY" >> "$GITHUB_OUTPUT"
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BDOY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Release
         if: ${{ false }}
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -53,7 +53,6 @@ jobs:
           echo "$BDOY" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Release
-        uses: softprops/action-gh-release@v2
-        with:
+        env:
           body: ${{ steps.set_body.outputs.body }}
-          tag_name: ${{ steps.set_revs.outputs.next_rev }}
+        run: echo $body

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,4 +1,5 @@
 name: utility-tag-repo
+
 on:
   workflow_call:
     inputs:
@@ -26,6 +27,8 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.repo_ref || 'main' }}
+        with:
           fetch-depth: 0
       - name: "Fetch git info"
         run: |
@@ -50,12 +53,10 @@ jobs:
             BODY='No changes'
           fi
           echo $BODY
-          echo 'body<<EOF' >> $GITHUB_OUTPUT
-          echo "$BODY" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
-
+          echo "body=$BODY" >> "$GITHUB_OUTPUT"
       - name: Release
-        env:
-          BODY: ${{ steps.set_body.outputs.body }}
-        run: |
-          echo $BODY
+        if: ${{ false }}
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.set_body.outputs.body }}
+          tag_name: ${{ steps.set_revs.outputs.next_rev }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,5 +1,4 @@
 name: utility-tag-repo
-
 on:
   workflow_call:
     inputs:
@@ -51,7 +50,10 @@ jobs:
             BODY='No changes'
           fi
           echo $BODY
-          echo "body=$BODY" >> "$GITHUB_OUTPUT"
+          echo 'body<<EOF' >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
       - name: Release
         if: ${{ false }}
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.repo_ref || 'main' }}
-        with:
           fetch-depth: 0
       - name: "Calculate Next Revision"
         id: set_revs

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -30,9 +30,6 @@ jobs:
           ref: ${{ inputs.repo_ref || 'main' }}
         with:
           fetch-depth: 0
-      - name: "Fetch git info"
-        run: |
-          git fetch --quiet
       - name: "Calculate Next Revision"
         id: set_revs
         run: |

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -53,7 +53,6 @@ jobs:
           echo "$BDOY" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Release
-        if: ${{ false }}
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.set_body.outputs.body }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: "Fetch git info"
         run: |
           git fetch --quiet

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -53,6 +53,7 @@ jobs:
           echo "$BODY" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Release
-        env:
+        uses: softprops/action-gh-release@v2
+        with:
           body: ${{ steps.set_body.outputs.body }}
-        run: echo $body
+          tag_name: ${{ steps.set_revs.outputs.next_rev }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -50,8 +50,10 @@ jobs:
           if [ -z "$BODY" ]; then
             BODY='No changes'
           fi
+          echo $BODY
           echo "body=$BODY" >> "$GITHUB_OUTPUT"
       - name: Release
+        if: ${{ false }}
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.set_body.outputs.body }}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -50,7 +50,7 @@ jobs:
           fi
           echo $BODY
           echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$BDOY" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Release
         env:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -55,8 +55,7 @@ jobs:
           echo 'EOF' >> $GITHUB_OUTPUT
 
       - name: Release
-        if: ${{ false }}
-        uses: softprops/action-gh-release@v2
-        with:
-          body: ${{ steps.set_body.outputs.body }}
-          tag_name: ${{ steps.set_revs.outputs.next_rev }}
+        env:
+          BODY: ${{ steps.set_body.outputs.body }}
+        run: |
+          echo $BODY


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4533

## 🛠 Changes

tag_release utility changed to add all changes since last release to release documentation.

## ℹ️ Context

There were two issues. First, the fetch-depth needed to be set to zero in checking out the code. Second setting the output variable required special multi-line handling.
Also a minor update to the trigger allows for testing by using the current branch.

## 🧪 Validation

Tagging ran successfully (and was then deleted).
<img width="1324" alt="release" src="https://github.com/user-attachments/assets/886acbdb-c5be-4794-983e-0e1e9f1fb804" />
