### PR TITLE
[On Call] DropWizard 4.0.11 -> 4.0.13

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/AuthRelatedLoggingFilter.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/logging/filters/AuthRelatedLoggingFilter.java
@@ -1,6 +1,6 @@
 package gov.cms.dpc.common.logging.filters;
 
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/AuthRelatedLoggingFilterTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/common/logging/filters/AuthRelatedLoggingFilterTest.java
@@ -1,7 +1,6 @@
 package gov.cms.dpc.common.logging.filters;
 
-
-import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.filter.Filter;
 import ch.qos.logback.core.spi.FilterReply;
 import io.dropwizard.logging.common.filter.FilterFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>4.0.11</dropwizard.version>
+        <dropwizard.version>4.0.13</dropwizard.version>
         <junit.jupiter.version>5.12.1</junit.jupiter.version>
         <slf4j.version>2.0.17</slf4j.version>
         <hapi.fhir.groupID>ca.uhn.hapi.fhir</hapi.fhir.groupID>


### PR DESCRIPTION
## 🎫 Ticket

None, part of on call

## 🛠 Changes

- Update DropWizard from 4.0.11 -> 4.0.13
- Update location of `IAccessEvent` class in `AuthRelatedLoggingFilter`.

## ℹ️ Context

Snyk opened https://github.com/CMSgov/dpc-app/pull/2640 to upgrade `dropwizard-json-logging`, and all of DropWizard, from 4.0.11 to 4.0.13.  The PR fails with a compilation error, though, because the `IAccessEvent` class was moved to a new location in the logback library.

## 🧪 Validation

Program compiles and all tests pass.
