### PR TITLE
Me/dpc 4872 remove attribution db from api

### DIFF
--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIConfiguration.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import gov.cms.dpc.bluebutton.config.BBClientConfiguration;
 import gov.cms.dpc.bluebutton.config.BlueButtonBundleConfiguration;
-import gov.cms.dpc.common.hibernate.attribution.IDPCDatabase;
 import gov.cms.dpc.common.hibernate.auth.IDPCAuthDatabase;
 import gov.cms.dpc.common.hibernate.queue.IDPCQueueDatabase;
 import gov.cms.dpc.fhir.configuration.DPCFHIRConfiguration;
@@ -26,7 +25,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-public class DPCAPIConfiguration extends Configuration implements IDPCDatabase, IDPCQueueDatabase, DPCQueueConfig, IDPCAuthDatabase, IDPCFHIRConfiguration, BlueButtonBundleConfiguration {
+public class DPCAPIConfiguration extends Configuration implements IDPCQueueDatabase, DPCQueueConfig, IDPCAuthDatabase, IDPCFHIRConfiguration, BlueButtonBundleConfiguration {
 
     @NotEmpty
     private String exportPath;
@@ -34,11 +33,6 @@ public class DPCAPIConfiguration extends Configuration implements IDPCDatabase, 
     @NotNull
     @JsonProperty
     private JerseyClientConfiguration httpClient = new JerseyClientConfiguration();
-
-    @Valid
-    @NotNull
-    @JsonProperty("database")
-    private DataSourceFactory database = new DataSourceFactory();
 
     @Valid
     @NotNull
@@ -91,11 +85,6 @@ public class DPCAPIConfiguration extends Configuration implements IDPCDatabase, 
 
     public void setTokenPolicy(TokenPolicy tokenPolicy) {
         this.tokenPolicy = tokenPolicy;
-    }
-
-    @Override
-    public DataSourceFactory getDatabase() {
-        return database;
     }
 
     @Override

--- a/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/DPCAPIService.java
@@ -12,8 +12,6 @@ import gov.cms.dpc.api.cli.organizations.OrganizationCommand;
 import gov.cms.dpc.api.cli.tokens.TokenCommand;
 import gov.cms.dpc.api.exceptions.JsonParseExceptionMapper;
 import gov.cms.dpc.bluebutton.BlueButtonClientModule;
-import gov.cms.dpc.common.hibernate.attribution.DPCHibernateBundle;
-import gov.cms.dpc.common.hibernate.attribution.DPCHibernateModule;
 import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateBundle;
 import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateModule;
 import gov.cms.dpc.common.hibernate.queue.DPCQueueHibernateBundle;
@@ -45,7 +43,6 @@ import java.util.Optional;
 
 public class DPCAPIService extends Application<DPCAPIConfiguration> {
 
-    private final DPCHibernateBundle<DPCAPIConfiguration> hibernateBundle = new DPCHibernateBundle<>();
     private final DPCQueueHibernateBundle<DPCAPIConfiguration> hibernateQueueBundle = new DPCQueueHibernateBundle<>();
     private final DPCAuthHibernateBundle<DPCAPIConfiguration> hibernateAuthBundle = new DPCAuthHibernateBundle<>(List.of(
             "gov.cms.dpc.macaroons.store.hibernate.entities"));
@@ -74,7 +71,6 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
         // The Hibernate bundle must be initialized before Guice.
         // The Hibernate Guice module requires an initialized SessionFactory,
         // so Dropwizard needs to initialize the HibernateBundle first to create the SessionFactory.
-        bootstrap.addBundle(hibernateBundle);
         bootstrap.addBundle(hibernateQueueBundle);
         bootstrap.addBundle(hibernateAuthBundle);
 
@@ -119,7 +115,6 @@ public class DPCAPIService extends Application<DPCAPIConfiguration> {
         JerseyGuiceUtils.reset();
         return GuiceBundle.builder()
                 .modules(
-                        new DPCHibernateModule<>(hibernateBundle),
                         new DPCQueueHibernateModule<>(hibernateQueueBundle),
                         new DPCAuthHibernateModule<>(hibernateAuthBundle),
                         new AuthModule(),

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/IpAddressResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/IpAddressResource.java
@@ -9,6 +9,7 @@ import gov.cms.dpc.api.jdbi.IpAddressDAO;
 import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.api.models.CreateIpAddressRequest;
 import gov.cms.dpc.api.resources.AbstractIpAddressResource;
+import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateBundle;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.hypersistence.utils.hibernate.type.basic.Inet;
@@ -42,7 +43,7 @@ public class IpAddressResource extends AbstractIpAddressResource {
     @Timed
     @ExceptionMetered
     @Authorizer
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @ApiOperation(
         value = "Fetch Ip addresses for an organization",
         authorizations = @Authorization(value = "access_token")
@@ -58,7 +59,7 @@ public class IpAddressResource extends AbstractIpAddressResource {
     @Timed
     @ExceptionMetered
     @Authorizer
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @ApiOperation(
             value = "Submits an Ip address for an organization",
             notes = "Organizations are currently limited to 8 Ip addresses.  If you attempt to submit more a 400 will be returned.",
@@ -96,7 +97,7 @@ public class IpAddressResource extends AbstractIpAddressResource {
     @Timed
     @ExceptionMetered
     @Authorizer
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @ApiOperation(
             value = "Deletes an Ip address for an organization",
             authorizations = @Authorization(value = "access_token")

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/KeyResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/KeyResource.java
@@ -13,6 +13,7 @@ import gov.cms.dpc.api.models.CollectionResponse;
 import gov.cms.dpc.api.resources.AbstractKeyResource;
 import gov.cms.dpc.common.annotations.NoHtml;
 import gov.cms.dpc.common.entities.OrganizationEntity;
+import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateBundle;
 import io.dropwizard.auth.Auth;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.swagger.annotations.*;
@@ -52,7 +53,7 @@ public class KeyResource extends AbstractKeyResource {
     @Timed
     @ExceptionMetered
     @Authorizer
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Fetch public keys for Organization",
             notes = "This endpoint returns all the public keys currently associated with the organization." +
@@ -67,7 +68,7 @@ public class KeyResource extends AbstractKeyResource {
     @Timed
     @ExceptionMetered
     @Path("/{keyID}")
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Authorizer
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Fetch public key for Organization",
@@ -87,7 +88,7 @@ public class KeyResource extends AbstractKeyResource {
     @Timed
     @ExceptionMetered
     @Path("/{keyID}")
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Produces(MediaType.APPLICATION_JSON)
     @Authorizer
     @ApiOperation(value = "Delete public key for Organization",
@@ -121,7 +122,7 @@ public class KeyResource extends AbstractKeyResource {
                     "- secp256r1" +
                     "- secp384r1")
     @ApiResponses(@ApiResponse(code = 400, message = "Public key is not valid."))
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Override
     public PublicKeyEntity submitKey(@ApiParam(hidden = true) @Auth OrganizationPrincipal organizationPrincipal,
                                      @ApiParam KeySignature keySignature,

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/OrganizationResource.java
@@ -12,6 +12,7 @@ import gov.cms.dpc.api.jdbi.PublicKeyDAO;
 import gov.cms.dpc.api.jdbi.TokenDAO;
 import gov.cms.dpc.api.resources.AbstractOrganizationResource;
 import gov.cms.dpc.common.MDCConstants;
+import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateBundle;
 import gov.cms.dpc.fhir.DPCResourceType;
 import gov.cms.dpc.fhir.annotations.FHIR;
 import gov.cms.dpc.fhir.annotations.FHIRParameter;
@@ -135,7 +136,7 @@ public class OrganizationResource extends AbstractOrganizationResource {
     @Timed
     @ExceptionMetered
     @AdminOperation
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @ApiOperation(value = "Delete Organization",
             notes = "FHIR endpoint which removes the organization currently registered with the application.\n" +
                     "This also removes all associated resources",

--- a/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/TokenResource.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/resources/v1/TokenResource.java
@@ -23,6 +23,7 @@ import gov.cms.dpc.common.MDCConstants;
 import gov.cms.dpc.common.annotations.APIV1;
 import gov.cms.dpc.common.annotations.NoHtml;
 import gov.cms.dpc.common.annotations.Public;
+import gov.cms.dpc.common.hibernate.auth.DPCAuthHibernateBundle;
 import gov.cms.dpc.macaroons.CaveatSupplier;
 import gov.cms.dpc.macaroons.MacaroonBakery;
 import gov.cms.dpc.macaroons.MacaroonCaveat;
@@ -97,7 +98,7 @@ public class TokenResource extends AbstractTokenResource {
 
     @Override
     @GET
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Timed
     @ExceptionMetered
     @Authorizer
@@ -110,7 +111,7 @@ public class TokenResource extends AbstractTokenResource {
 
     @GET
     @Path("/{tokenID}")
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Timed
     @ExceptionMetered
     @Authorizer
@@ -129,7 +130,7 @@ public class TokenResource extends AbstractTokenResource {
     }
 
     @POST
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Timed
     @ExceptionMetered
     @Authorizer
@@ -182,7 +183,7 @@ public class TokenResource extends AbstractTokenResource {
     @Override
     @DELETE
     @Path("/{tokenID}")
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Timed
     @ExceptionMetered
     @Authorizer
@@ -201,7 +202,7 @@ public class TokenResource extends AbstractTokenResource {
 
     @POST
     @Path("/auth")
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Timed
     @ExceptionMetered
     @ApiOperation(value = "Request API access token", notes = "Request access token for API access")
@@ -238,7 +239,7 @@ public class TokenResource extends AbstractTokenResource {
 
     @POST
     @Path("/validate")
-    @UnitOfWork
+    @UnitOfWork(value = DPCAuthHibernateBundle.BUNDLE_NAME)
     @Timed
     @ExceptionMetered
     @ApiOperation(value = "Validate API token request", notes = "Validates a given JWT to ensure the required claims and values are set correctly.", authorizations = @Authorization(value = ""))

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -1,19 +1,3 @@
-database:
-  driverClass: ${DB_DRIVER_CLASS:-"org.postgresql.Driver"}
-  url: ${ATTRIBUTION_DB_URL:-"jdbc:postgresql://db:5432/dpc_attribution"}
-  user: "${ATTRIBUTION_DB_USER:-postgres}"
-  password: "${ATTRIBUTION_DB_PASS:-dpc-safe}"  # Ignored in AWS, needed to run locally
-  initialSize: 5
-  minSize: 5
-  maxSize: 10
-  properties:
-    charSet: UTF-8
-    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
-    wrapperPlugins: iam,failover,efm2
-    iamRegion: us-east-1
-    sslmode: ${DB_SSL_MODE:-"prefer"}
-    sslrootcert: /awscert/global-bundle.pem
-
 queuedb:
   driverClass: ${DB_DRIVER_CLASS:-"org.postgresql.Driver"}
   url: ${QUEUE_DB_URL:-"jdbc:postgresql://db:5432/dpc_queue"}

--- a/dpc-api/src/main/resources/dev.application.env
+++ b/dpc-api/src/main/resources/dev.application.env
@@ -1,7 +1,5 @@
 APP_CONTEXT_PATH="/api"
 DB_SSL_MODE="verify-full"
-ATTRIBUTION_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_attribution"
-ATTRIBUTION_DB_USER="${ENV}-dpc_attribution-role"
 QUEUE_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_queue"
 QUEUE_DB_USER="${ENV}-dpc_queue-role"
 AUTH_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_auth"

--- a/dpc-api/src/main/resources/prod.application.env
+++ b/dpc-api/src/main/resources/prod.application.env
@@ -1,7 +1,5 @@
 APP_CONTEXT_PATH="/api"
 DB_SSL_MODE="verify-full"
-ATTRIBUTION_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_attribution"
-ATTRIBUTION_DB_USER="${ENV}-dpc_attribution-role"
 QUEUE_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_queue"
 QUEUE_DB_USER="${ENV}-dpc_queue-role"
 AUTH_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_auth"

--- a/dpc-api/src/main/resources/sandbox.application.env
+++ b/dpc-api/src/main/resources/sandbox.application.env
@@ -1,7 +1,5 @@
 APP_CONTEXT_PATH="/api"
 DB_SSL_MODE="verify-full"
-ATTRIBUTION_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_attribution"
-ATTRIBUTION_DB_USER="${ENV}-dpc_attribution-role"
 QUEUE_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_queue"
 QUEUE_DB_USER="${ENV}-dpc_queue-role"
 AUTH_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_auth"

--- a/dpc-api/src/main/resources/test.application.env
+++ b/dpc-api/src/main/resources/test.application.env
@@ -1,7 +1,5 @@
 APP_CONTEXT_PATH="/api"
 DB_SSL_MODE="verify-full"
-ATTRIBUTION_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_attribution"
-ATTRIBUTION_DB_USER="${ENV}-dpc_attribution-role"
 QUEUE_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_queue"
 QUEUE_DB_USER="${ENV}-dpc_queue-role"
 AUTH_DB_URL="jdbc:aws-wrapper:postgresql://${DB_HOST}:5432/dpc_auth"

--- a/dpc-api/src/test/resources/test.application.yml
+++ b/dpc-api/src/test/resources/test.application.yml
@@ -1,16 +1,4 @@
 # application.yml with changes to relative paths, urls, and logging for testing purposes
-database:
-  driverClass: org.postgresql.Driver
-  url: ${DATABASE_URL:-"jdbc:postgresql://localhost:5432/dpc_attribution"}
-  user: "${ATTRIBUTION_DB_USER:-postgres}"
-  password: "${ATTRIBUTION_DB_PASS:-dpc-safe}"
-  initialSize: 5
-  minSize: 5
-  maxSize: 10
-  properties:
-    charSet: UTF-8
-    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
-
 queuedb:
   driverClass: org.postgresql.Driver
   url: ${QUEUE_DB_URL:-"jdbc:postgresql://localhost:5432/dpc_queue"}

--- a/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/auth/DPCAuthHibernateBundle.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/common/hibernate/auth/DPCAuthHibernateBundle.java
@@ -23,6 +23,7 @@ import static gov.cms.dpc.common.hibernate.EntityScanner.applicationEntities;
 public class DPCAuthHibernateBundle<T extends Configuration & IDPCAuthDatabase> extends HibernateBundle<T> implements ConfiguredBundle<T> {
 
     public static final String PREFIX_STRING = "gov.cms.dpc.api.entities";
+    public static final String BUNDLE_NAME = "hibernate.auth";
 
     @Inject
     public DPCAuthHibernateBundle() {
@@ -40,6 +41,6 @@ public class DPCAuthHibernateBundle<T extends Configuration & IDPCAuthDatabase> 
 
     @Override
     protected String name() {
-        return "hibernate.auth";
+        return BUNDLE_NAME;
     }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4872

## 🛠 Changes

- Removed the attribution db from dpc-api, as it wasn't used.
- Update `@UnitOfWork` annotation to specify which DB to use in dpc-api.

## ℹ️ Context

We noticed that dpc-api had a connection to the attribution DB, but wasn't using it, and when we tried to remove it dpc-api started failing.

The issue was that our endpoints in dpc-api rely on the `@UnitOfWork` annotation to open and close hibernate transactions.  In a DropWizard service that uses multiple DBs, though, you have to specify which DB the annotation should open those transactions on, and we weren't.  In that case, it defaults to looking for a DB named "hibernate".  Coincidentally, the attribution DB that we weren't actually using was named "hibernate", so all transactions were being opened there even though the actual work was being done in the auth and queue DBs.  Fortunately this never caused any problems, most likely because the endpoints that hit the auth DB aren't in heavy usage.

This also meant that when the attribution DB was removed we started getting errors in dpc-api saying it couldn't find the "hibernate" bundle and tests wouldn't pass.

## 🧪 Validation

All integration and unit tests are passing now that the attribution DB has removed.
