### PR TITLE
[DPC-4420] add pagination to GET /v1/Patient

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/AbstractPatientResource.java
@@ -23,7 +23,7 @@ public abstract class AbstractPatientResource extends AbstractResourceWithSince 
     }
 
     @GET
-    public abstract Bundle patientSearch(OrganizationPrincipal organization, @NoHtml String patientMBI);
+    public abstract Bundle patientSearch(OrganizationPrincipal organization, @NoHtml String patientMBI, int limit, int page);
 
     @POST
     public abstract Response submitPatient(OrganizationPrincipal organization, @Valid @Profiled Patient patient);

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -16,6 +16,7 @@ import gov.cms.dpc.api.auth.annotations.PathAuthorizer;
 import gov.cms.dpc.api.resources.AbstractPatientResource;
 import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.common.annotations.NoHtml;
+import gov.cms.dpc.common.utils.PagingUtils;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.DPCResourceType;
 import gov.cms.dpc.fhir.FHIRExtractors;
@@ -85,16 +86,20 @@ public class PatientResource extends AbstractPatientResource {
     public Bundle patientSearch(@ApiParam(hidden = true)
                                 @Auth OrganizationPrincipal organization,
                                 @ApiParam(value = "Patient MBI")
-                                @QueryParam(value = Patient.SP_IDENTIFIER) @NoHtml String patientMBI) {
+                                @QueryParam(value = Patient.SP_IDENTIFIER) @NoHtml String patientMBI,
+                                @ApiParam(value = "Patients per page")
+                                @QueryParam(value = "_limit") int limit,
+                                @ApiParam(value = "Page number")
+                                @QueryParam(value = "_page") int page) {
 
-        final var request = this.client
+        var request = this.client
                 .search()
                 .forResource(Patient.class)
                 .encodedJson()
                 .where(Patient.ORGANIZATION.hasId(organization.getOrganization().getId()))
                 .returnBundle(Bundle.class);
 
-        if (patientMBI != null && !patientMBI.equals("")) {
+        if (patientMBI != null && !patientMBI.isEmpty()) {
 
             // Handle MBI parsing
             // This should come out as part of DPC-432
@@ -104,12 +109,18 @@ public class PatientResource extends AbstractPatientResource {
             } else {
                 expandedMBI = String.format("%s|%s", DPCIdentifierSystem.MBI.getSystem(), patientMBI);
             }
-            return request
-                    .where(Patient.IDENTIFIER.exactly().identifier(expandedMBI))
-                    .execute();
+            request = request.where(Patient.IDENTIFIER.exactly().identifier(expandedMBI));
         }
 
-        return request.execute();
+        return PagingUtils.handlePaging(request, limit, page, "/v1/Patient");
+    }
+
+    public Bundle patientSearch(OrganizationPrincipal organization, String patientMBI, int page) {
+        return patientSearch(organization, patientMBI, PagingUtils.defaultLimit, page);
+    }
+
+    public Bundle patientSearch(OrganizationPrincipal organization, String patientMBI) {
+        return patientSearch(organization, patientMBI, PagingUtils.defaultLimit, 1);
     }
 
     @FHIR

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -121,7 +121,7 @@ public class PatientResource extends AbstractPatientResource {
     }
 
     public Bundle patientSearch(OrganizationPrincipal organization, String patientMBI, int page) {
-        return patientSearch(organization, patientMBI, PagingUtils.DEFAULT_LIMIT, page);
+        return patientSearch(organization, patientMBI, PagingUtils.DEFAULT_COUNT, page);
     }
 
     // passing -1 means "do not paginate" for compatiblity reasons. See default value above

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -88,7 +88,7 @@ public class PatientResource extends AbstractPatientResource {
                                 @ApiParam(value = "Patient MBI")
                                 @QueryParam(value = Patient.SP_IDENTIFIER) @NoHtml String patientMBI,
                                 @ApiParam(value = "Patients per page")
-                                @QueryParam(value = "_limit") int limit,
+                                @QueryParam(value = "_count") int count,
                                 @ApiParam(value = "Page number")
                                 @QueryParam(value = "_page") @DefaultValue("-1") int page) {
 
@@ -113,7 +113,7 @@ public class PatientResource extends AbstractPatientResource {
         }
 
         if (page >= 1) {
-            return PagingUtils.handlePaging(request, limit, page, "/v1/Patient");
+            return PagingUtils.handlePaging(request, count, page, "/v1/Patient");
         }
         else {
             return request.execute(); // deprecated - legacy behavior for clients relying on full roster
@@ -121,11 +121,11 @@ public class PatientResource extends AbstractPatientResource {
     }
 
     public Bundle patientSearch(OrganizationPrincipal organization, String patientMBI, int page) {
-        return patientSearch(organization, patientMBI, PagingUtils.defaultLimit, page);
+        return patientSearch(organization, patientMBI, PagingUtils.DEFAULT_LIMIT, page);
     }
 
     public Bundle patientSearch(OrganizationPrincipal organization, String patientMBI) {
-        return patientSearch(organization, patientMBI, PagingUtils.defaultLimit, 1);
+        return patientSearch(organization, patientMBI, PagingUtils.DEFAULT_LIMIT, 1);
     }
 
     @FHIR

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -124,8 +124,9 @@ public class PatientResource extends AbstractPatientResource {
         return patientSearch(organization, patientMBI, PagingUtils.DEFAULT_LIMIT, page);
     }
 
+    // passing -1 means "do not paginate" for compatiblity reasons. See default value above
     public Bundle patientSearch(OrganizationPrincipal organization, String patientMBI) {
-        return patientSearch(organization, patientMBI, PagingUtils.DEFAULT_LIMIT, 1);
+        return patientSearch(organization, patientMBI, -1, -1);
     }
 
     @FHIR

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/PatientResource.java
@@ -90,7 +90,7 @@ public class PatientResource extends AbstractPatientResource {
                                 @ApiParam(value = "Patients per page")
                                 @QueryParam(value = "_limit") int limit,
                                 @ApiParam(value = "Page number")
-                                @QueryParam(value = "_page") int page) {
+                                @QueryParam(value = "_page") @DefaultValue("-1") int page) {
 
         var request = this.client
                 .search()
@@ -112,7 +112,12 @@ public class PatientResource extends AbstractPatientResource {
             request = request.where(Patient.IDENTIFIER.exactly().identifier(expandedMBI));
         }
 
-        return PagingUtils.handlePaging(request, limit, page, "/v1/Patient");
+        if (page >= 1) {
+            return PagingUtils.handlePaging(request, limit, page, "/v1/Patient");
+        }
+        else {
+            return request.execute(); // deprecated - legacy behavior for clients relying on full roster
+        }
     }
 
     public Bundle patientSearch(OrganizationPrincipal organization, String patientMBI, int page) {

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceUnitTest.java
@@ -134,7 +134,7 @@ public class PatientResourceUnitTest {
 
     @Test
     public void testPatientSearchLargerRoster() {
-        int largePatientNum = 125;
+        int largePatientNum = 900;
         UUID orgId = UUID.randomUUID();
         Organization organization = new Organization();
         organization.setId(orgId.toString());
@@ -191,7 +191,7 @@ public class PatientResourceUnitTest {
 
         Bundle actualResponse = patientResource.patientSearch(organizationPrincipal, null);
         assertEquals(bundle, actualResponse);
-        assertEquals(bundle.getEntry().size(), PagingUtils.defaultLimit);
+        assertEquals(bundle.getEntry().size(), PagingUtils.DEFAULT_LIMIT);
         assertEquals(bundle.getEntryFirstRep().getResource().getId(), "patient-1");
 
         String requestPath = "/v1/Patient?page=";
@@ -208,7 +208,7 @@ public class PatientResourceUnitTest {
 
         Bundle response2 = patientResource.patientSearch(organizationPrincipal, null, 2);
         assertEquals(bundle2, response2);
-        assertEquals(bundle2.getEntry().size(), PagingUtils.defaultLimit);
+        assertEquals(bundle2.getEntry().size(), PagingUtils.DEFAULT_LIMIT);
         assertEquals(bundle2.getEntryFirstRep().getResource().getId(), "patient-2");
 
         assertEquals(bundle2.getLink("self").getUrl(), requestPath + "2");
@@ -225,7 +225,7 @@ public class PatientResourceUnitTest {
 
         Bundle response3 = patientResource.patientSearch(organizationPrincipal, null, 3);
         assertEquals(bundle3, response3);
-        assertEquals(bundle3.getEntry().size(), PagingUtils.defaultLimit);
+        assertEquals(bundle3.getEntry().size(), PagingUtils.DEFAULT_LIMIT);
         assertEquals(bundle3.getEntryFirstRep().getResource().getId(), "patient-3");
 
         assertEquals(bundle3.getLink("self").getUrl(), requestPath + "3");

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceUnitTest.java
@@ -189,9 +189,9 @@ public class PatientResourceUnitTest {
         when(queryExec.where(any(ICriterion.class)).returnBundle(Bundle.class)).thenReturn(mockQuery);
         when(mockQuery.execute()).thenReturn(bundle);
 
-        Bundle actualResponse = patientResource.patientSearch(organizationPrincipal, null);
+        Bundle actualResponse = patientResource.patientSearch(organizationPrincipal, null, 1);
         assertEquals(bundle, actualResponse);
-        assertEquals(bundle.getEntry().size(), PagingUtils.DEFAULT_LIMIT);
+        assertEquals(PagingUtils.DEFAULT_LIMIT, bundle.getEntry().size());
         assertEquals(bundle.getEntryFirstRep().getResource().getId(), "patient-1");
 
         String requestPath = "/v1/Patient?page=";
@@ -208,7 +208,7 @@ public class PatientResourceUnitTest {
 
         Bundle response2 = patientResource.patientSearch(organizationPrincipal, null, 2);
         assertEquals(bundle2, response2);
-        assertEquals(bundle2.getEntry().size(), PagingUtils.DEFAULT_LIMIT);
+        assertEquals(PagingUtils.DEFAULT_LIMIT, bundle2.getEntry().size());
         assertEquals(bundle2.getEntryFirstRep().getResource().getId(), "patient-2");
 
         assertEquals(bundle2.getLink("self").getUrl(), requestPath + "2");
@@ -225,7 +225,7 @@ public class PatientResourceUnitTest {
 
         Bundle response3 = patientResource.patientSearch(organizationPrincipal, null, 3);
         assertEquals(bundle3, response3);
-        assertEquals(bundle3.getEntry().size(), PagingUtils.DEFAULT_LIMIT);
+        assertEquals(PagingUtils.DEFAULT_LIMIT, bundle3.getEntry().size());
         assertEquals(bundle3.getEntryFirstRep().getResource().getId(), "patient-3");
 
         assertEquals(bundle3.getLink("self").getUrl(), requestPath + "3");

--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceUnitTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/PatientResourceUnitTest.java
@@ -13,7 +13,6 @@ import com.google.common.net.HttpHeaders;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.bluebutton.client.BlueButtonClient;
 import gov.cms.dpc.common.utils.NPIUtil;
-import gov.cms.dpc.common.utils.PagingUtils;
 import gov.cms.dpc.fhir.DPCIdentifierSystem;
 import gov.cms.dpc.fhir.DPCResourceType;
 import gov.cms.dpc.queue.service.DataService;
@@ -196,6 +195,7 @@ public class PatientResourceUnitTest {
 
     @Test
     public void testPatientSearchPaging() {
+        int pageSize = 1;
         UUID orgId = UUID.randomUUID();
         Organization organization = new Organization();
         organization.setId(orgId.toString());
@@ -225,9 +225,9 @@ public class PatientResourceUnitTest {
         when(queryExec.where(any(ICriterion.class)).returnBundle(Bundle.class)).thenReturn(mockQuery);
         when(mockQuery.execute()).thenReturn(bundle);
 
-        Bundle actualResponse = patientResource.patientSearch(organizationPrincipal, null, 1);
+        Bundle actualResponse = patientResource.patientSearch(organizationPrincipal, null, pageSize, 1);
         assertEquals(bundle, actualResponse);
-        assertEquals(PagingUtils.DEFAULT_COUNT, bundle.getEntry().size());
+        assertEquals(pageSize, bundle.getEntry().size());
         assertEquals(bundle.getEntryFirstRep().getResource().getId(), "patient-1");
 
         String requestPath = "/v1/Patient?page=";
@@ -242,9 +242,9 @@ public class PatientResourceUnitTest {
 
         when(mockQuery.execute()).thenReturn(bundle2);
 
-        Bundle response2 = patientResource.patientSearch(organizationPrincipal, null, 2);
+        Bundle response2 = patientResource.patientSearch(organizationPrincipal, null, pageSize, 2);
         assertEquals(bundle2, response2);
-        assertEquals(PagingUtils.DEFAULT_COUNT, bundle2.getEntry().size());
+        assertEquals(pageSize, bundle2.getEntry().size());
         assertEquals(bundle2.getEntryFirstRep().getResource().getId(), "patient-2");
 
         assertEquals(bundle2.getLink("self").getUrl(), requestPath + "2");
@@ -259,9 +259,9 @@ public class PatientResourceUnitTest {
 
         when(mockQuery.execute()).thenReturn(bundle3);
 
-        Bundle response3 = patientResource.patientSearch(organizationPrincipal, null, 3);
+        Bundle response3 = patientResource.patientSearch(organizationPrincipal, null, pageSize, 3);
         assertEquals(bundle3, response3);
-        assertEquals(PagingUtils.DEFAULT_COUNT, bundle3.getEntry().size());
+        assertEquals(pageSize, bundle3.getEntry().size());
         assertEquals(bundle3.getEntryFirstRep().getResource().getId(), "patient-3");
 
         assertEquals(bundle3.getLink("self").getUrl(), requestPath + "3");

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -1,0 +1,33 @@
+package gov.cms.dpc.common.utils;
+
+import ca.uhn.fhir.rest.gclient.IQuery;
+import org.hl7.fhir.dstu3.model.Bundle;
+
+public class PagingUtils {
+    public static final int defaultLimit = 1;
+
+    private static String formatURL(String url, int page) {
+        return url + "?page=" + page;
+    }
+    public static Bundle handlePaging(IQuery<Bundle> request, int limit, int page, String requestPath) {
+        int offset = limit*(page-1);
+        request.offset(offset);
+        request.count(limit);
+        Bundle resultBundle = request.execute();
+
+        resultBundle.addLink().setRelation("self").setUrl(formatURL(requestPath, page));
+        resultBundle.addLink().setRelation("first").setUrl(formatURL(requestPath, 1));
+        if (page > 1) {
+            resultBundle.addLink().setRelation("previous").setUrl(formatURL(requestPath, page-1));
+        }
+
+        int total = resultBundle.getTotal();
+        int lastPage = total == 0 ? 1 : (int) Math.ceil((float) total / limit);
+        if (page + 1 <= lastPage) {
+            resultBundle.addLink().setRelation("next").setUrl(formatURL(requestPath, page+1));
+        }
+        resultBundle.addLink().setRelation("last").setUrl(formatURL(requestPath, lastPage));
+
+        return resultBundle;
+    }
+}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -9,24 +9,21 @@ public class PagingUtils {
     private static String formatURL(String url, int page) {
         return url + "?page=" + page;
     }
+
+    private static void addRelationLink(Bundle bundle, String name, String path, int page) {
+        bundle.addLink().setRelation(name).setUrl(formatURL(path, page));
+    }
+
     public static Bundle handlePaging(IQuery<Bundle> request, int limit, int page, String requestPath) {
-        int offset = limit*(page-1);
-        request.offset(offset);
-        request.count(limit);
-        Bundle resultBundle = request.execute();
+        Bundle resultBundle = request.offset(limit*(page-1)).count(limit).execute();
 
-        resultBundle.addLink().setRelation("self").setUrl(formatURL(requestPath, page));
-        resultBundle.addLink().setRelation("first").setUrl(formatURL(requestPath, 1));
-        if (page > 1) {
-            resultBundle.addLink().setRelation("previous").setUrl(formatURL(requestPath, page-1));
-        }
+        addRelationLink(resultBundle, "self", requestPath, page);
+        addRelationLink(resultBundle, "first", requestPath, 1);
+        if (page > 1) addRelationLink(resultBundle, "previous", requestPath, page-1);
 
-        int total = resultBundle.getTotal();
-        int lastPage = (int) Math.ceil((float) total / limit);
-        if (page + 1 <= lastPage) {
-            resultBundle.addLink().setRelation("next").setUrl(formatURL(requestPath, page+1));
-        }
-        resultBundle.addLink().setRelation("last").setUrl(formatURL(requestPath, lastPage));
+        int lastPage = (int) Math.ceil((float) resultBundle.getTotal() / limit);
+        if (page + 1 <= lastPage) addRelationLink(resultBundle, "next", requestPath, page+1);
+        addRelationLink(resultBundle, "last", requestPath, lastPage);
 
         return resultBundle;
     }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -22,7 +22,7 @@ public class PagingUtils {
         }
 
         int total = resultBundle.getTotal();
-        int lastPage = total == 0 ? 1 : (int) Math.ceil((float) total / limit);
+        int lastPage = (int) Math.ceil((float) total / limit);
         if (page + 1 <= lastPage) {
             resultBundle.addLink().setRelation("next").setUrl(formatURL(requestPath, page+1));
         }

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -15,7 +15,9 @@ public class PagingUtils {
     }
 
     public static Bundle handlePaging(IQuery<Bundle> request, int limit, int page, String requestPath) {
-        Bundle resultBundle = request.offset(limit*(page-1)).count(limit).execute();
+        request.offset(limit*(page-1));
+        request.count(limit);
+        Bundle resultBundle = request.execute();
 
         addRelationLink(resultBundle, "self", requestPath, page);
         addRelationLink(resultBundle, "first", requestPath, 1);

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -8,7 +8,7 @@ public final class PagingUtils {
         throw new UnsupportedOperationException("PagingUtils is a utility class and should not be instantiated");
     }
 
-    public static final int DEFAULT_LIMIT = 1;
+    public static final int DEFAULT_COUNT = 1;
 
     private static String formatURL(String url, int page) {
         return url + "?page=" + page;

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -8,7 +8,7 @@ public final class PagingUtils {
         throw new UnsupportedOperationException("PagingUtils is a utility class and should not be instantiated");
     }
 
-    public static final int DEFAULT_COUNT = 1;
+    public static final int DEFAULT_COUNT = 100;
 
     private static String formatURL(String url, int page) {
         return url + "?page=" + page;

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -4,7 +4,11 @@ import ca.uhn.fhir.rest.gclient.IQuery;
 import org.hl7.fhir.dstu3.model.Bundle;
 
 public class PagingUtils {
-    public static final int defaultLimit = 1;
+    private PagingUtils() {
+        throw new UnsupportedOperationException("PagingUtils is a utility class and should not be instantiated");
+    }
+
+    public static final int DEFAULT_LIMIT = 1;
 
     private static String formatURL(String url, int page) {
         return url + "?page=" + page;
@@ -14,16 +18,16 @@ public class PagingUtils {
         bundle.addLink().setRelation(name).setUrl(formatURL(path, page));
     }
 
-    public static Bundle handlePaging(IQuery<Bundle> request, int limit, int page, String requestPath) {
-        request.offset(limit*(page-1));
-        request.count(limit);
+    public static Bundle handlePaging(IQuery<Bundle> request, int count, int page, String requestPath) {
+        request.offset(count*(page-1));
+        request.count(count);
         Bundle resultBundle = request.execute();
 
         addRelationLink(resultBundle, "self", requestPath, page);
         addRelationLink(resultBundle, "first", requestPath, 1);
         if (page > 1) addRelationLink(resultBundle, "previous", requestPath, page-1);
 
-        int lastPage = (int) Math.ceil((float) resultBundle.getTotal() / limit);
+        int lastPage = (int) Math.ceil((float) resultBundle.getTotal() / count);
         if (page + 1 <= lastPage) addRelationLink(resultBundle, "next", requestPath, page+1);
         addRelationLink(resultBundle, "last", requestPath, lastPage);
 

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -25,10 +25,10 @@ public final class PagingUtils {
 
         addRelationLink(resultBundle, "self", requestPath, page);
         addRelationLink(resultBundle, "first", requestPath, 1);
-        if (page > 1) addRelationLink(resultBundle, "previous", requestPath, page-1);
-
         int lastPage = (int) Math.ceil((float) resultBundle.getTotal() / count);
-        if (page + 1 <= lastPage) addRelationLink(resultBundle, "next", requestPath, page+1);
+        if (page > 1 && page <= lastPage) addRelationLink(resultBundle, "previous", requestPath, page-1);
+
+        if (page < lastPage) addRelationLink(resultBundle, "next", requestPath, page+1);
         addRelationLink(resultBundle, "last", requestPath, lastPage);
 
         return resultBundle;

--- a/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/utils/PagingUtils.java
@@ -3,7 +3,7 @@ package gov.cms.dpc.common.utils;
 import ca.uhn.fhir.rest.gclient.IQuery;
 import org.hl7.fhir.dstu3.model.Bundle;
 
-public class PagingUtils {
+public final class PagingUtils {
     private PagingUtils() {
         throw new UnsupportedOperationException("PagingUtils is a utility class and should not be instantiated");
     }


### PR DESCRIPTION
## 🎫 Ticket

[DPC-4420](https://jira.cms.gov/browse/DPC-4420)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - added optional query parameters: `_count` and `_page`
 - these are used to paginate results of `patientSearch()`

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - this is a continuation from PoC that was conducted in [DPC-4175](https://jira.cms.gov/browse/DPC-4175)
 - This aims to address an issue where customers with too many patients to return will have this request fail and cause a degradation of service.
   - Legacy behavior is still enabled, meaning the full roster will be output when `_page` is not provided

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - Unit tests in `PatientResourceUnitTest.java`