### PR TITLE
Add welcome page to step tracker

### DIFF
--- a/dpc-portal/app/components/page/invitations/accept_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/accept_invitation_component.html.erb
@@ -1,5 +1,5 @@
-<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 1)) if @invitation.authorized_official? %>
-<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 1)) if @invitation.credential_delegate? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 2)) if @invitation.authorized_official? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 2)) if @invitation.credential_delegate? %>
 <div>
   <div>
     <% if @invitation.authorized_official? %>

--- a/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
@@ -1,5 +1,5 @@
-<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 0)) if @invitation.authorized_official? %>
-<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 0)) if @invitation.credential_delegate? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 1)) if @invitation.authorized_official? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 1)) if @invitation.credential_delegate? %>
 <div>
   <p>To register your organization you'll need to 1) have a Login.gov account and 2) verify your identity. Info to have ready:
     <ul>

--- a/dpc-portal/app/components/page/invitations/register_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/register_component.html.erb
@@ -1,4 +1,4 @@
-<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 2)) if @invitation.authorized_official? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 3)) if @invitation.authorized_official? %>
 <div>
   <div>
     <p>Complete your registration of <%= @organization.name %> (NPI <%= @organization.npi %>).</p>

--- a/dpc-portal/app/components/page/invitations/start_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/start_component.html.erb
@@ -13,7 +13,7 @@
         <div class="usa-prose">
           <% if @invitation.authorized_official? %>
             <p>To access the DPC API portal, an Authorized Official (AO) needs to register your organization. This registration request is for <strong><%= @invitation.invited_email %></strong> at <%= @organization.name %> (NPI <%= @organization.npi %>). Use this email to sign in or create a Login.gov account.</p>
-            <p>DPC uses Login.gov for identity verification. Continue to sign in or created a Login.gov account.</p>
+            <p>DPC uses Login.gov for identity verification. Continue to sign in or create a Login.gov account.</p>
           <% end %>
           <% if @invitation.credential_delegate? %>
             <p>Welcome <%= @invitation.show_attributes['full_name'] %> (<%= @invitation.invited_email %>).</p>

--- a/dpc-portal/app/components/page/invitations/start_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/start_component.html.erb
@@ -1,3 +1,5 @@
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 0)) if @invitation.authorized_official? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 0)) if @invitation.credential_delegate? %>
 <section class="usa-section">
   <div class="grid-row margin-x-neg-205 flex-justify-center">
     <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205">

--- a/dpc-portal/app/components/page/invitations/start_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/start_component.html.erb
@@ -4,12 +4,6 @@
   <div class="grid-row margin-x-neg-205 flex-justify-center">
     <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205">
       <div class="border-top border-base-lighter padding-top-4 desktop:border-0 desktop:padding-top-0">
-        <h1 class="display-none desktop:display-block margin-top-2">
-          Welcome to the DPC Portal
-        </h1>
-        <h1 class="desktop:display-none font-sans-lg margin-bottom-4 tablet:margin-top-neg-3">
-          Welcome to the DPC Portal
-        </h1>
         <div class="usa-prose">
           <% if @invitation.authorized_official? %>
             <p>To access the DPC API portal, an Authorized Official (AO) needs to register your organization. This registration request is for <strong><%= @invitation.invited_email %></strong> at <%= @organization.name %> (NPI <%= @organization.npi %>). Use this email to sign in or create a Login.gov account.</p>

--- a/dpc-portal/app/components/page/invitations/start_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/start_component.html.erb
@@ -1,6 +1,6 @@
 <%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 0)) if @invitation.authorized_official? %>
 <%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 0)) if @invitation.credential_delegate? %>
-<section class="usa-section">
+<section>
   <div class="grid-row margin-x-neg-205 flex-justify-center">
     <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205">
       <div class="border-top border-base-lighter padding-top-4 desktop:border-0 desktop:padding-top-0">

--- a/dpc-portal/app/components/page/invitations/success_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/success_component.html.erb
@@ -1,5 +1,5 @@
-<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 3)) if @invitation.authorized_official? %>
-<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 2)) if @invitation.credential_delegate? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::AO_STEPS, 4)) if @invitation.authorized_official? %>
+<%= render(Core::Navigation::StepIndicatorComponent.new(Invitation::CD_STEPS, 3)) if @invitation.credential_delegate? %>
 <div>
   <% if @invitation.credential_delegate? %>
     <div class="usa-alert usa-alert--success margin-bottom-4">

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -15,9 +15,9 @@ class Invitation < ApplicationRecord
   belongs_to :provider_organization, required: true
   belongs_to :invited_by, class_name: 'User', required: false
 
