### PR TITLE
[DPC-5583] Handle API errors and update auth failure path

### DIFF
--- a/dpc-portal/app/components/page/utility/error_component.rb
+++ b/dpc-portal/app/components/page/utility/error_component.rb
@@ -10,13 +10,13 @@ module Page
         clear: 'CLEAR'
       }.freeze
 
-      def initialize(invitation, reason, csp: '')
+      def initialize(invitation, reason, csp: nil)
         super()
         @invitation = invitation
         @org_name = invitation&.provider_organization&.name
         @ao_full_name = invitation&.invited_by_full_name
         @ao_email = invitation&.invited_by&.email
-        @csp_display_name = DISPLAY_NAMES.fetch(csp.to_sym, 'CSP')
+        @csp_display_name = DISPLAY_NAMES.fetch(csp&.to_sym, 'CSP')
         @reason = AoVerificationService::SERVER_ERRORS.include?(reason) ? :server_error : reason.to_sym
         @status = "verification.#{@reason}_status"
         @text = "verification.#{@reason}_text"

--- a/dpc-portal/app/components/page/utility/error_component.rb
+++ b/dpc-portal/app/components/page/utility/error_component.rb
@@ -16,7 +16,7 @@ module Page
         @org_name = invitation&.provider_organization&.name
         @ao_full_name = invitation&.invited_by_full_name
         @ao_email = invitation&.invited_by&.email
-        @csp_display_name = DISPLAY_NAMES.fetch(csp, 'CSP')
+        @csp_display_name = DISPLAY_NAMES.fetch(csp.to_sym, 'CSP')
         @reason = AoVerificationService::SERVER_ERRORS.include?(reason) ? :server_error : reason.to_sym
         @status = "verification.#{@reason}_status"
         @text = "verification.#{@reason}_text"

--- a/dpc-portal/app/controllers/concerns/csp_error_handling.rb
+++ b/dpc-portal/app/controllers/concerns/csp_error_handling.rb
@@ -34,8 +34,8 @@ module CspErrorHandling
 
   def handle_csp_auth_error
     log_event(:error, 'CSP Authentication error',
-              actionContext: LoggingConstants::ActionContext::Authentication,
-              actionType: LoggingConstants::ActionType::CspUnavailable,
+              action_context: LoggingConstants::ActionContext::Authentication,
+              action_type: LoggingConstants::ActionType::CspUnavailable,
               error: params[:message],
               csp: csp_param)
     render(Page::Utility::ErrorComponent.new(nil, 'server_error', csp: csp_param),

--- a/dpc-portal/app/controllers/concerns/csp_error_handling.rb
+++ b/dpc-portal/app/controllers/concerns/csp_error_handling.rb
@@ -4,8 +4,10 @@
 module CspErrorHandling
   extend ActiveSupport::Concern
 
+  CSP_AUTH_ERROR_MESSAGES = %w[server_error service_unavailable connection_failed internal_server_error timeout].freeze
+
   def csp_auth_error?
-    params[:message].present? && params[:strategy].present?
+    CSP_AUTH_ERROR_MESSAGES.include?(params[:message])
   end
 
   def handle_invitation_flow_failure(invitation_id)
@@ -22,18 +24,19 @@ module CspErrorHandling
   end
 
   def handle_csp_auth_error
+    csp = params[:strategy]
     Rails.logger.error(['CSP Authentication error',
                         { actionContext: LoggingConstants::ActionContext::Authentication,
                           actionType: LoggingConstants::ActionType::CspUnavailable,
                           error: params[:message],
-                          csp: params[:strategy] }])
+                          csp: }])
 
-    render(Page::Utility::ErrorComponent.new(nil, 'server_error'), status: :service_unavailable)
+    render(Page::Utility::ErrorComponent.new(nil, 'server_error', csp:), status: :service_unavailable)
   end
 
-  def handle_signin_fail(csp)
+  def handle_signin_fail
     Rails.logger.error 'CSP Configuration error'
-    render(Page::Utility::ErrorComponent.new(nil, 'csp_signin_fail', csp:))
+    render(Page::Utility::ErrorComponent.new(nil, 'csp_signin_fail', csp: params['strategy']))
   end
 
   def handle_signin_cancel(csp)

