### PR TITLE
DPC-4764 remove 'gf-' prefix from directories in dpc-ops

### DIFF
--- a/.github/workflows/check_healthy_gf.yml
+++ b/.github/workflows/check_healthy_gf.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   wait-for-services:
     name: Wait for services to be healthy
-    runs-on: self-hosted
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
     strategy:
       matrix:
         include:

--- a/.github/workflows/ecs-deploy-gf.yml
+++ b/.github/workflows/ecs-deploy-gf.yml
@@ -147,24 +147,24 @@ jobs:
           directory: .
       - name: Verify persistent plan
         run: |
-          cd dpc-ops/terraform/gf-${{ inputs.env }}/persistent
+          cd dpc-ops/terraform/${{ inputs.env }}/persistent
           terraform init
-          terraform plan -out dpc-release-gf-${{ inputs.env }}.tfplan 2>&1
+          terraform plan -out dpc-release-${{ inputs.env }}.tfplan 2>&1
       - name: Apply persistent plan
         run: |
-          cd dpc-ops/terraform/gf-${{ inputs.env }}/persistent
-          terraform apply dpc-release-gf-${{ inputs.env }}.tfplan
+          cd dpc-ops/terraform/${{ inputs.env }}/persistent
+          terraform apply dpc-release-${{ inputs.env }}.tfplan
       - name: Verify main environment plan
         run: |
-          cd dpc-ops/terraform/gf-${{ inputs.env }}
+          cd dpc-ops/terraform/${{ inputs.env }}
           terraform init
           terraform plan -var 'release_version=${{ inputs.app-version}}' \
                          -var 'image_tag=${{ steps.image-tag.outputs.image_tag }}' \
-                         -out dpc-release-gf-${{ inputs.env }}.tfplan
+                         -out dpc-release-${{ inputs.env }}.tfplan
       - name: Apply main environment plan
         run: |
-          cd dpc-ops/terraform/gf-${{ inputs.env }}
-          terraform apply dpc-release-gf-${{ inputs.env }}.tfplan
+          cd dpc-ops/terraform/${{ inputs.env }}
+          terraform apply dpc-release-${{ inputs.env }}.tfplan
       - uses: slackapi/slack-github-action@v2.0.0
         name: Slack failure
         if: ${{ failure() }}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4764

## 🛠 Changes

ecs-deploy-gf workflow updated to point to non-prefixed dpc-ops directory for deployment.
Run check_healthy on codebuild.

## ℹ️ Context

We are removing explicit references to greenfield in our operations processes as part of post-migration cleanup

## 🧪 Validation

Successfully ran deploy workflow using [dpc-ops branch](https://github.com/CMSgov/dpc-ops/pull/842) with gf- prefixes removed: https://github.com/CMSgov/dpc-app/actions/runs/15909902931