### PR TITLE
[DPC-5486] Upgrade java dependencies flagged by Snyk

### DIFF
--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/DPCProfileSupport.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/DPCProfileSupport.java
@@ -9,7 +9,7 @@ import ca.uhn.fhir.parser.IParser;
 import gov.cms.dpc.fhir.helpers.ServiceLoaderHelpers;
 import gov.cms.dpc.fhir.validations.profiles.IProfileLoader;
 import jakarta.inject.Inject;
-import org.hl7.fhir.dstu3.support.conformance.ProfileUtilities;
+import org.hl7.fhir.dstu3.conformance.ProfileUtilities;
 import org.hl7.fhir.dstu3.hapi.ctx.HapiWorkerContext;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
 import org.hl7.fhir.instance.model.api.IBaseResource;

--- a/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/DPCProfileSupport.java
+++ b/dpc-common/src/main/java/gov/cms/dpc/fhir/validations/DPCProfileSupport.java
@@ -9,7 +9,7 @@ import ca.uhn.fhir.parser.IParser;
 import gov.cms.dpc.fhir.helpers.ServiceLoaderHelpers;
 import gov.cms.dpc.fhir.validations.profiles.IProfileLoader;
 import jakarta.inject.Inject;
-import org.hl7.fhir.dstu3.conformance.ProfileUtilities;
+import org.hl7.fhir.dstu3.support.conformance.ProfileUtilities;
 import org.hl7.fhir.dstu3.hapi.ctx.HapiWorkerContext;
 import org.hl7.fhir.dstu3.model.StructureDefinition;
 import org.hl7.fhir.instance.model.api.IBaseResource;

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,11 @@
             </dependency>
             <dependency>
                 <groupId>${hapi.fhir.groupID}</groupId>
