### PR TITLE
DPC-5565 update portal documentation

### DIFF
--- a/dpc-portal/README.md
+++ b/dpc-portal/README.md
@@ -39,7 +39,7 @@ To support manual workflows, the system offers rake commands that perform admini
     $ rails dpc:invite_ao INVITE=Bob,Hoskins,bob@example.com,7838426501
 
     Invitation created for Bob Hoskins for Organization 7838426501
-    http://localhost:3100/portal/organizations/2/invitations/4/accept
+    http://localhost:3100/organizations/2/invitations/4/accept
     ```
 
 ## Local AO Verification Scenarios
@@ -69,11 +69,11 @@ Most generated NPIs will return a successful AO/organization verification when r
 
 ### Lookbook / View Components
 
-We utilize the [ViewComponent](https://viewcomponent.org/) library to create custom components. These components are documented and viewable within [Lookbook](http://localhost:3100/portal/lookbook).
+We utilize the [ViewComponent](https://viewcomponent.org/) library to create custom components. These components are documented and viewable within [Lookbook](http://localhost:3100/lookbook).
 
 ### Email Mailers
 
-Emails are not viewable in lookbook, but can be found [here](http://localhost:3100/portal/rails/mailers/).
+Emails are not viewable in lookbook, but can be found [here](http://localhost:3100/rails/mailers/).
 
 ## Accessing the VAL CPI API Gateway from Local Dev
 

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-# Sets up the application's routes. Note that this is served
-# under the /portal prefix, as configured in the application.rb
-# and config.ru via config.relative_url_root.
-#
+# Sets up the application's routes.
 Rails.application.routes.draw do
   # Former devise routes
   get '/users/auth/failure', to: 'csp#failure', as: 'csp_failure'


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5565](https://jira.cms.gov/browse/DPC-5565)

## 🛠 Changes

* updated localhost links in `README.md`
* updated comment in `routes.rb`

## ℹ️ Context

These changes bring the documentation about portal routing up to date.

## 🧪 Validation

Documentation refers to the correct urls for running the project locally.
