### PR TITLE
[DPC-5500] update sign in and verify buttons to link to all CSP's

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -142,6 +142,7 @@ services:
       - DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true
       - CPI_API_GW_BASE_URL=http://localhost:4567/
       - CMS_IDM_OAUTH_URL=http://localhost:4567/
+      - IDP_LOGIN_DOT_GOV_HOST=idp.int.identitysandbox.gov
       - IDP_ID_ME_HOST=api.idmelabs.com
       - IDP_ID_ME_CLIENT_ID=925bb2985ccf623114359caa76228919
       - RUBY_YJIT_ENABLE=1

--- a/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
@@ -8,8 +8,25 @@
       <% end %>
     </ul>
   </p>
-    <%= button_to 'Verify with id.me', login_id_me_organization_invitation_url(@invitation.provider_organization, @invitation), class: 'usa-button margin-bottom-1 margin-top-2', data: { turbo: false } %>
-    <%= button_to 'Verify with clear', login_clear_organization_invitation_url(@invitation.provider_organization, @invitation), class: 'usa-button margin-bottom-1 margin-top-2', data: { turbo: false } %>
-    <%= button_to 'Verify with login.gov', login_login_dot_gov_organization_invitation_url(@invitation.provider_organization, @invitation), class: 'usa-button margin-bottom-1 margin-top-2', data: { turbo: false } %>
+  <div class="grid-row margin-x-neg-205">
+    <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205 margin-bottom-4">
+      <div class="padding-y-3">
+        <h2 class="font-body-sm">Choose one of the following</h2>
+        </p>
+        <%
+          csps = [
+            { id: :clear, logo_class: 'clear-login-button__logo', text: 'Verify with CLEAR', verify_path: login_clear_organization_invitation_url(@invitation.provider_organization, @invitation) },
+            { id: :id_me, logo_class: 'idme-login-button__logo', text: 'Verify with ID.me', verify_path: login_id_me_organization_invitation_url(@invitation.provider_organization, @invitation) },
+            { id: :login_dot_gov, logo_class: 'lg-login-button__logo', text: 'Verify with Login.gov', verify_path: login_login_dot_gov_organization_invitation_url(@invitation.provider_organization, @invitation) },
+          ]
+        %>
+        <% csps.each do |csp| %>
+          <%= button_to csp[:verify_path], class: 'usa-button width-full margin-bottom-1', data: { turbo: false } do %>
+            <span class="<%= csp[:logo_class] %>"><%= csp[:text] %></span>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
   <div><%= link_to 'How to verify your identity', 'https://login.gov/help/verify-your-identity/how-to-verify-your-identity/', target: :_blank %> <%= link_to 'Login.gov FAQ', 'https://www.login.gov/help/', target: :_blank, class: 'margin-left-2' %></div>
 </div>

--- a/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
@@ -9,7 +9,7 @@
     </ul>
   </p>
   <div class="grid-row margin-x-neg-205">
-    <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205 margin-bottom-4">
+    <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205 margin-bottom-3">
       <div class="padding-y-3">
         <h2 class="font-body-sm">Choose one of the following</h2>
         </p>

--- a/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
@@ -15,9 +15,9 @@
         </p>
         <%
           csps = [
-            { id: :clear, logo_class: 'clear-login-button__logo', text: 'Verify with CLEAR', verify_path: login_clear_organization_invitation_url(@invitation.provider_organization, @invitation) },
-            { id: :id_me, logo_class: 'idme-login-button__logo', text: 'Verify with ID.me', verify_path: login_id_me_organization_invitation_url(@invitation.provider_organization, @invitation) },
-            { id: :login_dot_gov, logo_class: 'lg-login-button__logo', text: 'Verify with Login.gov', verify_path: login_login_dot_gov_organization_invitation_url(@invitation.provider_organization, @invitation) },
+            { id: :clear, logo_class: 'clear-login-button__logo', text: 'Verify with CLEAR', verify_path: login_organization_invitation_url(@invitation.provider_organization, @invitation, provider: :clear) },
+            { id: :id_me, logo_class: 'idme-login-button__logo', text: 'Verify with ID.me', verify_path: login_organization_invitation_url(@invitation.provider_organization, @invitation, provider: :id_me) },
+            { id: :login_dot_gov, logo_class: 'lg-login-button__logo', text: 'Verify with Login.gov', verify_path: login_organization_invitation_url(@invitation.provider_organization, @invitation, provider: :login_dot_gov) },
           ]
         %>
         <% csps.each do |csp| %>

