### PR TITLE
DPC-4782: Infrastructure for dpc-web accessibility tests

### DIFF
--- a/.github/workflows/dpc-web-accessibility-test.yml
+++ b/.github/workflows/dpc-web-accessibility-test.yml
@@ -1,0 +1,18 @@
+name: Dpc-Web Accessibility Tests
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: 'Run Axe Accessibility tests on DPC-Web'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: "Run Tests"
+        run: |
+          make ci-web-accessibility

--- a/.github/workflows/dpc-web-accessibility-test.yml
+++ b/.github/workflows/dpc-web-accessibility-test.yml
@@ -2,9 +2,6 @@ name: Dpc-Web Accessibility Tests
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - .github/workflows/dpc-web-accessibility-test.yml
 
 jobs:
   test:

--- a/.github/workflows/dpc-web-accessibility-test.yml
+++ b/.github/workflows/dpc-web-accessibility-test.yml
@@ -2,6 +2,9 @@ name: Dpc-Web Accessibility Tests
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/dpc-web-accessibility-test.yml
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,10 @@ ci-portal: secure-envs
 ci-portal-accessibility: secure-envs
 	@./dpc-portal-accessibility-test.sh
 
+.PHONY: ci-web-accessibility
+ci-web-accessibility: secure-envs
+	@./dpc-web-accessibility-test.sh
+
 .PHONY: ci-web-portal
 ci-web-portal: secure-envs
 	@./dpc-web-portal-test.sh

--- a/dpc-web-accessibility-test.sh
+++ b/dpc-web-accessibility-test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+function _finally {
+    docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml down
+    docker volume rm start-v1-portals_pgdata16
+}
+trap _finally EXIT
+
+echo "┌──────────────---───────--------------──┐"
+echo "│                                        │"
+echo "│ Setting up Portal Accessibility Tests  |"
+echo "│                                        │"
+echo "└───────────────────-----------------────┘"
+
+# Build the container
+make website
+
+# Prepare the environment 
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up db --wait
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
+
+# Run the tests
+echo "┌──────────────---───────--------------──┐"
+echo "│                                        │"
+echo "│   Running Portal Accessibility Tests   |"
+echo "│                                        │"
+echo "└──-─────────────────────────────-------─┘"
+
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint docker/accessibility-test.sh dpc_web
+
+echo "┌──────────────---───────--------------──┐"
+echo "│                                        │"
+echo "│  Portal Accessibility Tests Complete   │"
+echo "│                                        │"
+echo "└──-─────────────────────────────-------─┘"

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -73,6 +73,8 @@ group :development, :test do
 end
 
 group :test do
+  gem 'axe-core-capybara'
+  gem 'axe-core-rspec'
   gem 'selenium-webdriver'
   gem 'climate_control'
   gem 'rails-controller-testing', '>= 1.0.5'

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -83,6 +83,22 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    axe-core-api (4.10.3)
+      dumb_delegator
+      ostruct
+      virtus
+    axe-core-capybara (4.10.3)
+      axe-core-api (= 4.10.3)
+      dumb_delegator
+    axe-core-rspec (4.10.3)
+      axe-core-api (= 4.10.3)
+      dumb_delegator
+      ostruct
+      virtus
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     base64 (0.2.0)
     bcp47 (0.3.3)
       i18n
@@ -114,6 +130,8 @@ GEM
     childprocess (5.0.0)
     climate_control (1.2.0)
     coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -134,6 +152,8 @@ GEM
     database_cleaner-core (2.0.1)
     date (3.4.1)
     date_time_precision (0.8.1)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.9.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -152,6 +172,7 @@ GEM
       dotenv (= 3.1.0)
       railties (>= 6.1)
     drb (2.2.1)
+    dumb_delegator (1.1.0)
     erubi (1.13.0)
     execjs (2.9.1)
     factory_bot (6.4.6)
