### PR TITLE
Me/dpc 2832 patient everything error fix

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
@@ -187,7 +187,7 @@ public class JobBatchProcessor {
                     Flowable.just(
                         AggregationUtils.toOperationOutcome(
                             failReason,
-                            FHIRExtractors.getPatientMBI(patient),
+                            patient.getId(),
                             OperationOutcome.IssueType.SUPPRESSED
                         )
                     ),

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
@@ -184,9 +184,15 @@ public class JobBatchProcessor {
             if (!passesLookBack(answers)) {
                 OutcomeReason failReason = LookBackAnalyzer.analyze(answers);
                 return Pair.of(
-                        Flowable.just(AggregationUtils.toOperationOutcome(failReason, FHIRExtractors.getPatientMBI(patient))),
-                        failReason
-                        );
+                    Flowable.just(
+                        AggregationUtils.toOperationOutcome(
+                            failReason,
+                            FHIRExtractors.getPatientMBI(patient),
+                            OperationOutcome.IssueType.SUPPRESSED
+                        )
+                    ),
+                    failReason
+                );
             }
         }
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/util/AggregationUtils.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/util/AggregationUtils.java
@@ -43,16 +43,4 @@ public final class AggregationUtils {
             .setLocation(patientLocation);
         return outcome;
     }
-
-    public static org.hl7.fhir.r4.model.OperationOutcome toOperationOutcomeV2(OutcomeReason failReason, String patientID) {
-        final var patientLocation = List.of(new org.hl7.fhir.r4.model.StringType("Patient"),
-                new org.hl7.fhir.r4.model.StringType("id"), new org.hl7.fhir.r4.model.StringType(patientID));
-        final var outcome = new org.hl7.fhir.r4.model.OperationOutcome();
-        outcome.addIssue()
-                .setSeverity(org.hl7.fhir.r4.model.OperationOutcome.IssueSeverity.ERROR)
-                .setCode(org.hl7.fhir.r4.model.OperationOutcome.IssueType.EXCEPTION)
-                .setDetails(new org.hl7.fhir.r4.model.CodeableConcept().setText(failReason.detail))
-                .setLocation(patientLocation);
-        return outcome;
-    }
 }

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/util/AggregationUtils.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/util/AggregationUtils.java
@@ -23,14 +23,24 @@ public final class AggregationUtils {
         }
     }
 
+    /**
+     * Returns an {@link OperationOutcome} of type Exception.
+     * @param failReason The reason the operation failed
+     * @param patientID The patient's ID
+     * @return {@link OperationOutcome}
+     */
     public static OperationOutcome toOperationOutcome(OutcomeReason failReason, String patientID) {
+        return toOperationOutcome(failReason, patientID, OperationOutcome.IssueType.EXCEPTION);
+    }
+
+    public static OperationOutcome toOperationOutcome(OutcomeReason failReason, String patientID, OperationOutcome.IssueType issueType) {
         final var patientLocation = List.of(new StringType("Patient"), new StringType("id"), new StringType(patientID));
         final var outcome = new OperationOutcome();
         outcome.addIssue()
-                .setSeverity(OperationOutcome.IssueSeverity.ERROR)
-                .setCode(OperationOutcome.IssueType.EXCEPTION)
-                .setDetails(new CodeableConcept().setText(failReason.detail))
-                .setLocation(patientLocation);
+            .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+            .setCode(issueType)
+            .setDetails(new CodeableConcept().setText(failReason.detail))
+            .setLocation(patientLocation);
         return outcome;
     }
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/util/AggregationUtils.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/util/AggregationUtils.java
@@ -33,6 +33,13 @@ public final class AggregationUtils {
         return toOperationOutcome(failReason, patientID, OperationOutcome.IssueType.EXCEPTION);
     }
 
