### PR TITLE
Update webmock allows for accessiblity tests

### DIFF
--- a/dpc-portal/spec/spec_helper.rb
+++ b/dpc-portal/spec/spec_helper.rb
@@ -33,7 +33,7 @@ unless ENV['ACCESSIBILITY'] == 'true'
 end
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'objects.githubusercontent.com'])
+WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'release-assets.githubusercontent.com'])
 
 require 'support/fake_cpi_gateway'
 

--- a/dpc-web/spec/spec_helper.rb
+++ b/dpc-web/spec/spec_helper.rb
@@ -26,7 +26,7 @@ unless ENV['ACCESSIBILITY'] == 'true'
 end
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'objects.githubusercontent.com'])
+WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'release-assets.githubusercontent.com'])
 
 RSpec.configure do |config|
   config.filter_run_excluding type: :system


### PR DESCRIPTION
## 🎫 Ticket

No ticket.

## 🛠 Changes

spec_helper for dcp-web and dpc-portal allow calls to release-assets.githubusercontent.com instead of objects.githubusercontent.com

## ℹ️ Context

Something changed, so the call for the gecko driver for accessibility tests used a different host, so webmock complained of real calls.

## 🧪 Validation

Accessibility tests only fail on the fact that the sites fail axe standards instead of webmock exceptions:
dpc-web: https://github.com/CMSgov/dpc-app/actions/runs/16993607204
dpc-portal: https://github.com/CMSgov/dpc-app/actions/runs/16993614683
