### PR TITLE
[DPC-4700] use HOST_NAME for login.gov callback url

### DIFF
--- a/dpc-portal/lib/dpc_portal_utils.rb
+++ b/dpc-portal/lib/dpc_portal_utils.rb
@@ -6,11 +6,13 @@ module DpcPortalUtils
     env = ENV.fetch('ENV', nil)
     case env
     when 'local'
+      puts 'in local'
       'http://localhost:3100'
     else
+      puts 'in else'
       host_name = ENV.fetch('HOST_NAME', nil)
       Rails.logger.error 'HOST_NAME is not set by env' if host_name.nil?
-      host_name
+      "https://#{host_name}"
     end
   end
 end

--- a/dpc-portal/lib/dpc_portal_utils.rb
+++ b/dpc-portal/lib/dpc_portal_utils.rb
@@ -9,9 +9,7 @@ module DpcPortalUtils
       'http://localhost:3100'
     else
       host_name = ENV.fetch('HOST_NAME', nil)
-      if host_name == nil
-        Rails.logger.error "HOST_NAME is not set by env"
-      end
+      Rails.logger.error 'HOST_NAME is not set by env' if host_name.nil?
       host_name
     end
   end

--- a/dpc-portal/lib/dpc_portal_utils.rb
+++ b/dpc-portal/lib/dpc_portal_utils.rb
@@ -6,10 +6,8 @@ module DpcPortalUtils
     env = ENV.fetch('ENV', nil)
     case env
     when 'local'
-      puts 'in local'
       'http://localhost:3100'
     else
-      puts 'in else'
       host_name = ENV.fetch('HOST_NAME', nil)
       Rails.logger.error 'HOST_NAME is not set by env' if host_name.nil?
       "https://#{host_name}"

--- a/dpc-portal/lib/dpc_portal_utils.rb
+++ b/dpc-portal/lib/dpc_portal_utils.rb
@@ -7,10 +7,12 @@ module DpcPortalUtils
     case env
     when 'local'
       'http://localhost:3100'
-    when 'prod-sbx'
-      'https://sandbox.dpc.cms.gov'
     else
-      "https://#{env}.dpc.cms.gov"
+      host_name = ENV.fetch('HOST_NAME', nil)
+      if host_name == nil
+        Rails.logger.error "HOST_NAME is not set by env"
+      end
+      host_name
     end
   end
 end

--- a/dpc-portal/spec/lib/dpc_portal_utils_spec.rb
+++ b/dpc-portal/spec/lib/dpc_portal_utils_spec.rb
@@ -7,12 +7,9 @@ RSpec.describe DpcPortalUtils do
   it 'should return localhost' do
     expect(my_protocol_host).to eq 'http://localhost:3100'
   end
-  it 'should return sandbox.dpc.cms.gov if prod-sbx' do
-    expect(ENV).to receive(:fetch).with('ENV', nil).and_return('prod-sbx')
-    expect(my_protocol_host).to eq 'https://sandbox.dpc.cms.gov'
-  end
-  it 'should return {env}.dpc.cms.gov unless prod-sbx' do
-    expect(ENV).to receive(:fetch).with('ENV', nil).and_return('fake_env')
-    expect(my_protocol_host).to eq 'https://fake_env.dpc.cms.gov'
+  it 'should fetch HOST_NAME from env if not local' do
+    expect(ENV).to receive(:fetch).with('ENV', nil).and_return('dev')
+    expect(ENV).to receive(:fetch).with('HOST_NAME', nil).and_return('dev.dpc.cms.gov')
+    expect(my_protocol_host).to eq 'https://dev.dpc.cms.gov'
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4700

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
- Use HOST_NAME from environment variables to set login.gov callback url

## ℹ️ Context

We need to be able to get the correct URL when running in Greenfield. 

This depends on changes submitted in https://github.com/CMSgov/dpc-ops/pull/808/

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