--- a/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/invitation_login_component.html.erb
@@ -8,6 +8,8 @@
       <% end %>
     </ul>
   </p>
-    <%= button_to 'Verify my identity', login_organization_invitation_url(@invitation.provider_organization, @invitation), class: 'usa-button margin-bottom-1 margin-top-2', data: { turbo: false } %>
+    <%= button_to 'Verify with id.me', login_id_me_organization_invitation_url(@invitation.provider_organization, @invitation), class: 'usa-button margin-bottom-1 margin-top-2', data: { turbo: false } %>
+    <%= button_to 'Verify with clear', login_clear_organization_invitation_url(@invitation.provider_organization, @invitation), class: 'usa-button margin-bottom-1 margin-top-2', data: { turbo: false } %>
+    <%= button_to 'Verify with login.gov', login_login_dot_gov_organization_invitation_url(@invitation.provider_organization, @invitation), class: 'usa-button margin-bottom-1 margin-top-2', data: { turbo: false } %>
   <div><%= link_to 'How to verify your identity', 'https://login.gov/help/verify-your-identity/how-to-verify-your-identity/', target: :_blank %> <%= link_to 'Login.gov FAQ', 'https://www.login.gov/help/', target: :_blank, class: 'margin-left-2' %></div>
 </div>

--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -26,14 +26,8 @@
           </div>
         <% end %>
 
+        <div class="line-separator margin-bottom-2 margin-top-2"></div>
         <%= render(Core::Navigation::SystemUseAgreementLinkComponent.new) %>
-        <div class="line-separator"></div>
-        <p>
-          <strong>You must use your unique DPC Portal username and password to sign in.</strong>
-        </p>
-        <p>
-          You will have received an invite to set up these credentials.
-        </p>
       </div>
     </div>
     <div class="grid-col-12 mobile-lg:grid-col-10 tablet:grid-col-8 desktop:grid-col-6 padding-x-205">

--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -11,15 +11,15 @@
         <%# Build a login button for each CSP %>
         <%
           csps = [
-            { id: :clear, logo_class: 'clear-login-button__logo', text: 'CLEAR' },
-            { id: :id_me, logo_class: 'idme-login-button__logo', text: 'ID.me' },
-            { id: :login_dot_gov, logo_class: 'lg-login-button__logo', text: 'Login.gov' }
+            { id: :clear, logo_class: 'clear-login-button__logo', text: 'CLEAR', login_path: helpers.omniauth_authorize_path(:clear) },
+            { id: :id_me, logo_class: 'idme-login-button__logo', text: 'ID.me', login_path: helpers.omniauth_authorize_path(:id_me) },
+            { id: :login_dot_gov, logo_class: 'lg-login-button__logo', text: 'Login.gov', login_path: helpers.omniauth_authorize_path(:login_dot_gov) }
           ]
         %>
         <% csps.each do |csp| %>
           <% is_last_used = (@last_used_csp == csp[:id]) %>
           <div class="<%= class_names('last-used-login-wrapper margin-bottom-1': is_last_used) %>">
