### PR TITLE
Me/dpc 5620 force https flag on portal

### DIFF
--- a/dpc-portal/config/environments/production.rb
+++ b/dpc-portal/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   ## Disables log coloration
   config.colorize_logging = false

--- a/dpc-portal/config/environments/production.rb
+++ b/dpc-portal/config/environments/production.rb
@@ -52,6 +52,12 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
+  # The load balancer health check comes in over http, so we need to exclude it.
+  config.ssl_options = {
+    redirect: {
+      exclude: ->(request) { request.path == "/health_check" }
+    }
+  }
 
   ## Disables log coloration
   config.colorize_logging = false

--- a/dpc-portal/docker/entrypoint.sh
+++ b/dpc-portal/docker/entrypoint.sh
@@ -30,7 +30,7 @@ if [ "$1" == "portal" ]; then
   fi
 elif [ "$1" == "async" ]; then
   echo "Starting Solid Queue..."
-  if [[ "$ENV" == "production" ]]; then
+  if [[ "$ENV" == "prod" ]]; then
     echo "Starting in production"
     bundle exec rails solid_queue:start
   # For local, SolidQueue starts in same container

--- a/dpc-portal/docker/entrypoint.sh
+++ b/dpc-portal/docker/entrypoint.sh
@@ -18,7 +18,7 @@ if [ "$1" == "portal" ]; then
   echo "Migrating the database..."
   bundle exec rails db:migrate db:seed
 
-  if [[ "$ENV" == "production" ]]; then
+  if [[ "$ENV" == "prod" ]]; then
     echo "Starting in production"
     bundle exec rails server -b 0.0.0.0 -p 3100
   elif [[ "$ENV" == "local" ]]; then


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5620

## 🛠 Changes

- Enforces https usage on the portal.
- Fixes a bug that would've started the fake CPI gateway in prod.

## ℹ️ Context

Setting the ssl flag was required to meet security standards.  

In production, `$ENV` is set to "prod", not "production".  If we deployed the old version of the entrypoint.sh script to prod, the conditional that starts the portal would've fallen through and called the nonprod script, which would've also started the fake CPI gateway.  In prod we want to connect to the real thing.

## 🧪 Validation

Deployed to dev [here](https://github.com/CMSgov/dpc-app/actions/runs/31184971511).
