### PR TITLE
fix vulnerable ruby gems

### DIFF
--- a/dpc-admin/Gemfile
+++ b/dpc-admin/Gemfile
@@ -94,8 +94,6 @@ group :test do
   gem 'rails-controller-testing'
   gem 'selenium-webdriver'
   gem 'fakefs', require: 'fakefs/safe'
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/dpc-admin/Gemfile.lock
+++ b/dpc-admin/Gemfile.lock
@@ -240,7 +240,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     luhnacy (0.2.2)
@@ -358,8 +358,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.0.5)
       actionpack (= 8.0.5)
@@ -441,9 +441,11 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     securerandom (0.4.1)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.46.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
+      rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     simplecov (0.17.0)
       docile (~> 1.1)
@@ -499,10 +501,6 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
-    webdrivers (5.3.1)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0, < 4.11)
     webmock (3.26.2)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -585,7 +583,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -96,7 +96,7 @@ group :test do
   gem 'climate_control'
   gem 'fakefs', require: 'fakefs/safe'
   gem 'rails-controller-testing'
-  gem 'selenium-webdriver', '4.20.1'
+  gem 'selenium-webdriver'
   gem 'timecop'
 end
 

--- a/dpc-portal/Gemfile
+++ b/dpc-portal/Gemfile
@@ -96,7 +96,7 @@ group :test do
   gem 'climate_control'
   gem 'fakefs', require: 'fakefs/safe'
   gem 'rails-controller-testing'
-  gem 'selenium-webdriver'
+  gem 'selenium-webdriver', '4.20.1'
   gem 'timecop'
 end
 

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hana (1.3.7)
     hashdiff (1.1.1)
     hashie (5.1.0)
       logger
@@ -259,9 +260,11 @@ GEM
       bindata
       faraday (~> 2.0)
       faraday-follow_redirects
-    json-schema (6.2.0)
-      addressable (~> 2.8)
-      bigdecimal (>= 3.1, < 5)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jsonapi-renderer (0.2.2)
     jwt (3.2.0)
       base64
@@ -279,7 +282,10 @@ GEM
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     libdatadog (33.0.0.1.0)
+    libdatadog (33.0.0.1.0-arm64-darwin)
     libddwaf (1.30.0.0.2)
+      ffi (~> 1.0)
+    libddwaf (1.30.0.0.2-arm64-darwin)
       ffi (~> 1.0)
     lint_roller (1.1.0)
     listen (3.9.0)
@@ -291,7 +297,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lookbook (2.3.14)
@@ -318,8 +324,8 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.2)
-    mcp (0.10.0)
-      json-schema (>= 4.1)
+    mcp (0.24.0)
+      json_schemer (>= 2.4)
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
@@ -437,8 +443,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.0.5)
       actionpack (= 8.0.5)
@@ -527,9 +533,11 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.46.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
+      rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     simplecov (0.17.0)
       docile (~> 1.1)

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -523,7 +523,7 @@ GEM
       ruby-lsp (~> 0.26.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.3.2)
+    rubyzip (2.4.1)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -533,11 +533,10 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
-    selenium-webdriver (4.46.0)
+    selenium-webdriver (4.20.1)
       base64 (~> 0.2)
-      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 4.0)
+      rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     simplecov (0.17.0)
       docile (~> 1.1)
@@ -691,7 +690,7 @@ DEPENDENCIES
   rubocop-performance
   ruby-lsp-rspec
   sassc-rails (>= 2.1.2)
-  selenium-webdriver
+  selenium-webdriver (= 4.20.1)
   simplecov (<= 0.17)
   sinatra (>= 4.2.0)
   solid_queue (~> 1.2)

--- a/dpc-portal/Gemfile.lock
+++ b/dpc-portal/Gemfile.lock
@@ -533,10 +533,11 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
-    selenium-webdriver (4.20.1)
+    selenium-webdriver (4.46.0)
       base64 (~> 0.2)
+      logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
+      rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     simplecov (0.17.0)
       docile (~> 1.1)
@@ -690,7 +691,7 @@ DEPENDENCIES
   rubocop-performance
   ruby-lsp-rspec
   sassc-rails (>= 2.1.2)
-  selenium-webdriver (= 4.20.1)
+  selenium-webdriver
   simplecov (<= 0.17)
   sinatra (>= 4.2.0)
   solid_queue (~> 1.2)

--- a/dpc-portal/spec/rails_helper.rb
+++ b/dpc-portal/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require 'support/component_support'
 require 'support/dpc_client_support'
 require 'support/match_html_fragment'
 require 'support/fixture_helper'
+require 'support/selenium_driver'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'view_component/test_helpers'
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/dpc-portal/spec/support/selenium_driver.rb
+++ b/dpc-portal/spec/support/selenium_driver.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'selenium/webdriver'
+
+Capybara.register_driver :selenium_headless do |app|
+  options = Selenium::WebDriver::Firefox::Options.new(args: ['--headless'])
+  service = Selenium::WebDriver::Service.firefox(path: '/usr/bin/geckodriver')
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :firefox,
+    options:,
+    service:
+  )
+end

--- a/dpc-web/Gemfile.lock
+++ b/dpc-web/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hana (1.3.7)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
@@ -235,9 +236,11 @@ GEM
       reline (>= 0.4.2)
     jmespath (1.6.2)
     json (2.19.9)
-    json-schema (6.2.0)
-      addressable (~> 2.8)
-      bigdecimal (>= 3.1, < 5)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jsonapi-renderer (0.2.2)
     jwt (3.2.0)
       base64
@@ -276,7 +279,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     luhnacy (0.2.2)
@@ -292,8 +295,8 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.2)
-    mcp (0.10.0)
-      json-schema (>= 4.1)
+    mcp (0.24.0)
+      json_schemer (>= 2.4)
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
@@ -375,8 +378,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.0.5)
       actionpack (= 8.0.5)


### PR DESCRIPTION
## 🎫 Ticket

[(no ticket)](https://jira.cms.gov/browse/DPC-5562)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - Updated gems to latest compatible versions
 - Removed obsolete [webdrivers](https://github.com/titusfortner/webdrivers) gem 
 - Added helper to point to firefox/gecko with newer selenium version

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - I noticed `bundle audit check` was failing when I kicked off accessibility tests this morning: https://github.com/CMSgov/dpc-app/actions/runs/29604259514/job/87963582933
 - For the [webdrivers](https://github.com/titusfortner/webdrivers) gem, the maintainers directly recommend removing it when upgrading to Selenium 4.11+
 - Gem vulnerabilities did now show up in Snyk
<img width="1626" height="953" alt="Screenshot 2026-07-17 at 12 38 20 PM" src="https://github.com/user-attachments/assets/6e8b87b0-aa60-48c9-ac09-520a492c1fcc" />


## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - dpc-portal passes CI workflow: https://github.com/CMSgov/dpc-app/actions/runs/29615295315/job/87998964470



*used chat.cms.gov to format this PR and figure out geckodriver helper