### PR TITLE
Snyk Vulnerability Fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 bzt
-aiohttp>=3.10.11 # not directly required, pinned for Snyk to avoid a vulnerability
+aiohttp>=3.12.14 # not directly required, pinned for Snyk to avoid a vulnerability
+h11>=0.16.0 # not directly required, pinned for Snyk to avoid a vulnerability
 numpy>=1.22.2 # not directly required, pinned for Snyk to avoid a vulnerability
 requests>=2.32.2 # not directly required, pinned for Snyk to avoid a vulnerability
 setuptools>=74.1.2 # Pip will try to downgrade to 65.5.0 and break things


### PR DESCRIPTION
## 🎫 Ticket

None: https://app.snyk.io/org/oeda/project/1f63c1da-7c44-4774-b041-e7cf294c31b3?action=retest&success=true&result=RETESTED

## 🛠 Changes

Updated dependencies in requirements.txt based on Snyk recommendation.

## ℹ️ Context

Snyk is recommending upgrading these dependencies to avoid critical and high vulnerabilities.

### Note
Snyk actually recommends fully pinning (`==` instead of `>=`), so these will still be listed as vulnerabilities.  Once this is merged I'll mark them as ignored.

Their reasoning: "_Stay with (”pin to”) a specific version of an indirect dependency, to avoid pulling in a vulnerable version later._"

## 🧪 Validation

Ran smoke tests in dev [here](https://github.com/CMSgov/dpc-app/actions/runs/17101027263).
