### PR TITLE
Revert version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
             <dependency>
                 <groupId>software.amazon.jdbc</groupId>
                 <artifactId>aws-advanced-jdbc-wrapper</artifactId>
-                <version>2.6.3</version>
+                <version>2.6.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## 🎫 Ticket

No ticket.

## 🛠 Changes

Reverts version update for aws-advanced-jdbc-wrapper.

## ℹ️ Context

Dependencies included in aws-advanced-jdbc-wrapper changed in this version upgrade, and AWS SDK RDS v2.x is no longer included on the classpath.

## 🧪 Validation

Deploy passing.
