### PR TITLE
[Bugfix] Add Longer Wait for Aggregation Shut Down Test

### DIFF
--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
@@ -95,7 +96,7 @@ public class AggregationServiceTest {
 
         // Stop aggregation and make sure it pauses the batch
         APPLICATION.after();
-        await().until(() -> {
+        await().atMost(10, TimeUnit.SECONDS).until(() -> {
             JobQueueBatch batch = queue.getJobBatches(jobID).get(0);
             return batch.getStatus() == JobStatus.QUEUED;
         });

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
@@ -107,5 +107,6 @@ public class AggregationServiceTest {
             System.err.println("Batch failed to reach queued status, current state of batch: " + batch.getStatus());
             fail("Failing test due to batch status not set to queued, current status: " + batch.getStatus());
         }
+        
     }
 }

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
@@ -104,8 +104,9 @@ public class AggregationServiceTest {
             });
         } catch(ConditionTimeoutException e) {
             JobQueueBatch batch = queue.getJobBatches(jobID).get(0);
-            System.err.println("Batch failed to reach queued status, current state of batch: " + batch.getStatus());
-            fail();
+            String errorMsg = "Batch failed to reach queued status, current state of batch: " + batch.getStatus();
+            System.err.println(errorMsg);   // Print to stderr so the tree runner picks this up when running on GHA
+            fail(errorMsg);
         }
     }
 }

--- a/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
+++ b/dpc-aggregation/src/test/java/gov/cms/dpc/aggregation/AggregationServiceTest.java
@@ -105,8 +105,7 @@ public class AggregationServiceTest {
         } catch(ConditionTimeoutException e) {
             JobQueueBatch batch = queue.getJobBatches(jobID).get(0);
             System.err.println("Batch failed to reach queued status, current state of batch: " + batch.getStatus());
-            fail("Failing test due to batch status not set to queued, current status: " + batch.getStatus());
+            fail();
         }
-        
     }
 }


### PR DESCRIPTION
## 🎫 Ticket

Bugfix

## 🛠 Changes

In `AggregationServiceTest`, added a longer delay when waiting for the service to shut down.

## ℹ️ Context

This test was failing intermittently when run on Github, but not locally.  This _should_ fix it.  If the issue crops up again I'd consider bumping it up to 30 seconds, or just removing the test altogether.

## 🧪 Validation

Ran 10 times in a row over 2 days on Github with no failures:

1.  https://github.com/CMSgov/dpc-app/actions/runs/16323252682/job/46106473335?pr=2726
2.  https://github.com/CMSgov/dpc-app/actions/runs/16324109865/job/46109505579?pr=2726
3.  https://github.com/CMSgov/dpc-app/actions/runs/16324109865/job/46115670719?pr=2726
4.  https://github.com/CMSgov/dpc-app/actions/runs/16326415641/job/46117599239?pr=2726
5.  https://github.com/CMSgov/dpc-app/actions/runs/16327730602/job/46122132683?pr=2726
6.  https://github.com/CMSgov/dpc-app/actions/runs/16327730602/job/46124350975?pr=2726
7.  https://github.com/CMSgov/dpc-app/actions/runs/16327730602/job/46126630286?pr=2726
8.  https://github.com/CMSgov/dpc-app/actions/runs/16327730602/job/46128715587?pr=2726
9.  https://github.com/CMSgov/dpc-app/actions/runs/16327730602/job/46177761965?pr=2726
10.  https://github.com/CMSgov/dpc-app/actions/runs/16327730602/job/46191340481?pr=2726

