### PR TITLE
give permissions

### DIFF
--- a/.github/workflows/ecs-release.yml
+++ b/.github/workflows/ecs-release.yml
@@ -41,6 +41,10 @@ concurrency:
   group: release-to-${{ inputs.env || 'dev' }}
   cancel-in-progress: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   set-parameters:
     name: "Set Parameters"


### PR DESCRIPTION
## 🎫 Ticket
No ticket

## 🛠 Changes

ecs-release.yml permissions explicitly given

## ℹ️ Context

Github Actions permissions were tightened, and this stanza needed to be added to make it work. Permission stanza was already added in ecs-release-gf.yml

## 🧪 Validation

Ran and passed.
