### PR TITLE
DPC-4738 Update GHA permissions for lambda deploys

### DIFF
--- a/.github/workflows/api-waf-sync-deploy-gf.yml
+++ b/.github/workflows/api-waf-sync-deploy-gf.yml
@@ -29,6 +29,9 @@ jobs:
   deploy:
     name: 'Deploy API WAF sync'
     uses: ./.github/workflows/deploy_go_lambda_gf.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: ${{ inputs.env || 'dev' }}
       project: api-waf-sync

--- a/.github/workflows/api-waf-sync-deploy.yml
+++ b/.github/workflows/api-waf-sync-deploy.yml
@@ -29,6 +29,9 @@ jobs:
   deploy:
     name: 'Deploy API WAF sync'
     uses: ./.github/workflows/deploy_go_lambda.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: dev # ${{ inputs.env || 'dev' }} currently only available on dev
       project: api-waf-sync

--- a/.github/workflows/deploy_go_lambda_gf.yml
+++ b/.github/workflows/deploy_go_lambda_gf.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Promote lambda code to prod
         run: |
           aws s3 cp --no-progress \
-            function.zip
+            function.zip \
             "s3://${PROD_LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip"
           # TODO: uncomment when we really want to run the lambda from greenfield
           # aws lambda update-function-code --function-name dpc-prod-${{ inputs.project }} \

--- a/.github/workflows/deploy_go_lambda_gf.yml
+++ b/.github/workflows/deploy_go_lambda_gf.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   deploy:
     name: "Build and Deploy Lambda"
+    if: ${{ inputs.env != 'prod' }}
     permissions:
       contents: read
       id-token: write
@@ -36,18 +37,6 @@ jobs:
         run: |
           go build -o bootstrap ${{ inputs.go_files }}
           zip function.zip bootstrap
