### PR TITLE
DPC-4600: better expired authorization error message

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCUnauthorizedHandler.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/DPCUnauthorizedHandler.java
@@ -21,12 +21,15 @@ public class DPCUnauthorizedHandler implements UnauthorizedHandler {
     public Response buildResponse(String prefix, String realm) {
         final var outcome = new OperationOutcome();
         final var coding = new Coding();
+        final var concept = new CodeableConcept();
         coding.setSystem("http://hl7.org/fhir/ValueSet/operation-outcome");
-        coding.setCode("HTTP 401 Unauthorized, Credentials are required to access this resource.");
+        coding.setCode("MSG_AUTH_REQUIRED");
+        concept.addCoding(coding);
+        concept.setText("HTTP 401 Unauthorized, Credentials are required to access this resource.");
         outcome.addIssue()
                 .setSeverity(OperationOutcome.IssueSeverity.ERROR)
                 .setCode(OperationOutcome.IssueType.EXCEPTION)
-                .setDetails(new CodeableConcept().addCoding(coding));
+                .setDetails(concept);
 
         return Response.status(Status.UNAUTHORIZED)
                 .type(FHIR_JSON)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4600

## 🛠 Changes

Updated operation outcome in DPCUnauthorizedHandler

## ℹ️ Context

Our error message was out of fhir compliance. We had text where the code should go.

## 🧪 Validation

Running locally, 

`curl http://localhost:3002/api/v1/Organization/foo -H 'Authorization: Bearer foo'`

Returned
```
{
  "resourceType": "OperationOutcome",
  "issue": [
    {
      "severity": "error",
      "code": "exception",
      "details": {
        "coding": [
          {
            "system": "http://hl7.org/fhir/ValueSet/operation-outcome",
            "code": "MSG_AUTH_REQUIRED"
          }
        ],
        "text": "HTTP 401 Unauthorized, Credentials are required to access this resource."
      }
    }
  ]
}
```
