### PR TITLE
[None] Fix maven-config.sh

### DIFF
--- a/maven-config.sh
+++ b/maven-config.sh
@@ -5,11 +5,17 @@ mkdir -p ./.mvn
 : > ./.mvn/maven.config
 
 function process_line() {
+    # Don't process an empty line
+    if [ -z "$1" ]
+    then
+      return
+    fi
+
   KEY="$(echo "$1" | cut -d '=' -f1)"
   VALUE="$(echo "$1" | cut -d '=' -f2)"
 
   # Quoted values need special handling
-  # Before: Key="Value"
+  # Before: -DKey="Value"
   # After: "-DKey=Value"
   if [ "${VALUE:0:1}" == '"' ]
   then


### PR DESCRIPTION
## 🎫 Ticket

None, quick fix.

## 🛠 Changes

Fixes `maven-config.sh` not handling blank lines in our decrypted `local.env` file.

## ℹ️ Context

Somewhere along the way we added a blank line at the end of `ops/config/decrypted/local.env`.  `maven-config.sh` reads this and adds an empty parameter to `./mvn/maven.config` that breaks our build commands.  This PR makes sure we ignore empty lines and generate a valid `maven.config`.

## 🧪 Validation

Run `make maven-config`, then open the `maven.config` file and make sure there's not a line with just `-D` and no parameter.