-            <%= button_to @login_path, class: 'usa-button width-full margin-bottom-1', data: { turbo: false } do %>
+            <%= button_to csp[:login_path], class: 'usa-button width-full margin-bottom-1', data: { turbo: false } do %>
               <span class="<%= csp[:logo_class] %>"><%= csp[:text] %></span>
             <% end %>
             <%= content_tag(:span, 'LAST USED', class: 'last-used-login-wrapper__badge') if is_last_used %>

--- a/dpc-portal/app/components/page/session/login_component.rb
+++ b/dpc-portal/app/components/page/session/login_component.rb
@@ -4,9 +4,8 @@ module Page
   module Session
     # Renders the log in page
     class LoginComponent < ViewComponent::Base
-      def initialize(login_path, last_used_csp: nil)
+      def initialize(last_used_csp: nil)
         super()
-        @login_path = login_path
         @last_used_csp = last_used_csp
       end
     end

--- a/dpc-portal/app/components/page/session/login_component_preview.rb
+++ b/dpc-portal/app/components/page/session/login_component_preview.rb
@@ -13,7 +13,7 @@ module Page
         # Make sure if the user selects "None" that the value passed is actually nil and not "".
         csp_value = last_used_csp.presence
 
-        render(Page::Session::LoginComponent.new(root_path, last_used_csp: csp_value&.to_sym))
+        render(Page::Session::LoginComponent.new(last_used_csp: csp_value&.to_sym))
       end
     end
   end

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -72,35 +72,13 @@ class InvitationsController < ApplicationController
     handle_user_info_service_error(e, 2)
   end
 
-  def login_with_csp(csp)
+  def login
     login_session
     Rails.logger.info(['User began login flow',
                        { actionContext: LoggingConstants::ActionContext::Registration,
                          actionType: LoggingConstants::ActionType::BeginLogin,
                          invitation: @invitation.id }])
-    csp_config = CspConfig.for(csp)
-    url = URI(csp_config.authorization_endpoint)
-    url.query = { client_id: csp_config.identifier,
-                  redirect_uri: "#{my_protocol_host}#{csp_config.redirect_path}",
-                  response_type: 'code',
-                  acr_values: csp_config.acr_values,
-                  scope: csp_config.authorize_scope,
-                  nonce: @nonce,
-                  state: @state }.compact.to_query
-
-    redirect_to url, allow_other_host: true
-  end
-
-  def login_id_me
-    login_with_csp(:id_me)
-  end
-
-  def login_login_dot_gov
-    login_with_csp(:login_dot_gov)
-  end
-
-  def login_clear
-    login_with_csp(:clear) # this is WIP pending DPC-5401
+    csp_login_actions(params[:provider])
   end
 
   def renew
@@ -120,6 +98,21 @@ class InvitationsController < ApplicationController
   end
 
   private
+
+  def csp_login_actions(csp)
+    csp_config = CspConfig.for(csp)
+    url = URI(csp_config.authorization_endpoint)
+    url.query = { client_id: csp_config.identifier,
+                  redirect_uri: "#{my_protocol_host}#{csp_config.redirect_path}",
+                  response_type: 'code',
+                  acr_values: csp_config.acr_values,
+                  scope: csp_config.authorize_scope,
+                  nonce: @nonce,
+                  state: @state }.compact.to_query
+
+
+    redirect_to url, allow_other_host: true
+  end
 
   def invitation_matches_user
     user_info = UserInfoService.new.user_info(session)

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -72,22 +72,35 @@ class InvitationsController < ApplicationController
     handle_user_info_service_error(e, 2)
   end
 
-  def login
+  def login_with_csp(csp)
     login_session
     Rails.logger.info(['User began login flow',
                        { actionContext: LoggingConstants::ActionContext::Registration,
                          actionType: LoggingConstants::ActionType::BeginLogin,
                          invitation: @invitation.id }])
