### PR TITLE
Use separate java version for SonarQube quality gate

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -429,6 +429,11 @@ jobs:
       - name: Verify download
         run: |
           find . -name dpc-api-jacoco.xml
+      - name: Setup Java 21 for Sonar
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '21'
+          distribution: temurin
       - name: Run quality gate scan
         run: |
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar -Dsonar.projectKey=bcda-dpc-api -Dsonar.branch.name=${{ github.event_name == 'pull_request' && github.head_ref || github.event_name == 'pull_request' && github.head_ref || github.ref_name }} -Dsonar.working.directory=./.sonar_workspace -Dsonar.projectVersion=${{ github.ref_name == 'main' && github.sha || 'branch' }} -Dsonar.qualitygate.wait=true -Dsonar.coverage.jacoco.xmlReportPaths="../jacoco-reports/*.xml" -Dsonar.ci.autoconfig.disabled=true -Dsonar.branch.target=${{ github.base_ref }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -302,8 +302,8 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            SONAR_HOST_URL=/cdap/test/common/nonsensitive/sonarqube/url
-            SONAR_TOKEN=/cdap/test/common/sensitive/sonarqube/token
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -351,8 +351,8 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            SONAR_HOST_URL=/cdap/test/common/nonsensitive/sonarqube/url
-            SONAR_TOKEN=/cdap/test/common/sensitive/sonarqube/token
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -400,8 +400,8 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            SONAR_HOST_URL=/cdap/test/common/nonsensitive/sonarqube/url
-            SONAR_TOKEN=/cdap/test/common/sensitive/sonarqube/token
+            SONAR_HOST_URL=/sonarqube/url
+            SONAR_TOKEN=/sonarqube/token
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -302,8 +302,8 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            SONAR_HOST_URL=/sonarqube/url
-            SONAR_TOKEN=/sonarqube/token
+            SONAR_HOST_URL=/cdap/test/common/nonsensitive/sonarqube/url
+            SONAR_TOKEN=/cdap/test/common/sensitive/sonarqube/token
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -351,8 +351,8 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            SONAR_HOST_URL=/sonarqube/url
-            SONAR_TOKEN=/sonarqube/token
+            SONAR_HOST_URL=/cdap/test/common/nonsensitive/sonarqube/url
+            SONAR_TOKEN=/cdap/test/common/sensitive/sonarqube/token
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -400,8 +400,8 @@ jobs:
           AWS_REGION: ${{ vars.AWS_REGION }}
         with:
           params: |
-            SONAR_HOST_URL=/sonarqube/url
-            SONAR_TOKEN=/sonarqube/token
+            SONAR_HOST_URL=/cdap/test/common/nonsensitive/sonarqube/url
+            SONAR_TOKEN=/cdap/test/common/sensitive/sonarqube/token
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:


### PR DESCRIPTION
SonarQube requires Java 21 or newer.

## 🎫 Ticket

https://jira.cms.gov/browse/...

## 🛠 Changes

- ci-workflow.yml: use separate java version for SonarQube quality gate step.
- ensures project compilation is not affected

## ℹ️ Context

Github Actions workflows were failing due to outdated Java version 17 being used in SonarQube quality gate. 

## 🧪 Validation

Will validate that workflow is successful.
