### PR TITLE
[DPC-5546] Ignore webrick vulnerability

### DIFF
--- a/dpc-portal/Dockerfile
+++ b/dpc-portal/Dockerfile
@@ -34,7 +34,10 @@ RUN gem install bundler --no-document && \
 RUN gem install foreman
 
 # Run bundler audit
-RUN bundle exec bundle audit update && bundle exec bundle audit check
+# CVE-2026-38969 is for webrick, which is only used in our fake_cpi_gateway client and never exposed to the outside
+# world.  There's currently no fix, and the recommended solution is to remove or disable it.  That would break
+# the fake_cpi_gateway, though, so we can't do that.
+RUN bundle exec bundle audit update && bundle exec bundle audit check --ignore CVE-2026-38969
 
 # Copy the code, test the app, and build the assets pipeline
 COPY /dpc-portal /dpc-portal


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5546

## 🛠 Changes

Ignores CVE-2026-38969, which is:

> #15 2.042 Name: webrick
> #15 2.042 Version: 1.8.2
> #15 2.042 CVE: CVE-2026-38969
> #15 2.042 GHSA: GHSA-h4w6-wx8r-p68v
> #15 2.042 Criticality: Unknown
> #15 2.042 URL: https://nvd.nist.gov/vuln/detail/CVE-2026-38969
> #15 2.042 Title: ruby webrick through v1.9.2 WEBrick reparses trailer
> #15 2.042 Solution: remove or disable this gem until a patch is available!
> #15 2.042 
> #15 2.042 Vulnerabilities found!

## ℹ️ Context

We can safely ignore this since `webrick` is only used in the `fake_cpi_gateway` for internal testing, and there's currently no fix.  Long term, it's probably good to rewrite this around a different gem, but this gets the build process working.

## 🧪 Validation

CI is passing again.
