### PR TITLE
[DPC-4691] Create Promote Build (Greenfield) workflow

### DIFF
--- a/.github/workflows/promote-build-gf.yml
+++ b/.github/workflows/promote-build-gf.yml
@@ -41,10 +41,17 @@ jobs:
           echo "Target deployment environment \"${{ inputs.to_env }}\" must be specified and match confirmed deployment environment \"${{ inputs.confirm_env }}\"."
           exit 1
       - name: Configure AWS Credentials (non-prod)
+        if: ${{ inputs.from_env == 'dev' || inputs.from_env == 'test' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.from_env }}-github-actions
+      - name: Configure AWS Credentials (prod)
+        if: ${{ inputs.from_env == 'sandbox' || inputs.from_env == 'prod' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.from_env }}-github-actions
       - name: "Fetch Image and App Version from AWS"
         id: fetch-info
         run: |


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4691

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
This creates the Promote Build workflow for Greenfield.

## ℹ️ Context

This will allow us to do our normal dev promotion workflow: `dev` -> `test` -> `prod` and `test` -> `sandbox`.
<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

- [ ] Can successfully promote to both prod and [non-prod](https://github.com/CMSgov/dpc-app/actions/runs/15279880611) environments. Note that the sandbox deploy failed at one of the [health checks](https://github.com/CMSgov/dpc-app/actions/runs/15307219466/job/43063025383). This is not an issue with this workflow, and given that it is able to deploy, my take is that this workflow works as intended within its own scope.
- [ ] After merging this PR, promote to test, then to sandbox and prod.

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
