### PR TITLE
Update home buttons

### DIFF
--- a/dpc-portal/app/components/page/invitations/bad_invitation_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/bad_invitation_component.html.erb
@@ -18,11 +18,7 @@
         <% end %>
       <% when :cd_accepted %>
         <%= render Core::Button::ButtonComponent.new(label: "Go to DPC home",
-            destination: 'https://dpc.cms.gov/',
-            method: :get) %>
-      <% when :invalid %>
-        <%= render Core::Button::ButtonComponent.new(label: "Go to DPC home",
-            destination: 'https://dpc.cms.gov/',
+            destination: root_path,
             method: :get) %>
       <% when :pii_mismatch %>
         <%= render Core::Button::ButtonComponent.new(label: "Sign out of Login.gov",

--- a/dpc-portal/spec/components/page/invitations/bad_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/bad_invitation_component_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Page::Invitations::BadInvitationComponent, type: :component do
       end
 
       it 'should have Go to DPC home button' do
-        button_url = 'https://dpc.cms.gov/'
+        button_url = '/portal/'
         is_expected.to include(button_url)
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4592

## 🛠 Changes

- Removed "Go to DPC home" button from invalid invitation page.
- Updated "Go to DPC home" button on CD already accepted page to point to sign in page.

## ℹ️ Context

Changes requested from content/design.

## 🧪 Validation

Ran locally and all tests pass.

Invalid Invitation:
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/2d9f6462-1325-4caf-8e69-b2e0cc203183" />

CD Already Accepted:
<img width="1007" alt="image" src="https://github.com/user-attachments/assets/8f89dc23-0f4e-4f68-a94d-7c05a7011071" />

