### PR TITLE
[DPC-5450] Remove schema/tron validation

### DIFF
--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -139,8 +139,6 @@ httpClient:
 fhir:
   validation:
     enabled: true
-    schemaValidation: false
-    schematronValidation: false
 
 tokens:
   versionPolicy:

--- a/dpc-api/src/test/java/gov/cms/dpc/api/APITestHelpers.java
+++ b/dpc-api/src/test/java/gov/cms/dpc/api/APITestHelpers.java
@@ -160,8 +160,6 @@ public class APITestHelpers {
             // Validation config
             final DPCFHIRConfiguration.FHIRValidationConfiguration config = new DPCFHIRConfiguration.FHIRValidationConfiguration();
             config.setEnabled(true);
-            config.setSchematronValidation(true);
-            config.setSchemaValidation(true);
 
             final ValidationSupportChain support = new ValidationSupportChain(
                     new DPCProfileSupport(ctx),

--- a/dpc-api/src/test/resources/test.application.yml
+++ b/dpc-api/src/test/resources/test.application.yml
@@ -117,8 +117,6 @@ httpClient:
 fhir:
   validation:
     enabled: true
-    schemaValidation: false
-    schematronValidation: false
 
 tokens:
   versionPolicy:

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/configuration/DPCFHIRConfiguration.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/configuration/DPCFHIRConfiguration.java
@@ -22,8 +22,6 @@ public class DPCFHIRConfiguration {
     public static class FHIRValidationConfiguration {
 
         private boolean enabled;
-        private boolean schemaValidation;
-        private boolean schematronValidation;
         private boolean debugValidation;
 
         public FHIRValidationConfiguration() {
@@ -41,36 +39,6 @@ public class DPCFHIRConfiguration {
          */
         public void setEnabled(boolean enabled) {
             this.enabled = enabled;
-        }
-
-        public boolean isSchemaValidation() {
-            return schemaValidation;
-        }
-
-        /**
-         * Enable or disable FHIR schema validation
-         * <p>
-         * Note: If enabled, FHIR validation resource JARs must be in classpath.
-         *
-         * @param schemaValidation - {@code true} validation is enabled. {@code false} validation is disabled
-         */
-        public void setSchemaValidation(boolean schemaValidation) {
-            this.schemaValidation = schemaValidation;
-        }
-
-        public boolean isSchematronValidation() {
-            return schematronValidation;
-        }
-
-        /**
-         * Enable or disable Schematron validation
-         * <p>
-         * Note: If enabled, ph-schematron jar must be in classpath
-         *
-         * @param schematronValidation - {@code true} validation is enabled. {@code false} validation is disabled
-         */
-        public void setSchematronValidation(boolean schematronValidation) {
-            this.schematronValidation = schematronValidation;
         }
 
         public boolean isDebugValidation() {

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/dropwizard/FHIRValidatorProvider.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/dropwizard/FHIRValidatorProvider.java
@@ -53,10 +53,8 @@ public class FHIRValidatorProvider implements Provider<FhirValidator> {
 
     @Override
     public FhirValidator get() {
-        logger.debug("Schema validation enabled: {}", validationConfiguration.isSchemaValidation());
         final FhirInstanceValidator instanceValidator = new FhirInstanceValidator(ctx);
         final FhirValidator fhirValidator = ctx.newValidator();
-        fhirValidator.setValidateAgainstStandardSchema(validationConfiguration.isSchemaValidation());
         fhirValidator.registerValidatorModule(instanceValidator);
 
         instanceValidator.setValidationSupport(this.supportChain);

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/configuration/DPCFHIRConfigurationUnitTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/configuration/DPCFHIRConfigurationUnitTest.java
@@ -11,19 +11,13 @@ class DPCFHIRConfigurationUnitTest {
         DPCFHIRConfiguration.FHIRValidationConfiguration configuration = new DPCFHIRConfiguration.FHIRValidationConfiguration();
         assertAll(
                 () -> assertFalse(configuration.isEnabled()),
-                () -> assertFalse(configuration.isSchemaValidation()),
-                () -> assertFalse(configuration.isSchematronValidation()),
                 () -> assertFalse(configuration.isDebugValidation())
         );
 
         configuration.setEnabled(true);
-        configuration.setSchemaValidation(true);
-        configuration.setSchematronValidation(true);
         configuration.setDebugValidation(true);
         assertAll(
                 () -> assertTrue(configuration.isEnabled()),
-                () -> assertTrue(configuration.isSchemaValidation()),
-                () -> assertTrue(configuration.isSchematronValidation()),
                 () -> assertTrue(configuration.isDebugValidation())
         );
     }

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/AttestationValidationTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/AttestationValidationTest.java
@@ -37,8 +37,6 @@ class AttestationValidationTest {
         final FhirInstanceValidator instanceValidator = new FhirInstanceValidator(ctx);
 
         fhirValidator = ctx.newValidator();
-        fhirValidator.setValidateAgainstStandardSchematron(false);
-        fhirValidator.setValidateAgainstStandardSchema(false);
         fhirValidator.registerValidatorModule(instanceValidator);
 
 

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/FHIRValidatorProviderTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/FHIRValidatorProviderTest.java
@@ -7,7 +7,7 @@ import gov.cms.dpc.fhir.validations.dropwizard.FHIRValidatorProvider;
 import org.hl7.fhir.common.hapi.validation.support.ValidationSupportChain;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class FHIRValidatorProviderTest {
 
@@ -17,14 +17,12 @@ class FHIRValidatorProviderTest {
 
         DPCFHIRConfiguration.FHIRValidationConfiguration config = new DPCFHIRConfiguration.FHIRValidationConfiguration();
         config.setEnabled(true);
-        config.setSchematronValidation(true);
-        config.setSchemaValidation(true);
 
         ValidationSupportChain supportChain = new ValidationSupportChain(new DPCProfileSupport(ctx));
 
         FHIRValidatorProvider provider = new FHIRValidatorProvider(ctx, config, supportChain);
 
         FhirValidator validator = provider.get();
-        assertTrue(validator.isValidateAgainstStandardSchema());
+        assertFalse(validator.isValidateAgainstStandardSchema());
     }
 }

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/OrganizationValidationTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/OrganizationValidationTest.java
@@ -34,8 +34,6 @@ class OrganizationValidationTest {
         final FhirInstanceValidator instanceValidator = new FhirInstanceValidator(ctx);
 
         fhirValidator = ctx.newValidator();
-        fhirValidator.setValidateAgainstStandardSchematron(false);
-        fhirValidator.setValidateAgainstStandardSchema(false);
         fhirValidator.registerValidatorModule(instanceValidator);
 
         DPCProfileSupport dpcModule = new DPCProfileSupport(ctx);

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/PatientValidationTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/PatientValidationTest.java
@@ -35,8 +35,6 @@ class PatientValidationTest {
         final FhirInstanceValidator instanceValidator = new FhirInstanceValidator(ctx);
 
         fhirValidator = ctx.newValidator();
-        fhirValidator.setValidateAgainstStandardSchematron(false);
-        fhirValidator.setValidateAgainstStandardSchema(false);
         fhirValidator.registerValidatorModule(instanceValidator);
 
 

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/PractitionerValidationTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/PractitionerValidationTest.java
@@ -31,8 +31,6 @@ public class PractitionerValidationTest {
         final FhirInstanceValidator instanceValidator = new FhirInstanceValidator(ctx);
 
         fhirValidator = ctx.newValidator();
-        fhirValidator.setValidateAgainstStandardSchematron(false);
-        fhirValidator.setValidateAgainstStandardSchema(false);
         fhirValidator.registerValidatorModule(instanceValidator);
 
 

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/ProfileValidatorTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/ProfileValidatorTest.java
@@ -35,8 +35,6 @@ class ProfileValidatorTest {
         ctx = FhirContext.forDstu3();
 
         fhirValidator = ctx.newValidator();
-        fhirValidator.setValidateAgainstStandardSchematron(false);
-        fhirValidator.setValidateAgainstStandardSchema(false);
         FhirInstanceValidator instanceValidator = new FhirInstanceValidator(ctx);
         fhirValidator.registerValidatorModule(instanceValidator);
 

--- a/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/RosterValidationTest.java
+++ b/dpc-common/src/test/java/gov/cms/dpc/fhir/validations/RosterValidationTest.java
@@ -29,8 +29,6 @@ public class RosterValidationTest {
         final FhirInstanceValidator instanceValidator = new FhirInstanceValidator(ctx);
 
         fhirValidator = ctx.newValidator();
-        fhirValidator.setValidateAgainstStandardSchematron(false);
-        fhirValidator.setValidateAgainstStandardSchema(false);
         fhirValidator.registerValidatorModule(instanceValidator);
 
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5450

## 🛠 Changes

Removes code around schema and schematron validation, as FHIRValidator handles it.

## ℹ️ Context

From HAPI-FHIR:

> The Schema/Schematron validators were recommended early in the development of FHIR itself, as the official FHIR validation toolchain was still maturing. At this time, the FHIR [Instance Validator](./instance_validator.html) is very mature, and gives far more helpful error messages than the Schema/Schematron validator is able to. For this reason, the Schema/Schematron validators are not available for validating R5+ content and may be deprecated in the future for other versions of FHIR as well.

## 🧪 Validation

Tests passing.