-    csp_config = CspConfig.for(:id_me)
-    url = URI::HTTPS.build(host: csp_config.host,
-                           path: '/oauth/authorize',
-                           query: { client_id: csp_config.identifier,
-                                    redirect_uri: "#{my_protocol_host}/auth/id_me/callback",
-                                    response_type: 'code',
-                                    scope: 'openid http://idmanagement.gov/ns/assurance/ial/2/aal/2',
-                                    nonce: @nonce,
-                                    state: @state }.to_query)
+    csp_config = CspConfig.for(csp)
+    url = URI(csp_config.authorization_endpoint)
+    url.query = { client_id: csp_config.identifier,
+                  redirect_uri: "#{my_protocol_host}#{csp_config.redirect_path}",
+                  response_type: 'code',
+                  acr_values: csp_config.acr_values,
+                  scope: csp_config.authorize_scope,
+                  nonce: @nonce,
+                  state: @state }.compact.to_query
+
     redirect_to url, allow_other_host: true
+  end
+
+  def login_id_me
+    login_with_csp(:id_me)
+  end
+
+  def login_login_dot_gov
+    login_with_csp(:login_dot_gov)
+  end
+
+  def login_clear
+    login_with_csp(:clear) # this is WIP pending DPC-5401
   end
 
   def renew

--- a/dpc-portal/app/controllers/invitations_controller.rb
+++ b/dpc-portal/app/controllers/invitations_controller.rb
@@ -110,7 +110,6 @@ class InvitationsController < ApplicationController
                   nonce: @nonce,
                   state: @state }.compact.to_query
 
-
     redirect_to url, allow_other_host: true
   end
 

--- a/dpc-portal/app/models/csp_config.rb
+++ b/dpc-portal/app/models/csp_config.rb
@@ -6,10 +6,10 @@ class CspConfig
   ENV_NAME = ENV.fetch('ENV', 'local')
   CONFIG = Rails.application.config_for(:csp).freeze
 
-  def initialize(code, host, identifier, config)
-    @host = host
-    @identifier = identifier
+  def initialize(code, config)
     @code = code
+    @host = config[:host]
+    @identifier = config[:identifier]
     @user_info_endpoint = config[:user_info_endpoint]
     @log_out_path = config[:log_out_path]
     @token_expiration_interval = config[:token_expiration_interval]
@@ -20,12 +20,8 @@ class CspConfig
   end
 
   LOGIN_DOT_GOV = new('login_dot_gov',
-                      CONFIG[:login_dot_gov][:host],
-                      CONFIG[:login_dot_gov][:identifier],
                       CONFIG[:login_dot_gov])
   ID_ME = new('id_me',
-              CONFIG[:id_me][:host],
-              CONFIG[:id_me][:identifier],
               CONFIG[:id_me])
   #   CLEAR = new('clear',
   #               CONFIG[:clear][:host],

--- a/dpc-portal/app/models/csp_config.rb
+++ b/dpc-portal/app/models/csp_config.rb
@@ -6,27 +6,27 @@ class CspConfig
   ENV_NAME = ENV.fetch('ENV', 'local')
   CONFIG = Rails.application.config_for(:csp).freeze
 
-  def initialize(code, host, identifier, user_info_endpoint, log_out_path, token_expiration_interval) # rubocop:disable Metrics/ParameterLists
+  def initialize(code, host, identifier, config)
     @host = host
     @identifier = identifier
     @code = code
