### PR TITLE
Fix net-imap vulnerability

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -48,6 +48,7 @@ gem 'macaroons'
 gem 'sprockets-rails', '>= 3.4.2'
 gem 'truemail'
 gem 'nokogiri', '>= 1.18.3'
+gem 'net-imap', '>= 0.5.8'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -36,6 +36,7 @@ gem 'lograge'
 gem 'lookbook', '>= 2.2.1' # install lookbook so it can be deployed in lower environments.
 gem 'luhnacy', '~> 0.2.1'
 gem 'macaroons'
+gem 'net-imap', '>= 0.5.8'
 gem 'newrelic_rpm', '~> 8.10'
 gem 'nokogiri', '>= 1.18.3'
 gem 'omniauth_openid_connect'
@@ -57,7 +58,6 @@ gem 'uglifier', '>= 1.3.0'
 gem 'view_component', '~> 3.9'
 gem 'webrick'
 gem 'yard', '>= 0.9.36'
-gem 'net-imap', '>= 0.5.8'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -57,6 +57,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'view_component', '~> 3.9'
 gem 'webrick'
 gem 'yard', '>= 0.9.36'
+gem 'net-imap', '>= 0.5.8'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -49,6 +49,7 @@ gem 'rack', '>= 3.1.11'
 gem 'redis-namespace'
 gem 'bootstrap-table-rails'
 gem 'nokogiri', '>= 1.18.3'
+gem 'net-imap', '>= 0.5.8'
 
 gem 'api_client', path: 'vendor/api_client'
 


### PR DESCRIPTION
## 🎫 Ticket

no ticket

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - pin `net-imap` to a version that does not have DoS vulnerability

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - The team is prioritizing migration to new Greenfield AWS accounts as a major objective
   - For this task, I have started working on migrating docker-build and ran into a blocker because of this transitive dependency
   - see failed job [HERE](https://github.com/CMSgov/dpc-app/actions/runs/14764324776/job/41452267541#step:7:747)

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
See CI pipeline