### PR TITLE
DPC-4605 Upgrade terraform in deploy action

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -131,7 +131,7 @@ jobs:
       - name: install terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.0.0"
+          terraform_version: "1.10.5"
       - name: Verify persistent plan
         run: |
           cd dpc-ops/terraform/${{ inputs.env }}/persistent


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4605

## 🛠 Changes

Terraform installed in ecs-deploy.yml increased to 1.10.5

## ℹ️ Context

In order to set up our terraform state backends properly, we need to upgrade to 1.10.5. Also upgraded dependencies to ensure compatibility.

## 🧪 Validation

Deployed to dev using Github actions:
-    Without changes: https://github.com/CMSgov/dpc-app/actions/runs/14523894541
-   With new images: https://github.com/CMSgov/dpc-app/actions/runs/14524016825
