### PR TITLE
[DPC-5552] Consolidate duplicated auth unit tests across CSP's

### DIFF
--- a/dpc-portal/spec/requests/clear_spec.rb
+++ b/dpc-portal/spec/requests/clear_spec.rb
@@ -24,7 +24,13 @@ RSpec.describe 'Clear', type: :request do
                              ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } }
     end
 
-    it_behaves_like 'a CSP client', :clear, '/auth/clear', expected_id_token: 'id-token'
+    clear_config = {
+      provider: :clear,
+      auth_endpoint: '/auth/clear',
+      display_name: 'CLEAR',
+      expected_id_token: 'id-token'
+    }
+    it_behaves_like 'a CSP client', clear_config
 
     # IAL1 is no longer allowed should now be blocked entirely
     context 'IAL/1' do
@@ -196,21 +202,6 @@ RSpec.describe 'Clear', type: :request do
     end
   end
 
-  describe 'Get /auth/failure' do
-    it 'should succeed' do
-      get '/users/auth/failure'
-      expect(response).to be_ok
-    end
-
-    it 'should log on failure' do
-      allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with(['User cancelled login',
-                                                   { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                     actionType: LoggingConstants::ActionType::UserCancelledLogin }])
-      get '/users/auth/failure'
-    end
-  end
-
   describe 'Delete /logout' do
     let(:id_token) { 'id-token' }
     before do
@@ -246,57 +237,6 @@ RSpec.describe 'Clear', type: :request do
       delete "/logout?invitation_id=#{invitation.id}"
       expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
                                                                                  invitation.id)
