### PR TITLE
Run on correct code build

### DIFF
--- a/.github/workflows/load-test-unit-tests.yml
+++ b/.github/workflows/load-test-unit-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run unit tests
         run: yarn test
   test-authentication-utils:
-    runs-on: codebuild-dpc-app-${{github.run_id}}-${{github.run_attempt}}
+    runs-on: codebuild-dpc-app-non-prod-${{github.run_id}}-${{github.run_attempt}}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.3.0
       - name: Test Macaroons


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5627

## 🛠 Changes

The "Load Testing Unit Tests" workflow is failing.  See example on this Dependabot PR: https://github.com/CMSgov/dpc-app/pull/3089.  

After this is merged there the automated tests will pass.

## ℹ️ Context

The workflow is failing on the second step.  It's waiting for a production code build runner but needs non-prod.  

## 🧪 Validation

Successful run [here](https://github.com/CMSgov/dpc-app/actions/runs/31215680455).
