### PR TITLE
[dpc-4593] Update login.gov link

### DIFF
--- a/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
@@ -12,5 +12,5 @@
   Sign in with <span class="login-button__logo">Login.gov</span>
   <% end %>
   <%= render(Core::Navigation::SystemUseAgreementLinkComponent.new) %>
-  <div><%= link_to 'How to verify your identity', 'https://login.gov/help/verify-your-identity/how-to-verify-your-identity/' %> <%= link_to 'Login.gov help', 'https://www.login.gov/help/', target: :_blank, class: 'margin-left-2' %></div>
+  <div><%= link_to 'How to verify your identity', 'https://login.gov/help/verify-your-identity/how-to-verify-your-identity/', target: :_blank %> <%= link_to 'Login.gov help', 'https://www.login.gov/help/', target: :_blank, class: 'margin-left-2' %></div>
 </div>

--- a/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
@@ -12,5 +12,5 @@
   Sign in with <span class="login-button__logo">Login.gov</span>
   <% end %>
   <%= render(Core::Navigation::SystemUseAgreementLinkComponent.new) %>
-  <div><%= link_to 'How to verify your identity', 'https://login.gov/help/verify-your-identity/how-to-verify-your-identity/' %> <%= link_to 'Login.gov FAQ', 'https://www.login.gov/help/', class: 'margin-left-2' %></div>
+  <div><%= link_to 'How to verify your identity', 'https://login.gov/help/verify-your-identity/how-to-verify-your-identity/' %> <%= link_to 'Login.gov help', 'https://www.login.gov/help/', target: :_blank, class: 'margin-left-2' %></div>
 </div>


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4593

## 🛠 Changes

- Update "Login.gov FAQ" link to "Login.gov help" on sign in or create page.
- Updated link to open in new tab.

## ℹ️ Context

Changes asked for by design/content after UAT.

## 🧪 Validation

Ran locally.
<img width="800" alt="Screenshot 2025-03-28 at 9 24 52 AM" src="https://github.com/user-attachments/assets/ccce66f9-6475-4024-9444-d838e2951493" />


