### PR TITLE
DPC-5454 - Switching login.gov from IAL1 to IAL2

### DIFF
--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -130,8 +130,8 @@ class LoginDotGovController < ApplicationController
     session[:login_dot_gov_token_exp] = auth.credentials.expires_in.seconds.from_now
   end
 
-  def path(user, auth)
-    if user.blank? 
+  def path(user, _auth)
+    if user.blank?
       Rails.logger.info(['User logged in without account',
                          { actionContext: LoggingConstants::ActionContext::Authentication,
                            actionType: LoggingConstants::ActionType::UserLoginWithoutAccount }])

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -131,7 +131,7 @@ class LoginDotGovController < ApplicationController
   end
 
   def path(user, auth)
-    if user.blank? && auth.extra.raw_info.ial == 'http://idmanagement.gov/ns/assurance/ial/2'
+    if user.blank? 
       Rails.logger.info(['User logged in without account',
                          { actionContext: LoggingConstants::ActionContext::Authentication,
                            actionType: LoggingConstants::ActionType::UserLoginWithoutAccount }])

--- a/dpc-portal/app/controllers/login_dot_gov_controller.rb
+++ b/dpc-portal/app/controllers/login_dot_gov_controller.rb
@@ -131,7 +131,7 @@ class LoginDotGovController < ApplicationController
   end
 
   def path(user, auth)
-    if user.blank? && auth.extra.raw_info.ial == 'http://idmanagement.gov/ns/assurance/ial/1'
+    if user.blank? && auth.extra.raw_info.ial == 'http://idmanagement.gov/ns/assurance/ial/2'
       Rails.logger.info(['User logged in without account',
                          { actionContext: LoggingConstants::ActionContext::Authentication,
                            actionType: LoggingConstants::ActionType::UserLoginWithoutAccount }])

--- a/dpc-portal/config/initializers/omniauth.rb
+++ b/dpc-portal/config/initializers/omniauth.rb
@@ -21,7 +21,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
                     discovery: true,
                     scope: %i[openid email all_emails],
                     response_type: :code,
