### PR TITLE
DPC-4664 Upgrade Documentation to meet OSS Tier 2 documentation standards

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,17 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of the level of experience, gender, gender identity, expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers at opensource@cms.hhs.gov.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)
+
+## Acknowledgements
+
+This CODE_OF_CONDUCT.md was originally forked from the [United States Digital Service](https://usds.gov) [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool), and we would like to acknowledge and thank the community for their contributions.

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,29 @@
+# DPC App
+
+## Project Members
+
+| Role | Github Handle | Affiliation |
+| :----- | :------ | :------------- |
+| Developers/Contributors | lukey-luke | CMS/DASG/Contractor  |
+| Developers/Contributors | MEspositoE14s | CMS/DASG/Contractor  |
+| Developers/Contributors | chris-ronning-ny | CMS/DASG/Contractor  |
+| Developers/Contributors | ashley-weaver | CMS/DASG/Contractor  |
+| Developers/Contributors | jdettmannnava | CMS/DASG/Contractor  |
+
+For past contributions see [Contributors](https://github.com/CMSgov/dpc-app/graphs/contributors).
+
+### Principles
+
+These principles guide our data, product, and process decisions, architecture, and approach.
+
+- Practice empathy and humility.
+- Assume competence in your colleagues, clients and the public.
+- Assume that everyone we work with is doing their best work for the public.
+- Listen carefully and actively.
+- Ask questions, and seek to understand your partners&#39; context.
+- Encourage other people to listen as much as they speak.
+- Treat other people&#39;s identities and cultures with respect. Make an effort to say people&#39;s names correctly and refer to them by their chosen pronouns.
+
+## Community Guidelines
+
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/CDCgov/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.

--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -27,3 +27,7 @@ These principles guide our data, product, and process decisions, architecture, a
 ## Community Guidelines
 
 We want to ensure a welcoming environment for all of our projects. Our staff follow the [18F Code of Conduct](https://github.com/CDCgov/code-of-conduct/blob/master/code-of-conduct.md) and all contributors should do the same.
+
+## Acknowledgements
+
+We would like to acknowledge and thank the [United States Digital Service](https://usds.gov) and the [Justice40](https://thejustice40.com) open source [repository](https://github.com/usds/justice40-tool) for their previous work and their establishment of best practices.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contribution expectations
+
+The following expectations apply to each PR:
+
+1. The PR and branch are named for [automatic linking](https://support.atlassian.com/jira-cloud-administration/docs/use-the-github-for-jira-app/) to the most relevant JIRA issue (for example, `JRA-123 Adds foo` for PR title and `jra-123-adds-foo` for branch name).
+2. Reviewers are selected to include people from all teams impacted by the changes in the PR.
+3. The PR has been assigned to the people who will respond to reviews and merge when ready (usually the person filing the review, but can change when a PR is handed off to someone else).
+4. The PR is reasonably limited in scope to ensure:
+   - It doesn't bunch together disparate features, fixes, refactorings, etc.
+   - There isn't too much of a burden on reviewers.
+   - Any problems it causes have a small blast radius.
+   - Changes will be easier to roll back if necessary.
+5. The PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
+6. All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
+7. Any incomplete work introduced by the PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,9 @@
-# Contribution expectations
+# Contributing
+
+## Getting Started
+Full instructions on how to build and test the project is available on the [README](./README.md).
+
+## Contribution expectations
 
 The following expectations apply to each PR:
 
@@ -13,3 +18,12 @@ The following expectations apply to each PR:
 5. The PR includes any required documentation changes, including `README` updates and changelog or release notes entries.
 6. All new and modified code is appropriately commented to make the what and why of its design reasonably clear, even to those unfamiliar with the project.
 7. Any incomplete work introduced by the PR is detailed in `TODO` comments which include a JIRA ticket ID for any items that require urgent attention.
+
+## Issues
+Please report any issues to [Issues](./issues).
+
+## Policies
+Contributions to this project must comply with [Section 508](https://www.section508.gov/) accessibility standards.
+
+## Public Domain
+This project is subject to the [Creative Commons Zero 1.0 International License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This document serves as a guide for running the Data at the Point of Care (DPC) 
   * [Debugging Integration Tests](#debugging-integration-tests)
   * [Other Notes](#other-notes)
     * [BFD transaction time details](#bfd-transaction-time-details)
-  * [Troubleshooting](#troubleshooting) 
+  * [Troubleshooting](#troubleshooting)
+  * [More about DPC](#more-about-dpc)
 <!-- TOC -->
 
 
@@ -494,3 +495,31 @@ Therefore, using a fake patient ID which is guaranteed not to match is an easy w
 ###### [`^`](#table-of-contents)
 
 Please see the [troublshooting document ](Troubleshooting.md) for more help.
+
+## More About DPC
+###### [`^`](#table-of-contents)
+### Project Vision
+The project vision is available at [https://dpc.cms.gov](https://dpc.cms.gov).
+
+### Agency Mission
+
+See [https://www.cms.gov](https://www.cms.gov) for this project's agency's mission.
+
+### Team Mission
+
+DPC operates under the [Data Analytics and Systems Group](https://www.cms.gov/research-statistics-data-and-systems/data-analytics-and-systems-group).
+
+### Core Team
+Team members are listed on our [community page](./COMMUNITY.md).
+
+### Contributing
+Contributions should follow [our policy](./CONTRIBUTING.md).
+
+### Community Guidelines
+See the [Code of Conduct](./CODE_OF_CONDUCT.md) for community guidelines.
+
+### Policies
+Contributions to this project must comply with [Section 508](https://www.section508.gov/) accessibility standards.
+
+### Public Domain
+This project is subject to the [Creative Commons Zero 1.0 International License](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security and Responsible Disclosure Policy
+
+The Centers for Medicare & Medicaid Services is committed to ensuring the security of the American public by protecting their information from unwarranted disclosure. We want security researchers to feel comfortable reporting vulnerabilities they have discovered so we can fix them and keep our users safe. We developed our disclosure policy to reflect our values and uphold our sense of responsibility to security researchers who share their expertise with us in good faith.
+
+*Submit a vulnerability:* Vulnerability reports can be submitted through [Bugcrowd](https://bugcrowd.com/cms-vdp). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+
+Review the HHS Disclosure Policy and websites in scope:
+[https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
+
+This policy describes *what systems and types of research* are covered under this
+policy, *how to send* us vulnerability reports, and *how long* we ask security
+researchers to wait before publicly disclosing vulnerabilities.

--- a/code.json
+++ b/code.json
@@ -1,0 +1,71 @@
+{
+  "name": "dpc-app",
+  "description": "DPC is an application programming interface (API) whose goal is to enable healthcare providers to deliver high quality care directly to Medicare beneficiaries.",
+  "longDescription": "DPC is an application programming interface (API) whose goal is to enable healthcare providers to deliver high quality care directly to Medicare beneficiaries.",
+  "status": "production",
+  "permissions": {
+    "licenses": [
+      {
+        "URL": "LICENSE.md",
+        "name": "CC0-1.0"
+      }
+    ],
+    "usageType": "openSource"
+  },
+  "organization": "Centers for Medicare & Medicaid Services",
+  "repositoryURL": "https://github.com/CMSGov/dpc-app",
+  "repositoryHost": "github.com/CMSgov",
+  "repositoryVisibility": "public",
+  "vcs": "git",
+  "laborHours": null,
+  "reuseFrequency": {
+    "forks": 0
+  },
+  "platforms": [
+    "web"
+  ],
+  "categories": [
+    "healthcare"
+  ],
+  "softwareType": "standalone/web",
+  "languages": [
+    "java", "ruby", "go"
+  ],
+  "maintenance": "contract",
+  "contractNumber": "0",
+  "date": {
+    "created": "2019-02-05T09:49:55-05:00",
+    "lastModified": "2025-06-24T14:33:33+0000",
+    "metadataLastUpdated": "2025-06-24T14:33:33+0000"
+  },
+  "tags": [
+    "dsacms-tier2"
+  ],
+  "contact": {
+    "email": "opensource@cms.hhs.gov",
+    "name": "CMS Open Source Program Office"
+  },
+  "feedbackMechanisms": [
+    "https://github.com/CMSGov/dpc-app/issues"
+  ],
+  "localisation": "false",
+  "repositoryType": "Package",
+  "userInput": "Yes",
+  "fismaLevel": "Low",
+  "group": "DASG",
+  "projects": [
+    "DPC"
+  ],
+  "systems": [],
+  "upstream": [],
+  "subsetInHealthcare": [
+    "Policy",
+    "Operational",
+    "Medicare",
+    "Medicaid"
+  ],
+  "userType": [
+    "Providers"
+  ],
+  "maturityModelTier": 2
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4664

## 🛠 Changes

Added
- CODE_OF_CONDUCT.md
- COMMUNITY.md
- CONTRIBUTING.md
- LICENSE
- SECURITY.md
- code.json

Updated README.md to include more information about the project.

## ℹ️ Context

Because of the Share IT Act, our repositories need to meet certain minimum standards. These standards are described in https://github.com/DSACMS/repo-scaffolder/blob/main/maturity-model-tiers.md. Using the diagram on that page, I determined that our projects are at tier 2, and I added documentation accordingly.

## 🧪 Validation

Evaluated new markdown in firefox via markdown viewer, and it looked OK.