-  AO_STEPS = ['Sign in or create a Login.gov account', 'Confirm your identity', 'Confirm organization registration',
-              'Finished'].freeze
-  CD_STEPS = ['Sign in or create a Login.gov account', 'Accept invite', 'Finished'].freeze
+  AO_STEPS = ['Welcome to DPC Portal', 'Sign in or create a Login.gov account', 'Confirm your identity',
+              'Confirm organization registration', 'Finished'].freeze
+  CD_STEPS = ['Welcome to DPC Portal', 'Sign in or create a Login.gov account', 'Accept invite', 'Finished'].freeze
 
   def show_attributes
     { full_name: "#{invited_given_name} #{invited_family_name}",

--- a/dpc-portal/spec/components/page/invitations/accept_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/accept_invitation_component_spec.rb
@@ -26,9 +26,9 @@ RSpec.describe Page::Invitations::AcceptInvitationComponent, type: :component do
         is_expected.to include(form_method_action)
       end
 
-      it 'should have step component at step 2' do
+      it 'should have step component at step 3' do
         expect(page).to have_selector('.usa-step-indicator__current-step')
-        expect(page.find('.usa-step-indicator__current-step').text).to eq '2'
+        expect(page.find('.usa-step-indicator__current-step').text).to eq '3'
       end
 
       it 'should have Continue to register button' do
@@ -45,9 +45,9 @@ RSpec.describe Page::Invitations::AcceptInvitationComponent, type: :component do
         is_expected.to include(form_method_action)
       end
 
-      it 'should have step component at step 2' do
+      it 'should have step component at step 3' do
         expect(page).to have_selector('.usa-step-indicator__current-step')
-        expect(page.find('.usa-step-indicator__current-step').text).to eq '2'
+        expect(page.find('.usa-step-indicator__current-step').text).to eq '3'
       end
 
       it 'should have Accept invite button' do

--- a/dpc-portal/spec/components/page/invitations/ao_flow_fail_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/ao_flow_fail_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Page::Invitations::AoFlowFailComponent, type: :component do
     context 'step 1' do
       let(:step) { 1 }
       it 'should show step 1 header' do
-        expected_text = 'Step 2 of 4'
+        expected_text = 'Step 2 of 5'
         node = page.find('.usa-step-indicator__heading')
         result_text = node.text.split.map(&:strip).join(' ')
         expect(result_text).to include(expected_text)
@@ -22,7 +22,7 @@ RSpec.describe Page::Invitations::AoFlowFailComponent, type: :component do
     context 'step 2' do
       let(:step) { 2 }
       it 'should show step 2 header' do
-        expected_text = 'Step 3 of 4'
+        expected_text = 'Step 3 of 5'
         node = page.find('.usa-step-indicator__heading')
         result_text = node.text.split.map(&:strip).join(' ')
         expect(result_text).to include(expected_text)

--- a/dpc-portal/spec/components/page/invitations/invitation_login_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/invitation_login_component_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Page::Invitations::InvitationLoginComponent, type: :component do
     let(:invitation) { create(:invitation, :ao) }
     let(:component) { described_class.new(invitation) }
     before { render_inline(component) }
-    it 'should have step component at step 1' do
+    it 'should have step component at step 2' do
       expect(page).to have_selector('.usa-step-indicator__current-step')
-      expect(page.find('.usa-step-indicator__current-step').text).to eq '1'
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '2'
     end
   end
 
@@ -43,9 +43,9 @@ RSpec.describe Page::Invitations::InvitationLoginComponent, type: :component do
     let(:invitation) { create(:invitation, :cd) }
     let(:component) { described_class.new(invitation) }
     before { render_inline(component) }
-    it 'should have step component at step 1' do
+    it 'should have step component at step 2' do
       expect(page).to have_selector('.usa-step-indicator__current-step')
-      expect(page.find('.usa-step-indicator__current-step').text).to eq '1'
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '2'
     end
   end
 end

--- a/dpc-portal/spec/components/page/invitations/register_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/register_component_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Page::Invitations::RegisterComponent, type: :component do
 
   describe 'ao' do
     let(:invitation) { create(:invitation, :ao) }
-    it 'should have step component at step 3' do
+    it 'should have step component at step 4' do
       expect(page).to have_selector('.usa-step-indicator__current-step')
-      expect(page.find('.usa-step-indicator__current-step').text).to eq '3'
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '4'
     end
 
     it 'should post to register' do

--- a/dpc-portal/spec/components/page/invitations/start_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/start_component_spec.rb
@@ -8,6 +8,11 @@ RSpec.describe Page::Invitations::StartComponent, type: :component do
 
   describe 'ao' do
     let(:invitation) { create(:invitation, :ao) }
+    it 'should have step component at step 1' do
+      expect(page).to have_selector('.usa-step-indicator__current-step')
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '1'
+    end
+
     it 'should show start button' do
       button = page.find('.usa-button')
       expect(button.text).to eq 'Begin registration'
@@ -37,6 +42,11 @@ RSpec.describe Page::Invitations::StartComponent, type: :component do
 
   describe 'cd' do
     let(:invitation) { create(:invitation, :cd) }
+    it 'should have step component at step 1' do
+      expect(page).to have_selector('.usa-step-indicator__current-step')
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '1'
+    end
+
     it 'should show start button' do
       button = page.find('.usa-button')
       expect(button.text).to eq 'Accept invitation'

--- a/dpc-portal/spec/components/page/invitations/success_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/success_component_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Page::Invitations::SuccessComponent, type: :component do
 
     before { render_inline(component) }
 
-    it 'should have step component at step 4' do
+    it 'should have step component at step 5' do
       expect(page).to have_selector('.usa-step-indicator__current-step')
-      expect(page.find('.usa-step-indicator__current-step').text).to eq '4'
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '5'
     end
 
     it "should have the organization's name and NPI" do
@@ -31,9 +31,9 @@ RSpec.describe Page::Invitations::SuccessComponent, type: :component do
 
     before { render_inline(component) }
 
-    it 'should have step component at step 3' do
+    it 'should have step component at step 4' do
       expect(page).to have_selector('.usa-step-indicator__current-step')
-      expect(page.find('.usa-step-indicator__current-step').text).to eq '3'
+      expect(page.find('.usa-step-indicator__current-step').text).to eq '4'
     end
 
     it "should have the organization's name and NPI" do


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4541

## 🛠 Changes

Adds portal welcome page to step tracker as first step.

## ℹ️ Context

UX research suggested that users would prefer to see the step tracker as soon as possible, to better ascertain how long the process would take.

## 🧪 Validation

AO welcome page
![image](https://github.com/user-attachments/assets/121f85bb-ae81-4d34-816f-28fcd7822012)

CD welcome page
![image](https://github.com/user-attachments/assets/3710f45b-2458-4468-b35c-26f7cb2f5d40)
