### PR TITLE
[DPC-4673] Fix NPI Generator

### DIFF
--- a/dpc-load-testing/__tests__/npi-generator.test.js
+++ b/dpc-load-testing/__tests__/npi-generator.test.js
@@ -1,25 +1,6 @@
 import { generateNPI } from "../utils/npi-generator";
 import { isArrayUnique } from "../utils/test-utils";
-
-function luhnCheck(npi) {
-  const appendedNpi = "80840" + npi;
-  const reversed = appendedNpi.split('').reverse();
-  let total = 0;
-  for (const [index, value] of reversed.entries()) {
-    let x = parseInt(value);
-    if (index % 2 === 1) {
-      x = x * 2;
-      // if the result has two digits, add the digits together to get a single digit number
-      if (x > 9) {
-        x.toString().split('').map(Number).reduce((a, b) => a + b);
-      }
-    }
-
-    total += x;
-  }
-
-  return total % 10 === 0;
-}
+import luhn from "../lib/luhn.js";
 
 describe('generateNPI', () => {
   const npis = []
@@ -37,7 +18,7 @@ describe('generateNPI', () => {
 
   test('generated NPIs pass the luhnCheck', () => {
     npis.every(npi => {
-      expect(luhnCheck(npi)).toBeTruthy();
+      expect(luhn.isValid("80840" + npi)).toBeTruthy();
     })
   });
 

--- a/dpc-load-testing/eslint.config.js
+++ b/dpc-load-testing/eslint.config.js
@@ -2,7 +2,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import js from "@eslint/js";
 
 export default defineConfig([
-    [ globalIgnores(["__tests__", "macaroonTests.js"]) ],
+    [ globalIgnores(["__tests__", "macaroonTests.js", "lib"]) ],
 	{
 		files: ["**/*.js"],
 		plugins: { js },

--- a/dpc-load-testing/lib/luhn.js
+++ b/dpc-load-testing/lib/luhn.js
@@ -1,0 +1,102 @@
+/**
+ * Imported from https://github.com/EDumdum/luhn, available as `luhn-js` on NPM.
+ * 
+ * Available under MIT License: https://github.com/EDumdum/luhn/blob/master/LICENSE
+ */
+
+'use strict';
+
+const luhn = {
+    /**
+     * Check requirements.  
+     * Returns if the Luhn check digit is valid.
+     *
+     * Requirements:
+     * - rawValue must be not `Null`
+     * - rawValue must be of type `String`
+     * - rawValue must respect format `^[0-9]{2,}$`
+     * 
+     * @param {*} rawValue 
+     */
+    isValid: function(rawValue) {
+        const value = stringifyInput(rawValue);
+
+        if (!value.match(FORMAT_ISVALID)) {
+            throw new Error('Exception value of format \'' + FORMAT_ISVALID + '\', found: \'' + value + '\'');
+        }
+        
+        return getLuhnRemainder(value) === 0;
+    },
+
+    /**
+     * Check requirements.  
+     * Returns the Luhn check digit appended to the value.
+     * 
+     * Requirements:
+     * - rawValue must be not `Null`
+     * - rawValue must be of type `String`
+     * - rawValue must respest format `^[0-9]{1,}$`
+     * 
+     * @param {*} rawValue 
+     */
+    generate: function(rawValue) {
+        const value = stringifyInput(rawValue);
+
+        if (!value.match(FORMAT_GENERATE)) {
+            throw new Error('Exception value of format \'' + FORMAT_GENERATE + '\', found: \'' + value + '\'');
+        }
+
+        return value + ((10 - getLuhnRemainder(value + '0')) % 10).toString();
+    },
+
+    /**
+     * Does NOT check requirements.  
+     * Returns the Luhn remainder.
+     * Note: 
+     *   `getRemainder(value) === 0` is equivalent to `isValid(value)`. 
+     *   You may want to use this method instead of `isValid` if you ensure argument 
+     *   requirements on your side.
+     * 
+     * Requirements
+     * - rawValue must be not `Null`
+     * - rawValue must be of type `String`
+     * 
+     * @param {*} rawValue 
+     */
+    getRemainder: function(rawValue) {
+        return getLuhnRemainder(rawValue);
+    }
+};
+
+const FORMAT_ISVALID = /^[0-9]{2,}$/;
+const FORMAT_GENERATE = /^[0-9]{1,}$/;
+
+const CHARCODE_0 = '0'.charCodeAt(0);
+const MAPPING_EVEN = [0, 2, 4, 6, 8, 1, 3, 5, 7, 9];
+
+function getLuhnRemainder(value) {
+    var length = value.length;
+    var accumulator = 0;
+    var bit = 0;
+
+    while (length-- > 0) {
+        accumulator += (bit ^= 1) ? value.charCodeAt(length) - CHARCODE_0 : MAPPING_EVEN[value.charCodeAt(length) - CHARCODE_0];
+    }
+
+    return accumulator % 10;
+}
+
+function stringifyInput(rawValue) {
+    if (rawValue !== null && rawValue !== undefined) {
+        if (typeof rawValue === 'string') {
+            return rawValue;
+            
+        }
+        
+        throw new Error('Expecting value of type \'string\', found: \'' + (typeof rawValue) + '\'');
+    }
+
+    throw new Error('Expecting value of type \'string\', found: \'' + rawValue + '\'');
+}
+
+export default luhn;

--- a/dpc-load-testing/utils/npi-generator.js
+++ b/dpc-load-testing/utils/npi-generator.js
@@ -1,34 +1,8 @@
-/**
- * Returns a Luhn check digit, which should be the last digit of an NPI. This serves as a 
- * validation mechanism. 
- * @param {string} nineDigitNumber 
- * @returns {string} a digit to be appended to the nineDigitNumber
- */
-function generateLuhnCheckDigit(nineDigitNumber) {
-  const appendedNineDigitNumber = "80840" + nineDigitNumber;
-  const reversed = appendedNineDigitNumber.split('').reverse();
-  let total = 0;
-  for (const [index, value] of reversed.entries()) {
-    let x = parseInt(value);
-    if (index % 2 === 0) {
-      x = x * 2;
-      // if the result has two digits, add the digits together to get a single digit number
-      if (x > 9) {
-        x.toString().split('').map(Number).reduce((a, b) => a + b);
-      }
-    }
-
-    total += x;
-  }
-
-  const unitsDigit = total % 10;
-  const checkDigit = unitsDigit === 0 ? unitsDigit : (10 - (total % 10));
-  return checkDigit.toString();
-}
+import luhn from "../lib/luhn.js";
 
 export function generateNPI(counter) {
   const paddedNumber = counter.toString().padStart(9, '0');
-  return paddedNumber + generateLuhnCheckDigit(paddedNumber);
+  return luhn.generate('80840' + paddedNumber).slice(5);
 }
 
 export class NPIGenerator {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4673

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Fixes the NPI Generator by pulling in the [luhn-js](https://www.npmjs.com/package/luhn-js) library, replacing my hand-made implementation of the [Luhn algorithm](https://en.wikipedia.org/wiki/Luhn_algorithm).

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
During some testing, we found that POST v1/Practitioner was returning 400 errors after around 6 iterations. As it turns out, this was due to some errors in our NPI Generator. Pulling in the luhn-js third party library to replace the faulty logic resolves this problem. 

Because K6 does not run a Node.js runtime, we're unable to pull in NPM modules the usual way. I opted to get around this by pulling the library's main file into the `lib` directory, and import from there.

You can test this by updating `single-iteration.js` to run more than 6 total iterations, then running `make load-tests` locally. In my case, I ran 10 iterations per VU = 30 iterations.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
- [x] Load Test runs successfully in GH Actions for `single-iteration`. https://github.com/CMSgov/dpc-app/actions/runs/14715636860/job/41298239302
- [x] Update `single-iteration.js` to have an `iterations` value of more than 6. Running `make load-tests` passes with no failed calls to either POST v1/Organization or POST v1/Practitioner. See screenshot for my own run.

<img width="752" alt="Screenshot 2025-04-28 at 2 49 25 PM" src="https://github.com/user-attachments/assets/27fa9bb3-6e02-470d-9928-8aa87be10d19" />
