### PR TITLE
Update WCAG level

### DIFF
--- a/dpc-portal/spec/system/accessibility_spec.rb
+++ b/dpc-portal/spec/system/accessibility_spec.rb
@@ -9,17 +9,18 @@ RSpec.describe 'Accessibility', type: :system do
     driven_by(:selenium_headless)
   end
   let(:dpc_api_organization_id) { 'some-gnarly-guid' }
+  let(:axe_standard) { [ 'best-practice', 'wcag21aa' ] }
   context 'login' do
     it 'shows login page ok' do
       visit '/users/sign_in'
       expect(page).to_not have_text('You need to sign in or sign up before continuing.')
       expect(page).to have_text('Sign in')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'shows login failure' do
       visit '/users/auth/failure'
       expect(page).to have_text('Try again')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
 
     context 'bad user tries to log in' do
@@ -34,14 +35,14 @@ RSpec.describe 'Accessibility', type: :system do
       it 'shows no such user page' do
         visit '/users/auth/openid_connect/callback'
         expect(page).to have_text('You must have an account to sign in.')
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'shows sanctioned ao page' do
         create(:user, provider: :openid_connect, uid: '12345',
                       verification_status: 'rejected', verification_reason: 'ao_med_sanctions')
         visit '/users/auth/openid_connect/callback'
         expect(page).to have_text(I18n.t('verification.ao_med_sanctions_status'))
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
     end
   end
@@ -69,7 +70,7 @@ RSpec.describe 'Accessibility', type: :system do
       it 'empty' do
         visit '/organizations'
         expect(page).to have_text("You don't have any organizations to show.")
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       context 'ao' do
         before do
@@ -92,7 +93,7 @@ RSpec.describe 'Accessibility', type: :system do
           expect(page).to have_text(I18n.t('verification.sign_tos'))
           expect(page).to have_text(I18n.t('verification.configuration_needed'))
           expect(page).to have_text(I18n.t('verification.access_denied'))
-          expect(page).to be_axe_clean
+          expect(page).to be_axe_clean.according_to axe_standard
         end
       end
       context 'cd' do
@@ -113,7 +114,7 @@ RSpec.describe 'Accessibility', type: :system do
           expect(page).to have_text(I18n.t('cd_access.sign_tos'))
           expect(page).to have_text(I18n.t('cd_access.configuration_needed'))
           expect(page).to have_text(I18n.t('cd_access.access_denied'))
-          expect(page).to be_axe_clean
+          expect(page).to be_axe_clean.according_to axe_standard
         end
       end
       context 'ao cd mix' do
@@ -128,7 +129,7 @@ RSpec.describe 'Accessibility', type: :system do
           expect(page).to_not have_text("You don't have any organizations to show.")
           expect(page).to have_text(I18n.t('verification.configuration_needed'))
           expect(page).to have_text(I18n.t('cd_access.configuration_needed'))
-          expect(page).to be_axe_clean
+          expect(page).to be_axe_clean.according_to axe_standard
         end
       end
     end
@@ -139,14 +140,14 @@ RSpec.describe 'Accessibility', type: :system do
           visit "/organizations/#{org.id}"
           expect(page).to have_text('Terms of Service')
           expect(page).to_not have_text('You can assign anyone as a CD')
-          expect(page).to be_axe_clean
+          expect(page).to be_axe_clean.according_to axe_standard
         end
         it 'shows terms of service signed success' do
           visit "/organizations/#{org.id}"
           page.find('.usa-button', text: 'I have read and accepted the Terms of Service').click
           expect(page).to_not have_text('Terms of Service')
           expect(page).to have_text('You can assign anyone as a CD')
-          expect(page).to be_axe_clean
+          expect(page).to be_axe_clean.according_to axe_standard
         end
         context 'tos signed' do
           before { org.update!(terms_of_service_accepted_by: user) }
@@ -157,7 +158,7 @@ RSpec.describe 'Accessibility', type: :system do
             expect(page).to_not have_css('#credentials')
             expect(page).to_not have_css('#active-cd-table')
             expect(page).to_not have_css('#pending-cd-table')
-            expect(page).to be_axe_clean
+            expect(page).to be_axe_clean.according_to axe_standard
           end
           it 'should show with no credentials' do
             visit "/organizations/#{org.id}"
@@ -168,7 +169,7 @@ RSpec.describe 'Accessibility', type: :system do
             expect(page).to_not have_css('#client-tokens-table')
             expect(page).to_not have_css('#public-keys-table')
             expect(page).to_not have_css('#public-ips-table')
-            expect(page).to be_axe_clean
+            expect(page).to be_axe_clean.according_to axe_standard
           end
           context 'with credential delegates' do
             let(:active_cd) { create(:user) }
@@ -179,7 +180,7 @@ RSpec.describe 'Accessibility', type: :system do
               expect(page).to have_text('You can assign anyone as a CD')
               expect(page).to have_css('#active-cd-table')
               expect(page).to have_css('#pending-cd-table')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
           end
           context 'with tokens keys and ips' do
