### PR TITLE
Update vulnerable gems

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -47,8 +47,8 @@ gem 'sprockets-rails', '>= 3.4.2'
 gem 'truemail'
 gem 'nokogiri', '>= 1.19.3'
 gem 'net-imap', '>= 0.5.14'
-gem 'jwt', '>= 3.2.0'
 gem 'faraday', '>= 2.14.2'
+gem 'jwt', '>= 3.2.0'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -47,6 +47,8 @@ gem 'sprockets-rails', '>= 3.4.2'
 gem 'truemail'
 gem 'nokogiri', '>= 1.19.3'
 gem 'net-imap', '>= 0.5.14'
+gem 'jwt', '>= 3.2.0'
+gem 'faraday', '>= 2.14.2'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -168,11 +168,11 @@ GEM
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
     fakefs (2.5.0)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     ffi (1.17.4)
     fhir_models (4.3.0)
@@ -204,7 +204,7 @@ GEM
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
     jsonapi-renderer (0.2.2)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -539,8 +539,10 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   fakefs
+  faraday (>= 2.14.2)
   fhir_models
   health_check
+  jwt (>= 3.2.0)
   kaminari
   letter_opener
   listen (~> 3.2)

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -24,10 +24,12 @@ gem 'aws-sdk-cloudwatch'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'bundler', '>= 1.15.0'
 gem 'dotenv-rails', groups: %i[development test]
+gem 'faraday', '>= 2.14.2'
 gem 'fhir_models'
 gem 'health_check'
 gem 'jbuilder', '~> 2.7'
 gem 'json-jwt', '>= 1.16.6'
+gem 'jwt', '>= 3.2.0'
 gem 'kaminari'
 gem 'lograge'
 gem 'lookbook', '>= 2.3.3' # install lookbook so it can be deployed in lower environments.

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -190,13 +190,13 @@ GEM
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
     fakefs (2.5.0)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.3.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     ffi (1.17.4)
     ffi (1.17.4-arm64-darwin)
@@ -242,7 +242,7 @@ GEM
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
     jsonapi-renderer (0.2.2)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -613,10 +613,12 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   fakefs
+  faraday (>= 2.14.2)
   fhir_models
   health_check
   jbuilder (~> 2.7)
   json-jwt (>= 1.16.6)
+  jwt (>= 3.2.0)
   kaminari
   lograge
   lookbook (>= 2.3.3)

--- a/dpc-portal/package-lock.json
+++ b/dpc-portal/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "sass": "^1.86.3",
+        "uuid": "^11.1.1",
         "webpack-dev-server": "^5.2.4"
       }
     },
@@ -2964,6 +2965,17 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3246,13 +3258,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/dpc-portal/package.json
+++ b/dpc-portal/package.json
@@ -10,6 +10,7 @@
   "version": "0.1.0",
   "devDependencies": {
     "sass": "^1.86.3",
+    "uuid": "^11.1.1",
     "webpack-dev-server": "^5.2.4"
   },
   "scripts": {

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -48,6 +48,8 @@ gem 'rack-session', '>= 2.1.2'
 gem 'bootstrap-table-rails'
 gem 'nokogiri', '>= 1.19.3'
 gem 'net-imap', '>= 0.5.14'
+gem 'jwt', '>= 3.2.0'
+gem 'faraday', '>= 2.14.2'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-web/Gemfile
+++ b/dpc-web/Gemfile
@@ -48,8 +48,8 @@ gem 'rack-session', '>= 2.1.2'
 gem 'bootstrap-table-rails'
 gem 'nokogiri', '>= 1.19.3'
 gem 'net-imap', '>= 0.5.14'
-gem 'jwt', '>= 3.2.0'
 gem 'faraday', '>= 2.14.2'
+gem 'jwt', '>= 3.2.0'
 
 gem 'api_client', path: 'vendor/api_client'
 

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -197,11 +197,11 @@ GEM
     fakefs (2.5.0)
     faker (3.3.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     ffi (1.16.3)
     fhir_models (4.3.0)
@@ -234,7 +234,7 @@ GEM
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
     jsonapi-renderer (0.2.2)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -555,8 +555,10 @@ DEPENDENCIES
   factory_bot_rails (>= 6.2.0)
   fakefs
   faker
+  faraday (>= 2.14.2)
   fhir_models
   health_check (>= 3.1.0)
+  jwt (>= 3.2.0)
   kaminari (>= 1.2.2)
   kramdown (~> 2.3, >= 2.3.1)
   letter_opener (>= 1.7.0)


### PR DESCRIPTION
## 🎫 Ticket

No ticket.

## 🛠 Changes

Updates jwt, faraday, and uuid.

## ℹ️ Context

Dependabot reported vulnerabilities in [jwt](https://github.com/CMSgov/dpc-app/security/dependabot/994), [faraday](https://github.com/CMSgov/dpc-app/security/dependabot/989), and [uuid](https://github.com/CMSgov/dpc-app/security/dependabot/997).

## 🧪 Validation

Scans passing.
