### PR TITLE
[DPC-5535] Update portal homepage helper text to reflect multi-csp

### DIFF
--- a/dpc-portal/app/components/page/session/login_component.html.erb
+++ b/dpc-portal/app/components/page/session/login_component.html.erb
@@ -38,18 +38,18 @@
 	  Welcome to the DPC API Portal.
 	</h2>
         <div class="usa-prose">
-          <p>To sign in, you must:</p>
+          <p>Have an invite?</p>
           <ul class="sign-in-instructions">
-            <li>Have a unique DPC Portal Login.gov account</li>
-            <li>Have received an invite to create that account</li>
-            <li>Used the email address identified in your invite</li>
+            <li>Sign in using the account you created from your invitation. We recommend choosing the same identity provider you used when you set up your account.</li>
+            <li>Be sure to use the same email address the invite was sent to.</li>
           </ul>
-        <div class="line-separator"></div>
-          <p>
-            You don't need an invite to sign up for the DPC Sandbox. This publicly available resource gives you access to test data.
-          </p>
-          <div>
-            <a href="https://sandbox.dpc.cms.gov/" class="usa-button--outline usa-button">Sign up to use test data</a>
+          <div class="line-separator margin-y-3"></div>
+          <p>New to DPC?</p>
+          <ul class="sign-in-instructions">
+            <li>Production access is invite-only, but you can start exploring right away with our Sandbox — a publicly available environment with synthetic test data and no invite required.</li>
+          </ul>
+          <div class="margin-top-3">
+            <a href="https://sandbox.dpc.cms.gov/" class="usa-button--outline usa-button">Sign up for DPC Sandbox</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5535](https://jira.cms.gov/browse/DPC-5535)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
- updated homepage to reflect content from figma [HERE](www.figma.com/design/cvJ8ru6pzsVTS5zAmMwIAC/DPC-Production-Portal?node-id=2044-8972)

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - previously language specified "Login.gov" and should be agnostic of CSP
  - I confirmed with JB that the additional space (24px) should be O.K.
    - Sign in box on the left does not need to be updated to be taller
    - Sign in box on the left will change size based on whether or not the "Last CSP used" is displayed

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - verified locally at http://localhost:3100/
 - `make ci-portal` passes locally* 

* fails `bundle audit check`, but the actual tests are passing. See this PR for gem vulnerability updates: https://github.com/CMSgov/dpc-app/pull/3070