### PR TITLE
Optmize portals ci tests

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -239,6 +239,7 @@ services:
     environment:
       - REDIS_URL=redis://redis
       - DATABASE_URL=postgresql://db/dpc-portal_development
+      - TEST_DATABASE_URL=postgresql://db/dpc-portal_test
       - DB_USER=postgres
       - DB_PASS=dpc-safe
       - GOLDEN_MACAROON=${GOLDEN_MACAROON}

--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -61,6 +61,7 @@ services:
   web_sidekiq:
     volumes:
       - ./tmp/letter_opener/web:/dpc-web/tmp/letter_opener
+      - "./dpc-web/coverage:/dpc-web/coverage"
     build:
       context: .
       dockerfile: dpc-web/Dockerfile
@@ -133,6 +134,7 @@ services:
   admin_sidekiq:
     volumes:
       - ./tmp/letter_opener/admin:/dpc-admin/tmp/letter_opener
+      - "./dpc-admin/coverage:/dpc-admin/coverage"
     build:
       context: .
       dockerfile: dpc-admin/Dockerfile
@@ -230,6 +232,7 @@ services:
   portal_sidekiq:
     volumes:
       - ./tmp/letter_opener/portal:/dpc-portal/tmp/letter_opener
+      - "./dpc-portal/coverage:/dpc-portal/coverage"
       - "./dpc-portal/app:/dpc-portal/app"
     build:
       context: .

--- a/dpc-admin-portal-test.sh
+++ b/dpc-admin-portal-test.sh
@@ -18,7 +18,7 @@ make admin
 
 # Prepare the environment 
 docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up db --wait
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" web_sidekiq
 
 # Run the tests
 echo "┌───────────────────────────┐"
@@ -26,8 +26,8 @@ echo "│                           │"
 echo "│  Running DPC Admin Tests  │"
 echo "│                           │"
 echo "└───────────────────────────┘"
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_admin
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_admin
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" admin_sidekiq
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" admin_sidekiq
 
 echo "┌────────────────────────────────┐"
 echo "│                                │"

--- a/dpc-portal-test.sh
+++ b/dpc-portal-test.sh
@@ -18,7 +18,7 @@ make portal
 
 # Prepare the environment 
 docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up db --wait
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_portal
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" portal_sidekiq
 
 # Run the tests
 echo "┌───────────────────────────┐"
@@ -26,8 +26,8 @@ echo "│                           │"
 echo "│  Running DPC Portal Tests │"
 echo "│                           │"
 echo "└───────────────────────────┘"
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_portal
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_portal
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" portal_sidekiq
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" portal_sidekiq
 
 echo "┌────────────────────────────────┐"
 echo "│                                │"

--- a/dpc-portal/spec/spec_helper.rb
+++ b/dpc-portal/spec/spec_helper.rb
@@ -33,7 +33,7 @@ unless ENV['ACCESSIBILITY'] == 'true'
 end
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'objects.githubusercontent.com'])
+WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'release-assets.githubusercontent.com'])
 
 require 'support/fake_cpi_gateway'
 

--- a/dpc-portals-test.sh
+++ b/dpc-portals-test.sh
@@ -22,8 +22,8 @@ make portal
 
 # Prepare the environment
 docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up db --wait
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_portal
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" web_sidekiq
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" portal_sidekiq
 
 # Run the tests
 echo "┌─────────────────────────┐"
@@ -31,24 +31,24 @@ echo "│                         │"
 echo "│  Running DPC Web Tests  │"
 echo "│                         │"
 echo "└─────────────────────────┘"
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_web
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_web
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" web_sidekiq
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" web_sidekiq
 
 echo "┌───────────────────────────┐"
 echo "│                           │"
 echo "│  Running DPC Admin Tests  │"
 echo "│                           │"
 echo "└───────────────────────────┘"
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_admin
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_admin
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" admin_sidekiq
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" admin_sidekiq
 
 echo "┌───────────────────────────┐"
 echo "│                           │"
 echo "│  Running DPC Portal Tests │"
 echo "│                           │"
 echo "└───────────────────────────┘"
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_portal
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_portal
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" portal_sidekiq
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" portal_sidekiq
 
 echo "┌───────────────────────────────────────────────┐"
 echo "│                                               │"

--- a/dpc-web-accessibility-test.sh
+++ b/dpc-web-accessibility-test.sh
@@ -18,7 +18,7 @@ make website
 
 # Prepare the environment 
 docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up db --wait
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" web_sidekiq
 
 # Run the tests
 echo "┌──────────────---───────--------------──┐"
@@ -27,7 +27,7 @@ echo "│   Running Portal Accessibility Tests   |"
 echo "│                                        │"
 echo "└──-─────────────────────────────-------─┘"
 
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint docker/accessibility-test.sh dpc_web
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint docker/accessibility-test.sh web_sidekiq
 
 echo "┌──────────────---───────--------------──┐"
 echo "│                                        │"

--- a/dpc-web-portal-test.sh
+++ b/dpc-web-portal-test.sh
@@ -18,7 +18,7 @@ make website
 
 # Prepare the environment 
 docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml up db --wait
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" dpc_web
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rails db:create db:migrate RAILS_ENV=test" web_sidekiq
 
 # Run the tests
 echo "┌─────────────────────────┐"
@@ -26,8 +26,8 @@ echo "│                         │"
 echo "│  Running DPC Web Tests  │"
 echo "│                         |"
 echo "└─────────────────────────┘"
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" dpc_web
-docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" dpc_web
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rubocop" web_sidekiq
+docker compose -p start-v1-portals -f docker-compose.yml -f docker-compose.portals.yml run --entrypoint "bundle exec rspec" web_sidekiq
 
 echo "┌──────────────────────────────┐"
 echo "│                              │"

--- a/dpc-web/spec/spec_helper.rb
+++ b/dpc-web/spec/spec_helper.rb
@@ -26,7 +26,7 @@ unless ENV['ACCESSIBILITY'] == 'true'
 end
 
 require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'objects.githubusercontent.com'])
+WebMock.disable_net_connect!(allow_localhost: true, allow: ['github.com', 'release-assets.githubusercontent.com'])
 
 RSpec.configure do |config|
   config.filter_run_excluding type: :system


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

CI tests for portals run against "sidekiq" docker services instead of "web" docker services.

## ℹ️ Context

Both sidekiq and web docker services use the same image -- the main difference is whether they run sidekiq or rails server on startup. These distinctions do not matter for the ci tests.
The web services rely on the sidekiq services, so now, when running the tests, we also run the sidekiq services. By testing against the sidekiq services, we don't have redundant services running.

## 🧪 Validation

All tests run.