--- a/dpc-portal/app/controllers/concerns/csp_error_handling.rb
+++ b/dpc-portal/app/controllers/concerns/csp_error_handling.rb
@@ -4,6 +4,10 @@
 module CspErrorHandling
   extend ActiveSupport::Concern
 
+  def csp_auth_error?
+    params[:message].present? && params[:strategy].present?
+  end
+
   def handle_invitation_flow_failure(invitation_id)
     Rails.logger.info(['Failed invitation flow',
                        { actionContext: LoggingConstants::ActionContext::Registration,
@@ -15,6 +19,16 @@ module CspErrorHandling
     else
       render(Page::Invitations::AoFlowFailComponent.new(invitation, 'fail_to_proof', 1), status: :forbidden)
     end
+  end
+
+  def handle_csp_auth_error
+    Rails.logger.error(['CSP Authentication error',
+                        { actionContext: LoggingConstants::ActionContext::Authentication,
+                          actionType: LoggingConstants::ActionType::CspUnavailable,
+                          error: params[:message],
+                          csp: params[:strategy] }])
+
+    render(Page::Utility::ErrorComponent.new(nil, 'server_error'), status: :service_unavailable)
   end
 
   def handle_signin_fail(csp)

--- a/dpc-portal/app/controllers/concerns/csp_error_handling.rb
+++ b/dpc-portal/app/controllers/concerns/csp_error_handling.rb
@@ -5,9 +5,18 @@ module CspErrorHandling
   extend ActiveSupport::Concern
 
   CSP_AUTH_ERROR_MESSAGES = %w[server_error service_unavailable connection_failed internal_server_error timeout].freeze
+  CSP_USER_ERROR_MESSAGES = %w[access_denied].freeze
 
   def csp_auth_error?
     CSP_AUTH_ERROR_MESSAGES.include?(params[:message])
+  end
+
+  def csp_user_error?
+    CSP_USER_ERROR_MESSAGES.include?(params[:message])
+  end
+
+  def csp_param
+    params[:strategy]
   end
 
   def handle_invitation_flow_failure(invitation_id)
@@ -24,26 +33,26 @@ module CspErrorHandling
   end
 
   def handle_csp_auth_error
-    csp = params[:strategy]
     Rails.logger.error(['CSP Authentication error',
                         { actionContext: LoggingConstants::ActionContext::Authentication,
                           actionType: LoggingConstants::ActionType::CspUnavailable,
                           error: params[:message],
-                          csp: }])
+                          csp: csp_param }])
 
-    render(Page::Utility::ErrorComponent.new(nil, 'server_error', csp:), status: :service_unavailable)
+    render(Page::Utility::ErrorComponent.new(nil, 'server_error', csp: csp_param),
+           status: :service_unavailable)
   end
 
   def handle_signin_fail
     Rails.logger.error 'CSP Configuration error'
-    render(Page::Utility::ErrorComponent.new(nil, 'csp_signin_fail', csp: params['strategy']))
+    render(Page::Utility::ErrorComponent.new(nil, 'csp_signin_fail', csp: csp_param))
   end
 
-  def handle_signin_cancel(csp)
+  def handle_signin_cancel
     Rails.logger.info(['User cancelled login',
                        { actionContext: LoggingConstants::ActionContext::Authentication,
                          actionType: LoggingConstants::ActionType::UserCancelledLogin,
-                         **csp_log_context }])
-    render(Page::Utility::ErrorComponent.new(nil, 'csp_signin_cancel', csp:))
+                         csp: csp_param }])
+    render(Page::Utility::ErrorComponent.new(nil, 'csp_signin_cancel', csp: csp_param))
   end
 end

--- a/dpc-portal/app/controllers/csp_controller.rb
+++ b/dpc-portal/app/controllers/csp_controller.rb
@@ -24,6 +24,7 @@ class CspController < ApplicationController # rubocop:disable Metrics/ClassLengt
     csp = csp_session.current
     invitation_flow_match = session[:user_return_to]&.match(%r{/organizations/([0-9]+)/invitations/([0-9]+)})
     return handle_invitation_flow_failure(invitation_flow_match[2]) if invitation_flow_match
+    return handle_csp_auth_error if csp_auth_error?
     return handle_signin_fail(csp) if params[:code]
 
     handle_signin_cancel(csp)

