### PR TITLE
Portal works even if ALLOW_INVALID_SSL_CERT not set

### DIFF
--- a/engines/api_client/Makefile
+++ b/engines/api_client/Makefile
@@ -1,0 +1,8 @@
+build:
+	docker build . -t api_client
+test:
+	docker run --rm -v ${PWD}:/api-client -w /api-client api_client bundle exec rspec
+	docker run --rm -v ${PWD}:/api-client -w /api-client api_client bundle exec rubocop
+
+run:
+	docker run -it --rm -v ${PWD}:/api-client -w /api-client api_client sh

--- a/engines/api_client/README.md
+++ b/engines/api_client/README.md
@@ -33,7 +33,7 @@ Run the tests until they pass
 $ make test
 ```
 
-Jumb into the docker shell for iterative development
+Jump into the docker shell for iterative development
 ```
 make run
 ```

--- a/engines/api_client/README.md
+++ b/engines/api_client/README.md
@@ -25,11 +25,15 @@ Build the docker image
 
 In the api_client directory
 ```bash
-$ docker build . -t api_client
+$ make build
 ```
 
 Run the tests until they pass
 ```
-$ docker run --rm -v ${PWD}:/api-client -w /api-client api_client bundle exec rspec
-$ docker run --rm -v ${PWD}:/api-client -w /api-client api_client bundle exec rubocop
+$ make test
+```
+
+Jumb into the docker shell for iterative development
+```
+make run
 ```

--- a/engines/api_client/app/services/dpc_client.rb
+++ b/engines/api_client/app/services/dpc_client.rb
@@ -7,7 +7,7 @@ class DpcClient
   def initialize
     @base_url = ENV.fetch('API_METADATA_URL')
     @admin_url = ENV.fetch('API_ADMIN_URL')
-    @allow_invalid_ssl_cert = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ALLOW_INVALID_SSL_CERT'))
+    @allow_invalid_ssl_cert = ActiveModel::Type::Boolean.new.cast(ENV.fetch('ALLOW_INVALID_SSL_CERT', 'false'))
   end
 
   def json_content

--- a/engines/api_client/spec/services/dpc_client_spec.rb
+++ b/engines/api_client/spec/services/dpc_client_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DpcClient do
     allow(ENV).to receive(:fetch).with('API_METADATA_URL').and_return('http://dpc.example.com')
     allow(ENV).to receive(:fetch).with('API_ADMIN_URL').and_return('http://dpc.example.com')
     allow(ENV).to receive(:fetch).with('GOLDEN_MACAROON').and_return('MDAyM2xvY2F0aW9uIGh0dHA6Ly9sb2NhbGhvc3Q6MzAwMgowMDM0aWRlbnRpZmllciBiODY2NmVjMi1lOWY1LTRjODctYjI0My1jMDlhYjgyY2QwZTMKMDAyZnNpZ25hdHVyZSA1hzDOqfW_1hasj-tOps9XEBwMTQIW9ACQcZPuhAGxwwo')
-    allow(ENV).to receive(:fetch).with('ALLOW_INVALID_SSL_CERT').and_return('false')
+    allow(ENV).to receive(:fetch).with('ALLOW_INVALID_SSL_CERT', 'false').and_return('false')
   end
   # rubocop:enable Layout/LineLength
 
@@ -777,7 +777,7 @@ RSpec.describe DpcClient do
 
     context 'ignoring ssl errors' do
       it 'sets open ssl verify mode to none' do
-        allow(ENV).to receive(:fetch).with('ALLOW_INVALID_SSL_CERT').and_return('true')
+        allow(ENV).to receive(:fetch).with('ALLOW_INVALID_SSL_CERT', 'false').and_return('true')
 
         stub_request(:get, 'https://dpc.example.com/healthcheck')
           .with(


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

Updated fetch of ALLOW_INVALID_SSL_CERT to be false unless set

## ℹ️ Context

Running local was failing because ALLOW_INVALID_SSL_CERT was not set. We could always force it to be set, or assume false if it wasn't set. The latter made more sense to me.

## 🧪 Validation

Ran dpc-portal locally with the new client and successfully added a public key.