### PR TITLE
Force tag_release GHA to CodeBuild

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -3,11 +3,6 @@ name: utility-tag-repo
 on:
   workflow_call:
     inputs:
-      runner:
-        description: Which runner to use
-        required: false
-        default: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
-        type: 'string'
       repo_ref:
         description: Which branch or tag
         required: true
@@ -24,7 +19,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    runs-on: ${{ inputs.runner }}
+    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
     outputs:
       next_rev: ${{ steps.set_revs.outputs.next_rev }}
     steps:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4800

## 🛠 Changes

Update tag_release to only run on CodeBuild.

## ℹ️ Context

We should only be running on CodeBuild moving forward.

## 🧪 Validation

Created (and then deleted) new release, R199.
<img width="2262" height="992" alt="image" src="https://github.com/user-attachments/assets/9d848d39-3892-4a25-a4be-c42887699d6e" />

