### PR TITLE
dpc-5346 - updating additional gha actions

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -294,7 +294,7 @@ jobs:
         with:
           node-version: 24
       - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-web
@@ -343,7 +343,7 @@ jobs:
         with:
           node-version: 24
       - name: Run quality gate scan
-        uses: sonarsource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
+        uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-portal

--- a/.github/workflows/quicksight-report-deploy.yml
+++ b/.github/workflows/quicksight-report-deploy.yml
@@ -85,7 +85,7 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 #v4.1.1
 
       - name: Install Tofu
-        uses: cmsgov/cdap/actions/setup-tenv@8343fb96563ce4b74c4dececee9b268f42bd4a40
+        uses: cmsgov/cdap/actions/setup-tenv@main
 
       - name: Verify plan
         run: |

--- a/.github/workflows/tofu-apply.yml
+++ b/.github/workflows/tofu-apply.yml
@@ -42,9 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 #v4.1.1
-      - uses: cmsgov/cdap/actions/setup-tenv@8343fb96563ce4b74c4dececee9b268f42bd4a40
-      - uses: cmsgov/cdap/actions/setup-sops@84a6bcee5b70d63c44f8fec4f9b542cb5ec29a54
-      - uses: cmsgov/cdap/actions/setup-yq@328406d6e1d435b4e3da598bcdab22e576c3945e
+      - uses: cmsgov/cdap/actions/setup-tenv@main
+      - uses: cmsgov/cdap/actions/setup-sops@main
+      - uses: cmsgov/cdap/actions/setup-yq@main
       - uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: arn:aws:iam::${{ contains(fromJSON('["dev", "test"]'), inputs.environment) && secrets.NON_PROD_ACCOUNT_ID || secrets.PROD_ACCOUNT_ID }}:role/delegatedadmin/developer/dpc-${{ inputs.environment }}-github-actions


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5365

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

This change updates the following github actions to newer version on Node24.
* sonarqube scan action
* cdap action - setup tenv
* cdap action - setup sops
* cdap action - setup yq

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

Successful DPC CI Workflow
https://github.com/CMSgov/dpc-app/actions/runs/24731909521

Successful DPC - Set SSM Params test (tofu-apply)
https://github.com/CMSgov/dpc-app/actions/runs/24734854688

The DPC - QuickSight Report Deploy is currently unused. The following ticket was created to document workflow use case. 
https://jira.cms.gov/browse/DPC-5369