### PR TITLE
[DPC-4812] Moved foreman to Docker image

### DIFF
--- a/dpc-portal/Dockerfile
+++ b/dpc-portal/Dockerfile
@@ -39,6 +39,9 @@ RUN rm -rf /bin/yarn
 RUN npm run build:css
 RUN RAILS_ENV=production SECRET_KEY_BASE=dummy bundle exec rake assets:precompile --trace
 
+# Install foreman
+RUN gem install foreman
+
 # Clean up from the build
 RUN rm -rf /usr/local/bundle/cache/*.gem && \
     find /usr/local/bundle/gems/ -name "*.c" -delete && \
@@ -48,6 +51,7 @@ RUN rm -rf /usr/local/bundle/cache/*.gem && \
 # Add Federal Common Policy CA G2 root certificate for SMTP
 COPY certs/fcpcag2.crt /usr/local/share/ca-certificates/fcpcag2.crt
 RUN cat /usr/local/share/ca-certificates/fcpcag2.crt >> /etc/ssl/certs/ca-certificates.crt
+
 
 # Declare the entrypoint shell script
 ENTRYPOINT ["./docker/entrypoint.sh"]

--- a/dpc-portal/Dockerfile
+++ b/dpc-portal/Dockerfile
@@ -29,6 +29,9 @@ RUN gem install bundler --no-document && \
     bundle install && \
     npm install
 
+# Install foreman
+RUN gem install foreman
+
 # Run bundler audit
 RUN bundle exec bundle audit update && bundle exec bundle audit check
 
@@ -38,9 +41,6 @@ COPY /dpc-portal /dpc-portal
 RUN rm -rf /bin/yarn
 RUN npm run build:css
 RUN RAILS_ENV=production SECRET_KEY_BASE=dummy bundle exec rake assets:precompile --trace
-
-# Install foreman
-RUN gem install foreman
 
 # Clean up from the build
 RUN rm -rf /usr/local/bundle/cache/*.gem && \

--- a/dpc-portal/bin/dev
+++ b/dpc-portal/bin/dev
@@ -1,10 +1,5 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 

--- a/dpc-portal/bin/nonprod
+++ b/dpc-portal/bin/nonprod
@@ -1,10 +1,5 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
 echo "Testing removal of foreman log prefix (should be json)"
 export LOG_STR='06:21:25 web.1   | {"level": "debug", "time": "blahblahblah"}'
 export EVERYTHING_AFTER_PIPE_REGEX='s/[^|]*|//'

--- a/dpc-portal/bin/sidekiq-dev
+++ b/dpc-portal/bin/sidekiq-dev
@@ -1,10 +1,5 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 

--- a/dpc-portal/bin/sidekiq-nonprod
+++ b/dpc-portal/bin/sidekiq-nonprod
@@ -1,10 +1,5 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
-  echo "Installing foreman..."
-  gem install foreman
-fi
-
 echo "Starting Procfile.nonprod"
 export EVERYTHING_AFTER_PIPE_REGEX='s/[^|]*|//'
 exec foreman start -f Procfile.sidekiq-nonprod "$@" | sed $EVERYTHING_AFTER_PIPE_REGEX


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4812

## 🛠 Changes

Moved Foreman gem into the portal Docker image.

## ℹ️ Context

We had been installing Foreman on a per environment basis when the portal starts up, but as part of https://github.com/CMSgov/dpc-ops/pull/853 we won't be able to write to our containers anymore.  That means we can no longer install anything, so we're adding Foreman to the Docker image ahead of time instead.  The trade off is it'll get installed regardless of whether we actually intend to use it, but I don't think that's a big deal.

## 🧪 Validation

Full build and deploy with passing smoke tests [https://github.com/CMSgov/dpc-app/actions/runs/16526473477](https://github.com/CMSgov/dpc-app/compare/main...me/here).
