### PR TITLE
[dpc-4710] Shuts down dpc-queue after AggregationEngine

### DIFF
--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationService.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/DPCAggregationService.java
@@ -42,9 +42,12 @@ public class DPCAggregationService extends Application<DPCAggregationConfigurati
                 new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(), substitutor);
         bootstrap.setConfigurationSourceProvider(provider);
 
+        // AggregationAppModule needs to be added after DPCQueueHibernateModule, because DropWizard shuts these down
+        // in reverse order, and we don't want the queue DB to be disconnected until after the aggregation engine stops
+        // running.
         GuiceBundle guiceBundle = GuiceBundle.builder()
-                .modules(new AggregationAppModule(),
-                        new DPCQueueHibernateModule<>(queueHibernateBundle),
+                .modules(new DPCQueueHibernateModule<>(queueHibernateBundle),
+                        new AggregationAppModule(),
                         new DPCHibernateModule<>(hibernateBundle),
                         new JobQueueModule<DPCAggregationConfiguration>(),
                         new BlueButtonClientModule<DPCAggregationConfiguration>())

--- a/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
+++ b/dpc-aggregation/src/main/java/gov/cms/dpc/aggregation/engine/AggregationEngine.java
@@ -96,7 +96,10 @@ public class AggregationEngine implements Runnable {
 
         // If a batch is currently running, mark it paused.
         Optional<JobQueueBatch> optionalBatch = this.currentBatch.get();
-        optionalBatch.ifPresent(jobQueueBatch -> this.queue.pauseBatch(jobQueueBatch, aggregatorID));
+        optionalBatch.ifPresent(jobQueueBatch -> {
+            logger.info("Pausing batch: {}", jobQueueBatch.getBatchID());
+            this.queue.pauseBatch(jobQueueBatch, aggregatorID);
+        });
     }
 
     public boolean isRunning() {

--- a/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
+++ b/dpc-queue/src/main/java/gov/cms/dpc/queue/DistributedBatchQueue.java
@@ -239,6 +239,8 @@ public class DistributedBatchQueue extends JobQueueCommon {
             } finally {
                 tx.commit();
             }
+        } catch(Exception e) {
+            logger.error("Pausing batch: {} {}", job.getBatchID(), e.getMessage());
         }
     }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4710
Bugfix for https://github.com/CMSgov/dpc-app/pull/2706

## 🛠 Changes

Updated the order that `DPCQueueHibernateModule` and `AggregationAppModule` are added to the `DPCAggregationService`.

## ℹ️ Context

DropWizard shuts these modules down in the opposite order they are added, and we don't want the queue to shutdown until after the aggregation engine has finished processing or it won't be able to update its last batch.

This wasn't caught in initial testing for two reasons:

1. Our tests used the `MemoryBatchQueue` which doesn't connect to an external DB.
2. Our code was ignoring the errors when it tried to pause a batch instead of logging them. 

## 🧪 Validation

1. Go into your local queue DB and pick out your most recently completed batch.
2. Update the batch's `status` to 0 (_queued_), its `aggregator_id` to `null`, and its patient to `9S99EU8XY92`.  (this patient tells MockBfdClient to hang forever, simulating a long running patient)
3. Start up dpc-aggregation and it will pick up the batch and set its status to 1 (_running_).
4. Stop dpc-aggregation.  

If you do this on the current main branch, the status of the batch will still be 1 (_running_).  If you recompile from this branch and go through the same process the batch will be reset to 0 (_queued_), which is what we want.
