### PR TITLE
[DPC-4751] migrate ci-workflow to greenfield account

### DIFF
--- a/.github/workflows/ci-workflow-gf.yml
+++ b/.github/workflows/ci-workflow-gf.yml
@@ -1,0 +1,357 @@
+name: "DPC CI Workflow"
+
+on:
+  pull_request:
+    paths-ignore:
+      - .github/workflows/opt-out-*
+      - docs/**
+      - dpc-load-testing/**
+      - lambda/**
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  VAULT_PW: ${{ secrets.VAULT_PW }}
+  REPORT_COVERAGE: true
+  DPC_CA_CERT: ${{ secrets.DPC_CA_CERT }}
+  ENV: "github-ci"
+
+jobs:
+  build-api:
+    name: "Build and Test API"
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "corretto"
+          cache: maven
+      - name: Clean maven
+        run: mvn -ntp -U clean
+      - name: "Set up Python and install Ansible"
+        run: |
+          sudo dnf -y install python3 python3-pip
+          pip install ansible
+      - name: Install npm
+        run: |
+          sudo dnf -y install nodejs
+          npm --version
+          node --version
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "API Build"
+        id: ci-app
+        run: |
+          export PATH=$PATH:~/.local/bin
+          make ci-app
+      - name: "Debug db"
+        if: ${{ failure() && steps.ci-app.outcome == 'failure' }}
+        run: docker logs start-v1-app-db-1
+      - name: "Debug consent"
+        if: ${{ failure() && steps.ci-app.outcome == 'failure' }}
+        run: docker logs start-v1-app-consent-1
+      - name: "Debug attribution"
+        if: ${{ failure() && steps.ci-app.outcome == 'failure' }}
+        run: docker logs start-v1-app-attribution-1
+      - name: "Debug aggregation"
+        if: ${{ failure() && steps.ci-app.outcome == 'failure' }}
+        run: docker logs start-v1-app-aggregation-1
+      - name: "Debug api"
+        if: ${{ failure() && steps.ci-app.outcome == 'failure' }}
+        run: docker logs start-v1-app-api-1
+      - name: "Move jacoco reports"
+        run: |
+          sudo mkdir jacoco-reports
+          sudo cp ./dpc-aggregation/target/site/jacoco-it/jacoco.xml jacoco-reports/dpc-aggregation-it-jacoco.xml
+          sudo cp ./dpc-aggregation/target/site/jacoco/jacoco.xml jacoco-reports/dpc-aggregation-jacoco.xml
+          sudo cp ./dpc-api/target/site/jacoco-it/jacoco.xml jacoco-reports/dpc-api-it-jacoco.xml
+          sudo cp ./dpc-api/target/site/jacoco/jacoco.xml jacoco-reports/dpc-api-jacoco.xml
+          sudo cp ./dpc-attribution/target/site/jacoco-it/jacoco.xml jacoco-reports/dpc-attribution-it-jacoco.xml
+          sudo cp ./dpc-attribution/target/site/jacoco/jacoco.xml jacoco-reports/dpc-attribution-jacoco.xml
+          sudo cp ./dpc-bluebutton/target/site/jacoco/jacoco.xml jacoco-reports/dpc-bluebutton-jacoco.xml
+          sudo cp ./dpc-common/target/site/jacoco/jacoco.xml jacoco-reports/dpc-common-jacoco.xml
+          sudo cp ./dpc-consent/target/site/jacoco-it/jacoco.xml jacoco-reports/dpc-consent-it-jacoco.xml
+          sudo cp ./dpc-consent/target/site/jacoco/jacoco.xml jacoco-reports/dpc-consent-jacoco.xml
+          sudo cp ./dpc-macaroons/target/site/jacoco/jacoco.xml jacoco-reports/dpc-macaroons-jacoco.xml
+          sudo cp ./dpc-queue/target/site/jacoco/jacoco.xml jacoco-reports/dpc-queue-jacoco.xml
+      - name: Upload jacoco reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-api
+          path: ./jacoco-reports
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  build-dpc-web:
+    name: "Build and Test DPC Web"
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "DPC Web Build"
+        run: |
+          make ci-web-portal
+      - name: "Copy test results"
+        run: sudo cp dpc-web/coverage/.resultset.json web-resultset-raw.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-web
+          path: ./web-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  build-dpc-admin:
+    name: "Build and Test DPC Admin Portal"
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "DPC Admin Portal Build"
+        run: |
+          make ci-admin-portal
+      - name: "Copy test results"
+        run: sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-admin
+          path: ./admin-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  build-dpc-portal:
+    name: "Build and Test DPC Portal"
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: Install docker compose manually
+        run: |
+          mkdir -p /usr/local/lib/docker/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64 -o /usr/local/lib/docker/cli-plugins/docker-compose
+          chown root:root /usr/local/lib/docker/cli-plugins/docker-compose
+          chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      - name: "DPC Portal Build"
+        run: |
+          make ci-portal
+      - name: "Copy test results"
+        run: sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report-dpc-portal
+          path: ./portal-resultset-raw.json
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  build-dpc-client:
+    name: "Build and Test DPC Client"
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: "DPC Client Build"
+        run: |
+          make ci-api-client
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  sonar-quality-gate-dpc-web-and-admin:
+    name: Sonarqube Quality Gate for dpc-web and dpc-admin
+    needs: [build-dpc-admin, build-dpc-web]
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    env:
+      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: Download web code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-web
+      - name: Download admin code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-admin
+      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+        run: |
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-web") then .key |= sub("/dpc-web"; "${{ github.workspace }}/dpc-web") else . end)' web-resultset-raw.json > web-resultset.json
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-admin") then .key |= sub("/dpc-admin"; "${{ github.workspace }}/dpc-admin") else . end)' admin-resultset-raw.json > admin-resultset.json
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+      - name: Run quality gate scan
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args:
+            -Dsonar.projectKey=bcda-dpc-web
+            -Dsonar.sources=./dpc-web/app,./dpc-web/lib,./dpc-admin/app,./dpc-admin/lib
+            -Dsonar.ruby.coverage.reportPaths=./web-resultset.json,./admin-resultset.json
+            -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
+            -Dsonar.qualitygate.wait=true
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  sonar-quality-gate-dpc-portal:
+    name: Sonarqube Quality Gate for dpc-portal
+    needs: build-dpc-portal
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    env:
+      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: "Checkout code"
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: Download code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-portal
+      - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
+        run: |
+          sudo jq '.RSpec.coverage |= with_entries(if .key | contains("dpc-portal") then .key |= sub("/dpc-portal"; "${{ github.workspace }}/dpc-portal") else . end)' portal-resultset-raw.json > portal-resultset.json
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+      - name: Run quality gate scan
+        uses: sonarsource/sonarqube-scan-action@master
+        with:
+          args:
+            -Dsonar.projectKey=bcda-dpc-portal
+            -Dsonar.sources=./dpc-portal/app,./dpc-portal/lib
+            -Dsonar.coverage.exclusions=**/*_preview.rb,**/*html.erb,**/application_*
+            -Dsonar.ruby.coverage.reportPaths=./portal-resultset.json
+            -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+            -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
+            -Dsonar.qualitygate.wait=true
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh
+
+  sonar-quality-gate-dpc-api:
+    name: Sonarqube Quality Gate for dpc-api
+    needs: build-api
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    env:
+      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    steps:
+      - name: Assert Ownership
+        run: sudo chmod -R 777 .
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Cleanup Runner
+        run: ./scripts/cleanup-docker.sh
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: temurin
+          cache: maven
+      - name: Set env vars from AWS params
+        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        with:
+          params: |
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
+      - name: Install Maven 3.6.3
+        run: |
+          export PATH="$PATH:/opt/maven/bin"
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          if mvn -v; then echo "Maven already installed" && exit 0; else echo "Installing Maven"; fi
+          tmpdir="$(mktemp -d)"
+          curl -LsS https://archive.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C "$tmpdir"
+          sudo rm -rf /opt/maven
+          sudo mv "$tmpdir/apache-maven-3.6.3" /opt/maven
+      - name: Clean maven
+        run: |
+          mvn -ntp -U clean
+      - name: Compile Project
+        run: |
+          mvn clean compile -Perror-prone -B -V -ntp
+      - name: Download code coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: code-coverage-report-dpc-api
+          path: jacoco-reports
+      - name: Verify download
+        run: |
+          find . -name dpc-api-jacoco.xml
+      - name: Run quality gate scan
+        run: |
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"
+      - name: Cleanup
+        if: ${{ always() }}
+        run: ./scripts/cleanup-docker.sh


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4751](https://jira.cms.gov/browse/DPC-4751)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - Majority of workflows were migrated to greenfield prior to launch.
  - This workflow was not tracked in the backlog and I noticed ci-workflow was running on the old account's runners when it was failing.
  - Maven should automatically be installed as part of the setup-java action, so we don't have to manage how apache updates their maven downloads list
  ```
        - name: "Set up JDK 17"
        uses: actions/setup-java@v4
        with:
          java-version: "17"
          distribution: "corretto"
```

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