@@ -182,6 +203,7 @@ GEM
       railties (>= 5.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-console (0.8.0)
     irb (1.14.2)
       rdoc (>= 4.0.0)
@@ -272,6 +294,7 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
     orm_adapter (0.5.0)
+    ostruct (0.6.2)
     parallel (1.26.3)
     parser (3.3.6.0)
       ast (~> 2.4.1)
@@ -413,6 +436,7 @@ GEM
       sprockets (>= 3.0.0)
     stringio (3.1.2)
     thor (1.3.1)
+    thread_safe (0.3.6)
     tilt (2.3.0)
     timeout (0.4.3)
     truemail (3.3.1)
@@ -430,6 +454,10 @@ GEM
     uri (1.0.3)
     useragent (0.16.11)
     vcr (6.2.0)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -462,6 +490,8 @@ DEPENDENCIES
   activestorage (~> 7.2.2.1)
   activesupport (~> 7.2.2.1)
   api_client!
+  axe-core-capybara
+  axe-core-rspec
   bootsnap (>= 1.1.0)
   bootstrap-table-rails
   brakeman

--- a/dpc-web/config/environments/test.rb
+++ b/dpc-web/config/environments/test.rb
@@ -31,6 +31,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory
   config.active_storage.service = :test
 
+  # Need to have this set up for capybara accessibility tests
+  config.action_controller.asset_host = "file://#{::Rails.root}/public" if ENV['ACCESSIBILITY'] == 'true'
+
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/dpc-web/docker/accessibility-test.sh
+++ b/dpc-web/docker/accessibility-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+apk update
+apk add --no-cache icu-data-full
+apk add --no-cache firefox
+ACCESSIBILITY=true bundle exec rspec --tag type:system --format documentation

--- a/dpc-web/spec/spec_helper.rb
+++ b/dpc-web/spec/spec_helper.rb
@@ -3,6 +3,9 @@
 require 'fakeredis/rspec'
 require 'simplecov'
 
+require 'axe-rspec'
+require 'capybara/rspec'
+
 SimpleCov.start 'rails' do
   track_files '**/{app,lib}/**/*.rb'
 
@@ -19,7 +22,11 @@ SimpleCov.start 'rails' do
   SimpleCov.minimum_coverage_by_file 80
 end
 
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'objects.githubusercontent.com'])
+
 RSpec.configure do |config|
+  config.filter_run_excluding type: :system
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/dpc-web/spec/system/accessibility_spec.rb
+++ b/dpc-web/spec/system/accessibility_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Accessibility', type: :system do
+  include Devise::Test::IntegrationHelpers
+  include DpcClientSupport
+  before do
+    driven_by(:selenium_headless)
+  end
+  let(:dpc_api_organization_id) { 'some-gnarly-guid' }
+  context 'login' do
+    it 'shows login page ok' do
+      visit '/users/sign_in'
+      expect(page).to have_text('Log in')
+      expect(page).to be_axe_clean
+    end
+  end
+end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4782

## 🛠 Changes

- Makefile added ci-web-accessibility
- .github/workflows/dpc-web-accessibility-test.yml to run via github actions
- dpc-web-accessibility-test.sh to run the accessibility tests from the command line
- dpc-web/Gemfile: added axe gems
- dpc-web/config/environments/test.rb: use file system for assets
- dpc-web/docker/accessibility-test.sh: created to add firefox to container and run accessibility tests
- dpc-web/spec/spec_helper.rb: require axe, enable localhost web connect
- dpc-web/spec/system/accessibility_spec.rb: one accessibility test to show system working

## ℹ️ Context

We need to add automated accessibility tests to dpc-web. This PR is based on the setup of dpc-portal, which already has accessibility tests. See https://github.com/CMSgov/dpc-app/pull/2315/files

Note: firefox is a large bundle, so we only want to add it for accessibility tests and not have it as part of the deployed container.

## 🧪 Validation

Accessibility test runs (and fails, but only due to axe failures) via github actions (https://github.com/CMSgov/dpc-app/actions/runs/16271153868/job/45938854582).
CI does not run accessibility tests (which it shouldn't at this point).
