### PR TITLE
Upgrade pitest

### DIFF
--- a/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/tasks/GenerateClientTokenTests.java
@@ -2,7 +2,6 @@ package gov.cms.dpc.api.tasks;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.nitram509.jmacaroons.MacaroonsBuilder;
-import edu.emory.mathcs.backport.java.util.Collections;
 import gov.cms.dpc.api.auth.OrganizationPrincipal;
 import gov.cms.dpc.api.entities.PublicKeyEntity;
 import gov.cms.dpc.api.entities.TokenEntity;

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <jacoco.version>0.8.12</jacoco.version>
         <jooq.version>3.19.19</jooq.version>
         <bouncey.version>1.81</bouncey.version>
-        <pitest.version>1.5.1</pitest.version>
+        <pitest.version>1.20.3</pitest.version>
         <newrelic.agent.version>8.21.0</newrelic.agent.version>
         <newrelic.agent.type>zip</newrelic.agent.type>
         <h2.version>2.3.232</h2.version>


### PR DESCRIPTION
## 🎫 Ticket

No ticket

## 🛠 Changes

- pitest upgraded
- unnecessary import removed

## ℹ️ Context

Snyk found a vulnerability in our (very old) version fixed by upgrade.
Fix showed an odd import that was unnecessary and thus removed.
This change only affects tests.

## 🧪 Validation

Tests pass.
