### PR TITLE
fix gzip consent command not saving image properly

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -199,7 +199,7 @@ jobs:
           retention-days: 1
 
       - name: gzip image (4 of 4) - Consent
-        run: docker save ${{ steps.login-ecr.outputs.registry }}/dpc-consent:latest | gzip > ${{ runner.temp }}/dpc_consent_latest.tar.gz
+        run: docker save dpc-consent:latest | gzip > ${{ runner.temp }}/dpc_consent_latest.tar.gz
       - name: upload tar artifact (4 of 4) - Consent
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ecs-release.yml
+++ b/.github/workflows/ecs-release.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - dpc-**
       - engines/**
+      - .github/workflows/**
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## 🎫 Ticket

(no ticket) This is a follow-up to https://github.com/CMSgov/dpc-app/pull/2625
Slack discussion [HERE](https://cmsgov.slack.com/archives/C04UG13JF9B/p1746640468842269)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - fix formatting for the way the consent image is cached for runners to push consent image to ECR

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