@@ -192,7 +193,7 @@ RSpec.describe 'Accessibility', type: :system do
               expect(page).to have_css('#client-tokens-table')
               expect(page).to have_css('#public-keys-table')
               expect(page).to have_css('#public-ips-table')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
           end
           context 'create client token' do
@@ -201,7 +202,7 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/client_tokens/new"
               expect(page).to have_text('Create a new client token')
               expect(page).to_not have_text('Label required')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show error page' do
               expect(mock_client_token_manager).to receive(:create_client_token).and_return({})
@@ -209,7 +210,7 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/client_tokens/new"
               page.all('.usa-button')[1].click
               expect(page).to have_text('Test Error')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show success page' do
               success_response = { response: true, message: :token }
@@ -218,7 +219,7 @@ RSpec.describe 'Accessibility', type: :system do
               page.fill_in 'label', with: 'new token'
               page.all('.usa-button')[1].click
               expect(page).to have_text('Client token created')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
           end
           context 'create public key' do
@@ -227,7 +228,7 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/public_keys/new"
               expect(page).to have_text('Add public key')
               expect(page).to_not have_text('Required values missing')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show error page' do
               error_response = { errors: { root: 'Test Error' } }
@@ -235,7 +236,7 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/public_keys/new"
               page.all('.usa-button')[1].click
               expect(page).to have_text('Test Error')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show success page' do
               success_response = { response: { message: { 'id' => 'foo' } } }
@@ -245,7 +246,7 @@ RSpec.describe 'Accessibility', type: :system do
               page.fill_in 'public_key', with: 'key'
               page.all('.usa-button')[1].click
               expect(page).to have_text('Public key created successfully')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
           end
           context 'create IP address' do
@@ -254,7 +255,7 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/ip_addresses/new"
               expect(page).to have_text('Add public IP address')
               expect(page).to_not have_text('Label required')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show error page' do
               error_response = { errors: { root: 'Test Error' } }
@@ -262,7 +263,7 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/ip_addresses/new"
               page.find_button(value: 'Add IP').click
               expect(page).to have_text('Test Error')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show success page' do
               success_response = { response: { message: { 'id' => 'foo' } } }
@@ -270,7 +271,7 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/ip_addresses/new"
               page.find_button(value: 'Add IP').click
               expect(page).to have_text('IP address created successfully')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
           end
           context 'create credential delegate invitation' do
@@ -278,14 +279,14 @@ RSpec.describe 'Accessibility', type: :system do
               visit "/organizations/#{org.id}/credential_delegate_invitations/new"
               expect(page).to have_text('Send invite')
               expect(page).to_not have_text("can't be blank")
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show error page' do
               visit "/organizations/#{org.id}/credential_delegate_invitations/new"
               page.find('.usa-button', text: 'Send invite').click
               page.find_button(value: 'Yes, I acknowledge').click
               expect(page).to have_text("can't be blank")
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show success page' do
               visit "/organizations/#{org.id}/credential_delegate_invitations/new"
@@ -297,7 +298,7 @@ RSpec.describe 'Accessibility', type: :system do
               page.find_button(value: 'Yes, I acknowledge').click
               expect(page).to_not have_text("can't be blank")
               expect(page).to have_text('Credential Delegate invited successfully')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
             it 'should show duplicate error' do
               invitation = create(:invitation, :cd, provider_organization: org)
@@ -310,7 +311,7 @@ RSpec.describe 'Accessibility', type: :system do
               page.find_button(value: 'Yes, I acknowledge').click
               expect(page).to_not have_text("can't be blank")
               expect(page).to have_text(I18n.t('errors.attributes.base.duplicate_cd.status'))
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
           end
         end
@@ -320,7 +321,7 @@ RSpec.describe 'Accessibility', type: :system do
         it 'shows needs terms of service' do
           visit "/organizations/#{org.id}"
           expect(page).to have_text('is not ready for credential management')
-          expect(page).to be_axe_clean
+          expect(page).to be_axe_clean.according_to axe_standard
         end
         context 'tos signed' do
           before { org.update!(terms_of_service_accepted_by: user) }
@@ -332,7 +333,7 @@ RSpec.describe 'Accessibility', type: :system do
             expect(page).to_not have_css('#public-keys-table')
             expect(page).to_not have_css('#public-ips-table')
             expect(page).to have_text('you must create a unique client token')
-            expect(page).to be_axe_clean
+            expect(page).to be_axe_clean.according_to axe_standard
           end
           context 'with tokens keys and ips' do
             let(:tokens) { default_get_client_tokens['entities'] }
@@ -343,7 +344,7 @@ RSpec.describe 'Accessibility', type: :system do
               expect(page).to have_css('#client-tokens-table')
               expect(page).to have_css('#public-keys-table')
               expect(page).to have_css('#public-ips-table')
-              expect(page).to be_axe_clean
+              expect(page).to be_axe_clean.according_to axe_standard
             end
           end
         end
