### PR TITLE
Ja/dpc 5346 bump build deploy actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
       - name: "Set up JDK 17"
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "17"
           distribution: "corretto"
@@ -98,7 +98,7 @@ jobs:
           sudo cp ./dpc-macaroons/target/site/jacoco/jacoco.xml jacoco-reports/dpc-macaroons-jacoco.xml
           sudo cp ./dpc-queue/target/site/jacoco/jacoco.xml jacoco-reports/dpc-queue-jacoco.xml
       - name: Upload jacoco reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-report-dpc-api
           path: ./jacoco-reports
@@ -130,7 +130,7 @@ jobs:
       - name: "Copy test results"
         run: sudo cp dpc-web/coverage/.resultset.json web-resultset-raw.json
       - name: Archive code coverage results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-report-dpc-web
           path: ./web-resultset-raw.json
@@ -160,7 +160,7 @@ jobs:
       - name: "Copy test results"
         run: sudo cp dpc-admin/coverage/.resultset.json admin-resultset-raw.json
       - name: Archive code coverage results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-report-dpc-admin
           path: ./admin-resultset-raw.json
@@ -189,7 +189,7 @@ jobs:
           sudo dnf -y install python3 python3-pip
           pip install ansible
       - name: "Set up JDK 17"
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "17"
           distribution: "corretto"
@@ -202,7 +202,7 @@ jobs:
       - name: "Copy test results"
         run: sudo cp dpc-portal/coverage/.resultset.json portal-resultset-raw.json
       - name: Archive code coverage results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: code-coverage-report-dpc-portal
           path: ./portal-resultset-raw.json
@@ -233,7 +233,7 @@ jobs:
           sudo dnf -y install python3 python3-pip
           pip install ansible
       - name: "Set up JDK 17"
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "17"
           distribution: "corretto"
@@ -270,11 +270,11 @@ jobs:
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
       - name: Download web code coverage
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-dpc-web
       - name: Download admin code coverage
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-dpc-admin
       - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
@@ -324,7 +324,7 @@ jobs:
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
       - name: Download code coverage
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-dpc-portal
       - name: "Reformat test results" # Sonarqube will run in a docker container and wants the paths to be from /github/workspace
