### PR TITLE
[DPC-4526] add workflow_call trigger to build and deploy action

### DIFF
--- a/.github/workflows/ecs-release.yml
+++ b/.github/workflows/ecs-release.yml
@@ -27,7 +27,25 @@ on:
         required: false
         type: 'string'
         default: 'main'
-      
+
+  workflow_call:
+    inputs:
+      env:
+        description: AWS environment to deploy to
+        required: true
+        type: 'string'
+        default: 'dev'
+      confirm_env:
+        description: Double check for environment
+        required: true
+        type: 'string'
+        default: ''
+      ops-ref:
+        description: Branch of dpc-ops to use
+        required: false
+        type: 'string'
+        default: 'main'
+
 concurrency:
   group: release-to-${{ inputs.env || 'dev' }}
   cancel-in-progress: false


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4526](https://jira.cms.gov/browse/DPC-4526)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Adds `workflow_call` to DPC - Build and Deploy github actions workflow file

## ℹ️ Context
 - This is 1 of 2 PR's. Additional changes required in dpc-ops.
 - This enables other workflows to reuse this functionality using the `uses` syntax.
 - In order to achieve feature parity w/ Jenkins, we will want to continuously deliver on merge to the [ops repository](https://github.com/CMSgov/dpc-ops) as well.
<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
