### PR TITLE
Address Snyk alerts

### DIFF
--- a/dpc-api/pom.xml
+++ b/dpc-api/pom.xml
@@ -215,14 +215,13 @@
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
             <version>${mockserverVersion}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.minidev</groupId>
-                    <artifactId>json-smart</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.6.16</version>
         </dependency>
         <dependency>
             <groupId>gov.cms.dpc</groupId>

--- a/dpc-bluebutton/pom.xml
+++ b/dpc-bluebutton/pom.xml
@@ -76,20 +76,9 @@
         </dependency>
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
+            <artifactId>mockserver-netty-no-dependencies</artifactId>
             <version>${mockserverVersion}</version>
-            <classifier>shaded</classifier>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>net.minidev</groupId>
-                    <artifactId>json-smart</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/dpc-common/pom.xml
+++ b/dpc-common/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.9.0</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>4.0.14</dropwizard.version>
+        <dropwizard.version>4.0.16</dropwizard.version>
         <junit.jupiter.version>5.12.1</junit.jupiter.version>
         <slf4j.version>2.0.17</slf4j.version>
         <hapi.fhir.groupID>ca.uhn.hapi.fhir</hapi.fhir.groupID>
-        <hapi.fhir.version>7.6.1</hapi.fhir.version>
+        <hapi.fhir.version>8.4.0</hapi.fhir.version>
         <pgsql.version>42.7.7</pgsql.version>
         <java.version>17</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>
@@ -425,7 +425,7 @@
             <dependency>
                 <groupId>software.amazon.jdbc</groupId>
                 <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-                <version>2.6.1</version>
+                <version>2.6.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## 🎫 Ticket

No ticket.

## 🛠 Changes

Updates packages to remove vulnerable imports.

## ℹ️ Context

Snyk is reporting several security failures related to mockserver-netty dependencies, so I switched to using a version of the package with no included dependencies, and added io.swagger as needed. This PR also updates other packages with transitive vulnerabilities.

## 🧪 Validation

Build passing.