-      - name: AWS Credentials (non-prod)
-        if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
-      - name: AWS Credentials (prod)
-        if: ${{ inputs.env == 'sandbox' || inputs.env == 'prod' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
 
       - name: retrieve s3 bucket
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
@@ -62,6 +51,54 @@ jobs:
           LABEL: ${{ inputs.env }}-${{ inputs.project }}
         run: |
           aws s3 cp --no-progress function.zip \
-          "s3://${LAMBDA_BUCKET_NAME}/function.zip"
+          "s3://${LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip"
           aws lambda update-function-code --function-name "dpc-${LABEL}" \
-          --s3-bucket "$LAMBDA_BUCKET_NAME" --s3-key function.zip
+          --s3-bucket "$LAMBDA_BUCKET_NAME" --s3-key function-${{ github.sha }}.zip
+
+  promote:
+    name: "Promote to prod"
+    if: ${{ inputs.env == 'prod' }}
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    environment: prod
+    steps:
+      - name: AWS Credentials (non-prod)
+        if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
+      - name: retrieve test S3 bucket
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            TEST_LAMBDA_BUCKET_NAME=/dpc/${{ inputs.env }}/dpc-${{ inputs.env }}-${{ inputs.project }}-bucket
+      - name: Download lambda code from test
+        run: |
+          aws s3 cp --no-progress \
+            "s3://${TEST_LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip"
+            function.zip
+      - name: AWS Credentials (prod)
+        if: ${{ inputs.env == 'sandbox' || inputs.env == 'prod' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
+      - name: retrieve prod S3 bucket
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            PROD_LAMBDA_BUCKET_NAME=/dpc/${{ inputs.env }}/dpc-${{ inputs.env }}-${{ inputs.project }}-bucket
+      - name: Promote lambda code to prod
+        run: |
+          aws s3 cp --no-progress \
+            function.zip
+            "s3://${PROD_LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip"
+          aws lambda update-function-code --function-name dpc-prod-${{ inputs.project }} \
+            --s3-bucket $PROD_LAMBDA_BUCKET_NAME --s3-key function-${{ github.sha }}.zip

--- a/.github/workflows/deploy_go_lambda_gf.yml
+++ b/.github/workflows/deploy_go_lambda_gf.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           go build -o bootstrap ${{ inputs.go_files }}
           zip function.zip bootstrap
-      - name: AWS Credentials (non-prod) # there are no go lambdas on sandbox
+      - name: AWS Credentials (non-prod) # there are no go lambdas on sandbox, but lets make sure!
         if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -73,7 +73,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-test-github-actions
       - name: retrieve test S3 bucket
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
@@ -90,14 +90,14 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-prod-github-actions
       - name: retrieve prod S3 bucket
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            PROD_LAMBDA_BUCKET_NAME=/dpc/${{ inputs.env }}/dpc-${{ inputs.env }}-${{ inputs.project }}-bucket
+            PROD_LAMBDA_BUCKET_NAME=/dpc/prod/dpc-prod-${{ inputs.project }}-bucket
       - name: Promote lambda code to prod
         run: |
           aws s3 cp --no-progress \

--- a/.github/workflows/deploy_go_lambda_gf.yml
+++ b/.github/workflows/deploy_go_lambda_gf.yml
@@ -37,7 +37,12 @@ jobs:
         run: |
           go build -o bootstrap ${{ inputs.go_files }}
           zip function.zip bootstrap
-
+      - name: AWS Credentials (non-prod) # there are no go lambdas on sandbox
+        if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
       - name: retrieve s3 bucket
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:

--- a/.github/workflows/deploy_go_lambda_gf.yml
+++ b/.github/workflows/deploy_go_lambda_gf.yml
@@ -70,7 +70,6 @@ jobs:
     environment: prod
     steps:
       - name: AWS Credentials (non-prod)
-        if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
@@ -81,14 +80,13 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            TEST_LAMBDA_BUCKET_NAME=/dpc/${{ inputs.env }}/dpc-${{ inputs.env }}-${{ inputs.project }}-bucket
+            TEST_LAMBDA_BUCKET_NAME=/dpc/test/dpc-test-${{ inputs.project }}-bucket
       - name: Download lambda code from test
         run: |
           aws s3 cp --no-progress \
             "s3://${TEST_LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip"
             function.zip
       - name: AWS Credentials (prod)
-        if: ${{ inputs.env == 'sandbox' || inputs.env == 'prod' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
@@ -105,5 +103,6 @@ jobs:
           aws s3 cp --no-progress \
             function.zip
             "s3://${PROD_LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip"
-          aws lambda update-function-code --function-name dpc-prod-${{ inputs.project }} \
-            --s3-bucket $PROD_LAMBDA_BUCKET_NAME --s3-key function-${{ github.sha }}.zip
+          # TODO: uncomment when we really want to run the lambda from greenfield
+          # aws lambda update-function-code --function-name dpc-prod-${{ inputs.project }} \
+          #   --s3-bucket $PROD_LAMBDA_BUCKET_NAME --s3-key function-${{ github.sha }}.zip

--- a/.github/workflows/deploy_go_lambda_gf.yml
+++ b/.github/workflows/deploy_go_lambda_gf.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Download lambda code from test
         run: |
           aws s3 cp --no-progress \
-            "s3://${TEST_LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip"
+            "s3://${TEST_LAMBDA_BUCKET_NAME}/function-${{ github.sha }}.zip" \
             function.zip
       - name: AWS Credentials (prod)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/opt-out-export-deploy-gf.yml
+++ b/.github/workflows/opt-out-export-deploy-gf.yml
@@ -29,6 +29,9 @@ jobs:
   deploy:
     name: 'Deploy Opt Out Export'
     uses: ./.github/workflows/deploy_go_lambda_gf.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: ${{ inputs.env || 'dev' }}
       project: opt-out-export

--- a/.github/workflows/opt-out-export-deploy.yml
+++ b/.github/workflows/opt-out-export-deploy.yml
@@ -29,6 +29,9 @@ jobs:
   deploy:
     name: 'Deploy Opt Out Export'
     uses: ./.github/workflows/deploy_go_lambda.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: ${{ inputs.env || 'dev' }}
       project: opt-out-export

--- a/.github/workflows/opt-out-export-test-integration-gf.yml
+++ b/.github/workflows/opt-out-export-test-integration-gf.yml
@@ -8,19 +8,6 @@ on:
       - .github/workflows/deploy_go_lambda.yml
       - lambda/opt-out-export/**
   workflow_dispatch:
-    inputs:
-      env:
-        description: AWS environment to deploy to
-        required: true
-        type: 'string'
-        default: 'dev'
-  workflow_call:
-    inputs:
-      env:
-        description: AWS environment to deploy to
-        required: true
-        type: 'string'
-        default: 'dev'
 
 # Ensure we have only one integration test running at a time
 concurrency:
@@ -35,7 +22,7 @@ jobs:
       contents: read
       id-token: write
     with:
-      env: dev
+      env: test
     secrets: inherit
 
   trigger:
@@ -55,23 +42,16 @@ jobs:
         with:
           sparse-checkout: |
             lambda/opt-out-export
-      - name: Configure non-prod AWS Credentials
-        if: ${{ github.event_name == 'pull_request' || inputs.env == 'dev' || inputs.env == 'test' }}
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-      - name: Configure prod AWS Credentials
-        if: ${{ inputs.env == 'sandbox' || inputs.env == 'prod' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-prod-github-actions
+          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-test-github-actions
       - name: Send event to trigger export lambda function
         id: invoke-lambda
         run: |
           echo "STARTTIME=`date +%s`" >> "$GITHUB_OUTPUT"
-          aws lambda invoke --function-name dpc-dev-opt-out-export test-result.txt
+          aws lambda invoke --function-name dpc-test-opt-out-export test-result.txt
 
   verify-bucket:
     if: ${{ always() && needs.trigger.result == 'success' }}
@@ -81,43 +61,18 @@ jobs:
       id-token: write
     runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
     steps:
-      - name: Configure GHA non-prod AWS Credentials
-        if: ${{ github.event_name == 'pull_request' ||  inputs.env == 'dev' || inputs.env == 'test' }}
+      - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
-      - name: Configure GHA prod AWS Credentials
-        if: ${{ inputs.env == 'sandbox' || inputs.env == 'prod' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-prod-github-actions
-      - name: echo role arn
-        run: |
-          echo "/opt-out-import/dpc/${{ inputs.env || 'dev' }}/bfd-bucket-role-arn"
-
+          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-test-github-actions
       - name: retrieve bfd bucket role
         uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            BFD_BUCKET_ROLE=/opt-out-import/dpc/${{ inputs.env || 'dev' }}/bfd-bucket-role-arn
-
-      - name: Configure import lambda non-prod AWS Credentials
-        if: ${{ github.event_name == 'pull_request' || inputs.env == 'dev' || inputs.env == 'test' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-opt-out-import-function
-      - name: Configure import lambda non-prod AWS Credentials
-        if: ${{ inputs.env == 'sandbox' || inputs.env == 'prod' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-prod-opt-out-import-function
-
+            BFD_BUCKET_ROLE=/opt-out-import/dpc/test/bfd-bucket-role-arn
       - name: Configure BFD bucket credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/opt-out-export-test-integration-gf.yml
+++ b/.github/workflows/opt-out-export-test-integration-gf.yml
@@ -31,6 +31,9 @@ jobs:
   deploy:
     if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/opt-out-export-deploy-gf.yml
+    permissions:
+      contents: read
+      id-token: write
     with:
       env: dev
     secrets: inherit

--- a/.github/workflows/opt-out-export-test-integration.yml
+++ b/.github/workflows/opt-out-export-test-integration.yml
@@ -18,6 +18,9 @@ jobs:
   deploy:
     if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/opt-out-export-deploy.yml
+    permissions:
+      contents: read
+      id-token: write
     with:
       env: test
     secrets: inherit

--- a/.github/workflows/opt-out-import-deploy-gf.yml
+++ b/.github/workflows/opt-out-import-deploy-gf.yml
@@ -29,6 +29,9 @@ jobs:
   deploy:
     name: 'Deploy Opt Out Import'
     uses: ./.github/workflows/deploy_go_lambda_gf.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: ${{ inputs.env || 'dev' }}
       project: opt-out-import

--- a/.github/workflows/opt-out-import-deploy.yml
+++ b/.github/workflows/opt-out-import-deploy.yml
@@ -29,6 +29,9 @@ jobs:
   deploy:
     name: 'Deploy Opt Out Import'
     uses: ./.github/workflows/deploy_go_lambda.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       env: ${{ inputs.env || 'dev' }}
       project: opt-out-import


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4738

## 🛠 Changes

- Explicit permissions granted to called workflows in lambda-deploy workflows
- Go deploy for greenfield updated to reflect current legacy deploy pattern

## ℹ️ Context

Security was tightened in GHA, so we need to explicitly grant permissions to called workflows.
Also, lambda deploys to prod should first be deployed to test, then promoted to prod. It does this now.

## 🧪 Validation

All deploys ran successfully:
Api Waf Sync
Legacy
dev:
https://github.com/CMSgov/dpc-app/actions/runs/15310334895/job/43073262238

Greenfield
dev:
https://github.com/CMSgov/dpc-app/actions/runs/15310367866/job/43073367762

Opt Out Export
Legacy
dev
https://github.com/CMSgov/dpc-app/actions/runs/15310484002

Greenfield
dev
https://github.com/CMSgov/dpc-app/actions/runs/15310508302
test
https://github.com/CMSgov/dpc-app/actions/runs/15329349361
prod
https://github.com/CMSgov/dpc-app/actions/runs/15333364068/job/43145203615

Opt Out Import
Legacy
dev
https://github.com/CMSgov/dpc-app/actions/runs/15333422452/job/43145394890

Greenfield
dev
https://github.com/CMSgov/dpc-app/actions/runs/15333448607
test
https://github.com/CMSgov/dpc-app/actions/runs/15333487815/job/43145623340
prod
https://github.com/CMSgov/dpc-app/actions/runs/15333549718/job/43145827451