-    @user_info_endpoint = user_info_endpoint
-    @log_out_path = log_out_path
-    @token_expiration_interval = token_expiration_interval
+    @user_info_endpoint = config[:user_info_endpoint]
+    @log_out_path = config[:log_out_path]
+    @token_expiration_interval = config[:token_expiration_interval]
+    @authorization_endpoint = config[:authorization_endpoint]
+    @redirect_path = config[:redirect_path]
+    @authorize_scope = config[:authorize_scope]
+    @acr_values = config[:acr_values]
   end
 
   LOGIN_DOT_GOV = new('login_dot_gov',
                       CONFIG[:login_dot_gov][:host],
                       CONFIG[:login_dot_gov][:identifier],
-                      CONFIG[:login_dot_gov][:user_info_path],
-                      CONFIG[:login_dot_gov][:log_out_path],
-                      CONFIG[:login_dot_gov][:token_expiration_interval])
+                      CONFIG[:login_dot_gov])
   ID_ME = new('id_me',
               CONFIG[:id_me][:host],
               CONFIG[:id_me][:identifier],
-              CONFIG[:id_me][:user_info_path],
-              CONFIG[:id_me][:log_out_path],
-              CONFIG[:id_me][:token_expiration_interval])
+              CONFIG[:id_me])
   #   CLEAR = new('clear',
   #               CONFIG[:clear][:host],
   #               CONFIG[:clear][:identifier],
@@ -35,7 +35,8 @@ class CspConfig
   #               CONFIG[:clear][:token_expiration_interval])
   private_class_method :new
 
-  attr_reader :user_info_endpoint, :log_out_path, :token_expiration_interval, :host, :identifier
+  attr_reader :code, :user_info_endpoint, :log_out_path, :token_expiration_interval, :host, :identifier,
+              :authorization_endpoint, :redirect_path, :authorize_scope, :acr_values
 
   def self.for(code)
     case code.to_s

--- a/dpc-portal/app/views/users/sessions/new.html.erb
+++ b/dpc-portal/app/views/users/sessions/new.html.erb
@@ -1,1 +1,1 @@
-<%= render(Page::Session::LoginComponent.new(omniauth_authorize_path(:login_dot_gov), last_used_csp: cookies[:last_used_csp]&.to_sym)) %>
+<%= render(Page::Session::LoginComponent.new(last_used_csp: cookies[:last_used_csp]&.to_sym)) %>

--- a/dpc-portal/config/csp.yml
+++ b/dpc-portal/config/csp.yml
@@ -9,10 +9,12 @@ development: &development
     log_out_path: '/openid_connect/logout'
     token_expiration_interval: 300
     redirect_path: '/auth/login_dot_gov/callback'
+    acr_values: 'http://idmanagement.gov/ns/assurance/ial/2'
+    authorize_scope: 'openid email all_emails profile social_security_number'
     authorization_endpoint: <%= "https://#{ENV['IDP_LOGIN_DOT_GOV_HOST']}/openid_connect/authorize" %>
     token_endpoint: <%= "https://#{ENV['IDP_LOGIN_DOT_GOV_HOST']}/api/openid_connect/token" %>
     jwks_uri: <%= "https://#{ENV['IDP_LOGIN_DOT_GOV_HOST']}/api/openid_connect/certs" %>
-    
+
   id_me:
     host: <%= ENV['IDP_ID_ME_HOST'] %>
     identifier: <%= ENV['IDP_ID_ME_CLIENT_ID'] %>
@@ -22,6 +24,7 @@ development: &development
     user_info_endpoint: <%= "https://#{ENV['IDP_ID_ME_HOST']}/api/public/v3/userinfo" %>
     jwks_uri: <%= "https://#{ENV['IDP_ID_ME_HOST']}/oidc/.well-known/jwks" %> 
     redirect_path: '/auth/id_me/callback'
+    authorize_scope: 'openid http://idmanagement.gov/ns/assurance/ial/2/aal/2'
     log_out_path: '/oauth/logout'
     token_expiration_interval: 300
 

