### PR TITLE
Me/dpc 5338 smoketests on new codebuild runners

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,10 +30,11 @@ jobs:
       run:
         working-directory: ./dpc-load-testing
     name: Smoke Test
-    runs-on: >-
-      codebuild-dpc-app${{
-        contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
-      }}-${{ github.run_id }}-${{ github.run_attempt }}
+    #runs-on: >-
+    #  codebuild-dpc-app${{
+    #    contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
+    #  }}-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-dpc-app-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Starting

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,6 +49,7 @@ jobs:
                 footer: "<${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Smoke Test - Build ${{ github.run_id }}>"
                 mrkdown_in:
                   - footer
+          text: "Smoke test of `${{ inputs.env }}` has started"
       - name: "Checkout code"
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: AWS Credentials (non-prod)
@@ -106,6 +107,7 @@ jobs:
                 footer: "<${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Smoke Test - Build ${{ github.run_id }}>"
                 mrkdown_in:
                   - footer
+          text: "Smoke test of `${{ inputs.env }}` has succeeded"
       - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack failure
         if: ${{ failure() }}
@@ -121,3 +123,4 @@ jobs:
                 footer: "<${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Smoke Test - Build ${{ github.run_id }}>"
                 mrkdown_in:
                   - footer
+          text: "Smoke test of `${{ inputs.env }}` has failed"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -34,7 +34,6 @@ jobs:
       codebuild-dpc-app${{
         contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
       }}-${{ github.run_id }}-${{ github.run_attempt }}
-    #runs-on: codebuild-dpc-app-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Starting

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -66,7 +66,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
       - name: Install PACE cert
         env:
           PACE_CERT: ${{ secrets.PACE_CERT }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -49,7 +49,7 @@ jobs:
                 footer: "<${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Smoke Test - Build ${{ github.run_id }}>"
                 mrkdown_in:
                   - footer
-          text: "Smoke test of `${{ inputs.env }}` has started"
+            text: "Smoke test of `${{ inputs.env }}` has started"
       - name: "Checkout code"
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: AWS Credentials (non-prod)
@@ -107,7 +107,7 @@ jobs:
                 footer: "<${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Smoke Test - Build ${{ github.run_id }}>"
                 mrkdown_in:
                   - footer
-          text: "Smoke test of `${{ inputs.env }}` has succeeded"
+            text: "Smoke test of `${{ inputs.env }}` has succeeded"
       - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack failure
         if: ${{ failure() }}
@@ -123,4 +123,4 @@ jobs:
                 footer: "<${{ github.server_url}}/${{ github.repository}}/actions/runs/${{ github.run_id }}|Smoke Test - Build ${{ github.run_id }}>"
                 mrkdown_in:
                   - footer
-          text: "Smoke test of `${{ inputs.env }}` has failed"
+            text: "Smoke test of `${{ inputs.env }}` has failed"

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -35,7 +35,7 @@ jobs:
         contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
       }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Starting
         with:
           method: chat.postMessage
@@ -51,20 +51,20 @@ jobs:
                   - footer
             text: "Smoke test of `${{ inputs.env }}` has started"
       - name: "Checkout code"
-        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: AWS Credentials (non-prod)
         if: ${{ inputs.env == 'dev' || inputs.env == 'test' }}
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
       - name: AWS Credentials (prod)
         if: ${{ inputs.env == 'sandbox' || inputs.env == 'prod' }}
-        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.env }}-github-actions
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.24.x'
       - name: Install PACE cert
@@ -93,7 +93,7 @@ jobs:
           ENVIRONMENT: ${{ inputs.env }}
         run: |
           ./k6 run ./smoke-test.js
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Success
         with:
           method: chat.postMessage
@@ -108,7 +108,7 @@ jobs:
                 mrkdown_in:
                   - footer
             text: "Smoke test of `${{ inputs.env }}` has succeeded"
-      - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+      - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack failure
         if: ${{ failure() }}
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,11 +30,11 @@ jobs:
       run:
         working-directory: ./dpc-load-testing
     name: Smoke Test
-    #runs-on: >-
-    #  codebuild-dpc-app${{
-    #    contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
-    #  }}-${{ github.run_id }}-${{ github.run_attempt }}
-    runs-on: codebuild-dpc-app-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: >-
+      codebuild-dpc-app${{
+        contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
+      }}-${{ github.run_id }}-${{ github.run_attempt }}
+    #runs-on: codebuild-dpc-app-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Starting
@@ -93,7 +93,7 @@ jobs:
         env:
           ENVIRONMENT: ${{ inputs.env }}
         run: |
-          ./k6 run ./smoke-test.js
+          ./k6 run --http-debug="full" ./smoke-test.js
       - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Success
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build K6
         run: |
           # Install xk6
-          go install go.k6.io/xk6/cmd/xk6@v1.1.5
+          go install go.k6.io/xk6/cmd/xk6@v1.3.7
 
           # Build the k6 binary
           xk6 build

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,7 +30,10 @@ jobs:
       run:
         working-directory: ./dpc-load-testing
     name: Smoke Test
-    runs-on: codebuild-dpc-app-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: >-
+      codebuild-dpc-app${{
+        contains(fromJSON('["prod", "sandbox"]'), inputs.env) && '-prod' || '-non-prod'
+      }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         name: Slack Starting

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           ENVIRONMENT: ${{ inputs.env }}
         run: |
-          ./k6 run --http-debug="full" ./smoke-test.js
+          ./k6 run ./smoke-test.js
       - uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         name: Slack Success
         with:

--- a/dpc-load-testing/smoke-test.js
+++ b/dpc-load-testing/smoke-test.js
@@ -29,8 +29,8 @@ export const options = {
       executor: 'per-vu-iterations',
       vus: 3, // This has to stay at three to ensure even distribution of organizations.
       iterations: 1,
-      exec: "runSmokeTests",
-      maxDuration: '5m'
+      exec: "runSmokeTests"
+
     }
   }
 };

--- a/dpc-load-testing/smoke-test.js
+++ b/dpc-load-testing/smoke-test.js
@@ -29,8 +29,8 @@ export const options = {
       executor: 'per-vu-iterations',
       vus: 3, // This has to stay at three to ensure even distribution of organizations.
       iterations: 1,
-      exec: "runSmokeTests"
-
+      exec: "runSmokeTests",
+      maxDuration: '5m'
     }
   }
 };


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5338

## 🛠 Changes

- Switched to new arm64 code build runners.
- Bumped our actions calls, as a bunch of them were about to be deprecated.
- Bumped the corresponding Go and K6 versions.
- Added `text` field to Slack payloads.

## ℹ️ Context

The primary goal of this ticket was switching our smoke tests to the new arm64 based runners.  While I was in there, I fixed a number of long standing warnings as well.

1. We were getting a warning on not including a text property in our Slack payloads.
2. Most of our calls to other actions are about to be deprecated and needed to be bumped. (See [DPC-5346](https://jira.cms.gov/browse/DPC-5346))

## 🧪 Validation

Ran successfully against dev on the new runners: https://github.com/CMSgov/dpc-app/actions/runs/24262520514

## Note
Needs https://github.com/CMSgov/dpc-ops/pull/936#pullrequestreview-4099063650 to be deployed before it can be run consistently.
