### PR TITLE
dpc-5335 - undoing smoke test codebuild change

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,10 +30,7 @@ jobs:
       run:
         working-directory: ./dpc-load-testing
     name: Smoke Test
-    runs-on: >-
-      codebuild-dpc-app${{
-        contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
-      }}-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-dpc-app-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack Starting


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5335

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

Undoing switch to the new Arm64 Codebuild to unblock release.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

The following ticket is in progress to resolve related issues. https://jira.cms.gov/browse/DPC-5332

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

smoke test pass in each environment:

DEV
https://github.com/CMSgov/dpc-app/actions/runs/24135139141

TEST
https://github.com/CMSgov/dpc-app/actions/runs/24135414504

SANDBOX
https://github.com/CMSgov/dpc-app/actions/runs/24135621997

PROD
https://github.com/CMSgov/dpc-app/actions/runs/24135636007