### PR TITLE
Upgrade netty-handler-proxy

### DIFF
--- a/dpc-bluebutton/pom.xml
+++ b/dpc-bluebutton/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler-proxy</artifactId>
-            <version>4.2.1.Final</version>
+            <version>4.2.2.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/dpc-queue/pom.xml
+++ b/dpc-queue/pom.xml
@@ -95,6 +95,12 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatch</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.github.azagniotov</groupId>

--- a/dpc-queue/pom.xml
+++ b/dpc-queue/pom.xml
@@ -13,7 +13,7 @@
     <name>DPC Java Job Queue</name>
 
     <properties>
-        <aws.java.sdk.version>2.29.20</aws.java.sdk.version>
+        <aws.java.sdk.version>2.31.71</aws.java.sdk.version>
     </properties>
 
     <dependencyManagement>
@@ -95,16 +95,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatch</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.github.azagniotov</groupId>

--- a/dpc-queue/pom.xml
+++ b/dpc-queue/pom.xml
@@ -98,7 +98,11 @@
             <exclusions>
                 <exclusion>
                     <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## 🎫 Ticket

No ticket.

## 🛠 Changes

Upgrades netty-handler-proxy and awssdk.cloudwatch

## ℹ️ Context

Our version of cloudwatch was introducing a transitive vulnerability that needed to be excluded for the netty-handler-proxy upgrade to be clean on Snyk. The [automated PR](https://github.com/CMSgov/dpc-app/pull/2697) did not include this exclusion.

## 🧪 Validation

Passes Snyk security test.