--- a/dpc-portal/app/controllers/csp_controller.rb
+++ b/dpc-portal/app/controllers/csp_controller.rb
@@ -25,7 +25,7 @@ class CspController < ApplicationController # rubocop:disable Metrics/ClassLengt
     invitation_flow_match = session[:user_return_to]&.match(%r{/organizations/([0-9]+)/invitations/([0-9]+)})
     return handle_invitation_flow_failure(invitation_flow_match[2]) if invitation_flow_match
     return handle_csp_auth_error if csp_auth_error?
-    return handle_signin_fail(csp) if params[:code]
+    return handle_signin_fail if params[:message]
 
     handle_signin_cancel(csp)
   end

--- a/dpc-portal/app/controllers/csp_controller.rb
+++ b/dpc-portal/app/controllers/csp_controller.rb
@@ -24,9 +24,9 @@ class CspController < ApplicationController # rubocop:disable Metrics/ClassLengt
     invitation_flow_match = session[:user_return_to]&.match(%r{/organizations/([0-9]+)/invitations/([0-9]+)})
     return handle_invitation_flow_failure(invitation_flow_match[2]) if invitation_flow_match
     return handle_csp_auth_error if csp_auth_error?
-    return handle_signin_cancel if csp_user_error?
+    return handle_signin_fail unless csp_user_error?
 
-    handle_signin_fail
+    handle_signin_cancel
   end
 
   def logout

--- a/dpc-portal/app/controllers/csp_controller.rb
+++ b/dpc-portal/app/controllers/csp_controller.rb
@@ -21,13 +21,12 @@ class CspController < ApplicationController # rubocop:disable Metrics/ClassLengt
   end
 
   def failure
-    csp = csp_session.current
     invitation_flow_match = session[:user_return_to]&.match(%r{/organizations/([0-9]+)/invitations/([0-9]+)})
     return handle_invitation_flow_failure(invitation_flow_match[2]) if invitation_flow_match
     return handle_csp_auth_error if csp_auth_error?
-    return handle_signin_fail if params[:message]
+    return handle_signin_cancel if csp_user_error?
 
-    handle_signin_cancel(csp)
+    handle_signin_fail
   end
 
   def logout

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -60,5 +60,6 @@ module LoggingConstants
     InvalidFlashStatus = 'InvalidFlashStatus'
 
     InvalidCsp = 'InvalidCsp'
+    CspUnavailable = 'CspUnavailable'
   end
 end

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -3,7 +3,7 @@
 # Sets up the application's routes.
 Rails.application.routes.draw do
   # Former devise routes
-  get '/users/auth/failure', to: 'csp#failure', as: 'csp_failure'
+  get '/auth/failure', to: 'csp#failure', as: 'csp_failure'
   get '/auth/logged_out', to: 'users/sessions#logged_out'
   get '/auth/no_account', to: 'csp#no_account', as: 'no_account'
   delete '/logout', to: 'csp#logout', as: 'csp_logout'

--- a/dpc-portal/spec/requests/csp_spec.rb
+++ b/dpc-portal/spec/requests/csp_spec.rb
@@ -2,11 +2,12 @@
 
 require 'rails_helper'
 
-# These responses are the same across all CSP's.
+# These responses are the same across all CSPs.
 RSpec.describe 'CSP', type: :request do
   describe 'Get /auth/failure' do
+    let(:auth_failure_path) { '/auth/failure?message=access_denied&strategy=csp' }
     it 'should succeed' do
-      get '/auth/failure'
+      get auth_failure_path
       expect(response).to be_ok
     end
 
@@ -14,8 +15,9 @@ RSpec.describe 'CSP', type: :request do
       allow(Rails.logger).to receive(:info)
       expect(Rails.logger).to receive(:info).with(['User cancelled login',
                                                    { actionContext: LoggingConstants::ActionContext::Authentication,
-                                                     actionType: LoggingConstants::ActionType::UserCancelledLogin }])
-      get '/auth/failure'
+                                                     actionType: LoggingConstants::ActionType::UserCancelledLogin,
+                                                     csp: 'csp' }])
+      get auth_failure_path
     end
   end
 

--- a/dpc-portal/spec/requests/csp_spec.rb
+++ b/dpc-portal/spec/requests/csp_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe 'CSP', type: :request do
       expect(Rails.logger).to receive(:info).with(['User cancelled login',
                                                    hash_including(actionContext: LoggingConstants::ActionContext::Authentication,
                                                                   actionType: LoggingConstants::ActionType::UserCancelledLogin,
-                                                                  csp: 'csp')])
+                                                                  csp: 'csp',
+                                                                  timestamp: a_kind_of(String))])
       get auth_failure_path
     end
   end

