### PR TITLE
[DPC-5599] check AUTH_DISABLED and fail to run portal if set

### DIFF
--- a/docker-compose.portals.yml
+++ b/docker-compose.portals.yml
@@ -125,6 +125,7 @@ services:
       DATABASE_URL: postgresql://db/dpc-portal_development
       TEST_DATABASE_URL: postgresql://db/dpc-portal_test
       GOLDEN_MACAROON: ${GOLDEN_MACAROON}
+      AUTH_DISABLED: ${AUTH_DISABLED:-false}
       API_METADATA_URL: http://api:3002/api/v1
       API_ADMIN_URL: http://api:9900
       DB_USER: postgres

--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/staticauth/StaticAuthFilter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/staticauth/StaticAuthFilter.java
@@ -12,8 +12,6 @@ import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Organization;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 /**
@@ -24,7 +22,6 @@ import org.slf4j.MDC;
  */
 @Priority(Priorities.AUTHENTICATION)
 public class StaticAuthFilter extends AuthFilter<DPCAuthCredentials, OrganizationPrincipal> {
-    private static final Logger logger = LoggerFactory.getLogger(StaticAuthFilter.class);
 
     // Default organization ID to use, if no override is passed
     private static final String DEFAULT_ORG_ID = "46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0";

--- a/dpc-api/src/main/java/gov/cms/dpc/api/auth/staticauth/StaticAuthFilter.java
+++ b/dpc-api/src/main/java/gov/cms/dpc/api/auth/staticauth/StaticAuthFilter.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.Priorities;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.Organization;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 /**
@@ -22,6 +24,7 @@ import org.slf4j.MDC;
  */
 @Priority(Priorities.AUTHENTICATION)
 public class StaticAuthFilter extends AuthFilter<DPCAuthCredentials, OrganizationPrincipal> {
+    private static final Logger logger = LoggerFactory.getLogger(StaticAuthFilter.class);
 
     // Default organization ID to use, if no override is passed
     private static final String DEFAULT_ORG_ID = "46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0";
@@ -38,6 +41,9 @@ public class StaticAuthFilter extends AuthFilter<DPCAuthCredentials, Organizatio
 
         final String headerString = requestContext.getHeaderString(ORG_HEADER);
         final String orgID = headerString == null ? DEFAULT_ORG_ID : headerString;
+        if (headerString == null) {
+            logger.warn("AUTHENTICATION IS DISABLED - do not use in production");
+        }
 
         // Now that we have the organization_id, set it in the logging context
         MDC.clear();

--- a/dpc-portal/bin/dev
+++ b/dpc-portal/bin/dev
@@ -3,6 +3,12 @@
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
+if [ "$AUTH_DISABLED" = "true" ]; then
+  echo "Cannot start dpc-portal locally with dpc-api AUTH_DISABLED=true."
+  echo "Needs auth enabled so API credentials are scoped to organization in the portal"
+  exit 99
+fi
+
 if [ -z "$GOLDEN_MACAROON" ]; then
   echo "No golden macaroon found. Attempting to generate a new one..."
   export GOLDEN_MACAROON=$(curl -X POST -w '\n' ${API_ADMIN_URL}/tasks/generate-token || echo '')


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5599](https://jira.cms.gov/browse/DPC-5599)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - add additional logging when `authenticationDisabled` is set and defaulting to `DEFAULT_ORG_ID = "46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0"`
 - Monitor `AUTH_DISABLED` when running locally and fail to launch dpc-portal if set

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
  - Last week I was having issues with public keys, tokens, and ip addresses being unrestricted in dpc-portal on my local machine
    - after further investigation, there is some very old code that uses [authenticationDisabled](https://github.com/CMSgov/dpc-app/blob/7768dd1841855d503914195431d2619c9ee59bbb/dpc-api/src/main/resources/application.yml#L130) in dpc-api's `application.yml`
    - I had this setting enabled based on env var locally, so all tokens, ip addresses, and keys were linked to placeholder organization id `"46ac7ad6-7487-4dd0-baa0-6e2c8cae76a0"`
    - the use of `authenticationDisabled` is called out for running integration tests in README.md [HERE](https://github.com/CMSgov/dpc-app#manual-jar-execution)
    - this needs to actually be verified if it's required and _might_ require more significant refactor to remove placeholder values: [DPC-5617](https://jira.cms.gov/browse/DPC-5617)

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - verified public keys, tokens, and ip addresses do not show up across portal accounts when `AUTH_DISABLED=false`
 - verified portal fails to launch when `AUTH_DISABLED=true`