### PR TITLE
Add params to promote

### DIFF
--- a/.github/workflows/promote-build.yml
+++ b/.github/workflows/promote-build.yml
@@ -2,6 +2,7 @@ name: 'DPC - Promote Build'
 
 on:
   workflow_dispatch:
+    inputs:
       from_env:
         description: AWS environment to promote FROM
         required: true
@@ -11,7 +12,7 @@ on:
         description: AWS environment to promote TO
         required: true
         type: 'string'
-        default: 'dev'
+        default: 'test'
       confirm_env:
         description: Double check environment to promote TO
         required: true


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

"inputs" added to workflow dispatch, default 'to' changed to 'test'

## ℹ️ Context

Workflow_dispatch was missing "inputs" key; defaulted to promoting to same as from

## 🧪 Validation

Inputs currently available for promote from this branch
![promotetotest](https://github.com/user-attachments/assets/7bac9211-0e10-4059-8fc1-93400f31c36c)