--- a/dpc-portal/config/initializers/omniauth.rb
+++ b/dpc-portal/config/initializers/omniauth.rb
@@ -46,7 +46,7 @@ LOGIN_DOT_GOV_CLIENT_CONFIG = {
     host: "https://#{LOGIN_DOT_GOV_CONFIG[:host]}/",
     identifier: "urn:gov:cms:openidconnect.profiles:sp:sso:cms:dpc:#{ENV['ENV']}",
     private_key: ENV['LOGIN_DOT_GOV_CLIENT_PRIVATE_KEY'],
-    redirect_uri: "#{my_protocol_host}/portal/auth/login_dot_gov/callback",
+    redirect_uri: "#{my_protocol_host}/auth/login_dot_gov/callback",
 
     authorization_endpoint: LOGIN_DOT_GOV_CONFIG[:authorization_endpoint],
     token_endpoint: LOGIN_DOT_GOV_CONFIG[:token_endpoint],

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -31,7 +31,9 @@ Rails.application.routes.draw do
       get 'accept', on: :member
       post 'confirm', on: :member
       post 'register', on: :member
-      post 'login', on: :member
+      post 'login_id_me', on: :member
+      post 'login_login_dot_gov', on: :member
+      post 'login_clear', on: :member
       post 'renew', on: :member
       get 'confirm_cd', on: :member
       get 'set_idp_token', on: :member

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -31,9 +31,7 @@ Rails.application.routes.draw do
       get 'accept', on: :member
       post 'confirm', on: :member
       post 'register', on: :member
-      post 'login_id_me', on: :member
-      post 'login_login_dot_gov', on: :member
-      post 'login_clear', on: :member
+      post 'login', on: :member
       post 'renew', on: :member
       get 'confirm_cd', on: :member
       get 'set_idp_token', on: :member

--- a/dpc-portal/spec/components/page/invitations/invitation_login_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/invitation_login_component_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe Page::Invitations::InvitationLoginComponent, type: :component do
     let(:invitation) { create(:invitation, :cd, provider_organization:) }
     let(:component) { described_class.new(invitation) }
     before { render_inline(component) }
-    it 'should have a verify identity button' do
-      expect(page).to have_selector('button.usa-button')
-      expect(page.find('button.usa-button')).to have_content('Verify my identity')
+
+    it 'should have verify identity buttons for all csps' do
+      expect(page).to have_selector('button.usa-button span.lg-login-button__logo', text: 'Verify with Login.gov')
+      expect(page).to have_selector('button.usa-button span.clear-login-button__logo', text: 'Verify with CLEAR')
+      expect(page).to have_selector('button.usa-button span.idme-login-button__logo', text: 'Verify with ID.me')
     end
 
     it 'should render a link to the How to verify your identity url' do
@@ -20,11 +22,10 @@ RSpec.describe Page::Invitations::InvitationLoginComponent, type: :component do
                                 href: 'https://login.gov/help/verify-your-identity/how-to-verify-your-identity/')
     end
 
-    it 'should post to appropriate url' do
-      path = "organizations/#{provider_organization.id}/invitations/#{invitation.id}/login"
-      url = "http://test.host/#{path}"
-      expect(page.find('form')[:action]).to eq url
-      expect(page.find('form')[:method]).to eq 'post'
+    it 'should post each CSP to the appropriate url' do
+      expect(page).to have_selector("form[action*='?provider=clear'][method='post']")
+      expect(page).to have_selector("form[action*='?provider=id_me'][method='post']")
+      expect(page).to have_selector("form[action*='?provider=login_dot_gov'][method='post']")
     end
   end
 

--- a/dpc-portal/spec/components/page/session/login_component_spec.rb
+++ b/dpc-portal/spec/components/page/session/login_component_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
   include ComponentSupport
 
   describe 'login component' do
-    let(:url) { '/' }
     let(:sandbox_url) { 'https://sandbox.dpc.cms.gov/' }
-    let(:component) { described_class.new(url) }
+    let(:component) { described_class.new }
     before { render_inline(component) }
     it 'should be a usa section' do
       expect(page).to have_selector('section.usa-section')
@@ -33,9 +32,10 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
                                 href: Rails.application.routes.url_helpers.system_use_agreement_path)
     end
 