--- a/dpc-portal/spec/requests/csp_spec.rb
+++ b/dpc-portal/spec/requests/csp_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 # These responses are the same across all CSP's.
 RSpec.describe 'CSP', type: :request do
-  describe 'Get /users/auth/failure' do
+  describe 'Get /auth/failure' do
     it 'should succeed' do
-      get '/users/auth/failure'
+      get '/auth/failure'
       expect(response).to be_ok
     end
 
@@ -15,7 +15,7 @@ RSpec.describe 'CSP', type: :request do
       expect(Rails.logger).to receive(:info).with(['User cancelled login',
                                                    { actionContext: LoggingConstants::ActionContext::Authentication,
                                                      actionType: LoggingConstants::ActionType::UserCancelledLogin }])
-      get '/users/auth/failure'
+      get '/auth/failure'
     end
   end
 

--- a/dpc-portal/spec/requests/invitations_spec.rb
+++ b/dpc-portal/spec/requests/invitations_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'Invitations', type: :request do
     it 'should show error page if fail to proof' do
       org_id = invitation.provider_organization.id
       post "/organizations/#{org_id}/invitations/#{invitation.id}/login", params: provider_params
-      get '/users/auth/failure'
+      get '/auth/failure'
       expect(response).to be_forbidden
       expect(response.body).to include(I18n.t('verification.fail_to_proof_text'))
     end
@@ -357,7 +357,7 @@ RSpec.describe 'Invitations', type: :request do
             let(:org_id) { invitation.provider_organization.id }
             it 'should not show step navigation' do
               post "/organizations/#{org_id}/invitations/#{invitation.id}/login", params: provider_params
-              get '/users/auth/failure'
+              get '/auth/failure'
               expect(response).to be_forbidden
               expect(response.body).to_not include('<span class="usa-step-indicator__current-step">')
             end
@@ -380,7 +380,7 @@ RSpec.describe 'Invitations', type: :request do
             let(:org_id) { invitation.provider_organization.id }
             it 'should show step 2' do
               post "/organizations/#{org_id}/invitations/#{invitation.id}/login", params: provider_params
-              get '/users/auth/failure'
+              get '/auth/failure'
               expect(response).to be_forbidden
               expect(response.body).to include('<span class="usa-step-indicator__current-step">2</span>')
             end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -303,8 +303,8 @@ RSpec.shared_examples 'a CSP client' do |config|
       it 'renders the CSP sign-in fail component' do
         attempt_sign_in
         expect(response.body).not_to include(I18n.t('verification.server_error_status'))
-        expect(response.body).to include("#{display_name} sign-in failed")
-        expect(response.body).to include("Something went wrong while trying to sign-in with #{display_name}.")
+        expect(response.body).to include(I18n.t('verification.csp_signin_fail_status', csp_display_name: display_name))
+        expect(response.body).to include(I18n.t('verification.csp_signin_fail_text', csp_display_name: display_name))
       end
 
       it 'does not sign in the user' do
@@ -323,6 +323,57 @@ RSpec.shared_examples 'a CSP client' do |config|
       it 'logs the CSP authentication error' do
         allow(Rails.logger).to receive(:error)
         expect(Rails.logger).to receive(:error).with('CSP Configuration error')
