### PR TITLE
security updates - tell snyk to ignore incompatibile versions of jooq

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -90,4 +90,9 @@ ignore:
     - '*':
         reason: false positive; already upgraded
         created: 2021-12-22T12:46:0.0Z
+  "pkg:maven/org.jooq/jooq":
+    - reason: "Incompatible with JDK 17"
+      created: 2025-06-05T13:22:0.0Z
+      versions:
+        - ">=3.20.0"
 patch: {}


### PR DESCRIPTION
## 🎫 Ticket

No ticket.

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
add jooq to `ignore:` for `.snyk` file

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - As part of the weekly on-call responsibilities for DPC, engineers are tasked with reviewing automated package upgrade PR's as part of [DPC security tasks](https://confluence.cms.gov/display/DAPC/DPC+Security+Tasks).
 - newer versions of jooq are not compatible with the JDK for this project (JDK 17)
   - jooq compatibility matrix available [HERE](https://www.jooq.org/download/support-matrix-jdk#oss)


## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
n/a