### PR TITLE
Me/dpc 5601 async portal migrate db

### DIFF
--- a/dpc-portal/app/components/page/invitations/ao_flow_fail_component_preview.rb
+++ b/dpc-portal/app/components/page/invitations/ao_flow_fail_component_preview.rb
@@ -14,8 +14,8 @@ module Page
       private
 
       def error_codes
-        { choices: %i[user_not_authorized_official no_approved_enrollment bad_npi org_med_sanctions
-                      ao_med_sanctions missing_info server_error fail_to_proof] }
+        { choices: %i[user_not_authorized_official no_approved_enrollment bad_npi org_med_sanctions ao_med_sanctions
+                      missing_info server_error fail_to_proof] }
       end
     end
   end

--- a/dpc-portal/app/components/page/invitations/ao_flow_fail_component_preview.rb
+++ b/dpc-portal/app/components/page/invitations/ao_flow_fail_component_preview.rb
@@ -14,8 +14,8 @@ module Page
       private
 
       def error_codes
-        { choices: %i[user_not_authorized_official no_approved_enrollment bad_npi org_med_sanctions ao_med_sanctions
-                      missing_info server_error fail_to_proof] }
+        { choices: %i[user_not_authorized_official no_approved_enrollment bad_npi org_med_sanctions
+                      ao_med_sanctions missing_info server_error fail_to_proof] }
       end
     end
   end

--- a/dpc-portal/docker/entrypoint.sh
+++ b/dpc-portal/docker/entrypoint.sh
@@ -11,12 +11,12 @@ if [ -f tmp/solid_queue_pidfile ]; then
   rm tmp/solid_queue_pidfile
 fi
 
+echo "Migrating the database..."
+bundle exec rails db:migrate db:seed
+
 if [ "$1" == "portal" ]; then
   # Start the database service (and make accessible outside the Docker container)
   echo "Starting Rails server..."
-
-  echo "Migrating the database..."
-  bundle exec rails db:migrate db:seed
 
   if [[ "$ENV" == "prod" ]]; then
     echo "Starting in production"


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5601

## 🛠 Changes

Migrate the portal DB on the start of the portal and async portal.

## ℹ️ Context

Async portal failed to deploy to prod because the DB hadn't been migrated yet: 
`ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "solid_queue_recurring_tasks" does not exist (ActiveRecord::StatementInvalid)`

We run the migration when the portal starts, but not the async portal.  If the async portal happens to start first, and the DB hasn't been previously migrated, it will fail.

## 🧪 Validation

Deployed to dev [here](https://github.com/CMSgov/dpc-app/actions/runs/32152784957).