-    end
-  end
-
-  describe 'Get /auth/no_account' do
-    before do
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:clear,
-                               { uid: uuid,
-                                 info: { email: 'example1@example.com' },
-                                 extra: { raw_info: { sub: uuid,
-                                                      email: 'example1@example.com',
-                                                      SSN: '123456789',
-                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
-    end
-    it 'should show logout button' do
-      get '/auth/no_account'
-      expect(response.body).to include 'Sign out of CSP'
-    end
-  end
-
-  describe 'CSP inactive' do
-    let!(:csp) { Csp.find_by(name: 'clear') || create(:csp, :clear) }
-
-    before do
-      csp.end_date = DateTime.current - 1.year
-      csp.save!
-
-      user = create(:user)
-      create(:csp_user, user:, uuid:, csp:)
-
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:clear,
-                               { uid: uuid,
-                                 credentials: { expires_in: 899,
-                                                token: 'bearer-token',
-                                                id_token: 'id-token' },
-                                 info: { email: 'bob4@example.com' },
-                                 extra: { raw_info: { sub: uuid,
-                                                      email: 'bob4@example.com',
-                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
-    end
-
-    it 'should log error' do
-      allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with(
-        ['User attempted to login with CLEAR but no active CSP found',
-         { actionContext: LoggingConstants::ActionContext::Authentication,
-           actionType: LoggingConstants::ActionType::InvalidCsp }]
-      )
-      post '/auth/clear'
-      follow_redirect!
     end
   end
 end

--- a/dpc-portal/spec/requests/clear_spec.rb
+++ b/dpc-portal/spec/requests/clear_spec.rb
@@ -28,78 +28,9 @@ RSpec.describe 'Clear', type: :request do
       provider: :clear,
       auth_endpoint: '/auth/clear',
       display_name: 'CLEAR',
-      expected_id_token: 'id-token'
+      expected_id_token: 'id-token' # covers store_id_token = true for clear_controller
     }
     it_behaves_like 'a CSP client', clear_config
-
-    # IAL1 is no longer allowed should now be blocked entirely
-    context 'IAL/1' do
-      before do
-        OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(:clear,
-                                 { uid: uuid,
-                                   info: { email: 'bob@example.com' },
-                                   extra: { raw_info: { sub: uuid,
-                                                        email: 'bob@example.com',
-                                                        SSN: '123456789',
-                                                        ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
-      end
-
-      it 'returns 403 forbidden' do
-        post '/auth/clear'
-        follow_redirect!
-        expect(response).to have_http_status(:forbidden)
-      end
-
-      it 'renders the clear_signin_fail error component' do
-        post '/auth/clear'
-        follow_redirect!
-        expect(response.body).to include('CLEAR sign-in failed')
-      end
-
-      it 'logs the IAL1 blocked attempt' do
-        allow(Rails.logger).to receive(:info)
-        post '/auth/clear'
-        follow_redirect!
-        expect(Rails.logger).to have_received(:info).with(
-          ['User attempted IAL1 login with CLEAR — not permitted',
-           { actionContext: LoggingConstants::ActionContext::Authentication,
-             actionType: LoggingConstants::ActionType::UserLoginWithoutAccount }]
-        )
-      end
-
-      it 'does not sign in the user' do
-        post '/auth/clear'
-        follow_redirect!
-        expect(response).to be_forbidden
-      end
-
-      it 'does not set an authentication token' do
-        post '/auth/clear'
-        expect(request.session[:clear_token]).to be_nil
-        expect(request.session[:clear_token_exp]).to be_nil
-        expect(request.session[:clear_id_token]).to be_nil
-      end
-
-      context 'when a matching user account exists' do
-        before do
-          user = create(:user, given_name: 'Bob', family_name: 'Hoskins')
-          create(:csp_user, user:, uuid:, csp:)
-        end
-
-        it 'still returns 403 forbidden' do
-          post '/auth/clear'
-          follow_redirect!
-          expect(response).to have_http_status(:forbidden)
-        end
-
-        it 'does not sign in the user' do
-          post '/auth/clear'
-          follow_redirect!
-          expect(response).to be_forbidden
-        end
-      end
-    end
 
     context 'should add emails' do
       before do

--- a/dpc-portal/spec/requests/clear_spec.rb
+++ b/dpc-portal/spec/requests/clear_spec.rb
@@ -2,58 +2,12 @@
 
 require 'rails_helper'
 require 'securerandom'
+require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'Clear', type: :request do
   let(:uuid) { SecureRandom.uuid }
   describe 'POST /auth/clear' do
     let!(:csp) { Csp.find_by(name: 'clear') || create(:csp, :clear) }
-    RSpec.shared_examples 'a clear client' do
-      context 'user exists' do
-        before do
-          user = create(:user)
-          create(:csp_user, user:, uuid:, csp:)
-        end
-        it 'should sign in a user' do
-          post '/auth/clear'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_ok
-        end
-        it 'should log on successful sign in' do
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(['User logged in',
-                                                       { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                         actionType: LoggingConstants::ActionType::UserLoggedIn,
-                                                         csp: 'clear' }])
-          post '/auth/clear'
-          follow_redirect!
-        end
-        it 'should write a cookie with the last used csp' do
-          post '/auth/clear'
-          follow_redirect!
-          expect(cookies[:last_used_csp]).to eq 'clear'
-        end
-        it 'should not add another user credential' do
-          expect(CspUser.where(uuid:, csp:).count).to eq 1
-          expect do
-            post '/auth/clear'
-            follow_redirect!
-          end.to change { CspUser.count }.by(0)
-        end
-      end
-
-      context 'user does not exist' do
-        it 'should not persist user' do
-          expect do
-            post '/auth/clear'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-      end
-    end
-
     let(:token) { 'bearer-token' }
     let(:id_token) { 'id-token' }
     context 'IAL/2' do
@@ -73,7 +27,7 @@ RSpec.describe 'Clear', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
       end
 
-      it_behaves_like 'a clear client'
+      it_behaves_like 'a CSP client', :clear, '/auth/clear'
 
       context :user_exists do
         let(:db_user) { create(:user) }
@@ -370,8 +324,9 @@ RSpec.describe 'Clear', type: :request do
   end
 
   describe 'CSP inactive' do
+    let!(:csp) { Csp.find_by(name: 'clear') || create(:csp, :clear) }
+
     before do
-      csp = Csp.find_by(name: 'clear') || create(:csp, :clear)
       csp.end_date = DateTime.current - 1.year
       csp.save!
 

--- a/dpc-portal/spec/requests/clear_spec.rb
+++ b/dpc-portal/spec/requests/clear_spec.rb
@@ -10,78 +10,21 @@ RSpec.describe 'Clear', type: :request do
     let!(:csp) { Csp.find_by(name: 'clear') || create(:csp, :clear) }
     let(:token) { 'bearer-token' }
     let(:id_token) { 'id-token' }
-    context 'IAL/2' do
-      before do
-        OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(:clear,
-                                 { uid: uuid,
-                                   credentials: { expires_in: 899,
-                                                  token:,
-                                                  id_token: },
-                                   info: { email: 'bob2@example.com' },
-                                   extra: { raw_info: { sub: uuid,
-                                                        email: 'bob2@example.com',
-                                                        given_name: 'Bob',
-                                                        family_name: 'Hoskins',
-                                                        SSN: '123456789',
-                                                        ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
-      end
-
-      it_behaves_like 'a CSP client', :clear, '/auth/clear'
-
-      context :user_exists do
-        let(:db_user) { create(:user) }
-        before do
-          create(:csp_user, user: db_user, uuid:, csp:)
-        end
-        it 'updates user names' do
-          expect do
-            post '/auth/clear'
-            follow_redirect!
-          end.to change {
-            User.where(id: db_user.id, given_name: 'Bob',
-                       family_name: 'Hoskins').count
-          }.by 1
-          expect(response.location).to eq organizations_url
-        end
-
-        it 'sets authentication token' do
-          post '/auth/clear'
-          follow_redirect!
-
-          csp_session = CspSession.new(request.session)
-          expect(csp_session.current).to eq 'clear'
-          expect(csp_session.token).to eq token
-          expect(csp_session.token_exp).to_not be_nil
-          expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
-          expect(csp_session.id_token).to eq id_token
-        end
-      end
-
-      context :user_does_not_exist do
-        it 'does not sign in user' do
-          post '/auth/clear'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_redirect
-        end
-
-        it 'sets authentication token' do
-          post '/auth/clear'
-          follow_redirect!
-
-          csp_session = CspSession.new(request.session)
-          expect(csp_session.current).to eq 'clear'
-          expect(csp_session.token).to eq token
-          expect(csp_session.token_exp).to_not be_nil
-          expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
-          expect(csp_session.id_token).to eq id_token
-          expect(csp_session.user).to be_nil
-        end
-      end
+    let(:csp_auth_response) do
+      { uid: uuid,
+        credentials: { expires_in: 899,
+                       token:,
+                       id_token: },
+        info: { email: 'bob2@example.com' },
+        extra: { raw_info: { sub: uuid,
+                             email: 'bob2@example.com',
+                             given_name: 'Bob',
+                             family_name: 'Hoskins',
+                             SSN: '123456789',
+                             ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } }
     end
+
+    it_behaves_like 'a CSP client', :clear, '/auth/clear', expected_id_token: 'id-token'
 
     # IAL1 is no longer allowed should now be blocked entirely
     context 'IAL/1' do

--- a/dpc-portal/spec/requests/clear_spec.rb
+++ b/dpc-portal/spec/requests/clear_spec.rb
@@ -2,58 +2,12 @@
 
 require 'rails_helper'
 require 'securerandom'
+require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'Clear', type: :request do
   let(:uuid) { SecureRandom.uuid }
   describe 'POST /auth/clear' do
     let!(:csp) { Csp.find_by(name: 'clear') || create(:csp, :clear) }
-    RSpec.shared_examples 'a clear client' do
-      context 'user exists' do
-        before do
-          user = create(:user, email: 'bob1@example.com', provider: :clear)
-          create(:csp_user, user:, uuid:, csp:)
-        end
-        it 'should sign in a user' do
-          post '/auth/clear'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_ok
-        end
-        it 'should log on successful sign in' do
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(['User logged in',
-                                                       { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                         actionType: LoggingConstants::ActionType::UserLoggedIn,
-                                                         csp: 'clear' }])
-          post '/auth/clear'
-          follow_redirect!
-        end
-        it 'should write a cookie with the last used csp' do
-          post '/auth/clear'
-          follow_redirect!
-          expect(cookies[:last_used_csp]).to eq 'clear'
-        end
-        it 'should not add another user credential' do
-          expect(CspUser.where(uuid:, csp:).count).to eq 1
-          expect do
-            post '/auth/clear'
-            follow_redirect!
-          end.to change { CspUser.count }.by(0)
-        end
-      end
-
-      context 'user does not exist' do
-        it 'should not persist user' do
-          expect do
-            post '/auth/clear'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-      end
-    end
-
     let(:token) { 'bearer-token' }
     let(:id_token) { 'id-token' }
     context 'IAL/2' do
@@ -73,7 +27,7 @@ RSpec.describe 'Clear', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
       end
 
-      it_behaves_like 'a clear client'
+      it_behaves_like 'a CSP client', :clear, '/auth/clear'
 
       context :user_exists do
         let(:db_user) { create(:user, uid: '12345', provider: 'clear', email: 'bob@example.com') }
@@ -370,8 +324,9 @@ RSpec.describe 'Clear', type: :request do
   end
 
   describe 'CSP inactive' do
+    let!(:csp) { Csp.find_by(name: 'clear') || create(:csp, :clear) }
+
     before do
-      csp = Csp.find_by(name: 'clear')
       csp.end_date = DateTime.current - 1.year
       csp.save!
 

--- a/dpc-portal/spec/requests/clear_spec.rb
+++ b/dpc-portal/spec/requests/clear_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe 'Clear', type: :request do
       provider: :clear,
       auth_endpoint: '/auth/clear',
       display_name: 'CLEAR',
+      logout_host: ENV.fetch('CLEAR_IDP_HOST'),
       expected_id_token: 'id-token' # covers store_id_token = true for clear_controller
     }
     it_behaves_like 'a CSP client', clear_config
@@ -130,44 +131,6 @@ RSpec.describe 'Clear', type: :request do
         expect(email.reactivated_at).to_not be_nil
         expect(email.primary).to eq true
       end
-    end
-  end
-
-  describe 'Delete /logout' do
-    let(:id_token) { 'id-token' }
-    before do
-      uuid = SecureRandom.uuid
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:clear,
-                               { uid: uuid,
-                                 credentials: { expires_in: 899,
-                                                token: 'bearer-token',
-                                                id_token: },
-                                 info: { email: 'email1@example.com' },
-                                 extra: { raw_info: { sub: uuid,
-                                                      email: 'email1@example.com',
-                                                      given_name: 'Bob',
-                                                      family_name: 'Hoskins',
-                                                      SSN: '123456789',
-                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
-
-      user = create(:user)
-      csp = create(:csp, :clear)
-      create(:csp_user, user:, uuid:, csp:)
-      post '/auth/clear'
-      follow_redirect!
-    end
-    it 'should redirect to CLEAR' do
-      delete '/logout'
-      expect(response.location).to include(ENV.fetch('CLEAR_IDP_HOST'))
-      expect(response.location).to include("id_token_hint=#{id_token}")
-      expect(request.session[:user_return_to]).to be_nil
-    end
-    it 'should set return to invitation flow if invitation sent' do
-      invitation = create(:invitation, :ao)
-      delete "/logout?invitation_id=#{invitation.id}"
-      expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
-                                                                                 invitation.id)
     end
   end
 end

--- a/dpc-portal/spec/requests/csp_spec.rb
+++ b/dpc-portal/spec/requests/csp_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# These responses are the same across all CSP's.
+RSpec.describe 'CSP', type: :request do
+  describe 'Get /users/auth/failure' do
+    it 'should succeed' do
+      get '/users/auth/failure'
+      expect(response).to be_ok
+    end
+
+    it 'should log on failure' do
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with(['User cancelled login',
+                                                   { actionContext: LoggingConstants::ActionContext::Authentication,
+                                                     actionType: LoggingConstants::ActionType::UserCancelledLogin }])
+      get '/users/auth/failure'
+    end
+  end
+
+  describe 'Get /auth/no_account' do
+    it 'should show logout button' do
+      get '/auth/no_account'
+      expect(response.body).to include 'Sign out of CSP'
+    end
+  end
+end

--- a/dpc-portal/spec/requests/id_me_spec.rb
+++ b/dpc-portal/spec/requests/id_me_spec.rb
@@ -2,58 +2,12 @@
 
 require 'rails_helper'
 require 'securerandom'
+require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'IdMe', type: :request do
   let(:uuid) { SecureRandom.uuid }
   describe 'POST /auth/id_me' do
     let!(:csp) { Csp.find_by(name: 'id_me') || create(:csp, :id_me) }
-    RSpec.shared_examples 'an id.me client' do
-      context 'user exists' do
-        before do
-          user = create(:user)
-          create(:csp_user, user:, uuid:, csp:)
-        end
-        it 'should sign in a user' do
-          post '/auth/id_me'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_ok
-        end
-        it 'should log on successful sign in' do
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(['User logged in',
-                                                       { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                         actionType: LoggingConstants::ActionType::UserLoggedIn,
-                                                         csp: 'id_me' }])
-          post '/auth/id_me'
-          follow_redirect!
-        end
-        it 'should write a cookie with the last used csp' do
-          post '/auth/id_me'
-          follow_redirect!
-          expect(cookies[:last_used_csp]).to eq 'id_me'
-        end
-        it 'should not add another user credential' do
-          expect(CspUser.where(uuid:, csp:).count).to eq 1
-          expect do
-            post '/auth/id_me'
-            follow_redirect!
-          end.to change { CspUser.count }.by(0)
-        end
-      end
-
-      context 'user does not exist' do
-        it 'should not persist user' do
-          expect do
-            post '/auth/id_me'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-      end
-    end
-
     let(:token) { 'bearer-token' }
     context 'IAL/2' do
       before do
@@ -70,7 +24,7 @@ RSpec.describe 'IdMe', type: :request do
                                                         identity_assurance_level: 2 } } })
       end
 
-      it_behaves_like 'an id.me client'
+      it_behaves_like 'a CSP client', :id_me, '/auth/id_me'
 
       context :user_exists do
         let(:db_user) { create(:user) }
@@ -358,6 +312,7 @@ RSpec.describe 'IdMe', type: :request do
 
   describe 'CSP inactive' do
     let!(:csp) { Csp.find_by(name: 'id_me') || create(:csp, :id_me) }
+
     before do
       csp.end_date = DateTime.current - 1.year
       csp.save!

--- a/dpc-portal/spec/requests/id_me_spec.rb
+++ b/dpc-portal/spec/requests/id_me_spec.rb
@@ -24,79 +24,17 @@ RSpec.describe 'IdMe', type: :request do
     id_me_config = {
       provider: :id_me,
       auth_endpoint: '/auth/id_me',
-      display_name: 'ID.me'
+      display_name: 'ID.me',
+      ial1_auth_response: lambda {
+        {
+          uid: uuid,
+          info: { email: 'bob@example.com' },
+          extra: { raw_info: { emails_confirmed: %w[bob@example.com bob2@example.com],
+                               identity_assurance_level: 1 } }
+        }
+      }
     }
     it_behaves_like 'a CSP client', id_me_config
-
-    # IAL1 is no longer allowed should now be blocked entirely
-    context 'IAL/1' do
-      before do
-        OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(:id_me,
-                                 { uid: uuid,
-                                   info: { email: 'bob@example.com' },
-                                   extra: { raw_info: { emails_confirmed: %w[bob@example.com bob2@example.com],
-                                                        identity_assurance_level: 1 } } })
-      end
-
-      it 'returns 403 forbidden' do
-        post '/auth/id_me'
-        follow_redirect!
-        expect(response).to have_http_status(:forbidden)
-      end
-
-      it 'renders the id_me_signin_fail error component' do
-        post '/auth/id_me'
-        follow_redirect!
-        expect(response.body).to include('ID.me sign-in failed')
-      end
-
-      it 'logs the IAL1 blocked attempt' do
-        allow(Rails.logger).to receive(:info)
-        post '/auth/id_me'
-        follow_redirect!
-        expect(Rails.logger).to have_received(:info).with(
-          ['User attempted IAL1 login with ID.me — not permitted',
-           { actionContext: LoggingConstants::ActionContext::Authentication,
-             actionType: LoggingConstants::ActionType::UserLoginWithoutAccount }]
-        )
-      end
-
-      it 'does not sign in the user' do
-        post '/auth/id_me'
-        follow_redirect!
-        expect(response).to be_forbidden
-      end
-
-      it 'does not set an authentication token' do
-        post '/auth/id_me'
-        csp_session = CspSession.new(request.session)
-        expect(csp_session.current).to be_nil
-        expect(csp_session.token).to be_nil
-        expect(csp_session.token_exp).to be_nil
-        expect(csp_session.id_token).to be_nil
-        expect(csp_session.user).to be_nil
-      end
-
-      context 'when a matching user account exists' do
-        before do
-          user = create(:user, given_name: 'Bob', family_name: 'Hoskins')
-          create(:csp_user, user:, uuid:, csp:)
-        end
-
-        it 'still returns 403 forbidden' do
-          post '/auth/id_me'
-          follow_redirect!
-          expect(response).to have_http_status(:forbidden)
-        end
-
-        it 'does not sign in the user' do
-          post '/auth/id_me'
-          follow_redirect!
-          expect(response).to be_forbidden
-        end
-      end
-    end
 
     context 'should add emails' do
       before do

--- a/dpc-portal/spec/requests/id_me_spec.rb
+++ b/dpc-portal/spec/requests/id_me_spec.rb
@@ -2,58 +2,12 @@
 
 require 'rails_helper'
 require 'securerandom'
+require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'IdMe', type: :request do
   let(:uuid) { SecureRandom.uuid }
   describe 'POST /auth/id_me' do
     let!(:csp) { Csp.find_by(name: 'id_me') || create(:csp, :id_me) }
-    RSpec.shared_examples 'an id.me client' do
-      context 'user exists' do
-        before do
-          user = create(:user, email: 'bob1@example.com', provider: :id_me)
-          create(:csp_user, user:, uuid:, csp:)
-        end
-        it 'should sign in a user' do
-          post '/auth/id_me'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_ok
-        end
-        it 'should log on successful sign in' do
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(['User logged in',
-                                                       { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                         actionType: LoggingConstants::ActionType::UserLoggedIn,
-                                                         csp: 'id_me' }])
-          post '/auth/id_me'
-          follow_redirect!
-        end
-        it 'should write a cookie with the last used csp' do
-          post '/auth/id_me'
-          follow_redirect!
-          expect(cookies[:last_used_csp]).to eq 'id_me'
-        end
-        it 'should not add another user credential' do
-          expect(CspUser.where(uuid:, csp:).count).to eq 1
-          expect do
-            post '/auth/id_me'
-            follow_redirect!
-          end.to change { CspUser.count }.by(0)
-        end
-      end
-
-      context 'user does not exist' do
-        it 'should not persist user' do
-          expect do
-            post '/auth/id_me'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-      end
-    end
-
     let(:token) { 'bearer-token' }
     context 'IAL/2' do
       before do
@@ -70,7 +24,7 @@ RSpec.describe 'IdMe', type: :request do
                                                         identity_assurance_level: 2 } } })
       end
 
-      it_behaves_like 'an id.me client'
+      it_behaves_like 'a CSP client', :id_me, '/auth/id_me'
 
       context :user_exists do
         let(:db_user) { create(:user, uid: '12345', provider: 'id_me', email: 'bob@example.com') }
@@ -358,6 +312,7 @@ RSpec.describe 'IdMe', type: :request do
 
   describe 'CSP inactive' do
     let!(:csp) { Csp.find_by(name: 'id_me') || create(:csp, :id_me) }
+
     before do
       csp.end_date = DateTime.current - 1.year
       csp.save!

--- a/dpc-portal/spec/requests/id_me_spec.rb
+++ b/dpc-portal/spec/requests/id_me_spec.rb
@@ -21,7 +21,12 @@ RSpec.describe 'IdMe', type: :request do
                              identity_assurance_level: 2 } } }
     end
 
-    it_behaves_like 'a CSP client', :id_me, '/auth/id_me'
+    id_me_config = {
+      provider: :id_me,
+      auth_endpoint: '/auth/id_me',
+      display_name: 'ID.me'
+    }
+    it_behaves_like 'a CSP client', id_me_config
 
     # IAL1 is no longer allowed should now be blocked entirely
     context 'IAL/1' do
@@ -189,21 +194,6 @@ RSpec.describe 'IdMe', type: :request do
     end
   end
 
-  describe 'Get /auth/failure' do
-    it 'should succeed' do
-      get '/users/auth/failure'
-      expect(response).to be_ok
-    end
-
-    it 'should log on failure' do
-      allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with(['User cancelled login',
-                                                   { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                     actionType: LoggingConstants::ActionType::UserCancelledLogin }])
-      get '/users/auth/failure'
-    end
-  end
-
   describe 'Delete /logout' do
     before do
       uuid = SecureRandom.uuid
@@ -235,53 +225,6 @@ RSpec.describe 'IdMe', type: :request do
       delete "/logout?invitation_id=#{invitation.id}"
       expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
                                                                                  invitation.id)
-    end
-  end
-
-  describe 'Get /auth/no_account' do
-    before do
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:id_me,
-                               { uid: uuid,
-                                 info: { email: 'example1@example.com' },
-                                 extra: { raw_info: { emails_confirmed: %w[bob4@example.com bobby@example.com],
-                                                      identity_assurance_level: 1 } } })
-    end
-    it 'should show logout button' do
-      get '/auth/no_account'
-      expect(response.body).to include 'Sign out of CSP'
-    end
-  end
-
-  describe 'CSP inactive' do
-    let!(:csp) { Csp.find_by(name: 'id_me') || create(:csp, :id_me) }
-
-    before do
-      csp.end_date = DateTime.current - 1.year
-      csp.save!
-
-      user = create(:user)
-      create(:csp_user, user:, uuid:, csp:)
-
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:id_me,
-                               { uid: uuid,
-                                 credentials: { expires_in: 899,
-                                                token: 'bearer-token' },
-                                 info: { email: 'bob4@example.com' },
-                                 extra: { raw_info: { emails_confirmed: %w[bob4@example.com bobby@example.com],
-                                                      identity_assurance_level: 2 } } })
-    end
-
-    it 'should log error' do
-      allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with(
-        ['User attempted to login with ID.me but no active CSP found',
-         { actionContext: LoggingConstants::ActionContext::Authentication,
-           actionType: LoggingConstants::ActionType::InvalidCsp }]
-      )
-      post '/auth/id_me'
-      follow_redirect!
     end
   end
 end

--- a/dpc-portal/spec/requests/id_me_spec.rb
+++ b/dpc-portal/spec/requests/id_me_spec.rb
@@ -9,76 +9,19 @@ RSpec.describe 'IdMe', type: :request do
   describe 'POST /auth/id_me' do
     let!(:csp) { Csp.find_by(name: 'id_me') || create(:csp, :id_me) }
     let(:token) { 'bearer-token' }
-    context 'IAL/2' do
-      before do
-        OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(:id_me,
-                                 { uid: uuid,
-                                   credentials: { expires_in: 899,
-                                                  token: },
-                                   info: { email: 'bob2@example.com' },
-                                   extra: { raw_info: { given_name: 'Bob',
-                                                        family_name: 'Hoskins',
-                                                        social_security_number: '1-2-3',
-                                                        emails_confirmed: %w[email1@example.com email2@example.com],
-                                                        identity_assurance_level: 2 } } })
-      end
-
-      it_behaves_like 'a CSP client', :id_me, '/auth/id_me'
-
-      context :user_exists do
-        let(:db_user) { create(:user) }
-        before do
-          create(:csp_user, user: db_user, uuid:, csp:)
-        end
-        it 'updates user names' do
-          expect do
-            post '/auth/id_me'
-            follow_redirect!
-          end.to change {
-            User.where(id: db_user.id, given_name: 'Bob',
-                       family_name: 'Hoskins').count
-          }.by 1
-          expect(response.location).to eq organizations_url
-        end
-
-        it 'sets authentication token' do
-          post '/auth/id_me'
-          follow_redirect!
-
-          csp_session = CspSession.new(request.session)
-          expect(csp_session.current).to eq 'id_me'
-          expect(csp_session.token).to eq token
-          expect(csp_session.token_exp).to_not be_nil
-          expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
-          expect(csp_session.id_token).to be_nil
-        end
-      end
-
-      context :user_does_not_exist do
-        it 'does not sign in user' do
-          post '/auth/id_me'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_redirect
-        end
-
-        it 'sets authentication token' do
-          post '/auth/id_me'
-          follow_redirect!
-
-          csp_session = CspSession.new(request.session)
-          expect(csp_session.current).to eq 'id_me'
-          expect(csp_session.token).to eq token
-          expect(csp_session.token_exp).to_not be_nil
-          expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
-          expect(csp_session.id_token).to be_nil
-          expect(csp_session.user).to be_nil
-        end
-      end
+    let(:csp_auth_response) do
+      { uid: uuid,
+        credentials: { expires_in: 899,
+                       token: },
+        info: { email: 'bob2@example.com' },
+        extra: { raw_info: { given_name: 'Bob',
+                             family_name: 'Hoskins',
+                             social_security_number: '1-2-3',
+                             emails_confirmed: %w[email1@example.com email2@example.com],
+                             identity_assurance_level: 2 } } }
     end
+
+    it_behaves_like 'a CSP client', :id_me, '/auth/id_me'
 
     # IAL1 is no longer allowed should now be blocked entirely
     context 'IAL/1' do

--- a/dpc-portal/spec/requests/id_me_spec.rb
+++ b/dpc-portal/spec/requests/id_me_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'IdMe', type: :request do
       provider: :id_me,
       auth_endpoint: '/auth/id_me',
       display_name: 'ID.me',
+      logout_host: ENV.fetch('IDP_ID_ME_HOST'),
       ial1_auth_response: lambda {
         {
           uid: uuid,
@@ -129,40 +130,6 @@ RSpec.describe 'IdMe', type: :request do
         expect(email.reactivated_at).to_not be_nil
         expect(email.primary).to eq true
       end
-    end
-  end
-
-  describe 'Delete /logout' do
-    before do
-      uuid = SecureRandom.uuid
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:id_me,
-                               { uid: uuid,
-                                 credentials: { expires_in: 899,
-                                                token: 'bearer-token' },
-                                 info: { email: 'email1@example.com' },
-                                 extra: { raw_info: { given_name: 'Bob',
-                                                      family_name: 'Hoskins',
-                                                      social_security_number: '1-2-3',
-                                                      emails_confirmed: %w[email1@example.com email2@example.com],
-                                                      identity_assurance_level: 2 } } })
-
-      user = create(:user)
-      csp = create(:csp, :id_me)
-      create(:csp_user, user:, uuid:, csp:)
-      post '/auth/id_me'
-      follow_redirect!
-    end
-    it 'should redirect to ID.me' do
-      delete '/logout'
-      expect(response.location).to include(ENV.fetch('IDP_ID_ME_HOST'))
-      expect(request.session[:user_return_to]).to be_nil
-    end
-    it 'should set return to invitation flow if invitation sent' do
-      invitation = create(:invitation, :ao)
-      delete "/logout?invitation_id=#{invitation.id}"
-      expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
-                                                                                 invitation.id)
     end
   end
 end

--- a/dpc-portal/spec/requests/id_me_spec.rb
+++ b/dpc-portal/spec/requests/id_me_spec.rb
@@ -5,7 +5,9 @@ require 'securerandom'
 require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'IdMe', type: :request do
-  let(:uuid) { SecureRandom.uuid }
+  auth_uid = SecureRandom.uuid
+  let(:uuid) { auth_uid }
+
   describe 'POST /auth/id_me' do
     let!(:csp) { Csp.find_by(name: 'id_me') || create(:csp, :id_me) }
     let(:token) { 'bearer-token' }
@@ -26,13 +28,11 @@ RSpec.describe 'IdMe', type: :request do
       auth_endpoint: '/auth/id_me',
       display_name: 'ID.me',
       logout_host: ENV.fetch('IDP_ID_ME_HOST'),
-      ial1_auth_response: lambda {
-        {
-          uid: uuid,
-          info: { email: 'bob@example.com' },
-          extra: { raw_info: { emails_confirmed: %w[bob@example.com bob2@example.com],
-                               identity_assurance_level: 1 } }
-        }
+      ial1_auth_response: {
+        uid: auth_uid,
+        info: { email: 'bob@example.com' },
+        extra: { raw_info: { emails_confirmed: %w[bob@example.com bob2@example.com],
+                             identity_assurance_level: 1 } }
       }
     }
     it_behaves_like 'a CSP client', id_me_config

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -2,58 +2,12 @@
 
 require 'rails_helper'
 require 'securerandom'
+require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'LoginDotGov', type: :request do
   let(:uuid) { SecureRandom.uuid }
   describe 'POST /auth/login_dot_gov' do
     let!(:csp) { Csp.find_by(name: 'login_dot_gov') || create(:csp, :login_dot_gov) }
-    RSpec.shared_examples 'a login.gov client' do
-      context 'user exists' do
-        before do
-          user = create(:user, email: 'bob1@example.com', provider: :login_dot_gov)
-          create(:csp_user, user:, uuid:, csp:)
-        end
-        it 'should sign in a user' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_ok
-        end
-        it 'should log on successful sign in' do
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(['User logged in',
-                                                       { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                         actionType: LoggingConstants::ActionType::UserLoggedIn,
-                                                         csp: 'login_dot_gov' }])
-          post '/auth/login_dot_gov'
-          follow_redirect!
-        end
-        it 'should write a cookie with the last used csp' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(cookies[:last_used_csp]).to eq 'login_dot_gov'
-        end
-        it 'should not add another user credential' do
-          expect(CspUser.where(uuid:, csp:).count).to eq 1
-          expect do
-            post '/auth/login_dot_gov'
-            follow_redirect!
-          end.to change { CspUser.count }.by(0)
-        end
-      end
-
-      context 'user does not exist' do
-        it 'should not persist user' do
-          expect do
-            post '/auth/login_dot_gov'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-      end
-    end
-
     let(:token) { 'bearer-token' }
     context 'IAL/2' do
       before do
@@ -70,7 +24,7 @@ RSpec.describe 'LoginDotGov', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
       end
 
-      it_behaves_like 'a login.gov client'
+      it_behaves_like 'a CSP client', :login_dot_gov, '/auth/login_dot_gov'
 
       context :user_exists do
         let(:db_user) { create(:user, uid: '12345', provider: 'login_dot_gov', email: 'bob@example.com') }
@@ -354,9 +308,11 @@ RSpec.describe 'LoginDotGov', type: :request do
   end
 
   describe 'CSP inactive' do
+    let!(:csp) { Csp.find_by(name: 'login_dot_gov') || create(:csp, :login_dot_gov) }
+
     before do
-      Csp.where(name: 'login_dot_gov').update_all(end_date: DateTime.current - 1.year)
-      csp = Csp.where(name: 'login_dot_gov').first
+      csp.end_date = DateTime.current - 1.year
+      csp.save!
 
       user = create(:user, email: 'bob5@example.com', provider: :login_dot_gov)
       create(:csp_user, user:, uuid:, csp:)

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -2,58 +2,12 @@
 
 require 'rails_helper'
 require 'securerandom'
+require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'LoginDotGov', type: :request do
   let(:uuid) { SecureRandom.uuid }
   describe 'POST /auth/login_dot_gov' do
     let!(:csp) { Csp.find_by(name: 'login_dot_gov') || create(:csp, :login_dot_gov) }
-    RSpec.shared_examples 'a login.gov client' do
-      context 'user exists' do
-        before do
-          user = create(:user)
-          create(:csp_user, user:, uuid:, csp:)
-        end
-        it 'should sign in a user' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_ok
-        end
-        it 'should log on successful sign in' do
-          allow(Rails.logger).to receive(:info)
-          expect(Rails.logger).to receive(:info).with(['User logged in',
-                                                       { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                         actionType: LoggingConstants::ActionType::UserLoggedIn,
-                                                         csp: 'login_dot_gov' }])
-          post '/auth/login_dot_gov'
-          follow_redirect!
-        end
-        it 'should write a cookie with the last used csp' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(cookies[:last_used_csp]).to eq 'login_dot_gov'
-        end
-        it 'should not add another user credential' do
-          expect(CspUser.where(uuid:, csp:).count).to eq 1
-          expect do
-            post '/auth/login_dot_gov'
-            follow_redirect!
-          end.to change { CspUser.count }.by(0)
-        end
-      end
-
-      context 'user does not exist' do
-        it 'should not persist user' do
-          expect do
-            post '/auth/login_dot_gov'
-            follow_redirect!
-          end.to change { User.count }.by(0)
-        end
-      end
-    end
-
     let(:token) { 'bearer-token' }
     context 'IAL/2' do
       before do
@@ -70,7 +24,7 @@ RSpec.describe 'LoginDotGov', type: :request do
                                                         ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
       end
 
-      it_behaves_like 'a login.gov client'
+      it_behaves_like 'a CSP client', :login_dot_gov, '/auth/login_dot_gov'
 
       context :user_exists do
         let(:db_user) { create(:user) }
@@ -355,6 +309,7 @@ RSpec.describe 'LoginDotGov', type: :request do
 
   describe 'CSP inactive' do
     let!(:csp) { Csp.find_by(name: 'login_dot_gov') || create(:csp, :login_dot_gov) }
+
     before do
       csp.end_date = DateTime.current - 1.year
       csp.save!

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -21,7 +21,12 @@ RSpec.describe 'LoginDotGov', type: :request do
                              ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } }
     end
 
