### PR TITLE
Update it-debug make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,16 +117,17 @@ start-macaroon-tests:
 
 .PHONY: start-dpc-debug
 start-dpc-debug: secure-envs
+	@docker compose down
 	@mvn clean install -Pci -Pdebug -DskipTests -ntp
-	@DEBUG_MODE=true docker compose -f docker-compose.yml up aggregation api --wait
-	@docker compose -f docker-compose.yml -f docker-compose.portals.yml up dpc_web dpc_admin dpc_portal --wait
+	@DEBUG_MODE=true docker compose up aggregation api --wait
+	@docker compose -f docker-compose.yml -f docker-compose.portals.yml -f docker-compose.override.yml up dpc_web dpc_admin dpc_portal --wait
 	@docker ps
 
 .PHONY: start-app-debug
 start-app-debug: secure-envs
 	@docker compose down
 	@mvn clean install -Pci -Pdebug -DskipTests -ntp
-	@DEBUG_MODE=true docker compose -f docker-compose.yml up api aggregation --wait
+	@DEBUG_MODE=true docker compose up api aggregation --wait
 
 .PHONY: start-it-debug
 start-it-debug: secure-envs


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4583

## 🛠 Changes

Makefile targets `start-app-debug` and `start-it-debug` updated so they start the system with the debugger and db ports open.

## ℹ️ Context

In testing, it was noticed that `start-dpc-debug` and `start-app-debug` weren't opening the DB port for easier debugging.

## 🧪 Validation

Ran locally and verified that the DB and debugger ports are open.
