### PR TITLE
[DPC-5548] Update portal invites to route to organizations page

### DIFF
--- a/dpc-portal/app/components/page/invitations/success_component.html.erb
+++ b/dpc-portal/app/components/page/invitations/success_component.html.erb
@@ -23,5 +23,5 @@
       <% end %>
   </ul>
   <% end %>
-  <%= link_to 'Go to DPC Portal', sign_in_path, class: 'usa-button margin-right-0' %>
+  <%= link_to 'Go to DPC Portal', root_url, class: 'usa-button margin-right-0' %>
 </div>

--- a/dpc-portal/spec/components/page/invitations/success_component_spec.rb
+++ b/dpc-portal/spec/components/page/invitations/success_component_spec.rb
@@ -22,6 +22,11 @@ RSpec.describe Page::Invitations::SuccessComponent, type: :component do
     it "should not have the invited user's name" do
       expect(page).not_to have_text('Paola Pineiro')
     end
+
+    it 'should link to portal homepage' do
+      go_to_dpc_path = URI(page.find_link('Go to DPC Portal')[:href]).path
+      expect(go_to_dpc_path).to eq('/')
+    end
   end
 
   describe 'cd' do
@@ -42,6 +47,11 @@ RSpec.describe Page::Invitations::SuccessComponent, type: :component do
 
     it "should not have the invited user's name" do
       expect(page).not_to have_text('Paola Pineiro')
+    end
+
+    it 'should link to portal homepage' do
+      go_to_dpc_path = URI(page.find_link('Go to DPC Portal')[:href]).path
+      expect(go_to_dpc_path).to eq('/')
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5548](https://jira.cms.gov/browse/DPC-5548)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
- updated invitations to link to the portal homepage (e.g. `http://localhost:3100` or `https://portal.dpc.cms.gov/`) for last step of invitation

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - Existing session logic keeps the users "signed in" with a "sign out" button after they click "Go to DPC Portal" at the end of the invite flow.
    - This meant when users clicked "Go back to portal" at the end of the invitation flow, they would have all 3 CSP buttons visible, but not be able to see their organizations without manually routing to `"/"`
    - Invites needed URL to be updated to not explicitly routed to `http://localhost:3100/users/sign_in`
    - There is already a check to ensure that expired sessions log out [HERE](https://github.com/CMSgov/dpc-app/blob/cde5d8b4d11fd2a63145c5f413826f75553045ed/dpc-portal/app/controllers/application_controller.rb#L50)
  - Apparently Capybara by default uses `http://test.host/` for hostname - [link](https://api.rubyonrails.org/v7.1.0/classes/ActionDispatch/TestRequest.html) 
    - new test check only `.path()` points to root instead of checking the URL for this reason


## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Manually tested new invitation:

https://github.com/user-attachments/assets/8df649f1-40f6-4450-b6fd-456acd927be5



Unit tests passing