@@ -374,7 +374,7 @@ jobs:
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
       - name: Setup Java
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: temurin
@@ -407,7 +407,7 @@ jobs:
         run: |
           mvn clean compile -Perror-prone -B -V -ntp
       - name: Download code coverage
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: code-coverage-report-dpc-api
           path: jacoco-reports

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -107,7 +107,7 @@ jobs:
       - name: gzip the image
         run: docker save dpc-${{ matrix.ecr_repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
       - name: upload tar artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-${{ matrix.ecr_repository }}
           path: ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
@@ -132,7 +132,7 @@ jobs:
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
       - name: "Set up JDK 17"
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "17"
           distribution: "corretto"
@@ -171,19 +171,19 @@ jobs:
         run: docker save dpc-aggregation:latest | gzip > ${{ runner.temp }}/dpc_aggregation_latest.tar.gz
 
       - name: upload tar artifact (1 of 3) - API
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-api
           path: ${{ runner.temp }}/dpc_api_latest.tar.gz
           retention-days: 1
       - name: upload tar artifact (2 of 3) - Attribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-attribution
           path: ${{ runner.temp }}/dpc_attribution_latest.tar.gz
           retention-days: 1
       - name: upload tar artifact (3 of 3) - Aggregation
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-aggregation
           path: ${{ runner.temp }}/dpc_aggregation_latest.tar.gz
@@ -205,7 +205,7 @@ jobs:
     needs: [ docker_build_rails_apps, docker_build_java, generate_docker_tag ]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dpc-${{ matrix.ecr_repository }}
           path: ${{ runner.temp }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -226,7 +226,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-dev-github-actions
       - name: Login to Amazon ECR (non-prod)
         id: login-ecr-non-prod
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # v2.1.3
       - name: Push image to registries for non-prod aws account
         env:
           IMAGE_TAG: ${{ needs.generate_docker_tag.outputs.docker_tag }}
@@ -249,7 +249,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-prod-github-actions
       - name: Login to Amazon ECR (prod)
         id: login-ecr-prod
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # v2.1.3
       - name: Push image to registries for prod aws account
         if: ${{ startsWith(needs.generate_docker_tag.outputs.docker_tag, 'rls-r') }}
         env:

--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -148,7 +148,7 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 #v4.1.1
 
       - name: Install Tofu
-        uses: cmsgov/cdap/actions/setup-tenv@f4c14d47cc20e7f6de9112d7155af1213c9bca5a
+        uses: cmsgov/cdap/actions/setup-tenv@main
 
       - name: Verify persistent plan
         run: |

--- a/.github/workflows/quick-release.yml
+++ b/.github/workflows/quick-release.yml
@@ -182,7 +182,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.NON_PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-test-github-actions
       - name: Login to Amazon ECR (non-prod)
         id: login-ecr-non-prod
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        uses: aws-actions/amazon-ecr-login@376925c9d111252e87ae59691e5a442dd100ef6a # v2.1.3
       - name: Push image to registries for non-prod aws account
         env:
           IMAGE_TAG: ${{ needs.set-parameters.outputs.docker_tag }}

--- a/.github/workflows/quick-release.yml
+++ b/.github/workflows/quick-release.yml
@@ -94,7 +94,7 @@ jobs:
       - name: gzip the image
         run: docker save dpc-${{ matrix.ecr_repository }}:latest | gzip > ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
       - name: upload tar artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-${{ matrix.ecr_repository }}
           path: ${{ runner.temp }}/dpc_${{ matrix.ecr_repository }}_latest.tar.gz
@@ -114,7 +114,7 @@ jobs:
       - name: Cleanup Runner
         run: ./scripts/cleanup-docker.sh
       - name: "Set up JDK 17"
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: "17"
           distribution: "corretto"
@@ -136,19 +136,19 @@ jobs:
         run: docker save dpc-aggregation:latest | gzip > ${{ runner.temp }}/dpc_aggregation_latest.tar.gz
 
       - name: upload tar artifact (1 of 3) - API
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-api
           path: ${{ runner.temp }}/dpc_api_latest.tar.gz
           retention-days: 1
       - name: upload tar artifact (2 of 3) - Attribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-attribution
           path: ${{ runner.temp }}/dpc_attribution_latest.tar.gz
           retention-days: 1
       - name: upload tar artifact (3 of 3) - Aggregation
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dpc-aggregation
           path: ${{ runner.temp }}/dpc_aggregation_latest.tar.gz
@@ -167,7 +167,7 @@ jobs:
     needs: [ docker_build_rails_apps, docker_build_java, set-parameters ]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: dpc-${{ matrix.ecr_repository }}
           path: ${{ runner.temp }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -81,7 +81,7 @@ jobs:
           # Build the k6 binary
           xk6 build
       - name: Set env vars from AWS params
-        uses: cmsgov/cdap/actions/aws-params-env-action@8343fb96563ce4b74c4dececee9b268f42bd4a40
+        uses: cmsgov/cdap/actions/aws-params-env-action@main
         env:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5346

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

This change updates the following github actions to newer version on Node24.
* setup java
*  upload artifact
* download artifact
* amazon ecr login
* cdap action - setup-tenv
* cdpa action - aws-params-env-action

This change also removes the opt-out-export-test-integration.yml since lambda was removed.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. 

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

Successful DPC Build and Deploy to test environment
https://github.com/CMSgov/dpc-app/actions/runs/24677112015

Successful ECS Deploy to test environment:
https://github.com/CMSgov/dpc-app/actions/runs/24725130753

Successful Quick Release to test environment
https://github.com/CMSgov/dpc-app/actions/runs/24679798104

Successful CI Workflow
https://github.com/CMSgov/dpc-app/actions/runs/24681119658