### PR TITLE
Run dpc-load-test workflow with authorization turned off test

### DIFF
--- a/.github/workflows/dpc-load-test.yml
+++ b/.github/workflows/dpc-load-test.yml
@@ -10,31 +10,54 @@ on:
         default: 'main'
 
 jobs:
+  set-parameters:
+    # Environments atart up much more quickly when deploying same image
+    runs-on: self-hosted
+    outputs:
+      app_version: ${{ steps.fetch-info.outputs.app_version }}
+      ecr_image_tag: ${{ steps.fetch-info.outputs.ecr_image_tag }}
+      admin_url: ${{ steps.fetch-info.outputs.admin_url }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
+      - name: "Fetch Image and App Version from AWS"
+        id: fetch-info
+        run: |
+          SERVICE_INFO=$(aws ecs describe-services --services dpc-test-api-v9 --cluster dpc-test-frontend --query "services[0].deployments[0]")
+          TASK_DEFINITION=`echo $SERVICE_INFO | jq -r '.taskDefinition | split(":")[-1]'`
+          TASK_INFO=`aws ecs describe-task-definition --task-definition dpc-test-api:$TASK_DEFINITION --query "taskDefinition.containerDefinitions[0].{Image: image, Version: environment[?name=='APP_VERSION'].value | [0]}"`
+          IMAGE_TAG=`echo $TASK_INFO | jq -r '.Image | split(":")[1]'`
+          echo $IMAGE_TAG
+          echo "ecr_image_tag=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          APP_VERSION=`echo $TASK_INFO | jq -r '.Version'`
+          echo $APP_VERSION
+          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+          ADMIN_URL=$(aws elbv2 describe-load-balancers --names dpc-test-frontend-internal | jq -r '.LoadBalancers[0].DNSName')
+          echo "admin_url=$ADMIN_URL" >> "$GITHUB_OUTPUT"
+
   start-test-with-auth-disabled:
     name: "Start test environment with auth disabled"
+    needs: set-parameters
     uses: ./.github/workflows/ecs-deploy.yml
     with:
       env: 'test'
       confirm_env: 'test'
       ops-ref: ${{ inputs.ops-ref }}
+      ecr_image_tag: ${{ needs.set-parameters.outputs.ecr_image_tag }}
+      app-version: ${{ needs.set-parameters.outputs.app_version }}
       auth-disabled: 'true'
     secrets: inherit
 
   run-load-test:
     name: "Run DPC API Load Test"
     runs-on: self-hosted
-    needs: start-test-with-auth-disabled
+    needs:
+      - set-parameters
+      - start-test-with-auth-disabled
     steps:
-      - name: AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-test-github-actions
-      - name: Get admin url
-        id: admin-url
-        run: |
-          ADMIN_URL=$(aws elbv2 describe-load-balancers --names dpc-test-frontend-internal | jq -r '.LoadBalancers[0].DNSName')
-          echo "admin_url=$ADMIN_URL" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -58,7 +81,7 @@ jobs:
       - name: Run K6 with StatsD output
         env:
           ENVIRONMENT: 'test'
-          API_ADMIN_URL: ${{ steps.admin-url.outputs.admin_url }}
+          API_ADMIN_URL: ${{ needs.set-parameters.outputs.admin_url }}
         run: |
           ./k6 run \
             --out output-statsd=addr=localhost:8125,enableTags=true \
@@ -73,15 +96,18 @@ jobs:
             docker rm newrelic-statsd
           fi
   restart-test-with-auth-enabled:
-    if: ${{ always() }}
+    if: ${{ always() && needs.start-test-with-auth-disabled.result == 'success' }}
     name: "Restart test environment with auth enabled"
-    needs: run-load-test
+    needs:
+      - start-test-with-auth-disabled
+      - run-load-test
+      - set-parameters
     uses: ./.github/workflows/ecs-deploy.yml
     with:
       env: 'test'
       confirm_env: 'test'
       ops-ref: ${{ inputs.ops-ref }}
-      ecr_image_tag: 'rls-r190-202503122037-13821075659'
-      app-version: 'r190'
+      ecr_image_tag: ${{ needs.set-parameters.outputs.ecr_image_tag }}
+      app-version: ${{ needs.set-parameters.outputs.app_version }}
       auth-disabled: 'false'
     secrets: inherit

--- a/.github/workflows/dpc-load-test.yml
+++ b/.github/workflows/dpc-load-test.yml
@@ -2,18 +2,43 @@ name: DPC Load Test
 
 on:
   workflow_dispatch:
+    inputs:
+      ops-ref:
+        description: Branch of dpc-ops to use
+        required: false
+        type: 'string'
+        default: 'main'
 
 jobs:
+  start-test-with-auth-disabled:
+    name: "Start test environment with auth disabled"
+    uses: ./.github/workflows/ecs-deploy.yml
+    with:
+      env: 'test'
+      confirm_env: 'test'
+      ops-ref: ${{ inputs.ops-ref }}
+      auth-disabled: 'true'
+    secrets: inherit
+
   run-load-test:
     name: "Run DPC API Load Test"
     runs-on: self-hosted
 
     steps:
+      - name: AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-test-github-actions
+      - name: Get admin url
+        id: admin-url
+        run: |
+          ADMIN_URL=$(aws elbv2 describe-load-balancers --names dpc-test-frontend-internal | jq -r '.LoadBalancers[0].DNSName')
+          echo "admin_url=$ADMIN_URL" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@v4
         with:
           path: ./dpc-app
-
       - name: Start StatsD Integration
         run: |
           docker run -d \
@@ -32,8 +57,8 @@ jobs:
 
       - name: Run K6 with StatsD output
         env:
-          LOAD_TEST_ORGANIZATION_ID: ${{ secrets.LOAD_TEST_ORGANIZATION_ID }}
-          API_ADMIN_URL: ${{ secrets.API_ADMIN_URL }}
+          ENVIRONMENT: 'test'
+          API_ADMIN_URL: ${{ steps.admin-url.outputs.admin_url }}
         run: |
           ./k6 run \
             --out output-statsd=addr=localhost:8125,enableTags=true \
@@ -47,3 +72,14 @@ jobs:
             docker stop newrelic-statsd
             docker rm newrelic-statsd
           fi
+  restart-test-with-auth-enabled:
+    name: "Restart test environment with auth enabled"
+    uses: ./.github/workflows/ecs-deploy.yml
+    with:
+      env: 'test'
+      confirm_env: 'test'
+      ops-ref: ${{ inputs.ops-ref }}
+      ecr_image_tag: 'rls-r190-202503122037-13821075659'
+      app-version: 'r190'
+      auth-disabled: 'false'
+    secrets: inherit

--- a/.github/workflows/dpc-load-test.yml
+++ b/.github/workflows/dpc-load-test.yml
@@ -23,7 +23,7 @@ jobs:
   run-load-test:
     name: "Run DPC API Load Test"
     runs-on: self-hosted
-
+    needs: start-test-with-auth-disabled
     steps:
       - name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -73,7 +73,9 @@ jobs:
             docker rm newrelic-statsd
           fi
   restart-test-with-auth-enabled:
+    if: ${{ always() }}
     name: "Restart test environment with auth enabled"
+    needs: run-load-test
     uses: ./.github/workflows/ecs-deploy.yml
     with:
       env: 'test'

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -84,7 +84,7 @@ jobs:
           echo "Target deployment environment \"${{ inputs.env }}\" must be specified and match confirmed deployment environment \"${{ inputs.confirm_env }}\"."
           exit 1
       - name: Run and Fail if auth disabled but not test environment
-        if: ${{ inputs.disable-auth == "true" && inputs.env != "test" }}
+        if: ${{ inputs.disable-auth == 'true' && inputs.env != 'test' }}
         run: |
           echo "Target deployment environment \"${{ inputs.env }}\" must == \"test\" if auth disabled"
           exit 1
@@ -152,13 +152,13 @@ jobs:
           cd dpc-ops/terraform/${{ inputs.env }}/persistent
           terraform apply dpc-release-${{ inputs.env }}.tfplan
       - name: Verify main environment plan
-        if: ${{ inputs.disable-auth != "true" }}
+        if: ${{ inputs.disable-auth != 'true' }}
         run: |
           cd dpc-ops/terraform/${{ inputs.env }}
           terraform init
           terraform plan -var 'release_version=${{ inputs.app-version}}' -var 'aggregation_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'api_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'attribution_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'consent_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_admin_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_portal_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_image_tag=${{ steps.image-tag.outputs.image_tag }}' -out dpc-release-${{ inputs.env }}.tfplan
       - name: Verify main environment plan with auth disabled (test environment only)
-        if: ${{ inputs.disable-auth == "true" }}
+        if: ${{ inputs.disable-auth == 'true' }}
         run: |
           cd dpc-ops/terraform/test
           terraform init

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -55,6 +55,11 @@ on:
         required: false
         type: 'string'
         default: 'main'
+      disable-auth:
+        description: Set AUTH_DISABLED flag to true (test environment only)
+        required: false
+        type: 'string'
+        default: 'false'
 
 concurrency:
   group: deploy-to-${{ inputs.env }}
@@ -73,10 +78,15 @@ jobs:
     outputs:
       image_tag: ${{ steps.image-tag.outputs.image_tag }}
     steps:
-      - name: Run and Fail if Inputs Invalid
+      - name: Run and Fail if env not match confirm env
         if: ${{ inputs.env != inputs.confirm_env }}
         run: |
           echo "Target deployment environment \"${{ inputs.env }}\" must be specified and match confirmed deployment environment \"${{ inputs.confirm_env }}\"."
+          exit 1
+      - name: Run and Fail if auth disabled but not test environment
+        if: ${{ inputs.disable-auth == "true" && inputs.env != "test" }}
+        run: |
+          echo "Target deployment environment \"${{ inputs.env }}\" must == \"test\" if auth disabled"
           exit 1
       - name: Install Dependencies
         run: |
@@ -142,10 +152,17 @@ jobs:
           cd dpc-ops/terraform/${{ inputs.env }}/persistent
           terraform apply dpc-release-${{ inputs.env }}.tfplan
       - name: Verify main environment plan
+        if: ${{ inputs.disable-auth != "true" }}
         run: |
           cd dpc-ops/terraform/${{ inputs.env }}
           terraform init
           terraform plan -var 'release_version=${{ inputs.app-version}}' -var 'aggregation_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'api_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'attribution_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'consent_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_admin_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_portal_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_image_tag=${{ steps.image-tag.outputs.image_tag }}' -out dpc-release-${{ inputs.env }}.tfplan
+      - name: Verify main environment plan with auth disabled (test environment only)
+        if: ${{ inputs.disable-auth == "true" }}
+        run: |
+          cd dpc-ops/terraform/test
+          terraform init
+          terraform plan -var 'release_version=${{ inputs.app-version}}' -var 'aggregation_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'api_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'attribution_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'consent_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_admin_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_portal_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'auth_disabled=true' -out dpc-release-test.tfplan
       - name: Apply main environment plan
         run: |
           cd dpc-ops/terraform/${{ inputs.env }}

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -55,7 +55,7 @@ on:
         required: false
         type: 'string'
         default: 'main'
-      disable-auth:
+      auth-disabled:
         description: Set AUTH_DISABLED flag to true (test environment only)
         required: false
         type: 'string'
@@ -84,7 +84,7 @@ jobs:
           echo "Target deployment environment \"${{ inputs.env }}\" must be specified and match confirmed deployment environment \"${{ inputs.confirm_env }}\"."
           exit 1
       - name: Run and Fail if auth disabled but not test environment
-        if: ${{ inputs.disable-auth == 'true' && inputs.env != 'test' }}
+        if: ${{ inputs.auth-disabled == 'true' && inputs.env != 'test' }}
         run: |
           echo "Target deployment environment \"${{ inputs.env }}\" must == \"test\" if auth disabled"
           exit 1
@@ -152,13 +152,13 @@ jobs:
           cd dpc-ops/terraform/${{ inputs.env }}/persistent
           terraform apply dpc-release-${{ inputs.env }}.tfplan
       - name: Verify main environment plan
-        if: ${{ inputs.disable-auth != 'true' }}
+        if: ${{ inputs.auth-disabled != 'true' }}
         run: |
           cd dpc-ops/terraform/${{ inputs.env }}
           terraform init
           terraform plan -var 'release_version=${{ inputs.app-version}}' -var 'aggregation_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'api_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'attribution_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'consent_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_admin_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_portal_image_tag=${{ steps.image-tag.outputs.image_tag }}' -var 'web_image_tag=${{ steps.image-tag.outputs.image_tag }}' -out dpc-release-${{ inputs.env }}.tfplan
       - name: Verify main environment plan with auth disabled (test environment only)
-        if: ${{ inputs.disable-auth == 'true' }}
+        if: ${{ inputs.auth-disabled == 'true' }}
         run: |
           cd dpc-ops/terraform/test
           terraform init

--- a/dpc-load-testing/dpc-api-client.js
+++ b/dpc-load-testing/dpc-api-client.js
@@ -4,7 +4,6 @@ import {
   generateProviderResourceBody,
   generatePatientResourceBody
 } from "./resource-request-bodies.js"
-import tokenCache from './generate-dpc-token.js';
 
 const urlRoot = __ENV.ENVIRONMENT == 'local' ? 'http://host.docker.internal:3002/v1' : 'https://test.dpc.cms.gov/api/v1';
 
@@ -12,7 +11,6 @@ export function createOrganization(npi, name) {
   const body = generateOrganizationResourceBody(npi, name);
   const res = http.post(`${urlRoot}/Organization/$submit`, JSON.stringify(body), {
     headers: {
-      'Authorization': `Bearer ${tokenCache.goldenMacaroon}`,
       'Content-Type': 'application/fhir+json',
       'Accept': 'application/fhir+json'
     }
@@ -21,11 +19,11 @@ export function createOrganization(npi, name) {
   return res;
 }
 
-export function createProvider(npi) {
+export function createProvider(npi, orgId) {
   const body = generateProviderResourceBody(npi);
   const res = http.post(`${urlRoot}/Practitioner`, JSON.stringify(body), {
     headers: {
-      'Authorization': `Bearer ${tokenCache.token}`,
+      'Organization': orgId,
       'Content-Type': 'application/fhir+json',
       'Accept': 'application/fhir+json'
     }
@@ -34,11 +32,11 @@ export function createProvider(npi) {
   return res;
 }
 
-export function createPatient(mbi) {
+export function createPatient(mbi, orgId) {
   const body = generatePatientResourceBody(mbi);
   const res = http.post(`${urlRoot}/Patient`, JSON.stringify(body), {
     headers: {
-      'Authorization': `Bearer ${tokenCache.token}`,
+      'Organization': orgId,
       'Content-Type': 'application/fhir+json',
       'Accept': 'application/fhir+json'
     }
@@ -48,9 +46,9 @@ export function createPatient(mbi) {
 }
 
 export function getOrganization(id) {
-  const res = http.get(`${urlRoot}/Organization/${id}`, {
+  const res = http.get(`${urlRoot}/Organization`, {
     headers: {
-      'Authorization': `Bearer ${tokenCache.token}`,
+      'Organization': id,
       'Content-Type': 'application/fhir+json',
       'Accept': 'application/fhir+json'
     }
@@ -62,7 +60,6 @@ export function getOrganization(id) {
 export function deleteOrganization(id) {
   const res = http.del(`${urlRoot}/Organization/${id}`, null, {
     headers: {
-      'Authorization': `Bearer ${tokenCache.goldenMacaroon}`,
       'Content-Type': 'application/fhir+json',
       'Accept': 'application/fhir+json'
     }

--- a/dpc-load-testing/dpc-api-client.js
+++ b/dpc-load-testing/dpc-api-client.js
@@ -7,6 +7,17 @@ import {
 
 const urlRoot = __ENV.ENVIRONMENT == 'local' ? 'http://host.docker.internal:3002/v1' : 'https://test.dpc.cms.gov/api/v1';
 
+export function findByNpi(npiA, npiB) {
+  const res = http.get(`${urlRoot}/Admin/Organization?npis=npi|${npiA},${npiB}`, {
+    headers: {
+      'Content-Type': 'application/fhir+json',
+      'Accept': 'application/fhir+json'
+    }
+  });
+
+  return res;
+}
+
 export function createOrganization(npi, name) {
   const body = generateOrganizationResourceBody(npi, name);
   const res = http.post(`${urlRoot}/Organization/$submit`, JSON.stringify(body), {

--- a/dpc-load-testing/generate-dpc-token.js
+++ b/dpc-load-testing/generate-dpc-token.js
@@ -1,6 +1,7 @@
 import http from 'k6/http';
 
 const adminUrl = __ENV.ENVIRONMENT == 'local' ? 'http://host.docker.internal:9903' : __ENV.API_ADMIN_URL;
+const goldenMacaroon = __ENV.GOLDEN_MACAROON;
 
 const fetchGoldenMacaroonURL = `${adminUrl}/tasks/generate-token`
 const fetchTokenURL = id => `${fetchGoldenMacaroonURL}?organization=${id}`;
@@ -29,6 +30,7 @@ class TokenCache {
 }
 
 export function fetchGoldenMacaroon() {
+  if (goldenMacaroon) { return goldenMacaroon }
   const headers = { 
     'Accept': 'application/json',
     'Content-Type': 'application/x-www-form-urlencoded'

--- a/dpc-load-testing/generate-dpc-token.js
+++ b/dpc-load-testing/generate-dpc-token.js
@@ -1,7 +1,6 @@
 import http from 'k6/http';
 
 const adminUrl = __ENV.ENVIRONMENT == 'local' ? 'http://host.docker.internal:9903' : __ENV.API_ADMIN_URL;
-const testOrgId = __ENV.LOAD_TEST_ORGANIZATION_ID;
 
 const fetchGoldenMacaroonURL = `${adminUrl}/tasks/generate-token`
 const fetchTokenURL = id => `${fetchGoldenMacaroonURL}?organization=${id}`;

--- a/dpc-load-testing/script.js
+++ b/dpc-load-testing/script.js
@@ -1,7 +1,6 @@
 import { check, fail } from 'k6';
 import exec from 'k6/execution'
-import tokenCache, { generateDPCToken, fetchGoldenMacaroon } from './generate-dpc-token.js';
-import { createOrganization, deleteOrganization, getOrganization } from './dpc-api-client.js';
+import { createOrganization, deleteOrganization, findByNpi, getOrganization } from './dpc-api-client.js';
 
 // See https://grafana.com/docs/k6/latest/using-k6/k6-options/reference for
 // details on this configuration object.
@@ -25,6 +24,12 @@ export const options = {
 // Sets up two test organizations
 export function setup() {
   // Fake NPIs generated online: https://jsfiddle.net/alexdresko/cLNB6
+  const existingOrgs = findByNpi('2782823019', '8197402604').json();
+  if ( existingOrgs.total ) {
+    for ( const entry of existingOrgs.entry ) {
+      deleteOrganization(entry.resource.id);
+    }
+  }
   const org1 = createOrganization('2782823019', 'Test Org 1');
   const org2 = createOrganization('8197402604', 'Test Org 2');
 

--- a/dpc-load-testing/script.js
+++ b/dpc-load-testing/script.js
@@ -22,11 +22,8 @@ export const options = {
   }
 };
 
-let goldenMacaroon;
-
 // Sets up two test organizations
 export function setup() {
-  tokenCache.setGoldenMacaroon();
   // Fake NPIs generated online: https://jsfiddle.net/alexdresko/cLNB6
   const org1 = createOrganization('2782823019', 'Test Org 1');
   const org2 = createOrganization('8197402604', 'Test Org 2');
@@ -62,14 +59,6 @@ export function setup() {
 
 export function workflowA(data) {
   const orgId = data[exec.vu.idInInstance];
-  const tokenResponse = generateDPCToken(orgId);
-  if (tokenResponse.status.toString() == '200') {
-    tokenCache.setToken(orgId, tokenResponse.body);
-    console.log('bearer token for workflow A fetched successfully!');
-  } else {
-    fail('failed to fetch bearer token for workflow A');
-  }
-  
   const orgResponse = getOrganization(orgId);
   const checkOutput = check(
     orgResponse, 
@@ -83,14 +72,6 @@ export function workflowA(data) {
 
 export function workflowB(data) {
   const orgId = data[exec.vu.idInInstance];
-  const tokenResponse = generateDPCToken(orgId);
-  if (tokenResponse.status.toString() == '200') {
-    tokenCache.setToken(orgId, tokenResponse.body);
-    console.log('bearer token for workflow B fetched successfully!');
-  } else {
-    fail('failed to fetch bearer token for workflow B');
-  }
-
   const orgResponse = getOrganization(orgId);
   const checkOutput = check(
     orgResponse, 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4565

## 🛠 Changes

- dpc-load-test.yml added stanzas to startup test environment with auth disabled then start again with auth enabled
- Token management removed from load test script.

## ℹ️ Context

The API is not set up to handle dynamic org generation and teardown with authorization enabled, so we need to run performance tests with auth disabled.
In dpc-ops, only test accepts the variable to run without auth, and there are additional checks in the workflows to ensure that it only runs against test.

## 🧪 Validation

Ran load tests on test environment generation and teardown of organizations: https://github.com/CMSgov/dpc-app/actions/runs/13907244565

