### PR TITLE
[Bugfix] Lookbook preview fix for compound_show_component

### DIFF
--- a/dpc-portal/app/components/page/organization/compound_show_component_preview.rb
+++ b/dpc-portal/app/components/page/organization/compound_show_component_preview.rb
@@ -6,15 +6,14 @@ module Page
     class CompoundShowComponentPreview < ViewComponent::Preview
       def authorized_official
         org = ProviderOrganization.new(name: 'Health Hut', npi: '1111111111', id: 2)
-        status_display = { icon: 'verified', classes: %i[text-accent-cool], status: 'Manage your organization.' }
+        status_display = ['verified', %i[text-accent-cool], 'Manage your organization.']
         render(Page::Organization::CompoundShowComponent.new(org, { active: [], pending: [], expired: [] }, true,
                                                              'Authorized Official', status_display))
       end
 
       def credential_delegate
         org = ProviderOrganization.new(name: 'Health Hut', npi: '1111111111', id: 2)
-        status_display = { icon: 'lock', classes: %i[text-gray-50],
-                           status: 'Your organization is in the Medicare Exclusions Database.' }
+        status_display = ['lock', %i[text-gray-50], 'Your organization is in the Medicare Exclusions Database.']
         render(Page::Organization::CompoundShowComponent.new(org, {}, true, 'Credential Delegate', status_display))
       end
     end


### PR DESCRIPTION
## 🎫 Ticket

None

## 🛠 Changes

Updated Page -> Organization -> Compound Show -> Authorized Official and Credential Delegate to no longer error out.

## ℹ️ Context

Noticed while using Lookbook that these were failing.

## 🧪 Validation

Run Lookbook and see that the previews work again.
