### PR TITLE
[DPC-4697] Remove PUBLIC_URL from env variables

### DIFF
--- a/dpc-api/src/main/resources/dev.application.env
+++ b/dpc-api/src/main/resources/dev.application.env
@@ -1,4 +1,3 @@
-PUBLIC_URL="https://dev.dpc.cms.gov/api"
 DATABASE_URL="jdbc:postgresql://db.dpc-dev.local:5432/dpc_attribution"
 QUEUE_DB_URL="jdbc:postgresql://db.dpc-dev.local:5432/dpc_queue"
 AUTH_DB_URL="jdbc:postgresql://db.dpc-dev.local:5432/dpc_auth"

--- a/dpc-api/src/main/resources/prod-sbx.application.env
+++ b/dpc-api/src/main/resources/prod-sbx.application.env
@@ -1,4 +1,3 @@
-PUBLIC_URL="https://sandbox.dpc.cms.gov/api"
 APP_CONTEXT_PATH="/api"
 DATABASE_URL="jdbc:postgresql://db.dpc-prod-sbx.local:5432/dpc_attribution"
 AUTH_DB_URL="jdbc:postgresql://db.dpc-prod-sbx.local:5432/dpc_auth"

--- a/dpc-api/src/main/resources/prod.application.env
+++ b/dpc-api/src/main/resources/prod.application.env
@@ -1,4 +1,3 @@
-PUBLIC_URL="https://prod.dpc.cms.gov/api"
 DATABASE_URL="jdbc:postgresql://db.dpc-prod.local:5432/dpc_attribution"
 QUEUE_DB_URL="jdbc:postgresql://db.dpc-prod.local:5432/dpc_queue"
 AUTH_DB_URL="jdbc:postgresql://db.dpc-prod.local:5432/dpc_auth"

--- a/dpc-api/src/main/resources/test.application.env
+++ b/dpc-api/src/main/resources/test.application.env
@@ -1,4 +1,3 @@
-PUBLIC_URL="https://test.dpc.cms.gov/api"
 APP_CONTEXT_PATH="/api"
 DATABASE_URL="jdbc:postgresql://db.dpc-test.local:5432/dpc_attribution"
 QUEUE_DB_URL="jdbc:postgresql://db.dpc-test.local:5432/dpc_queue"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4697

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
- remove PUBLIC_URL from environment variables

## ℹ️ Context

This should cause DPC to pull that value from the AWS environment once https://github.com/CMSgov/dpc-ops/pull/803 is merged. Please take a look at that code to understand more context.

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
- [ ] Deploy to test once https://github.com/CMSgov/dpc-ops/pull/803 is merged; ensure that everything works okay.
