### PR TITLE
Me/dpc 5554 fix already registered org error message

### DIFF
--- a/dpc-portal/app/components/page/utility/error_component.html.erb
+++ b/dpc-portal/app/components/page/utility/error_component.html.erb
@@ -25,7 +25,7 @@
             destination: renew_organization_invitation_path(@invitation.provider_organization, @invitation)) %>
       <% when :ao_accepted %>
         <%= link_to sign_in_path, class: 'usa-button', data: { turbo: false } do %>
-          Sign in with <span class="login-button__logo"><%= @csp_display_name %></span>
+          Sign in to DPC Portal
         <% end %>
       <% when :cd_accepted %>
         <%= link_to 'Go to DPC home', root_url, class: 'usa-button margin-right-0' %>

--- a/dpc-portal/spec/components/core/modal/modal_component_spec.rb
+++ b/dpc-portal/spec/components/core/modal/modal_component_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe Core::Modal::ModalComponent, type: :component do
                           'No',
                           'verify-modal')
     end
+
+    let(:sprite_path) { ActionController::Base.helpers.asset_path('@uswds/uswds/dist/img/sprite.svg') }
+
     let(:expected_html) do
       <<~HTML
         <div class="usa-modal" id="verify-modal" aria-labelledby="verify-modal-heading" aria-describedby="verify-modal-description">
@@ -46,7 +49,7 @@ RSpec.describe Core::Modal::ModalComponent, type: :component do
             </div>
             <button type="button" class="usa-button usa-modal__close" aria-label="Close this window" data-close-modal>
               <svg class="usa-icon" aria-hidden="true">
-                <use xlink:href="/assets/@uswds/uswds/dist/img/sprite-9865eea7b251e43137fb770626d6cd51c474a3a436678a6e66cafce50968076f.svg#close"></use>
+                <use xlink:href="#{sprite_path}#close"></use>
               </svg>
             </button>
           </div>

--- a/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/new_invitation_component_spec.rb
@@ -13,8 +13,9 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
 
     let(:org) { ComponentSupport::MockOrg.new }
     let(:cd_invite) { Invitation.new(invitation_type: :credential_delegate) }
-
     let(:component) { described_class.new(org, cd_invite) }
+
+    let(:sprite_path) { ActionController::Base.helpers.asset_path('@uswds/uswds/dist/img/sprite.svg') }
 
     before do
       render_inline(component)
@@ -118,7 +119,7 @@ RSpec.describe Page::CredentialDelegate::NewInvitationComponent, type: :componen
               </div>
               <button type="button" class="usa-button usa-modal__close" aria-label="Close this window" data-close-modal>
                   <svg class="usa-icon" aria-hidden="true">
-                    <use xlink:href=/assets/@uswds/uswds/dist/img/sprite-9865eea7b251e43137fb770626d6cd51c474a3a436678a6e66cafce50968076f.svg#close></use>
+                    <use xlink:href=#{sprite_path}#close></use>
                   </svg>
               </button>
           </div></div>

--- a/dpc-portal/spec/components/page/organization/organization_list_component_spec.rb
+++ b/dpc-portal/spec/components/page/organization/organization_list_component_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe Page::Organization::OrganizationListComponent, type: :component d
         link = CdOrgLink.new(provider_organization: org)
         described_class.new(ao_or_cd: :cd, links: [link])
       end
+      let(:sprite_path) { ActionController::Base.helpers.asset_path('@uswds/uswds/dist/img/sprite.svg') }
       let(:expected_html) do
         <<~HTML
           <div class="usa-table-container--scrollable" tabindex="0">
@@ -79,7 +80,7 @@ RSpec.describe Page::Organization::OrganizationListComponent, type: :component d
                   <td style="width: 25%;">
                       <div class="clearfix">
                         <div class="float-left">  <svg class="text-gold usa-icon" aria-hidden="true">
-                          <use xlink:href=/assets/@uswds/uswds/dist/img/sprite-9865eea7b251e43137fb770626d6cd51c474a3a436678a6e66cafce50968076f.svg#warning></use>
+                          <use xlink:href=#{sprite_path}#warning></use>
                         </svg>
                         </div>
                       <div class="float-left margin-left-1 margin-top-neg-2px">Setup needed</div>

--- a/dpc-portal/spec/components/page/utility/error_component_spec.rb
+++ b/dpc-portal/spec/components/page/utility/error_component_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe Page::Utility::ErrorComponent, type: :component do
           it 'should have login button' do
             button_url = '/users/sign_in'
             is_expected.to include(button_url)
-            is_expected.to include("Sign in with <span class=\"login-button__logo\">#{display_name}</span>")
+            is_expected.to include('Sign in to DPC Portal')
           end
         end
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5554

## 🛠 Changes

- Update button on error page when an org is already registered from "Sign in with {CSP}" to "Sign in to DPC Portal".
- Fixed asset pipeline bug that was intermittently causing tests to fail.

## ℹ️ Context

This was a design decision.

## 🧪 Validation

- Deployed to dev [here](https://github.com/CMSgov/dpc-app/actions/runs/29754503327).
- Tests passing.

<img width="817" height="357" alt="image" src="https://github.com/user-attachments/assets/d0a55816-9a9f-4f6c-84e7-a8bfdbd4984f" />
