### PR TITLE
Fix error encountered during login flow when using login.gov as CSP

### DIFF
--- a/dpc-portal/config/initializers/omniauth.rb
+++ b/dpc-portal/config/initializers/omniauth.rb
@@ -31,7 +31,7 @@ CLEAR_OIDC_CLAIMS_PARAM = JSON.generate(CLEAR_OIDC_CLAIMS).freeze
 
 ## Build Login.gov RSA private key object before defining the config constant
 LOGIN_DOT_GOV_PRIVATE_KEY = begin
-  OpenSSL::PKey::RSA.new(ENV['LOGIN_DOT_GOV_CLIENT_PRIVATE_KEY'])
+  OpenSSL::PKey::RSA.new(ENV['LOGIN_DOT_GOV_CLIENT_PRIVATE_KEY']&.gsub('\\n', "\n"))
 rescue TypeError, OpenSSL::PKey::RSAError => e
   Rails.logger.error("Unable to create Login.gov private key for omniauth: #{e}")
   OpenSSL::PKey::RSA.new(1024)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5561

## 🛠 Changes

Replace literal slash and n characters with a new line character to fix the issue with Login.gov

## ℹ️ Context

Wrong key was causing "Client assertion Signature verification failed" error as the client assertion was getting signed with wrong key due to misrepresentation of new line character in the env variable used to store private key.

## 🧪 Validation
Verified the cause by comparing the length of env variable before and after in and outside of container to ensure it works irrespective of the mechanism used to inject env variables in environment through docker compose's env_file vs bash and account for the differences in handling of \n characters.