+                <artifactId>org.hl7.fhir.dstu3.support</artifactId>
+                <version>${hl7.fhir.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${hapi.fhir.groupID}</groupId>
                 <artifactId>org.hl7.fhir.r4</artifactId>
                 <version>${hl7.fhir.core.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <dropwizard.version>5.0.1</dropwizard.version>
+        <dropwizard.version>5.0.2</dropwizard.version>
         <junit.jupiter.version>5.12.1</junit.jupiter.version>
         <slf4j.version>2.0.17</slf4j.version>
         <hapi.fhir.groupID>ca.uhn.hapi.fhir</hapi.fhir.groupID>
-        <hapi.fhir.version>8.4.0</hapi.fhir.version>
+        <hapi.fhir.version>8.4.3</hapi.fhir.version>
         <pgsql.version>42.7.11</pgsql.version>
         <java.version>17</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>
@@ -48,7 +48,7 @@
         <newrelic.agent.version>8.21.0</newrelic.agent.version>
         <newrelic.agent.type>zip</newrelic.agent.type>
         <h2.version>2.3.232</h2.version>
-        <aws.java.sdk.version>2.42.38</aws.java.sdk.version>
+        <aws.java.sdk.version>2.44.14</aws.java.sdk.version>
         <sonar.coverage.exclusions>**/MockBlueButton*.java</sonar.coverage.exclusions>
     </properties>
 
@@ -138,7 +138,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
-                <version>12.1.6</version>
+                <version>12.1.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,16 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.validation</artifactId>
+                <version>6.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>ca.uhn.hapi.fhir</groupId>
+                <artifactId>org.hl7.fhir.utilities</artifactId>
+                <version>6.9.9</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
                 <version>12.1.10</version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
         <slf4j.version>2.0.17</slf4j.version>
         <hapi.fhir.groupID>ca.uhn.hapi.fhir</hapi.fhir.groupID>
         <hapi.fhir.version>8.4.3</hapi.fhir.version>
-        <hl7.fhir.core.version>6.9.9</hl7.fhir.core.version>
         <pgsql.version>42.7.11</pgsql.version>
         <java.version>17</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>
@@ -295,36 +294,6 @@
                 <groupId>${hapi.fhir.groupID}</groupId>
                 <artifactId>hapi-fhir-caching-caffeine</artifactId>
                 <version>${hapi.fhir.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${hapi.fhir.groupID}</groupId>
-                <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>${hl7.fhir.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${hapi.fhir.groupID}</groupId>
-                <artifactId>org.hl7.fhir.validation</artifactId>
-                <version>${hl7.fhir.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${hapi.fhir.groupID}</groupId>
-                <artifactId>org.hl7.fhir.dstu3</artifactId>
-                <version>${hl7.fhir.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${hapi.fhir.groupID}</groupId>
-                <artifactId>org.hl7.fhir.dstu3.support</artifactId>
-                <version>${hl7.fhir.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${hapi.fhir.groupID}</groupId>
-                <artifactId>org.hl7.fhir.r4</artifactId>
-                <version>${hl7.fhir.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>${hapi.fhir.groupID}</groupId>
-                <artifactId>org.hl7.fhir.convertors</artifactId>
-                <version>${hl7.fhir.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.smoketurner</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <hapi.fhir.groupID>ca.uhn.hapi.fhir</hapi.fhir.groupID>
         <hapi.fhir.version>8.4.3</hapi.fhir.version>
+        <hl7.fhir.core.version>6.9.9</hl7.fhir.core.version>
         <pgsql.version>42.7.11</pgsql.version>
         <java.version>17</java.version>
         <jib.container.appRoot>/app</jib.container.appRoot>
@@ -135,16 +136,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.validation</artifactId>
-                <version>6.9.9</version>
-            </dependency>
-            <dependency>
-                <groupId>ca.uhn.hapi.fhir</groupId>
-                <artifactId>org.hl7.fhir.utilities</artifactId>
-                <version>6.9.9</version>
-            </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-bom</artifactId>
@@ -304,6 +295,31 @@
                 <groupId>${hapi.fhir.groupID}</groupId>
                 <artifactId>hapi-fhir-caching-caffeine</artifactId>
                 <version>${hapi.fhir.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${hapi.fhir.groupID}</groupId>
+                <artifactId>org.hl7.fhir.utilities</artifactId>
+                <version>${hl7.fhir.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${hapi.fhir.groupID}</groupId>
+                <artifactId>org.hl7.fhir.validation</artifactId>
+                <version>${hl7.fhir.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${hapi.fhir.groupID}</groupId>
+                <artifactId>org.hl7.fhir.dstu3</artifactId>
+                <version>${hl7.fhir.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${hapi.fhir.groupID}</groupId>
+                <artifactId>org.hl7.fhir.r4</artifactId>
+                <version>${hl7.fhir.core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${hapi.fhir.groupID}</groupId>
+                <artifactId>org.hl7.fhir.convertors</artifactId>
+                <version>${hl7.fhir.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.smoketurner</groupId>


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5486](https://jira.cms.gov/browse/DPC-5486)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - pom updates for various java dependencies

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - upgrading dropwizard addresses HTTP Request Smuggling - [CVE-2026-45367](https://www.cve.org/CVERecord?id=CVE-2026-45367)
  - upgrading awssdk addresses various io.netty vulnerabilities
  - upgrading jetty addresses another HTTP request smuggling vulnerability - [CVE-2026-2332](https://www.cve.org/CVERecord?id=CVE-2026-2332)
  - vulnerabilities related to HAPI-FHIR have fixes in downstream HL7 dependencies, which are incompatible with HAPI-FHIR version 8.4
    - hapi-fhir 8.10 uses 6.9.x for HL7 dependencies, but there's no published working version that incorporates the 6.9.9 updates
    - see dependencies for latest version here: https://mvnrepository.com/artifact/ca.uhn.hapi.fhir/hapi-fhir-validation/8.10.0/dependencies


## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
