### PR TITLE
Me/dpc 4791 create release and test gha

### DIFF
--- a/.github/workflows/ecs-release.yml
+++ b/.github/workflows/ecs-release.yml
@@ -111,7 +111,7 @@ jobs:
     if: |
       !cancelled() && 
       (needs.build.result == 'skipped' || needs.build.result == 'success') &&
-      (needs.set-parameters.result == 'skipped' || needs.set-parameters.result == 'success')
+      (needs.set-parameters.result == 'success')
     uses: ./.github/workflows/ecs-deploy.yml
     with:
       env: ${{ inputs.env || 'dev'  }}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4791

## 🛠 Changes

Added a flag to ecs-release.yml so we can run it without building docker images.

## ℹ️ Context

We're going to be updating dpc-ops so that changes there call to this repo to do a deploy and run the smoke tests.  In that scenario, we don't want to rebuild our docker images since they haven't changed.  We just want to test our terraform updates.

We could just have dpc-ops call the deploy and smoke test workflows individually, but the calls are done asynchronously, and there's no way to make it wait for the deploy to finish before starting the smoke tests.  

## 🧪 Validation

- Deploy without building docker images: https://github.com/CMSgov/dpc-app/actions/runs/16268102754
- Deploy with building docker images: https://github.com/CMSgov/dpc-app/actions/runs/16229205015
