### PR TITLE
DPC-4660 Patient Aggregation Logs

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
@@ -128,9 +128,20 @@ public class JobBatchProcessor {
         queue.completePartialBatch(job, aggregatorID);
 
         final String resourcesRequested = job.getResourceTypes().stream().map(DPCResourceType::getPath).collect(Collectors.joining(";"));
+
+        final String resourceFileSizes = job.getResourceTypes().stream()
+                .map(resourceType -> String.format("%s=%s",
+                        resourceType.getPath(),
+                        job.getJobQueueBatchFiles().stream()
+                                .filter(file -> file.getResourceType().equals(resourceType))
+                                .mapToLong(JobQueueBatchFile::getFileLength)
+                                .sum()))
+                .collect(Collectors.joining(";"));
+
         final String failReasonLabel = failReason.map(Enum::name).orElse("NA");
         stopWatch.stop();
-        logger.info("dpcMetric=DataExportResult,dataRetrieved={},failReason={},resourcesRequested={},duration={}", failReason.isEmpty(), failReasonLabel, resourcesRequested, stopWatch.getDuration());
+        logger.info("dpcMetric=DataExportResult,PatientMbi {}, AggregatorId {}, dataRetrieved={},failReason={},resourcesRequested={},duration={} , resourceFileSizes={}",
+                mbi, aggregatorID,failReason.isEmpty(), failReasonLabel, resourcesRequested, stopWatch.getDuration(),resourceFileSizes);
         return results;
     }
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
@@ -131,9 +131,10 @@ public class JobBatchProcessor {
         AtomicReference<String> fileSize = new AtomicReference<>("");
         results.forEach(file -> {
                     if (file.getResourceType() != null) {
-                        fileSize.set(fileSize + file.getResourceType().name() + ":" + file.getFileLength() + ";");
+                        fileSize.set(fileSize + file.getResourceType().name() + ":" + file.getPatientFileSize() + ";");
                     }
                 });
+
         double durationInSeconds = stopWatch.getDuration().getSeconds() + ((double) stopWatch.getDuration().getNano() / 1000000000);
         final String failReasonLabel = failReason.map(Enum::name).orElse("NA");
         stopWatch.stop();

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/JobBatchProcessor.java
@@ -130,7 +130,7 @@ public class JobBatchProcessor {
         final String resourcesRequested = job.getResourceTypes().stream().map(DPCResourceType::getPath).collect(Collectors.joining(";"));
 
         final String resourceFileSizes = job.getResourceTypes().stream()
-                .map(resourceType -> String.format("%s=%s",
+                .map(resourceType -> String.format("%s:%s",
                         resourceType.getPath(),
                         job.getJobQueueBatchFiles().stream()
                                 .filter(file -> file.getResourceType().equals(resourceType))
@@ -140,8 +140,8 @@ public class JobBatchProcessor {
 
         final String failReasonLabel = failReason.map(Enum::name).orElse("NA");
         stopWatch.stop();
-        logger.info("dpcMetric=DataExportResult,PatientMbi {}, AggregatorId {}, dataRetrieved={},failReason={},resourcesRequested={},duration={} , resourceFileSizes={}",
-                mbi, aggregatorID,failReason.isEmpty(), failReasonLabel, resourcesRequested, stopWatch.getDuration(),resourceFileSizes);
+        logger.info("dpcMetric=DataExportResult,PatientIndex {}, AggregatorId {}, dataRetrieved={},failReason={},resourcesRequested={},duration={} , resourceFileSizes={}",
+               job.getPatientIndex(), aggregatorID,failReason.isEmpty(), failReasonLabel, resourcesRequested, stopWatch.getDuration(),resourceFileSizes);
         return results;
     }
 

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceWriter.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceWriter.java
@@ -90,6 +90,8 @@ class ResourceWriter {
                 writer.write(str.getBytes(StandardCharsets.UTF_8));
                 writer.write(DELIM);
             }
+            int dataSize = byteStream.size();
+            file.setFileLength(dataSize);
             writer.flush();
             writer.close();
             writeToFile(byteStream.toByteArray(), outputPath, shouldAppendToFile);

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceWriter.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/ResourceWriter.java
@@ -91,7 +91,7 @@ class ResourceWriter {
                 writer.write(DELIM);
             }
             int dataSize = byteStream.size();
-            file.setFileLength(dataSize);
+            file.setPatientFileSize(dataSize);
             writer.flush();
             writer.close();
             writeToFile(byteStream.toByteArray(), outputPath, shouldAppendToFile);

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/JobBatchProcessorUnitTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/engine/JobBatchProcessorUnitTest.java
@@ -552,19 +552,17 @@ class JobBatchProcessorUnitTest {
 
         // Process job
         jobBatchProcessor.processJobBatchPartial(aggregatorId, queue, job, mbi);
+        String patientIndex = "Patient/-20140000008325";
 
         // Verify log message format
         // Verify log message format
         String logMessage = testLogger.getLastLogMessage();
         assertTrue(logMessage.contains("dpcMetric=DataExportResult"), "Log should contain metric name");
-        assertTrue(logMessage.contains("PatientIndex " + job.getPatientIndex()), "Log should contain patient index");
-        assertTrue(logMessage.contains("AggregatorId " + aggregatorId), "Log should contain aggregator ID");
+        assertTrue(logMessage.contains("PatientId=" + patientIndex), "Log should contain patient index");
+        assertTrue(logMessage.contains("AggregatorId=" + aggregatorId), "Log should contain aggregator ID");
         assertTrue(logMessage.contains("dataRetrieved=true"), "Log should indicate data was retrieved");
         assertTrue(logMessage.contains("failReason=NA"), "Log should show no failure");
-        assertTrue(logMessage.contains("resourcesRequested=patient;coverage"), "Log should list requested resources");
         assertTrue(logMessage.contains("resourceFileSizes="), "Log should contain resource sizes");
-        assertTrue(logMessage.contains("patient:"), "Log should contain Patient resource size");
-        assertTrue(logMessage.contains("coverage:"), "Log should contain Coverage resource size");
         // Cleanup
         logger.detachAppender(testLogger);
     }

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatchFile.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/models/JobQueueBatchFile.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -106,9 +107,13 @@ public class JobQueueBatchFile implements Serializable {
     @Column(name = "file_length")
     private long fileLength;
 
+    @Transient
+    private long patientFileSize;
+
     public JobQueueBatchFile() {
         // for hibernate
     }
+
 
     public JobQueueBatchFile(UUID jobID, UUID batchID, DPCResourceType resourceType, int sequence, int count) {
         this.jobQueueBatchFileID = new JobQueueBatchFileID(batchID, resourceType, sequence);
@@ -163,6 +168,14 @@ public class JobQueueBatchFile implements Serializable {
 
     public void setFileLength(long fileLength) {
         this.fileLength = fileLength;
+    }
+
+    public long getPatientFileSize() {
+        return patientFileSize;
+    }
+
+    public void setPatientFileSize(long patientFileSize) {
+        this.patientFileSize = patientFileSize;
     }
 
     @Override


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4660

## 🛠 Changes

Updated DPC Metric logs to capture patientid, processing time  and file size for each resource 

## ℹ️ Context

These changes are made to log on splunk to understand hwo long it takes to process a single patient and the size of files it generates 

this is a simple log change and we are logging PatientId not patietnMBI and doesnt impact 
  - Adds a new software dependency or dependencies. NO 
  - Modifies or invalidates one or more of our security controls. NO 
  - Stores or transmits data that was not stored or transmitted before. NO 
  - Requires additional review of security implications for other reasons. NO 

## 🧪 Validation

Changes will be validated by running our tests and inspecting logs 