### PR TITLE
remove duplicated permission

### DIFF
--- a/.github/workflows/opt-out-export-deploy-gf.yml
+++ b/.github/workflows/opt-out-export-deploy-gf.yml
@@ -28,9 +28,6 @@ on:
 jobs:
   deploy:
     name: 'Deploy Opt Out Export'
-    permissions:
-      contents: read
-      id-token: write
     uses: ./.github/workflows/deploy_go_lambda_gf.yml
     permissions:
       id-token: write


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

duplicate permission stanza removed from opt-out-export-deploy-gf.yml

## ℹ️ Context

Invalid yaml

## 🧪 Validation
No longer flagged as invalid
