### PR TITLE
upgrade rack due to CVE-2025-49007

### DIFF
--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-protection (4.1.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -375,7 +375,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-oauth2 (2.2.1)
       activesupport
       attr_required

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -289,7 +289,7 @@ GEM
     puma (6.4.3)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Rails apps updated to use Rack 3.1.16

## ℹ️ Context

Addresses CVE-2025-49007

## 🧪 Validation

Builds and passes ci
