### PR TITLE
Aggregation Integration Test Fix

### DIFF
--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
@@ -92,6 +92,10 @@ public class AggregationServiceTest {
 
         // Stop aggregation and make sure it pauses the batch
         APPLICATION.after();
+        await().until(() -> {
+            JobQueueBatch batch = queue.getJobBatches(jobID).get(0);
+            return batch.getStatus() == JobStatus.QUEUED;
+        });
         assertEquals(JobStatus.QUEUED, queue.getJobBatches(jobID).get(0).getStatus());
     }
 }


### PR DESCRIPTION
## 🎫 Ticket

Bugfix

## 🛠 Changes

Fix aggregation integration test that fails intermittently.  

## ℹ️ Context

`AggregationServiceTest.testStoppingEngineMidBatch` is failing intermittently.  See [this deploy](https://github.com/CMSgov/dpc-app/actions/runs/16228794610/job/45826969874) where it failed.

## 🧪 Validation

Ran test and it passed.  All checks pass on this PR.
