### PR TITLE
[DPC-5345] Update SonarQube checks to use ARM64 runners

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -260,9 +260,6 @@ jobs:
     name: Sonarqube Quality Gate for dpc-web and dpc-admin
     needs: [build-dpc-admin, build-dpc-web]
     runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
-    env:
-      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: Assert Ownership
         run: sudo chmod -R 777 .
@@ -317,9 +314,6 @@ jobs:
     name: Sonarqube Quality Gate for dpc-portal
     needs: build-dpc-portal
     runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
-    env:
-      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
     steps:
       - name: Assert Ownership
         run: sudo chmod -R 777 .
@@ -370,9 +364,6 @@ jobs:
     name: Sonarqube Quality Gate for dpc-api
     needs: build-api
     runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
-    env:
-      # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Assert Ownership
         run: sudo chmod -R 777 .

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -259,7 +259,7 @@ jobs:
   sonar-quality-gate-dpc-web-and-admin:
     name: Sonarqube Quality Gate for dpc-web and dpc-admin
     needs: [build-dpc-admin, build-dpc-web]
-    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -312,7 +312,7 @@ jobs:
   sonar-quality-gate-dpc-portal:
     name: Sonarqube Quality Gate for dpc-portal
     needs: build-dpc-portal
-    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: "true"
@@ -361,7 +361,7 @@ jobs:
   sonar-quality-gate-dpc-api:
     name: Sonarqube Quality Gate for dpc-api
     needs: build-api
-    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     env:
       # Workaround until https://jira.cms.gov/browse/PLT-338 is implemented.
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -292,6 +292,10 @@ jobs:
           params: |
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         with:
@@ -340,6 +344,10 @@ jobs:
           params: |
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         with:
@@ -388,6 +396,10 @@ jobs:
           params: |
             SONAR_HOST_URL=/sonarqube/url
             SONAR_TOKEN=/sonarqube/token
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
       - name: Install Maven 3.6.3
         run: |
           export PATH="$PATH:/opt/maven/bin"

--- a/.github/workflows/dpc-web-accessibility-test.yml
+++ b/.github/workflows/dpc-web-accessibility-test.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - name: "Checkout code"
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5345

## 🛠 Changes

Moves workflows to use ARM64 runners.

## ℹ️ Context

We're migrating to ARM64 runners.

## 🧪 Validation

Scans passing.