+        attempt_sign_in
+      end
+    end
+
+    context "when #{display_name} returns 403 access denied" do
+      let(:error) { :access_denied }
+      let(:attempt_sign_in) do
+        post auth_endpoint
+        follow_redirect!
+        expect(response.location).to eq("/auth/failure?message=#{error}&strategy=#{csp_name}")
+        follow_redirect!
+      end
+      before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.mock_auth[provider] = error
+      end
+
+      it 'does not return 503 service unavailable' do
+        attempt_sign_in
+        expect(response).to be_ok
+      end
+
+      it 'renders the CSP sign-in cancel component' do
+        attempt_sign_in
+        expect(response.body).not_to include(I18n.t('verification.server_error_status'))
+        expect(response.body).to include(I18n.t('verification.csp_signin_cancel_status',
+                                                csp_display_name: display_name))
+        expect(response.body).to include(I18n.t('verification.csp_signin_cancel_text', csp_display_name: display_name))
+      end
+
+      it 'does not sign in the user' do
+        attempt_sign_in
+        csp_session = CspSession.new(request.session)
+        expect(csp_session.user).to be_nil
+        expect(csp_session.token).to be_nil
+      end
+
+      it 'does not create a CspUser' do
+        expect do
+          attempt_sign_in
+        end.to change { CspUser.count }.by(0)
+      end
+
+      it 'logs the CSP authentication error' do
+        allow(Rails.logger).to receive(:info)
+        expect(Rails.logger).to receive(:info).with(
+          ['User cancelled login',
+           { actionContext: LoggingConstants::ActionContext::Authentication,
+             actionType: LoggingConstants::ActionType::UserCancelledLogin,
+             csp: csp_name }]
+        )
         attempt_sign_in
       end
     end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -233,7 +233,7 @@ RSpec.shared_examples 'a CSP client' do |config|
     end
   end
 
-  describe 'CSP API errors' do
+  describe 'API errors' do
     context "when #{display_name} returns 500 server error" do
       let(:error) { :server_error }
       let(:attempt_sign_in) do
@@ -279,6 +279,50 @@ RSpec.shared_examples 'a CSP client' do |config|
              error: error.to_s,
              csp: csp_name }]
         )
+        attempt_sign_in
+      end
+    end
+    context "when #{display_name} returns 400 invalid argument" do
+      let(:error) { :bad_request }
+      let(:attempt_sign_in) do
+        post auth_endpoint
+        follow_redirect!
+        expect(response.location).to eq("/auth/failure?message=#{error}&strategy=#{csp_name}")
+        follow_redirect!
+      end
+      before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.mock_auth[provider] = error
+      end
+
+      it 'does not return 503 service unavailable' do
+        attempt_sign_in
+        expect(response).to be_ok
+      end
+
+      it 'renders the CSP sign-in fail component' do
+        attempt_sign_in
+        expect(response.body).not_to include(I18n.t('verification.server_error_status'))
+        expect(response.body).to include("#{display_name} sign-in failed")
+        expect(response.body).to include("Something went wrong while trying to sign-in with #{display_name}.")
+      end
+
+      it 'does not sign in the user' do
+        attempt_sign_in
+        csp_session = CspSession.new(request.session)
+        expect(csp_session.user).to be_nil
+        expect(csp_session.token).to be_nil
+      end
+
+      it 'does not create a CspUser' do
+        expect do
+          attempt_sign_in
+        end.to change { CspUser.count }.by(0)
+      end
+
+      it 'logs the CSP authentication error' do
+        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error).with('CSP Configuration error')
         attempt_sign_in
       end
     end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -276,10 +276,11 @@ RSpec.shared_examples 'a CSP client' do |config|
         allow(Rails.logger).to receive(:error)
         expect(Rails.logger).to receive(:error).with(
           ['CSP Authentication error',
-           { actionContext: LoggingConstants::ActionContext::Authentication,
-             actionType: LoggingConstants::ActionType::CspUnavailable,
-             error: error.to_s,
-             csp: csp_name }]
+           hash_including(actionContext: LoggingConstants::ActionContext::Authentication,
+                          actionType: LoggingConstants::ActionType::CspUnavailable,
+                          error: error.to_s,
+                          csp: csp_name,
+                          timestamp: a_kind_of(String))]
         )
         attempt_sign_in
       end
@@ -324,7 +325,13 @@ RSpec.shared_examples 'a CSP client' do |config|
 
       it 'logs the CSP authentication error' do
         allow(Rails.logger).to receive(:error)
-        expect(Rails.logger).to receive(:error).with('CSP Configuration error')
+        expect(Rails.logger).to receive(:error).with(
+          ['CSP Configuration error',
+           hash_including(actionContext: LoggingConstants::ActionContext::Registration,
+                          actionType: LoggingConstants::ActionType::FailedLogin,
+                          csp: csp_name,
+                          timestamp: a_kind_of(String))]
+        )
         attempt_sign_in
       end
     end
