### PR TITLE
[DPC-4633] Configure Stress Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ start-load-tests: secure-envs
 
 start-average-load-test: ## Run average load test locally in a Docker image provided by Grafana/K6
 start-average-load-test: secure-envs
-	@TEST_TYPE=single-iteration && \
+	@TEST_TYPE=average-load-test && \
 	docker run --rm -v $(shell pwd)/dpc-load-testing:/src --env-file $(shell pwd)/ops/config/decrypted/local.env -e ENVIRONMENT=local -e TEST_TYPE=$$TEST_TYPE -i grafana/k6 run /src/$$TEST_TYPE.js
 
 start-stress-test:

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,10 @@ start-average-load-test: secure-envs
 	@TEST_TYPE=single-iteration && \
 	docker run --rm -v $(shell pwd)/dpc-load-testing:/src --env-file $(shell pwd)/ops/config/decrypted/local.env -e ENVIRONMENT=local -e TEST_TYPE=$$TEST_TYPE -i grafana/k6 run /src/$$TEST_TYPE.js
 
+start-stress-test:
+start-stress-test: secure-envs
+	@TEST_TYPE=stress-test && \
+	docker run --rm -v $(shell pwd)/dpc-load-testing:/src --env-file $(shell pwd)/ops/config/decrypted/local.env -e ENVIRONMENT=local -e TEST_TYPE=$$TEST_TYPE -i grafana/k6 run /src/$$TEST_TYPE.js
 
 start-macaroon-tests: ## Test load-test macaroons
 start-macaroon-tests:

--- a/dpc-load-testing/constants.js
+++ b/dpc-load-testing/constants.js
@@ -2,7 +2,7 @@ function getVUsCount() {
   if (__ENV.TEST_TYPE === 'single-iteration' || __ENV.TEST_TYPE === 'average-load-test') {
     return 3;
   } else if (__ENV.TEST_TYPE === 'stress-test') {
-    return 12; 
+    return 5; 
   }
 }
 

--- a/dpc-load-testing/constants.js
+++ b/dpc-load-testing/constants.js
@@ -2,7 +2,7 @@ function getVUsCount() {
   if (__ENV.TEST_TYPE === 'single-iteration' || __ENV.TEST_TYPE === 'average-load-test') {
     return 3;
   } else if (__ENV.TEST_TYPE === 'stress-test') {
-    return 10; // This is a placeholder -- will do correct calculation as part of DPC-4633
+    return 12; 
   }
 }
 

--- a/dpc-load-testing/stress-test.js
+++ b/dpc-load-testing/stress-test.js
@@ -13,7 +13,7 @@ export const options = {
         { target: 50, duration: '30m' },
         { target: 100, duration: '30m' },
         { target: 150, duration: '30m' },
-        { target: 200, duration: '30m' },
+        { target: 250, duration: '30m' },
       ],
       exec: "workflow"
     }

--- a/dpc-load-testing/stress-test.js
+++ b/dpc-load-testing/stress-test.js
@@ -1,0 +1,23 @@
+import { workflow, setup, teardown } from "./workflows.js";
+
+// See https://grafana.com/docs/k6/latest/using-k6/k6-options/reference for
+// details on this configuration object.
+export const options = {
+  scenarios: {
+    workflow: {
+      executor: 'ramping-arrival-rate',
+      startRate: 50,
+      timeUnit: '1h',
+      preAllocatedVUs: 10,
+      stages: [
+        { target: 50, duration: '30m' },
+        { target: 100, duration: '30m' },
+        { target: 150, duration: '30m' },
+        { target: 200, duration: '30m' },
+      ],
+      exec: "workflow"
+    }
+  }
+};
+
+export { workflow, setup, teardown };

--- a/dpc-load-testing/stress-test.js
+++ b/dpc-load-testing/stress-test.js
@@ -1,4 +1,5 @@
 import { workflow, setup, teardown } from "./workflows.js";
+import { constants } from "./constants.js";
 
 // See https://grafana.com/docs/k6/latest/using-k6/k6-options/reference for
 // details on this configuration object.
@@ -8,7 +9,8 @@ export const options = {
       executor: 'ramping-arrival-rate',
       startRate: 50,
       timeUnit: '1h',
-      preAllocatedVUs: 10,
+      preAllocatedVUs: constants.preAllocatedVUs,
+      maxVUs: constants.maxVUs,
       stages: [
         { target: 50, duration: '30m' },
         { target: 100, duration: '30m' },


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4633
## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
- Adds a configuration object for stress tests
- Sets a maxVUs number for stress tests
- Creates a new Makefile command to run stress tests locally

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
This allows us to run stress tests as part of our load testing suite. Stress tests are designed to ramp up the load to test the limits of an API -- in our case, we'll ramp up from 1x of the average load, to 2x, 3x, and finally 5x, in half hour increments.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