-    it 'login.gov button should post to appropriate url' do
-      expect(page.find('form', match: :first)[:action]).to eq url
-      expect(page.find('form', match: :first)[:method]).to eq 'post'
+    it 'CSP buttons should post to appropriate urls' do
+      expect(page.find('form[action="/auth/login_dot_gov"]')[:method]).to eq 'post'
+      expect(page.find('form[action="/auth/clear"]')[:method]).to eq 'post'
+      expect(page.find('form[action="/auth/id_me"]')[:method]).to eq 'post'
     end
 
     it 'test data button should link to sandbox url' do
@@ -48,8 +48,7 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
   end
 
   describe 'last used csp was CLEAR' do
-    let(:url) { '/' }
-    let(:component) { described_class.new(url, last_used_csp: :clear) }
+    let(:component) { described_class.new(last_used_csp: :clear) }
     before { render_inline(component) }
 
     it 'wraps only the CLEAR button' do
@@ -63,8 +62,7 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
   end
 
   describe 'last used csp was ID.me' do
-    let(:url) { '/' }
-    let(:component) { described_class.new(url, last_used_csp: :id_me) }
+    let(:component) { described_class.new(last_used_csp: :id_me) }
     before { render_inline(component) }
 
     it 'wraps only the ID.me button' do
@@ -78,8 +76,7 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
   end
 
   describe 'last used csp was Login.gov' do
-    let(:url) { '/' }
-    let(:component) { described_class.new(url, last_used_csp: :login_dot_gov) }
+    let(:component) { described_class.new(last_used_csp: :login_dot_gov) }
     before { render_inline(component) }
 
     it 'wraps only the Login.gov button' do
@@ -92,8 +89,7 @@ RSpec.describe Page::Session::LoginComponent, type: :component do
     end
 
     describe 'no last used csp' do
-      let(:url) { '/' }
-      let(:component) { described_class.new(url, last_used_csp: nil) }
+      let(:component) { described_class.new(last_used_csp: nil) }
       before { render_inline(component) }
 
       it "doesn't wrap any buttons" do

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -14,8 +14,10 @@ RSpec.describe 'Invitations', type: :request do
     let(:org) { invitation.provider_organization }
     let(:bad_org) { create(:provider_organization) }
     let(:expected_success_status) { 200 }
+    let(:request_params) { {} }
     it 'should be ok or redirect' do
-      send(method, "/organizations/#{org.id}/invitations/#{invitation.id}/#{path_suffix}")
+      # Most calls will be empty params, but for /login, param required to specify which IDP to use
+      send(method, "/organizations/#{org.id}/invitations/#{invitation.id}/#{path_suffix}", params: request_params)
       expect(response.status).to eq(expected_success_status)
     end
     it 'should show warning page with 404 if missing' do
@@ -143,9 +145,19 @@ RSpec.describe 'Invitations', type: :request do
     RSpec.shared_examples 'a login endpoint' do
       it 'should redirect to login.gov' do
         org_id = invitation.provider_organization.id
-        post "/organizations/#{org_id}/invitations/#{invitation.id}/login"
+        post "/organizations/#{org_id}/invitations/#{invitation.id}/login",
+             params: { provider: :login_dot_gov }
         redirect_params = Rack::Utils.parse_query(URI.parse(response.location).query)
-        expect(redirect_params['redirect_uri']).to start_with('http://localhost:3100/auth/')
+        expect(redirect_params['redirect_uri']).to eq('http://localhost:3100/auth/login_dot_gov/callback')
+        expect(request.session[:user_return_to]).to eq expected_redirect
+      end
+
+      it 'should redirect to ID.me' do
+        org_id = invitation.provider_organization.id
+        post "/organizations/#{org_id}/invitations/#{invitation.id}/login",
+             params: { provider: :id_me }
+        redirect_params = Rack::Utils.parse_query(URI.parse(response.location).query)
+        expect(redirect_params['redirect_uri']).to eq('http://localhost:3100/auth/id_me/callback')
         expect(request.session[:user_return_to]).to eq expected_redirect
       end
 
