### PR TITLE
[DPC-5340] bump aws sdk version to address netty vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <newrelic.agent.version>8.21.0</newrelic.agent.version>
         <newrelic.agent.type>zip</newrelic.agent.type>
         <h2.version>2.3.232</h2.version>
-        <aws.java.sdk.version>2.41.2</aws.java.sdk.version>
+        <aws.java.sdk.version>2.42.38</aws.java.sdk.version>
         <sonar.coverage.exclusions>**/MockBlueButton*.java</sonar.coverage.exclusions>
     </properties>
 


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5340](https://jira.cms.gov/browse/DPC-5340)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - bump aws sdk version in root pom.xml

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - This is a follow-up to https://github.com/CMSgov/dpc-app/pull/2994
  - Remaining java vulnerabilities require further involvement
    - HAPI-FHIR includes dependencies that do not include the latest security patches
    - Jetty 11 needs to be upgraded to 12+, which includes breaking changes and probably needs to be done with upgrade to dropwizard 5
    - Additional details in comment section of ticket: https://jira.cms.gov/browse/DPC-5340

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Build & Deploy passed here: https://github.com/CMSgov/dpc-app/actions/runs/24915225705