### PR TITLE
DPC-5642 Remove the CD email column from the active CD table

### DIFF
--- a/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
@@ -7,13 +7,12 @@
             <%= render(Core::Table::HeaderComponent.new(
                     caption: 'Active Credential Delegates',
                     columns: [
-                        { label: 'Name', sortable: true }, 
-                        { label: 'Email', sortable: true }, 
+                        { label: 'Name', sortable: true },
                         { label: 'Active since', sortable: true }
                     ]
                 )
             ) %>
-            <%= render(Core::Table::RowComponent.with_collection(@active_credential_delegates, keys: ['full_name', 'email', 'activated_at'])) %>
+            <%= render(Core::Table::RowComponent.with_collection(@active_credential_delegates, keys: ['full_name', 'activated_at'])) %>
           <% end %>
         <% else %>
           <p>You have no active Credential Delegates.</p>

--- a/dpc-portal/app/components/page/credential_delegate/list_component_preview.rb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component_preview.rb
@@ -15,9 +15,11 @@ module Page
       end
 
       def active
-        user1 = User.new(given_name: 'Bob', family_name: 'Hodges', email: 'bob@example.com')
-        user2 = User.new(given_name: 'Lisa', family_name: 'Franklin', email: 'lisa@example.com')
-        cds = [CdOrgLink.new(user: user1, created_at: 1.week.ago), CdOrgLink.new(user: user2, created_at: 2.weeks.ago)]
+        user1 = User.new(given_name: 'Bob', family_name: 'Hodges')
+        user2 = User.new(given_name: 'Lisa', family_name: 'Franklin')
+
+        cds = [CdOrgLink.new(user: user1, created_at: 1.week.ago, invitation: Invitation.new),
+               CdOrgLink.new(user: user2, created_at: 2.weeks.ago, invitation: Invitation.new)]
         render(Page::CredentialDelegate::ListComponent.new(org, [], [], cds))
       end
 

--- a/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
     context 'Active credential delegate' do
       let(:user) { User.new(given_name: 'Bob', family_name: 'Hodges') }
       let(:invitation) do
-        Invitation.new(invited_given_name: 'Bob', invited_family_name: 'Hodges', invited_email: 'bob@example.com')
+        Invitation.new(invited_given_name: nil, invited_family_name: nil, invited_email: nil)
       end
       let(:pending_invitations) { [] }
       let(:expired_invitations) { [] }
@@ -89,9 +89,6 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
                   Name
                 </th>
                 <th data-sortable scope="col" aria-sort="descending">
-                  Email
-                </th>
-                <th data-sortable scope="col" aria-sort="descending">
                   Active since
                 </th>
               </tr>
@@ -105,7 +102,6 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
         expected_html = <<~HTML
           <tr>
             <td data-sort-value="Bob Hodges">Bob Hodges</td>
-            <td data-sort-value="bob@example.com">bob@example.com</td>
             <td data-sort-value="#{activated}">#{activated}</td>
           </tr>
         HTML


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5642

## 🛠 Changes

* Removed the email column from the active CD table

## ℹ️ Context

The email column is [populated by the email the AO sent the invitation to](https://github.com/CMSgov/dpc-app/blob/main/dpc-portal/app/models/cd_org_link.rb#L9-L13) and [the invitation email is removed after the invitation is accepted](https://github.com/CMSgov/dpc-app/blob/main/dpc-portal/app/models/invitation.rb#L51-L57). This means that a blank invitation is required to render the lookbook page and that the invitation email is not available in the active CD table.

## 🧪 Validation

View the page in lookbook and render the page in the application.
<img width="1896" height="586" alt="credential_delegate_list_active" src="https://github.com/user-attachments/assets/ac2f3a72-c4b8-42ae-bc9c-f0a6ed2a8462" />
