### PR TITLE
Fix accessibility test issues

### DIFF
--- a/dpc-portal/docker/accessibility-test.sh
+++ b/dpc-portal/docker/accessibility-test.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 
+apk update
+apk add --no-cache icu-data-full
 apk add --no-cache firefox
 ACCESSIBILITY=true bundle exec rspec --tag type:system --format documentation

--- a/dpc-portal/spec/system/accessibility_spec.rb
+++ b/dpc-portal/spec/system/accessibility_spec.rb
@@ -378,14 +378,14 @@ RSpec.describe 'Accessibility', type: :system do
     it 'should show accept page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
-      expect(page).to have_text('Step 2')
+      expect(page).to have_text('Step 3')
       expect(page).to be_axe_clean
     end
     it 'should show register page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
       page.find('.usa-button', text: 'Continue to register').click
-      expect(page).to have_text('Step 3')
+      expect(page).to have_text('Step 4')
       expect(page).to be_axe_clean
     end
     it 'should show success page' do
@@ -393,7 +393,7 @@ RSpec.describe 'Accessibility', type: :system do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
       page.find('.usa-button', text: 'Continue to register').click
       page.find('.usa-button', text: 'Complete registration').click
-      expect(page).to have_text('Step 4')
+      expect(page).to have_text('Step 5')
       expect(page).to be_axe_clean
     end
     context :failure do


### PR DESCRIPTION
## 🎫 Ticket
No ticket

## 🛠 Changes

- Accessibility test entrypoint adds icu-data-full before adding firefox
- Tests updated

## ℹ️ Context

For some reason, an update to the the ruby docker image made it so the icu-data-full needs to be explicitly added before firefox before it will install.
We also updated the invitation flow, which required a fix to the tests

## 🧪 Validation

Accessibility tests run locally and on GHA with only accessibility failures.
