### PR TITLE
Fix test flakiness

### DIFF
--- a/dpc-admin/config/environments/test.rb
+++ b/dpc-admin/config/environments/test.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes
Eager load app in test environment

## ℹ️ Context

dpc-admin and dpc-web tests are intermittently failing since the upgrade to Rails 8. It looks related to [this issue](https://github.com/heartcombo/devise/pull/5695). Although eager loading is probably not the best solution, it should do until devise fixes it.

## 🧪 Validation

Before fix, tests failed with the following seeds: 28654 and 24842. They pass with the fix.
In the dpc admin container:
`bundle exec rspec --seed 28654`
`bundle exec rspec --seed 24842`
In the dpc web container:
`bundle exec rspec --seed 39498`