-                    acr_values: 'http://idmanagement.gov/ns/assurance/ial/1',
+                    acr_values: 'http://idmanagement.gov/ns/assurance/ial/2',
                     client_auth_method: :jwt_bearer,
                     client_options: {
                       port: 443,

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -97,64 +97,7 @@ RSpec.describe 'LoginDotGov', type: :request do
         it 'does not sign in user' do
           post '/auth/login_dot_gov'
           follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_redirect
-        end
-
-        it 'sets authentication token' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(request.session[:login_dot_gov_token]).to eq token
-          expect(request.session[:login_dot_gov_token_exp]).to_not be_nil
-          expect(request.session[:login_dot_gov_token_exp]).to be_within(1.second).of 899.seconds.from_now
-        end
-      end
-    end
-
-    context 'IAL/1' do
-      before do
-        OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(:login_dot_gov,
-                                 { uid: uuid,
-                                   info: { email: 'bob3@example.com' },
-                                   extra: { raw_info: { all_emails: %w[bob3@example.com bobby@example.com],
-                                                        ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
-      end
-
-      it_behaves_like 'an openid client'
-
-      context :user_exists do
-        before do
-          user = create(:user, email: 'bob3@example.com', given_name: 'Bob',
-                               family_name: 'Hoskins')
-          create(:csp_user, user:, uuid:, csp:)
-        end
-        it 'does not update user names' do
-          expect(User.where(email: 'bob3@example.com', given_name: 'Bob',
-                            family_name: 'Hoskins').count).to eq 1
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(User.where(email: 'bob3@example.com', given_name: 'Bob',
-                            family_name: 'Hoskins').count).to eq 1
-        end
-
-        it 'does not set authentication token' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(request.session[:login_dot_gov_token]).to be_nil
-          expect(request.session[:login_dot_gov_token_exp]).to be_nil
-        end
-      end
-
-      context 'user does not exist' do
-        it 'does not sign in user' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
           expect(response.location).to eq no_account_url
-          expect(response).to be_redirect
         end
 
         it 'should log' do
@@ -168,11 +111,12 @@ RSpec.describe 'LoginDotGov', type: :request do
           follow_redirect!
         end
 
-        it 'does not set authentication token' do
+        it 'sets authentication token' do
           post '/auth/login_dot_gov'
           follow_redirect!
-          expect(request.session[:login_dot_gov_token]).to be_nil
-          expect(request.session[:login_dot_gov_token_exp]).to be_nil
+          expect(request.session[:login_dot_gov_token]).to eq token
+          expect(request.session[:login_dot_gov_token_exp]).to_not be_nil
+          expect(request.session[:login_dot_gov_token_exp]).to be_within(1.second).of 899.seconds.from_now
         end
       end
     end
@@ -316,7 +260,7 @@ RSpec.describe 'LoginDotGov', type: :request do
                                { uid: uuid,
                                  info: { email: 'bob4@example.com' },
                                  extra: { raw_info: { all_emails: %w[bob4@example.com bobby@example.com],
-                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
+                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
     end
 
     it 'should log error' do

--- a/dpc-portal/spec/support/login_support.rb
+++ b/dpc-portal/spec/support/login_support.rb
@@ -11,9 +11,14 @@ module LoginSupport
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(csp.name,
                              { uid: csp_user.uuid,
+                               credentials: { expires_in: 899,
+                                              token: 'bearer-token' },
                                info: { email: user.email },
-                               extra: { raw_info: { all_emails: [user.email],
-                                                    ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
+                               extra: { raw_info: { given_name: 'Bob',
+                                                    family_name: 'Hoskins',
+                                                    social_security_number: '1-2-3',
+                                                    all_emails: [user.email],
+                                                    ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
     post '/auth/login_dot_gov'
     follow_redirect!
   end

--- a/dpc-portal/spec/system/accessibility_spec.rb
+++ b/dpc-portal/spec/system/accessibility_spec.rb
@@ -18,9 +18,14 @@ RSpec.describe 'Accessibility', type: :system do
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(:login_dot_gov,
                              { uid:,
+                               credentials: { expires_in: 899,
+                                              token: 'bearer-token' },
                                info: { email: 'bob@example.com' },
-                               extra: { raw_info: { all_emails: %w[bob@example.com bob2@example.com],
-                                                    ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
+                               extra: { raw_info: { given_name: 'Bob',
+                                                    family_name: 'Hoskins',
+                                                    social_security_number: '1-2-3',
+                                                    all_emails: %w[bob@example.com bob2@example.com],
+                                                    ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
   end
   def sign_in
     visit '/auth/login_dot_gov/callback'

--- a/dpc-portal/spec/system/new_invitation_spec.rb
+++ b/dpc-portal/spec/system/new_invitation_spec.rb
@@ -15,9 +15,14 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :system, 
     OmniAuth.config.test_mode = true
     OmniAuth.config.add_mock(:login_dot_gov,
                              { uid:,
+                               credentials: { expires_in: 899,
+                                              token: 'bearer-token' },
                                info: { email: 'bob@example.com' },
-                               extra: { raw_info: { all_emails: %w[bob@example.com bob2@example.com],
-                                                    ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
+                               extra: { raw_info: { given_name: 'Bob',
+                                                    family_name: 'Hoskins',
+                                                    social_security_number: '1-2-3',
+                                                    all_emails: %w[bob@example.com bob2@example.com],
+                                                    ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
   end
   def sign_in
     visit '/auth/login_dot_gov/callback'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5454

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->

This change updates login.gov sign-in from IAL1 to IAL2.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

This is part of our larger efforts to enable and align our integration with multiple CSPs. 

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->

Local CI test pass

Successfully deployed to test and confirmed users can register and login. 
https://github.com/CMSgov/dpc-app/actions/runs/26583600135