### PR TITLE
Fix consent test

### DIFF
--- a/dpc-consent/src/test/java/gov/cms/dpc/consent/resources/ConsentResourceUnitTest.java
+++ b/dpc-consent/src/test/java/gov/cms/dpc/consent/resources/ConsentResourceUnitTest.java
@@ -57,7 +57,6 @@ public class ConsentResourceUnitTest {
         // Broke when introducing findBy
         ConsentEntity goodRecord = ConsentEntity.defaultConsentEntity(Optional.of(TEST_ID), Optional.of(TEST_HICN), Optional.of(TEST_MBI));
         List<ConsentEntity> goodRecordList = List.of(goodRecord);
-        when(mockedDAO.getConsent(null)).thenThrow(new IllegalArgumentException("empty"));
         when(mockedDAO.getConsent(TEST_ID)).thenReturn(Optional.of(goodRecord));
         when(mockedDAO.findBy("mbi", TEST_MBI)).thenReturn(goodRecordList);
         when(mockedDAO.findBy("hicn", TEST_HICN)).thenReturn(goodRecordList);


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4579

## 🛠 Changes

Fixes inconsistent error in test and changes exception handling to be more verbose.

## ℹ️ Context

Race condition where consent resource's meta lastUpdated was being accessed before being set.

`com.fasterxml.jackson.databind.JsonMappingException: InstantType contains null value (through reference chain: org.hl7.fhir.dstu3.model.Consent["meta"]->org.hl7.fhir.dstu3.model.Meta["lastUpdatedElement"]->org.hl7.fhir.dstu3.model.InstantType["today"])`

## 🧪 Validation

Ran 20k times without failure.
![Screenshot 2025-04-03 at 9 01 12 AM](https://github.com/user-attachments/assets/694c5776-2a96-4ce3-84be-4711595949b3)
