### PR TITLE
Pin bzt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bzt
+bzt==1.16.45
 aiohttp>=3.12.14 # not directly required, pinned for Snyk to avoid a vulnerability
 h11>=0.16.0 # not directly required, pinned for Snyk to avoid a vulnerability
 numpy>=1.22.2 # not directly required, pinned for Snyk to avoid a vulnerability


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

- bzt (smoke test library) pinned to 1.16.45 in requirements.txt

## ℹ️ Context

Version 1.16.46 of bzt somehow led to some odd jackson collision in jmeter, so we are pinning at what works.

## 🧪 Validation
Smoke tests pass: https://github.com/CMSgov/dpc-app/actions/runs/17835961112