@@ -369,25 +370,25 @@ RSpec.describe 'Accessibility', type: :system do
     it 'should show intro page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}"
       expect(page).to have_text('Not be listed on the Medicare Exclusions Database')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'should show login page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
       expect(page).to have_text('Sign in or create')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'should show accept page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
       expect(page).to have_text('Step 3')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'should show register page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/accept"
       page.find('.usa-button', text: 'Continue to register').click
       expect(page).to have_text('Step 4')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'should show success page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
@@ -395,7 +396,7 @@ RSpec.describe 'Accessibility', type: :system do
       page.find('.usa-button', text: 'Continue to register').click
       page.find('.usa-button', text: 'Complete registration').click
       expect(page).to have_text('Step 5')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     context :failure do
       let(:user_info) do
@@ -410,27 +411,27 @@ RSpec.describe 'Accessibility', type: :system do
       it 'should show bad invitation' do
         visit "/organizations/#{org.id}/invitations/bad-id"
         expect(page).to have_text('Your link is invalid.')
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'should show expired invitation' do
         invitation.update(created_at: 4.days.ago)
         visit "/organizations/#{org.id}/invitations/#{invitation.id}"
         expect(page).to have_text(I18n.t('verification.ao_expired_status'))
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'should show successful renewal of invitation' do
         invitation.update(created_at: 4.days.ago)
         visit "/organizations/#{org.id}/invitations/#{invitation.id}"
         page.find('.usa-button', text: 'Request new link').click
         expect(page).to have_text(renew_success)
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'should show already-renewed error' do
         invitation.update(status: :renewed)
         visit "/organizations/#{org.id}/invitations/#{invitation.id}"
         expect(page).to_not have_text(renew_success)
         expect(page).to have_text(I18n.t('verification.ao_renewed_text'))
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'should show email does not match error' do
         mismatched_invitation = create(:invitation, :ao, provider_organization: org,
@@ -439,7 +440,7 @@ RSpec.describe 'Accessibility', type: :system do
         visit "/organizations/#{org.id}/invitations/#{mismatched_invitation.id}/set_idp_token"
         visit "/organizations/#{org.id}/invitations/#{mismatched_invitation.id}/accept"
         expect(page).to have_text("The email you used to sign in doesn't match your invite.")
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'should show failed ao check' do
         visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
@@ -447,7 +448,7 @@ RSpec.describe 'Accessibility', type: :system do
         page.find('.usa-button', text: 'Continue to register').click
         expect(page).to have_text('Step 3')
         expect(page).to have_text('You’re not the Authorized Official.')
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
     end
   end
@@ -471,25 +472,25 @@ RSpec.describe 'Accessibility', type: :system do
     it 'should show intro page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}"
       expect(page).to have_text("You've been delegated to manage access")
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'should show login page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/confirm_cd"
       expect(page).to have_text('Sign in or create a Login.gov account')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'should show confirm page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/confirm_cd"
       expect(page).to have_text('Accept invite')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     it 'should show success page' do
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/set_idp_token"
       visit "/organizations/#{org.id}/invitations/#{invitation.id}/confirm_cd"
       page.find('.usa-button', text: 'Accept invite').click
       expect(page).to have_text('Thank you for accepting your invite.')
-      expect(page).to be_axe_clean
+      expect(page).to be_axe_clean.according_to axe_standard
     end
     context :failure do
       let(:user_info) do
@@ -505,7 +506,7 @@ RSpec.describe 'Accessibility', type: :system do
         invitation.update(created_at: 4.days.ago)
         visit "/organizations/#{org.id}/invitations/#{invitation.id}"
         expect(page).to have_text(I18n.t('verification.cd_expired_status'))
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'should show email does not match error' do
         mismatched_invitation = create(:invitation, :cd, provider_organization: org,
@@ -514,7 +515,7 @@ RSpec.describe 'Accessibility', type: :system do
         visit "/organizations/#{org.id}/invitations/#{mismatched_invitation.id}/set_idp_token"
         visit "/organizations/#{org.id}/invitations/#{mismatched_invitation.id}/confirm_cd"
         expect(page).to have_text(I18n.t('verification.pii_mismatch_status'))
-        expect(page).to be_axe_clean
+        expect(page).to be_axe_clean.according_to axe_standard
       end
     end
   end

--- a/dpc-portal/spec/system/accessibility_spec.rb
+++ b/dpc-portal/spec/system/accessibility_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Accessibility', type: :system do
     driven_by(:selenium_headless)
   end
   let(:dpc_api_organization_id) { 'some-gnarly-guid' }
-  let(:axe_standard) { [ 'best-practice', 'wcag21aa' ] }
+  let(:axe_standard) { %w[best-practice wcag21aa] }
   context 'login' do
     it 'shows login page ok' do
       visit '/users/sign_in'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4679

## 🛠 Changes

Increases Axe accessibility standard to WCAG 2.1AA.

## ℹ️ Context

We want our portal to be accessible to a higher standard than default.

## 🧪 Validation

[Accessibility tests](https://github.com/CMSgov/dpc-app/actions/runs/14624557229) running as expected.