### PR TITLE
Address Snyk Findings - Bump aws.java.sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <newrelic.agent.version>8.21.0</newrelic.agent.version>
         <newrelic.agent.type>zip</newrelic.agent.type>
         <h2.version>2.3.232</h2.version>
-        <aws.java.sdk.version>2.31.71</aws.java.sdk.version>
+        <aws.java.sdk.version>2.33.9</aws.java.sdk.version>
         <sonar.coverage.exclusions>**/MockBlueButton*.java</sonar.coverage.exclusions>
     </properties>
 


### PR DESCRIPTION
## 🎫 Ticket

None.  Created as part of weekly security checks. 

## 🛠 Changes

Bump `software.amazon.awssdk` version.

## ℹ️ Context

Snyk detected a number of `io.netty` issues in the older version of the AWS java SDK.  This newer version bumps `io.netty` and fixes them.

## 🧪 Validation

Tests pass, successful deploy [here](https://github.com/CMSgov/dpc-app/actions/runs/17741283282).
