### PR TITLE
[DPC-2802] Bugfix Smoketests

### DIFF
--- a/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
+++ b/dpc-smoketest/src/main/java/gov/cms/dpc/testing/smoketests/SmokeTest.java
@@ -109,7 +109,9 @@ public class SmokeTest extends AbstractJavaSamplerClient {
         try {
             String clientToken = registerOrg(organizationID, smokeTestSampler);
             Pair<UUID, PrivateKey> keyTuple = generateAndUploadKey(smokeTestSampler);
-            final IGenericClient exportClient = APIAuthHelpers.buildAuthenticatedClient(fhirContext, apiHost, clientToken, keyTuple.getLeft(), keyTuple.getRight(), true, true);
+
+            // Adding "Prefer: respond-async" to all requests
+            final IGenericClient exportClient = APIAuthHelpers.buildAuthenticatedClient(fhirContext, apiHost, clientToken, keyTuple.getLeft(), keyTuple.getRight(), true, true, true);
 
             Bundle providerBundle = submitPractitionerBundle(exportClient, smokeTestSampler);
             Map<String, Reference> patientReferences = submitPatientBundle(exportClient, smokeTestSampler);


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-2802

## 🛠 Changes

Due to https://github.com/CMSgov/dpc-app/pull/2739, the default HAPI client no longer sends a `Prefer` header.  The smoke tests were depending on it, though, so this adds it back in.

## ℹ️ Context

As part of the previous PR, we removed the default `Prefer` header from our HAPI client because it shouldn't be sent on every request.  The smoke tests relied on it being there, though, instead of only adding it when necessary.  This gets them working again.

## 🧪 Validation

Smoke tests pass: https://github.com/CMSgov/dpc-app/actions/runs/16477267873
