### PR TITLE
Security task: fix merge vulnerability

### DIFF
--- a/dpc-portal/package-lock.json
+++ b/dpc-portal/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "sass": "^1.86.3",
-        "watch": "^1.0.2",
+        "watch": "^0.13.0",
         "webpack-dev-server": "^5.0.4"
       }
     },
@@ -1194,16 +1194,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/exec-sh": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "merge": "^1.2.0"
-      }
-    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -1892,13 +1882,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/streamich"
       }
-    },
-    "node_modules/merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
@@ -2996,20 +2979,18 @@
       }
     },
     "node_modules/watch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
-      "integrity": "sha512-1u+Z5n9Jc1E2c7qDO8SinPoZuHj7FgbgU1olSFoyaklduDvvtX7GMMtlE6OC9FTXq4KvNAOfj6Zu4vI1e9bAKA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.13.0.tgz",
+      "integrity": "sha512-yTgNlr/8OjaGYq2FIv/PjU0zlv/pdAOmVSEeHNVcApFTT6ocWnMLhXlB6n/Rz9VVWXZmZkvkDnJ+iAIi/JjUJA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "engines": [
+        "node >=0.1.95"
+      ],
       "dependencies": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
+        "minimist": "^1.1.0"
       },
       "bin": {
         "watch": "cli.js"
-      },
-      "engines": {
-        "node": ">=0.1.95"
       }
     },
     "node_modules/wbuf": {

--- a/dpc-portal/package.json
+++ b/dpc-portal/package.json
@@ -10,7 +10,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "sass": "^1.86.3",
-    "watch": "^1.0.2",
+    "watch": "^0.13.0",
     "webpack-dev-server": "^5.0.4"
   },
   "scripts": {


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

npm watch pushed down to 0.13.0 to remove merge vulnerability

## ℹ️ Context

Watch isn't really doing anything anyway, but removing it causes all sorts of other problems.
Addresses https://github.com/CMSgov/dpc-app/security/dependabot/448

## 🧪 Validation

Removes merge library from package-lock.json
