### PR TITLE
[DPC-5366] Update lambda workflows to include latest LTS version of node

### DIFF
--- a/.github/workflows/deploy_go_lambda.yml
+++ b/.github/workflows/deploy_go_lambda.yml
@@ -33,7 +33,7 @@ jobs:
     environment: ${{ inputs.env }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.24.x'
       - name: Build ${{ inputs.project }} zip file

--- a/.github/workflows/load-test-unit-tests.yml
+++ b/.github/workflows/load-test-unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 22
+          node-version: 24
       - name: Install yarn
         run: npm install -g yarn
       - name: Set up tests for dpc-load-testing utilities

--- a/.github/workflows/opt-out-import-unit.yml
+++ b/.github/workflows/opt-out-import-unit.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./lambda/opt-out-import
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.24.4'
       - name: check go version

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -57,7 +57,7 @@ jobs:
           echo "$BODY" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
       - name: Release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8A # v2.3.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body: ${{ steps.set_body.outputs.body }}
           tag_name: ${{ steps.set_revs.outputs.next_rev }}


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5366](https://jira.cms.gov/browse/DPC-5366)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - bump a few actions to latest commit hashes in order to jump from Node 20 -> Node 24
   - .github/workflows/deploy_go_lambda.yml
   - .github/workflows/opt-out-export-test-integration.yml
   - .github/workflows/tag_release.yml
 - bump node version for load test unit tests
   - updated from 22 -> 24 so that this aligns with same LTS as other workflows

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - Most GHA workflows have already been migrated from Node 20 to 24. Node 20 is reaching end of life at the end of April and workflows that use node should be updated to be sure the latest security updates are included.
 - See related slack thread from CMS slack here: https://cmsgov.slack.com/archives/C04UG13JF9B/p1776357441649319
 - Note: dpc-ops uses the same workflow as dpc-app for cutting new releases, so changes from this PR should be sufficient to ensure dpc-ops releases are running on Node24
 - Additional notes on all actions reviewed available in comments section of original ticket [HERE](https://jira.cms.gov/browse/DPC-5366) 

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Tested manually here: 
Load test unit tests:
https://github.com/CMSgov/dpc-app/actions/runs/24683281430

Deploy go lambda:
https://github.com/CMSgov/dpc-app/actions/runs/24692444684

Opt out import unit:
https://github.com/CMSgov/dpc-app/actions/runs/24692725651

Cut release workflow:
https://github.com/CMSgov/dpc-app/actions/runs/24692097120

