### PR TITLE
Reduced size of test data in DataResourceTest

### DIFF
--- a/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/DataResourceTest.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/resources/v1/DataResourceTest.java
@@ -60,7 +60,7 @@ class DataResourceTest extends AbstractSecureApplicationTest {
 	@ParameterizedTest
 	@MethodSource("downloadArgs")
 	void canDownloadFiles(boolean compressFile, Map<String, String> requestHeaders) throws IOException {
-		String testData = "test data".repeat(10000);
+		String testData = "test data".repeat(500);
 		String fileName = createTestExport(testData, compressFile);
 
 		try (ClassicHttpResponse response = downloadExport(fileName, requestHeaders)) {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5357

## 🛠 Changes

Reduce test data size in DataResource integration tests.

## ℹ️ Context

This test is occasionally failing with a 500, but usually works when rerun.  I'm assuming this is a resource issue with the new CodeBuild runners since we've seen similar problems in the past, and that reducing the size of the test data will fix it.  If it doesn't, we'll have to do a deeper dive to figure out if there's something else going on.

See this [run](https://github.com/CMSgov/dpc-app/actions/runs/24482232626/job/71549221552?pr=2986) for an example.  The actual error dpc-api logs is: `{"code":500,"message":"There was an error processing your request. It has been logged (ID 03877f2240833f4e)."}`

## 🧪 Validation

CI is passing.