@@ -156,12 +168,14 @@ RSpec.describe 'Invitations', type: :request do
                                                        actionType: LoggingConstants::ActionType::BeginLogin,
                                                        invitation: invitation.id }])
         org_id = invitation.provider_organization.id
-        post "/organizations/#{org_id}/invitations/#{invitation.id}/login"
+        post "/organizations/#{org_id}/invitations/#{invitation.id}/login",
+             params: { provider: :login_dot_gov }
       end
 
       it 'should show error page if fail to proof' do
         org_id = invitation.provider_organization.id
-        post "/organizations/#{org_id}/invitations/#{invitation.id}/login"
+        post "/organizations/#{org_id}/invitations/#{invitation.id}/login",
+             params: { provider: :login_dot_gov }
         get '/users/auth/failure'
         expect(response).to be_forbidden
         expect(response.body).to include(I18n.t('verification.fail_to_proof_text'))
@@ -172,6 +186,7 @@ RSpec.describe 'Invitations', type: :request do
       it_behaves_like 'an invitation endpoint', :post, 'login', :cd do
         let(:invitation) { create(:invitation, :cd) }
         let(:expected_success_status) { 302 }
+        let(:request_params) { { provider: :login_dot_gov } }
       end
       it_behaves_like 'a login endpoint', :post, 'register' do
         let(:invitation) { create(:invitation, :cd) }
@@ -183,7 +198,8 @@ RSpec.describe 'Invitations', type: :request do
         let(:invitation) { create(:invitation, :cd) }
         it 'should not show step navigation' do
           org_id = invitation.provider_organization.id
-          post "/organizations/#{org_id}/invitations/#{invitation.id}/login"
+          post "/organizations/#{org_id}/invitations/#{invitation.id}/login",
+               params: { provider: :login_dot_gov }
           get '/users/auth/failure'
           expect(response).to be_forbidden
           expect(response.body).to_not include('<span class="usa-step-indicator__current-step">')
@@ -194,6 +210,7 @@ RSpec.describe 'Invitations', type: :request do
       it_behaves_like 'an invitation endpoint', :post, 'login', :ao do
         let(:invitation) { create(:invitation, :ao) }
         let(:expected_success_status) { 302 }
+        let(:request_params) { { provider: :login_dot_gov } }
       end
       it_behaves_like 'a login endpoint', :post, 'register' do
         let(:invitation) { create(:invitation, :ao) }
@@ -203,7 +220,8 @@ RSpec.describe 'Invitations', type: :request do
         let(:invitation) { create(:invitation, :ao) }
         it 'should show step 2' do
           org_id = invitation.provider_organization.id
-          post "/organizations/#{org_id}/invitations/#{invitation.id}/login"
+          post "/organizations/#{org_id}/invitations/#{invitation.id}/login",
+               params: { provider: :login_dot_gov }
           get '/users/auth/failure'
           expect(response).to be_forbidden
           expect(response.body).to include('<span class="usa-step-indicator__current-step">2</span>')


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5500](https://jira.cms.gov/browse/DPC-5500)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - fixed login.gov redirect failing on localhost
 - updated text on sign in page to reflect figma spec
 - updated buttons on verify invitation page to match sign in
 - updated links for sign in and verify buttons to map to all CSP's

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  -  figma for sign in page here: https://www.figma.com/design/cvJ8ru6pzsVTS5zAmMwIAC/DPC-Production-Portal?node-id=1764-259&p=f&m=dev
  - 

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
<img width="1296" height="894" alt="Screenshot 2026-06-03 at 8 50 49 AM" src="https://github.com/user-attachments/assets/e47a88db-92ab-4111-ba83-fde9853eaa10" />

<img width="1290" height="976" alt="Screenshot 2026-06-03 at 8 51 26 AM" src="https://github.com/user-attachments/assets/7e73159d-2fa6-41d3-b30e-e81f87557a37" />