+    /**
+     * Returns an {@link OperationOutcome} of type Exception.
+     * @param failReason The reason the operation failed
+     * @param patientID The patient's ID
+     * @param issueType The {@link OperationOutcome.IssueType} that lead to the {@link OperationOutcome}
+     * @return {@link OperationOutcome}
+     */
     public static OperationOutcome toOperationOutcome(OutcomeReason failReason, String patientID, OperationOutcome.IssueType issueType) {
         final var patientLocation = List.of(new StringType("Patient"), new StringType("id"), new StringType(patientID));
         final var outcome = new OperationOutcome();

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/util/AggregationUtilsUnitTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/util/AggregationUtilsUnitTest.java
@@ -1,0 +1,39 @@
+package gov.cms.dpc.aggregation.util;
+
+import gov.cms.dpc.aggregation.engine.OutcomeReason;
+import org.hl7.fhir.dstu3.model.OperationOutcome;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AggregationUtilsUnitTest {
+
+	@Test
+	void toOperationOutcome_happy_path() {
+		OutcomeReason outcomeReason = OutcomeReason.LOOK_BACK_NO_DATA;
+		String patientId = "patientId";
+		OperationOutcome.IssueType issueType = OperationOutcome.IssueType.SUPPRESSED;
+
+		OperationOutcome operationOutcome = AggregationUtils.toOperationOutcome(outcomeReason, patientId, issueType);
+		OperationOutcome.OperationOutcomeIssueComponent issue = operationOutcome.getIssueFirstRep();
+
+		assertEquals(1, operationOutcome.getIssue().size());
+		assertEquals(OutcomeReason.LOOK_BACK_NO_DATA.detail, issue.getDetails().getText());
+		assertTrue(issue.hasLocation(patientId));
+		assertEquals(issueType, issue.getCode());
+	}
+
+	@Test
+	void toOperationOutcome_default_IssueType() {
+		OutcomeReason outcomeReason = OutcomeReason.LOOK_BACK_NO_DATA;
+		String patientId = "patientId";
+
+		OperationOutcome operationOutcome = AggregationUtils.toOperationOutcome(outcomeReason, patientId);
+		OperationOutcome.OperationOutcomeIssueComponent issue = operationOutcome.getIssueFirstRep();
+
+		assertEquals(1, operationOutcome.getIssue().size());
+		assertEquals(OutcomeReason.LOOK_BACK_NO_DATA.detail, issue.getDetails().getText());
+		assertTrue(issue.hasLocation(patientId));
+		assertEquals(OperationOutcome.IssueType.EXCEPTION, issue.getCode());
+	}
+}

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -2,6 +2,7 @@ package gov.cms.dpc.api.resources.v1;
 
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import ca.uhn.fhir.validation.FhirValidator;
 import ca.uhn.fhir.validation.ResultSeverityEnum;
 import ca.uhn.fhir.validation.ValidationOptions;
@@ -63,7 +64,10 @@ public class PatientResource extends AbstractPatientResource {
     private final BlueButtonClient bfdClient;
 
     @Inject
-    public PatientResource(@Named("attribution") IGenericClient client, FhirValidator validator, DataService dataService, BlueButtonClient bfdClient) {
+    public PatientResource(@Named("attribution") IGenericClient client,
+                           FhirValidator validator,
+                           DataService dataService,
+                           BlueButtonClient bfdClient) {
         this.client = client;
         this.validator = validator;
         this.dataService = dataService;
@@ -228,9 +232,8 @@ public class PatientResource extends AbstractPatientResource {
         }
         if (DPCResourceType.OperationOutcome.getPath().equals(result.getResourceType().getPath())) {
             // An OperationOutcome (ERROR) was returned
-            OperationOutcome resultOp = (OperationOutcome) result;
-            // getIssueFirstRep() grabs the first issue only - there may be others
-            throw new WebApplicationException(resultOp.getIssueFirstRep().getDetails().getText(), Response.Status.FORBIDDEN);
+            OperationOutcome operationOutcome = (OperationOutcome) result;
+            throw new ForbiddenOperationException(operationOutcome.getIssueFirstRep().getDetails().getText(), operationOutcome);
         }
 
         throw new WebApplicationException(HttpStatus.INTERNAL_SERVER_ERROR_500);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -230,7 +230,7 @@ public class PatientResource extends AbstractPatientResource {
             // An OperationOutcome (ERROR) was returned
             OperationOutcome resultOp = (OperationOutcome) result;
             // getIssueFirstRep() grabs the first issue only - there may be others
-            throw new WebApplicationException(resultOp.getIssueFirstRep().getDetails().getText());
+            throw new WebApplicationException(resultOp.getIssueFirstRep().getDetails().getText(), Response.Status.FORBIDDEN);
         }
 
         throw new WebApplicationException(HttpStatus.INTERNAL_SERVER_ERROR_500);

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -27,7 +27,10 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpHeaders;
 import org.eclipse.jetty.http.HttpStatus;
 import org.hl7.fhir.dstu3.model.*;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -684,7 +687,10 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
         ForbiddenOperationException exception = assertThrows(ForbiddenOperationException.class, getEverythingOperation::execute,
             "Expected forbidden when retrieving patient that fails look back."
         );
-        assertTrue(exception.getResponseBody().contains("\"text\":\"DPC couldn't find any claims for this MBI; unable to demonstrate relationship with provider or organization\""),
+
+        OperationOutcome resultOperationOutcome = (OperationOutcome) exception.getOperationOutcome();
+        assertTrue(resultOperationOutcome.getIssueFirstRep().getDetails().getText().contains(
+            "DPC couldn't find any claims for this MBI; unable to demonstrate relationship with provider or organization"),
             "Incorrect or missing operation outcome in response body."
         );
     }

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceTest.java
@@ -7,7 +7,10 @@ import ca.uhn.fhir.rest.gclient.IOperationUntypedWithInput;
 import ca.uhn.fhir.rest.gclient.IReadExecutable;
 import ca.uhn.fhir.rest.gclient.IUpdateExecutable;
 import ca.uhn.fhir.rest.param.StringParam;
-import ca.uhn.fhir.rest.server.exceptions.*;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.UnprocessableEntityException;
 import gov.cms.dpc.aggregation.service.ConsentResult;
 import gov.cms.dpc.api.APITestHelpers;
 import gov.cms.dpc.api.AbstractSecureApplicationTest;
@@ -489,8 +492,11 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
                 .useHttpGet()
                 .withAdditionalHeader("X-Provenance", generateProvenance(ORGANIZATION_ID, practitioner.getId()));
 
-        InternalErrorException exception = assertThrows(InternalErrorException.class, getEverythingOperation::execute, "Expected Internal server error when retrieving opted out patient.");
-        assertTrue(exception.getResponseBody().contains("\"text\":\"Data not available for opted out patient\""), "Incorrect or missing operation outcome in response body.");
+        ForbiddenOperationException exception = assertThrows(ForbiddenOperationException.class, getEverythingOperation::execute,
+            "Expected Internal server error when retrieving opted out patient.");
+        OperationOutcome outcome = (OperationOutcome) exception.getOperationOutcome();
+        assertTrue(outcome.getIssueFirstRep().getDetails().getText().contains("Data not available for opted out patient"),
+            "Incorrect or missing operation outcome in response body.");
     }
 
     @Test
@@ -516,8 +522,11 @@ class PatientResourceTest extends AbstractSecureApplicationTest {
                 .useHttpGet()
                 .withAdditionalHeader("X-Provenance", generateProvenance(ORGANIZATION_ID, practitioner.getId()));
 
-        InternalErrorException exception = assertThrows(InternalErrorException.class, getEverythingOperation::execute, "Expected Internal server error when retrieving opted out patient.");
-        assertTrue(exception.getResponseBody().contains("\"text\":\"Data not available for opted out patient\""), "Incorrect or missing operation outcome in response body.");
+        ForbiddenOperationException exception = assertThrows(ForbiddenOperationException.class, getEverythingOperation::execute,
+            "Expected Internal server error when retrieving opted out patient.");
+        OperationOutcome outcome = (OperationOutcome) exception.getOperationOutcome();
+        assertTrue(outcome.getIssueFirstRep().getDetails().getText().contains("Data not available for opted out patient"),
+            "Incorrect or missing operation outcome in response body.");
     }
 
     @Test

--- a/src/main/resources/bb-test-data/patient/-20140000008325.json
+++ b/src/main/resources/bb-test-data/patient/-20140000008325.json
@@ -1,0 +1,107 @@
+{
+  "resourceType": "Bundle",
+  "id": "bc89bf94-d55f-4347-995d-0fa7e9c8d312",
+  "type": "searchset",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "-20140000008325",
+        "meta": {
+          "lastUpdated": "2023-04-26T15:19:31.964-04:00"
+        },
+        "extension": [
+          {
+            "url": "https://bluebutton.cms.gov/resources/variables/race",
+            "valueCoding": {
+              "system": "https://bluebutton.cms.gov/resources/variables/race",
+              "code": "5",
+              "display": "Hispanic"
+            }
+          },
+          {
+            "url": "https://bluebutton.cms.gov/resources/variables/rfrnc_yr",
+            "valueDate": "2023"
+          },
+          {
+            "url": "https://bluebutton.cms.gov/resources/variables/dual_01",
+            "valueCoding": {
+              "system": "https://bluebutton.cms.gov/resources/variables/dual_01",
+              "code": "NA",
+              "display": "Non-Medicaid"
+            }
+          },
+          {
+            "url": "https://bluebutton.cms.gov/resources/variables/dual_02",
+            "valueCoding": {
+              "system": "https://bluebutton.cms.gov/resources/variables/dual_02",
+              "code": "NA",
+              "display": "Non-Medicaid"
+            }
+          },
+          {
+            "url": "https://bluebutton.cms.gov/resources/variables/dual_03",
+            "valueCoding": {
+              "system": "https://bluebutton.cms.gov/resources/variables/dual_03",
+              "code": "NA",
+              "display": "Non-Medicaid"
+            }
+          },
+          {
+            "url": "https://bluebutton.cms.gov/resources/variables/dual_04",
+            "valueCoding": {
+              "system": "https://bluebutton.cms.gov/resources/variables/dual_04",
+              "code": "NA",
+              "display": "Non-Medicaid"
+            }
+          },
+          {
+            "url": "https://bluebutton.cms.gov/resources/variables/dual_05",
+            "valueCoding": {
+              "system": "https://bluebutton.cms.gov/resources/variables/dual_05",
+              "code": "NA",
+              "display": "Non-Medicaid"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://bluebutton.cms.gov/resources/variables/bene_id",
+            "value": "-20140000008325"
+          },
+          {
+            "extension": [
+              {
+                "url": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+                "valueCoding": {
+                  "system": "https://bluebutton.cms.gov/resources/codesystem/identifier-currency",
+                  "code": "current",
+                  "display": "Current"
+                }
+              }
+            ],
+            "system": "http://hl7.org/fhir/sid/us-mbi",
+            "value": "2SW4N00AA00"
+          }
+        ],
+        "name": [
+          {
+            "use": "usual",
+            "family": "Ruecker817",
+            "given": [
+              "Kurt412"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1972-11-11",
+        "address": [
+          {
+            "state": "05",
+            "postalCode": "92596"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-2832

## 🛠 Changes

- When a patient fails look back, dpc-aggregation returns a more descriptive `OperationOutcome` to dpc-api.
- `OperationOutcome` issue type is set to SURPRESSED.
- `OperationOutcome` location is set to the patient's fhir resource id instead of their MBI.
- On a `patient/$everything` failed look back, dpc-api throws a `ForbiddenOperationException`, which returns a 403 and the `OperationOutcome` from dpc-aggregation to the caller.


## ℹ️ Context

When calling `patient/$everything`, if the patient failed its look back check dpc-api would return a generic internal server error.  Customers were complaining and wanted something more specific.

## 🧪 Validation

Ran locally and added integration tests to check functionality.