-    it_behaves_like 'a CSP client', :login_dot_gov, '/auth/login_dot_gov'
+    login_dot_gov_config = {
+      provider: :login_dot_gov,
+      auth_endpoint: '/auth/login_dot_gov',
+      display_name: 'Login.gov'
+    }
+    it_behaves_like 'a CSP client', login_dot_gov_config
 
     # IAL1 is no longer allowed should now be blocked entirely
     context 'IAL/1' do
@@ -189,21 +194,6 @@ RSpec.describe 'LoginDotGov', type: :request do
     end
   end
 
-  describe 'Get /auth/failure' do
-    it 'should succeed' do
-      get '/users/auth/failure'
-      expect(response).to be_ok
-    end
-
-    it 'should log on failure' do
-      allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with(['User cancelled login',
-                                                   { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                     actionType: LoggingConstants::ActionType::UserCancelledLogin }])
-      get '/users/auth/failure'
-    end
-  end
-
   describe 'Delete /logout' do
     before do
       uuid = SecureRandom.uuid
@@ -235,53 +225,6 @@ RSpec.describe 'LoginDotGov', type: :request do
       delete "/logout?invitation_id=#{invitation.id}"
       expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
                                                                                  invitation.id)
-    end
-  end
-
-  describe 'Get /auth/no_account' do
-    before do
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:login_dot_gov,
-                               { uid: uuid,
-                                 info: { email: 'example1@example.com' },
-                                 extra: { raw_info: { all_emails: %w[bob4@example.com bobby@example.com],
-                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
-    end
-    it 'should show logout button' do
-      get '/auth/no_account'
-      expect(response.body).to include 'Sign out of CSP'
-    end
-  end
-
-  describe 'CSP inactive' do
-    let!(:csp) { Csp.find_by(name: 'login_dot_gov') || create(:csp, :login_dot_gov) }
-
-    before do
-      csp.end_date = DateTime.current - 1.year
-      csp.save!
-
-      user = create(:user)
-      create(:csp_user, user:, uuid:, csp:)
-
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:login_dot_gov,
-                               { uid: uuid,
-                                 credentials: { expires_in: 899,
-                                                token: 'bearer-token' },
-                                 info: { email: 'bob4@example.com' },
-                                 extra: { raw_info: { all_emails: %w[bob4@example.com bobby@example.com],
-                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
-    end
-
-    it 'should log error' do
-      allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with(
-        ['User attempted to login with Login.gov but no active CSP found',
-         { actionContext: LoggingConstants::ActionContext::Authentication,
-           actionType: LoggingConstants::ActionType::InvalidCsp }]
-      )
-      post '/auth/login_dot_gov'
-      follow_redirect!
     end
   end
 end

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -24,79 +24,17 @@ RSpec.describe 'LoginDotGov', type: :request do
     login_dot_gov_config = {
       provider: :login_dot_gov,
       auth_endpoint: '/auth/login_dot_gov',
-      display_name: 'Login.gov'
+      display_name: 'Login.gov',
+      ial1_auth_response: lambda {
+        {
+          uid: uuid,
+          info: { email: 'bob@example.com' },
+          extra: { raw_info: { all_emails: %w[bob@example.com bob2@example.com],
+                               ial: 'http://idmanagement.gov/ns/assurance/ial/1' } }
+        }
+      }
     }
     it_behaves_like 'a CSP client', login_dot_gov_config
-
-    # IAL1 is no longer allowed should now be blocked entirely
-    context 'IAL/1' do
-      before do
-        OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(:login_dot_gov,
-                                 { uid: uuid,
-                                   info: { email: 'bob@example.com' },
-                                   extra: { raw_info: { all_emails: %w[bob@example.com bob2@example.com],
-                                                        ial: 'http://idmanagement.gov/ns/assurance/ial/1' } } })
-      end
-
-      it 'returns 403 forbidden' do
-        post '/auth/login_dot_gov'
-        follow_redirect!
-        expect(response).to have_http_status(:forbidden)
-      end
-
-      it 'renders the login_gov_signin_fail error component' do
-        post '/auth/login_dot_gov'
-        follow_redirect!
-        expect(response.body).to include('Login.gov sign-in failed')
-      end
-
-      it 'logs the IAL1 blocked attempt' do
-        allow(Rails.logger).to receive(:info)
-        post '/auth/login_dot_gov'
-        follow_redirect!
-        expect(Rails.logger).to have_received(:info).with(
-          ['User attempted IAL1 login with Login.gov — not permitted',
-           { actionContext: LoggingConstants::ActionContext::Authentication,
-             actionType: LoggingConstants::ActionType::UserLoginWithoutAccount }]
-        )
-      end
-
-      it 'does not sign in the user' do
-        post '/auth/login_dot_gov'
-        follow_redirect!
-        expect(response).to be_forbidden
-      end
-
-      it 'does not set an authentication token' do
-        post '/auth/login_dot_gov'
-        csp_session = CspSession.new(request.session)
-        expect(csp_session.current).to be_nil
-        expect(csp_session.token).to be_nil
-        expect(csp_session.token_exp).to be_nil
-        expect(csp_session.id_token).to be_nil
-        expect(csp_session.user).to be_nil
-      end
-
-      context 'when a matching user account exists' do
-        before do
-          user = create(:user, given_name: 'Bob', family_name: 'Hoskins')
-          create(:csp_user, user:, uuid:, csp:)
-        end
-
-        it 'still returns 403 forbidden' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(response).to have_http_status(:forbidden)
-        end
-
-        it 'does not sign in the user' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(response).to be_forbidden
-        end
-      end
-    end
 
     context 'should add emails' do
       before do

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -9,73 +9,19 @@ RSpec.describe 'LoginDotGov', type: :request do
   describe 'POST /auth/login_dot_gov' do
     let!(:csp) { Csp.find_by(name: 'login_dot_gov') || create(:csp, :login_dot_gov) }
     let(:token) { 'bearer-token' }
-    context 'IAL/2' do
-      before do
-        OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(:login_dot_gov,
-                                 { uid: uuid,
-                                   credentials: { expires_in: 899,
-                                                  token: },
-                                   info: { email: 'bob2@example.com' },
-                                   extra: { raw_info: { given_name: 'Bob',
-                                                        family_name: 'Hoskins',
-                                                        social_security_number: '1-2-3',
-                                                        all_emails: %w[bob2@example.com bobby@example.com],
-                                                        ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
-      end
-
-      it_behaves_like 'a CSP client', :login_dot_gov, '/auth/login_dot_gov'
-
-      context :user_exists do
-        let(:db_user) { create(:user) }
-        before { create(:csp_user, user: db_user, uuid:, csp:) }
-
-        it 'updates user names' do
-          expect do
-            post '/auth/login_dot_gov'
-            follow_redirect!
-          end.to change {
-            User.where(id: db_user.id, given_name: 'Bob', family_name: 'Hoskins').count
-          }.by 1
-          expect(response.location).to eq organizations_url
-        end
-
-        it 'sets authentication token' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-
-          csp_session = CspSession.new(request.session)
-          expect(csp_session.current).to eq 'login_dot_gov'
-          expect(csp_session.token).to eq token
-          expect(csp_session.token_exp).to_not be_nil
-          expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
-          expect(csp_session.id_token).to be_nil
-        end
-      end
-
-      context :user_does_not_exist do
-        it 'does not sign in user' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          expect(response.location).to eq organizations_url
-          expect(response).to be_redirect
-          follow_redirect!
-          expect(response).to be_redirect
-        end
-
-        it 'sets authentication token' do
-          post '/auth/login_dot_gov'
-          follow_redirect!
-          csp_session = CspSession.new(request.session)
-          expect(csp_session.current).to eq 'login_dot_gov'
-          expect(csp_session.token).to eq token
-          expect(csp_session.token_exp).to_not be_nil
-          expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
-          expect(csp_session.user).to be_nil
-          expect(csp_session.id_token).to be_nil
-        end
-      end
+    let(:csp_auth_response) do
+      { uid: uuid,
+        credentials: { expires_in: 899,
+                       token: },
+        info: { email: 'bob2@example.com' },
+        extra: { raw_info: { given_name: 'Bob',
+                             family_name: 'Hoskins',
+                             social_security_number: '1-2-3',
+                             all_emails: %w[bob2@example.com bobby@example.com],
+                             ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } }
     end
+
+    it_behaves_like 'a CSP client', :login_dot_gov, '/auth/login_dot_gov'
 
     # IAL1 is no longer allowed should now be blocked entirely
     context 'IAL/1' do

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -5,7 +5,9 @@ require 'securerandom'
 require 'support/csp_auth_shared_examples'
 
 RSpec.describe 'LoginDotGov', type: :request do
-  let(:uuid) { SecureRandom.uuid }
+  auth_uid = SecureRandom.uuid
+  let(:uuid) { auth_uid }
+
   describe 'POST /auth/login_dot_gov' do
     let!(:csp) { Csp.find_by(name: 'login_dot_gov') || create(:csp, :login_dot_gov) }
     let(:token) { 'bearer-token' }
@@ -26,13 +28,11 @@ RSpec.describe 'LoginDotGov', type: :request do
       auth_endpoint: '/auth/login_dot_gov',
       display_name: 'Login.gov',
       logout_host: ENV.fetch('IDP_LOGIN_DOT_GOV_HOST'),
-      ial1_auth_response: lambda {
-        {
-          uid: uuid,
-          info: { email: 'bob@example.com' },
-          extra: { raw_info: { all_emails: %w[bob@example.com bob2@example.com],
-                               ial: 'http://idmanagement.gov/ns/assurance/ial/1' } }
-        }
+      ial1_auth_response: {
+        uid: auth_uid,
+        info: { email: 'bob@example.com' },
+        extra: { raw_info: { all_emails: %w[bob@example.com bob2@example.com],
+                             ial: 'http://idmanagement.gov/ns/assurance/ial/1' } }
       }
     }
     it_behaves_like 'a CSP client', login_dot_gov_config

--- a/dpc-portal/spec/requests/login_dot_gov_spec.rb
+++ b/dpc-portal/spec/requests/login_dot_gov_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'LoginDotGov', type: :request do
       provider: :login_dot_gov,
       auth_endpoint: '/auth/login_dot_gov',
       display_name: 'Login.gov',
+      logout_host: ENV.fetch('IDP_LOGIN_DOT_GOV_HOST'),
       ial1_auth_response: lambda {
         {
           uid: uuid,
@@ -129,40 +130,6 @@ RSpec.describe 'LoginDotGov', type: :request do
         expect(email.reactivated_at).to_not be_nil
         expect(email.primary).to eq true
       end
-    end
-  end
-
-  describe 'Delete /logout' do
-    before do
-      uuid = SecureRandom.uuid
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:login_dot_gov,
-                               { uid: uuid,
-                                 credentials: { expires_in: 899,
-                                                token: 'bearer-token' },
-                                 info: { email: 'email1@example.com' },
-                                 extra: { raw_info: { given_name: 'Bob',
-                                                      family_name: 'Hoskins',
-                                                      social_security_number: '1-2-3',
-                                                      all_emails: %w[email1@example.com email2@example.com],
-                                                      ial: 'http://idmanagement.gov/ns/assurance/ial/2' } } })
-
-      user = create(:user)
-      csp = create(:csp, :login_dot_gov)
-      create(:csp_user, user:, uuid:, csp:)
-      post '/auth/login_dot_gov'
-      follow_redirect!
-    end
-    it 'should redirect to login.gov' do
-      delete '/logout'
-      expect(response.location).to include(ENV.fetch('IDP_LOGIN_DOT_GOV_HOST'))
-      expect(request.session[:user_return_to]).to be_nil
-    end
-    it 'should set return to invitation flow if invitation sent' do
-      invitation = create(:invitation, :ao)
-      delete "/logout?invitation_id=#{invitation.id}"
-      expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
-                                                                                 invitation.id)
     end
   end
 end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -1,54 +1,114 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a CSP client' do |provider, auth_endpoint|
+RSpec.shared_examples 'a CSP client' do |provider, auth_endpoint, expected_id_token: nil|
   csp_name = provider.to_s
 
-  context 'user exists' do
+  context 'IAL/2' do
     before do
-      user = create(:user, email: 'bob1@example.com', provider:)
-      create(:csp_user, user:, uuid:, csp:)
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(provider, csp_auth_response)
     end
 
-    it 'should sign in a user' do
-      post auth_endpoint
-      follow_redirect!
-      expect(response.location).to eq organizations_url
-      expect(response).to be_redirect
-      follow_redirect!
-      expect(response).to be_ok
-    end
+    context 'user exists' do
+      before do
+        user = create(:user)
+        create(:csp_user, user:, uuid:, csp:)
+      end
 
-    it 'should log on successful sign in' do
-      allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).to receive(:info).with(['User logged in',
-                                                   { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                     actionType: LoggingConstants::ActionType::UserLoggedIn,
-                                                     csp: csp_name }])
-      post auth_endpoint
-      follow_redirect!
-    end
-
-    it 'should write a cookie with the last used csp' do
-      post auth_endpoint
-      follow_redirect!
-      expect(cookies[:last_used_csp]).to eq csp_name
-    end
-
-    it 'should not add another user credential' do
-      expect(CspUser.where(uuid:, csp:).count).to eq 1
-      expect do
+      it 'should sign in a user' do
         post auth_endpoint
         follow_redirect!
-      end.to change { CspUser.count }.by(0)
-    end
-  end
+        expect(response.location).to eq organizations_url
+        expect(response).to be_redirect
+        follow_redirect!
+        expect(response).to be_ok
+      end
 
-  context 'user does not exist' do
-    it 'should not persist user' do
-      expect do
+      it 'should log on successful sign in' do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(['User logged in',
+                                                     { actionContext: LoggingConstants::ActionContext::Authentication,
+                                                       actionType: LoggingConstants::ActionType::UserLoggedIn,
+                                                       csp: csp_name }])
         post auth_endpoint
         follow_redirect!
-      end.to change { User.count }.by(0)
+      end
+
+      it 'should write a cookie with the last used csp' do
+        post auth_endpoint
+        follow_redirect!
+        expect(cookies[:last_used_csp]).to eq csp_name
+      end
+
+      it 'should not add another user credential' do
+        expect(CspUser.where(uuid:, csp:).count).to eq 1
+        expect do
+          post auth_endpoint
+          follow_redirect!
+        end.to change { CspUser.count }.by(0)
+      end
+    end
+
+    context 'user does not exist' do
+      it 'should not persist user' do
+        expect do
+          post auth_endpoint
+          follow_redirect!
+        end.to change { User.count }.by(0)
+      end
+    end
+
+    context :user_exists do
+      let(:db_user) { create(:user) }
+
+      before do
+        create(:csp_user, user: db_user, uuid:, csp:)
+      end
+
+      it 'updates user names' do
+        expect do
+          post auth_endpoint
+          follow_redirect!
+        end.to change {
+          User.where(id: db_user.id, given_name: 'Bob', family_name: 'Hoskins').count
+        }.by 1
+        expect(response.location).to eq organizations_url
+      end
+
+      it 'sets authentication token' do
+        post auth_endpoint
+        follow_redirect!
+
+        csp_session = CspSession.new(request.session)
+        expect(csp_session.current).to eq csp_name
+        expect(csp_session.token).to eq token
+        expect(csp_session.token_exp).to_not be_nil
+        expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
+        expect(csp_session.id_token).to eq expected_id_token
+      end
+    end
+
+    context :user_does_not_exist do
+      it 'does not sign in user' do
+        post auth_endpoint
+        follow_redirect!
+        expect(response.location).to eq organizations_url
+        expect(response).to be_redirect
+        follow_redirect!
+        expect(response).to be_redirect
+      end
+
+      it 'sets authentication token' do
+        post auth_endpoint
+        follow_redirect!
+        csp_session = CspSession.new(request.session)
+        expect(csp_session.current).to eq csp_name
+        expect(csp_session.token).to eq token
+        expect(csp_session.token_exp).to_not be_nil
+        expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
+        expect(csp_session.id_token).to eq expected_id_token
+        expect(csp_session.user).to be_nil
+      end
     end
   end
 end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -5,6 +5,7 @@ RSpec.shared_examples 'a CSP client' do |config|
   auth_endpoint = config[:auth_endpoint]
   display_name = config[:display_name]
   expected_id_token = config[:expected_id_token]
+  ial1_auth_response = config[:ial1_auth_response]
   csp_name = provider.to_s
 
   context 'IAL/2' do
@@ -112,6 +113,75 @@ RSpec.shared_examples 'a CSP client' do |config|
         expect(csp_session.token_exp).to be_within(1.second).of 899.seconds.from_now
         expect(csp_session.id_token).to eq expected_id_token
         expect(csp_session.user).to be_nil
+      end
+    end
+  end
+
+  # Login.gov and ID.me allow users to request assurance level based on input parameters
+  # IAL1 is no longer allowed across dpc-portal and should now be blocked
+  if ial1_auth_response
+    context 'IAL/1' do
+      before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.add_mock(provider, instance_exec(&ial1_auth_response))
+      end
+
+      it 'returns 403 forbidden' do
+        post auth_endpoint
+        follow_redirect!
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it 'renders the csp_signin_fail error component' do
+        post auth_endpoint
+        follow_redirect!
+        expect(response.body).to include("#{display_name} sign-in failed")
+      end
+
+      it 'logs the IAL1 blocked attempt' do
+        allow(Rails.logger).to receive(:info)
+        post auth_endpoint
+        follow_redirect!
+        expect(Rails.logger).to have_received(:info).with(
+          ["User attempted IAL1 login with #{display_name} — not permitted",
+           { actionContext: LoggingConstants::ActionContext::Authentication,
+             actionType: LoggingConstants::ActionType::UserLoginWithoutAccount }]
+        )
+      end
+
+      it 'does not sign in the user' do
+        post auth_endpoint
+        follow_redirect!
+        expect(response).to be_forbidden
+      end
+
+      it 'does not set an authentication token' do
+        post auth_endpoint
+        csp_session = CspSession.new(request.session)
+        expect(csp_session.current).to be_nil
+        expect(csp_session.token).to be_nil
+        expect(csp_session.token_exp).to be_nil
+        expect(csp_session.id_token).to be_nil
+        expect(csp_session.user).to be_nil
+      end
+
+      context 'when a matching user account exists' do
+        before do
+          user = create(:user, given_name: 'Bob', family_name: 'Hoskins')
+          create(:csp_user, user:, uuid:, csp:)
+        end
+
+        it 'still returns 403 forbidden' do
+          post auth_endpoint
+          follow_redirect!
+          expect(response).to have_http_status(:forbidden)
+        end
+
+        it 'does not sign in the user' do
+          post auth_endpoint
+          follow_redirect!
+          expect(response).to be_forbidden
+        end
       end
     end
   end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'a CSP client' do |provider, auth_endpoint, expected_id_token: nil|
+RSpec.shared_examples 'a CSP client' do |config|
+  provider = config[:provider]
+  auth_endpoint = config[:auth_endpoint]
+  display_name = config[:display_name]
+  expected_id_token = config[:expected_id_token]
   csp_name = provider.to_s
 
   context 'IAL/2' do
@@ -109,6 +113,30 @@ RSpec.shared_examples 'a CSP client' do |provider, auth_endpoint, expected_id_to
         expect(csp_session.id_token).to eq expected_id_token
         expect(csp_session.user).to be_nil
       end
+    end
+  end
+
+  describe 'CSP inactive' do
+    before do
+      csp.end_date = DateTime.current - 1.year
+      csp.save!
+
+      user = create(:user)
+      create(:csp_user, user:, uuid:, csp:)
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(provider, csp_auth_response)
+    end
+
+    it 'should log error' do
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with(
+        ["User attempted to login with #{display_name} but no active CSP found",
+         { actionContext: LoggingConstants::ActionContext::Authentication,
+           actionType: LoggingConstants::ActionType::InvalidCsp }]
+      )
+      post auth_endpoint
+      follow_redirect!
     end
   end
 end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a CSP client' do |provider, auth_endpoint|
+  csp_name = provider.to_s
+
+  context 'user exists' do
+    before do
+      user = create(:user, email: 'bob1@example.com', provider:)
+      create(:csp_user, user:, uuid:, csp:)
+    end
+
+    it 'should sign in a user' do
+      post auth_endpoint
+      follow_redirect!
+      expect(response.location).to eq organizations_url
+      expect(response).to be_redirect
+      follow_redirect!
+      expect(response).to be_ok
+    end
+
+    it 'should log on successful sign in' do
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with(['User logged in',
+                                                   { actionContext: LoggingConstants::ActionContext::Authentication,
+                                                     actionType: LoggingConstants::ActionType::UserLoggedIn,
+                                                     csp: csp_name }])
+      post auth_endpoint
+      follow_redirect!
+    end
+
+    it 'should write a cookie with the last used csp' do
+      post auth_endpoint
+      follow_redirect!
+      expect(cookies[:last_used_csp]).to eq csp_name
+    end
+
+    it 'should not add another user credential' do
+      expect(CspUser.where(uuid:, csp:).count).to eq 1
+      expect do
+        post auth_endpoint
+        follow_redirect!
+      end.to change { CspUser.count }.by(0)
+    end
+  end
+
+  context 'user does not exist' do
+    it 'should not persist user' do
+      expect do
+        post auth_endpoint
+        follow_redirect!
+      end.to change { User.count }.by(0)
+    end
+  end
+end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -124,7 +124,7 @@ RSpec.shared_examples 'a CSP client' do |config|
     context 'IAL/1' do
       before do
         OmniAuth.config.test_mode = true
-        OmniAuth.config.add_mock(provider, instance_exec(&ial1_auth_response))
+        OmniAuth.config.add_mock(provider, ial1_auth_response)
       end
 
       it 'returns 403 forbidden' do
@@ -170,6 +170,7 @@ RSpec.shared_examples 'a CSP client' do |config|
         before do
           user = create(:user, given_name: 'Bob', family_name: 'Hoskins')
           create(:csp_user, user:, uuid:, csp:)
+          # create(:csp_user, user:, uuid: ial1_auth_response[:uid], csp:)
         end
 
         it 'still returns 403 forbidden' do

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -4,6 +4,7 @@ RSpec.shared_examples 'a CSP client' do |config|
   provider = config[:provider]
   auth_endpoint = config[:auth_endpoint]
   display_name = config[:display_name]
+  logout_host = config[:logout_host]
   expected_id_token = config[:expected_id_token]
   ial1_auth_response = config[:ial1_auth_response]
   csp_name = provider.to_s
@@ -207,6 +208,33 @@ RSpec.shared_examples 'a CSP client' do |config|
       )
       post auth_endpoint
       follow_redirect!
+    end
+  end
+
+  describe 'Delete /logout' do
+    before do
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.add_mock(provider, csp_auth_response)
+
+      user = create(:user)
+      create(:csp_user, user:, uuid:, csp:)
+      post auth_endpoint
+      follow_redirect!
+    end
+
+    it "should redirect to #{display_name}" do
+      delete '/logout'
+      expect(response.location).to include(logout_host)
+      # id_token_hint for CLEAR csp only
+      expect(response.location).to include("id_token_hint=#{expected_id_token}") if expected_id_token
+      expect(request.session[:user_return_to]).to be_nil
+    end
+
+    it 'should set return to invitation flow if invitation sent' do
+      invitation = create(:invitation, :ao)
+      delete "/logout?invitation_id=#{invitation.id}"
+      expect(request.session[:user_return_to]).to eq organization_invitation_url(invitation.provider_organization.id,
+                                                                                 invitation.id)
     end
   end
 end


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5552](https://jira.cms.gov/browse/DPC-5552)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - majority of tests from  `dpc-portal/spec/requests/{csp}.rb` moved to `shared_examples`
 - tests that are agnostic of CSP moved to `csp_spec.rb`

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - When working on multi-csp effort last sprint, I noticed that we had multiple spec files that were essentially doing the exact same thing. I wanted to make sure that as we expand test coverage, It would cover all of our CSP's whenever possible
  - tests related to `UserEmail` are left as-is, because responses differ across CSP's and only Login and ID.me provide multiple emails
  - config objects used to make it easier to see what parameters are required for auth tests
    - NOTE: all params are the same except `expected_id_token`, because of the additional requirement for CLEAR logout

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - `bundle exec rspec` locally