@@ -372,9 +379,10 @@ RSpec.shared_examples 'a CSP client' do |config|
         allow(Rails.logger).to receive(:info)
         expect(Rails.logger).to receive(:info).with(
           ['User cancelled login',
-           { actionContext: LoggingConstants::ActionContext::Authentication,
-             actionType: LoggingConstants::ActionType::UserCancelledLogin,
-             csp: csp_name }]
+           hash_including(actionContext: LoggingConstants::ActionContext::Authentication,
+                          actionType: LoggingConstants::ActionType::UserCancelledLogin,
+                          csp: csp_name,
+                          timestamp: a_kind_of(String))]
         )
         attempt_sign_in
       end

--- a/dpc-portal/spec/support/csp_auth_shared_examples.rb
+++ b/dpc-portal/spec/support/csp_auth_shared_examples.rb
@@ -233,6 +233,57 @@ RSpec.shared_examples 'a CSP client' do |config|
     end
   end
 
+  describe 'CSP API errors' do
+    context "when #{display_name} returns 500 server error" do
+      let(:error) { :server_error }
+      let(:attempt_sign_in) do
+        post auth_endpoint
+        follow_redirect!
+        expect(response.location).to eq("/auth/failure?message=#{error}&strategy=#{csp_name}")
+        follow_redirect!
+      end
+      before do
+        OmniAuth.config.test_mode = true
+        OmniAuth.config.mock_auth[provider] = error
+      end
+
+      it 'returns 503 service unavailable' do
+        attempt_sign_in
+        expect(response).to have_http_status(:service_unavailable)
+      end
+
+      it 'renders the server error component' do
+        attempt_sign_in
+        expect(response.body).to include(I18n.t('verification.server_error_status'))
+      end
+
+      it 'does not sign in the user' do
+        attempt_sign_in
+        csp_session = CspSession.new(request.session)
+        expect(csp_session.user).to be_nil
+        expect(csp_session.token).to be_nil
+      end
+
+      it 'does not create a CspUser' do
+        expect do
+          attempt_sign_in
+        end.to change { CspUser.count }.by(0)
+      end
+
+      it 'logs the CSP authentication error' do
+        allow(Rails.logger).to receive(:error)
+        expect(Rails.logger).to receive(:error).with(
+          ['CSP Authentication error',
+           { actionContext: LoggingConstants::ActionContext::Authentication,
+             actionType: LoggingConstants::ActionType::CspUnavailable,
+             error: error.to_s,
+             csp: csp_name }]
+        )
+        attempt_sign_in
+      end
+    end
+  end
+
   describe 'Delete /logout' do
     before do
       OmniAuth.config.test_mode = true

--- a/dpc-portal/spec/system/accessibility_spec.rb
+++ b/dpc-portal/spec/system/accessibility_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Accessibility', type: :system do
       it 'shows login failure' do
         OmniAuth.config.mock_auth[provider] = :access_denied
 
-        visit "/auth/failure?message=access_denied&strategy=#{provider.to_s}"
+        visit "/auth/failure?message=access_denied&strategy=#{provider}"
         expect(page).to have_text('sign-in was unsuccessful')
         expect(page).to be_axe_clean.according_to axe_standard
       end

--- a/dpc-portal/spec/system/accessibility_spec.rb
+++ b/dpc-portal/spec/system/accessibility_spec.rb
@@ -45,7 +45,9 @@ RSpec.describe 'Accessibility', type: :system do
         expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'shows login failure' do
-        visit '/auth/failure'
+        OmniAuth.config.mock_auth[provider] = :access_denied
+
+        visit "/auth/failure?message=access_denied&strategy=#{provider.to_s}"
         expect(page).to have_text('sign-in was unsuccessful')
         expect(page).to be_axe_clean.according_to axe_standard
       end

--- a/dpc-portal/spec/system/accessibility_spec.rb
+++ b/dpc-portal/spec/system/accessibility_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Accessibility', type: :system do
         expect(page).to be_axe_clean.according_to axe_standard
       end
       it 'shows login failure' do
-        visit '/users/auth/failure'
+        visit '/auth/failure'
         expect(page).to have_text('sign-in was unsuccessful')
         expect(page).to be_axe_clean.according_to axe_standard
       end


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5583

## 🛠 Changes

Adds handling for when the CSP is unavailable, and updates the auth failure path to the accurate one for OmniAuth without Devise.

## ℹ️ Context

Note: while testing this I found that we had the failure path misconfigured for OmniAuth, the `/users/` part was a Devise holdover.

## 🧪 Validation

Tested manually, specs updated.
