### PR TITLE
[DPC-4441] Add URI to logs where we log gzip

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/LogHeaderFilter.java
@@ -22,6 +22,6 @@ public class LogHeaderFilter implements ContainerRequestFilter {
 			headerValue = headerValue.replace(",", "\\,");
 		}
 
-		logger.info("{}={}", headerKey, headerValue);
+		logger.info("{}={}, uri={}", headerKey, headerValue, requestContext.getUriInfo().getRequestUri());
 	}
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/LogHeaderFilterUnitTest.java
@@ -5,10 +5,13 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.UriInfo;
+import org.glassfish.jersey.server.internal.routing.UriRoutingContext;
 import org.junit.jupiter.api.*;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URI;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -42,10 +45,17 @@ class LogHeaderFilterUnitTest {
 	@Test
 	void testLogsHeader() throws IOException {
 		final String headerValue = "fakeValue,fakervalue";
-		final String headerValueLogged = headerKey + "=fakeValue\\,fakervalue";
+        final String fakeUrl = "fake/fake/path";
+		final String fakeHeaderValueAdded = headerKey + "=fakeValue\\,fakervalue";
+        final String fakeUriValueAdded = "uri=" + fakeUrl;
+        final String headerValueLogged = fakeHeaderValueAdded + ", " + fakeUriValueAdded;
 
 		ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
 		when(requestContext.getHeaderString(headerKey)).thenReturn(headerValue);
+        final URI fakeUri = URI.create(fakeUrl);
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(uriInfo.getRequestUri()).thenReturn(fakeUri);
+        when(requestContext.getUriInfo()).thenReturn(uriInfo);
 
 		logHeaderFilter.filter(requestContext);
 


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4441](https://jira.cms.gov/browse/DPC-4441)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Add additional logging to include `uri` where we log gzip headers.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - currently there isn't a way to view which types of requests are gzipped
 - as a maintainer of the system, I want to know if the bulkiest endpoints containing more data get gzipped

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
