### PR TITLE
Me/dpc 5592 run full sq scan on ci

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -310,6 +310,8 @@ jobs:
           node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
+        env:
+          CODEBUILD_BUILD_ID: "" # When SonarQube sees CodeBuild and GHA env vars auto config gets confused and fails.
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-web
@@ -356,6 +358,8 @@ jobs:
           node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
+        env:
+          CODEBUILD_BUILD_ID: "" # When SonarQube sees CodeBuild and GHA env vars auto config gets confused and fails.
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-portal
@@ -424,6 +428,8 @@ jobs:
         run: |
           find . -name dpc-api-jacoco.xml
       - name: Run quality gate scan
+        env:
+          CODEBUILD_BUILD_ID: "" # When SonarQube sees CodeBuild and GHA env vars auto config gets confused and fails.
         run: |
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"
       - name: Cleanup

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -310,16 +310,17 @@ jobs:
           node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
-        env:
-          CODEBUILD_BUILD_ID: "" # When SonarQube sees CodeBuild and GHA env vars auto config gets confused and fails.
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-web
             -Dsonar.sources=./dpc-web/app,./dpc-web/lib,./dpc-admin/app,./dpc-admin/lib
             -Dsonar.ruby.coverage.reportPaths=./web-resultset.json,./admin-resultset.json
             -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
             -Dsonar.qualitygate.wait=true
+            -Dsonar.ci.autoconfig.disabled=true
+            -Dsonar.branch.target=${{ github.base_ref }}
       - name: Cleanup
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh
@@ -358,8 +359,6 @@ jobs:
           node-version: 24
       - name: Run quality gate scan
         uses: sonarsource/sonarqube-scan-action@299e4b793aaa83bf2aba7c9c14bedbb485688ec4 # v7.1.0
-        env:
-          CODEBUILD_BUILD_ID: "" # When SonarQube sees CodeBuild and GHA env vars auto config gets confused and fails.
         with:
           args:
             -Dsonar.projectKey=bcda-dpc-portal
@@ -367,8 +366,11 @@ jobs:
             -Dsonar.coverage.exclusions=**/*_preview.rb,**/*html.erb,**/application_*
             -Dsonar.ruby.coverage.reportPaths=./portal-resultset.json
             -Dsonar.working.directory=./sonar_workspace
+            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
             -Dsonar.qualitygate.wait=true
+            -Dsonar.ci.autoconfig.disabled=true
+            -Dsonar.branch.target=${{ github.base_ref }}
       - name: Cleanup
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh
@@ -428,10 +430,8 @@ jobs:
         run: |
           find . -name dpc-api-jacoco.xml
       - name: Run quality gate scan
-        env:
-          CODEBUILD_BUILD_ID: "" # When SonarQube sees CodeBuild and GHA env vars auto config gets confused and fails.
         run: |
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml" -Dsonar.ci.autoconfig.disabled=true -Dsonar.branch.target=${{ github.base_ref }}
       - name: Cleanup
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,6 +1,9 @@
 name: "DPC CI Workflow"
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     paths:
       - .github/workflows/ci-workflow.yml
@@ -313,11 +316,8 @@ jobs:
             -Dsonar.sources=./dpc-web/app,./dpc-web/lib,./dpc-admin/app,./dpc-admin/lib
             -Dsonar.ruby.coverage.reportPaths=./web-resultset.json,./admin-resultset.json
             -Dsonar.working.directory=./sonar_workspace
-            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
             -Dsonar.qualitygate.wait=true
-            -Dsonar.ci.autoconfig.disabled=true
-            -Dsonar.branch.target=${{ github.base_ref }}
       - name: Cleanup
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh
@@ -363,11 +363,8 @@ jobs:
             -Dsonar.coverage.exclusions=**/*_preview.rb,**/*html.erb,**/application_*
             -Dsonar.ruby.coverage.reportPaths=./portal-resultset.json
             -Dsonar.working.directory=./sonar_workspace
-            -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
             -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }}
             -Dsonar.qualitygate.wait=true
-            -Dsonar.ci.autoconfig.disabled=true
-            -Dsonar.branch.target=${{ github.base_ref }}
       - name: Cleanup
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh
@@ -428,7 +425,7 @@ jobs:
           find . -name dpc-api-jacoco.xml
       - name: Run quality gate scan
         run: |
-          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml" -Dsonar.ci.autoconfig.disabled=true -Dsonar.branch.target=${{ github.base_ref }}
+          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml"
       - name: Cleanup
         if: ${{ always() }}
         run: ./scripts/cleanup-docker.sh


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5592

## 🛠 Changes

Forces SonarQube to do a full scan on our main branch every time it's updated.

## ℹ️ Context

As part of our SIA prep, we noticed that the SonarQube [Overview](https://sonarqube.cloud.cms.gov/dashboard?id=bcda-dpc-portal) for our main branch shows it was last analyzed one month ago, despite changes being merged regularly.  Since we're using this to "check the box" for static code analysis, that's a problem.

The issue is that we were only running the scan on pull requests, and when SQ recognizes that it's running on a PR it only scans the diff, not the full services.  The way around this is to (hopefully) force a scan when we merge to main, which should force a full scan.

Also, part of the ticket was to use SonarQube's autconfig, but that won't work when running on our CodeBuild runners.  SQ sees the auto-populated env vars from the GHA and the CodeBuild runner, gets confused where it's running and fails with this error `ERROR Multiple CI environments are detected: [AwsCodeBuild, Github Actions]. Please check environment variables or set property sonar.ci.autoconfig.disabled to true.`

## 🧪 Validation

Ran scan on this branch to verify it works and causes a full scan [here](https://github.com/CMSgov/dpc-app/actions/runs/31525810511).
<img width="510" height="254" alt="image" src="https://github.com/user-attachments/assets/51d3576e-8812-4858-b160-d670197011ab" />


**Note**: Unfortunately, there's no way to verify this will fix the problem for sure in SonarQube without merging it and checking if the main branch overview is updated.

**Note2**:  This change means that there might be issues missed when scanning a PR that get picked up after a merge.