### PR TITLE
[DPC-5628] Allow AO to revoke CD access

### DIFF
--- a/dpc-portal/app/components/core/table/row_component.html.erb
+++ b/dpc-portal/app/components/core/table/row_component.html.erb
@@ -14,6 +14,12 @@
           button_to("Yes, delete invite", "#{delete_path}/#{obj['id']}", method: :delete, class: 'usa-button'),
           'No, go back',
           "delete-modal-#{obj['id']}")) %>
+    <% elsif obj_name == 'Credential Delegate' %>
+      <%= render(Core::Modal::ModalComponent.new("Remove [#{obj['full_name']}] as a #{obj_name}?",
+          "This person will immediately lose access to the DPC Portal, where they set up and manage your organization's API credentials. Any credentials they already created will keep working — removing them from the Portal doesn't rotate keys or revoke tokens.",
+          button_to("Yes, remove #{obj_name}", delete_path, method: :delete, class: 'usa-button'),
+          'No, go back',
+          "delete-modal-#{obj['id']}")) %>
     <% else %>
       <%= render(Core::Modal::ModalComponent.new("Permanently revoke #{obj_name}?",
           "Once revoked, the #{obj_name} will not work to access production data.",

--- a/dpc-portal/app/components/core/table/row_component.rb
+++ b/dpc-portal/app/components/core/table/row_component.rb
@@ -13,7 +13,7 @@ module Core
         @obj = obj
         @attributes = []
         @iteration = obj_iteration
-        @delete_path = delete_path
+        @delete_path = delete_path.respond_to?(:call) ? delete_path.call(obj) : delete_path
         @obj_name = obj_name
         keys.each do |key|
           attributes << format_if_date(obj[key] || key)

--- a/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component.html.erb
@@ -9,11 +9,15 @@
                     columns: [
                         { label: 'Name', sortable: true }, 
                         { label: 'Email', sortable: true }, 
-                        { label: 'Active since', sortable: true }
+                        { label: 'Active since', sortable: true },
+                        { label: '<span class="usa-sr-only">Actions</span>'.html_safe }
                     ]
                 )
             ) %>
-            <%= render(Core::Table::RowComponent.with_collection(@active_credential_delegates, keys: ['full_name', 'email', 'activated_at'])) %>
+            <%= render(Core::Table::RowComponent.with_collection(@active_credential_delegates,
+                                                                 keys: ['full_name', 'email', 'activated_at'],
+                                                                 delete_path: ->(cd) { organization_cd_org_link_path(@organization.path_id, cd[:id]) },
+                                                                 obj_name: 'Credential Delegate')) %>
           <% end %>
         <% else %>
           <p>You have no active Credential Delegates.</p>

--- a/dpc-portal/app/components/page/credential_delegate/list_component_preview.rb
+++ b/dpc-portal/app/components/page/credential_delegate/list_component_preview.rb
@@ -15,9 +15,10 @@ module Page
       end
 
       def active
-        user1 = User.new(given_name: 'Bob', family_name: 'Hodges', email: 'bob@example.com')
-        user2 = User.new(given_name: 'Lisa', family_name: 'Franklin', email: 'lisa@example.com')
-        cds = [CdOrgLink.new(user: user1, created_at: 1.week.ago), CdOrgLink.new(user: user2, created_at: 2.weeks.ago)]
+        user1 = User.new(given_name: 'Bob', family_name: 'Hodges')
+        user2 = User.new(given_name: 'Lisa', family_name: 'Franklin')
+        cds = [CdOrgLink.new(id: 1, user: user1, created_at: 1.week.ago),
+               CdOrgLink.new(id: 2, user: user2, created_at: 2.weeks.ago)]
         render(Page::CredentialDelegate::ListComponent.new(org, [], [], cds))
       end
 

--- a/dpc-portal/app/controllers/cd_org_links_controller.rb
+++ b/dpc-portal/app/controllers/cd_org_links_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Handles deletion of CdOrgLinks
+class CdOrgLinksController < ApplicationController
+  before_action :authenticate_user!
+  before_action :verify_ao_for_organization
+
+  def destroy
+    cd_org_link.destroy!
+    log_event(:info, 'Credential Delegate removed from organization',
+              action_context: LoggingConstants::ActionContext::Registration,
+              action_type: LoggingConstants::ActionType::CdRemovedFromOrg,
+              **csp_log_context)
+    flash[:success] = 'Successfully removed Credential Delegate.'
+  rescue ActiveRecord::RecordNotDestroyed
+    log_event(:error, 'Credential Delegate not removed from organization',
+              action_context: LoggingConstants::ActionContext::Registration,
+              action_type: LoggingConstants::ActionType::CdNotRemovedFromOrg,
+              **csp_log_context)
+    flash[:alert] = 'Failed to remove Credential Delegate. Please try again later.'
+  ensure
+    redirect_to organization_path(organization)
+  end
+
+  private
+
+  def organization
+    @organization ||= ProviderOrganization.find(params[:organization_id])
+  end
+
+  def cd_org_link
+    @cd_org_link ||= organization.cd_org_links.find(params[:id])
+  end
+
+  def verify_ao_for_organization
+    return if current_user.ao?(organization)
+
+    redirect_to organization_path(organization)
+  end
+end

--- a/dpc-portal/app/controllers/cd_org_links_controller.rb
+++ b/dpc-portal/app/controllers/cd_org_links_controller.rb
@@ -3,7 +3,9 @@
 # Handles deletion of CdOrgLinks
 class CdOrgLinksController < ApplicationController
   before_action :authenticate_user!
-  before_action :verify_ao_for_organization
+  before_action :check_user_verification
+  before_action :load_organization
+  before_action :require_ao
 
   def destroy
     cd_org_link.destroy!
@@ -12,13 +14,13 @@ class CdOrgLinksController < ApplicationController
               action_type: LoggingConstants::ActionType::CdRemovedFromOrg,
               **csp_log_context)
     flash[:success] = 'Successfully removed Credential Delegate.'
+    redirect_to organization_path(organization)
   rescue ActiveRecord::RecordNotDestroyed
     log_event(:error, 'Credential Delegate not removed from organization',
               action_context: LoggingConstants::ActionContext::Registration,
               action_type: LoggingConstants::ActionType::CdNotRemovedFromOrg,
               **csp_log_context)
     flash[:alert] = 'Failed to remove Credential Delegate. Please try again later.'
-  ensure
     redirect_to organization_path(organization)
   end
 
@@ -30,11 +32,5 @@ class CdOrgLinksController < ApplicationController
 
   def cd_org_link
     @cd_org_link ||= organization.cd_org_links.find(params[:id])
-  end
-
-  def verify_ao_for_organization
-    return if current_user.ao?(organization)
-
-    redirect_to organization_path(organization)
   end
 end

--- a/dpc-portal/app/controllers/cd_org_links_controller.rb
+++ b/dpc-portal/app/controllers/cd_org_links_controller.rb
@@ -8,14 +8,14 @@ class CdOrgLinksController < ApplicationController
   before_action :require_ao
 
   def destroy
-    cd_org_link.destroy!
+    cd_org_link.disable!
     log_event(:info, 'Credential Delegate removed from organization',
               action_context: LoggingConstants::ActionContext::Registration,
               action_type: LoggingConstants::ActionType::CdRemovedFromOrg,
               **csp_log_context)
     flash[:success] = 'Successfully removed Credential Delegate.'
     redirect_to organization_path(organization)
-  rescue ActiveRecord::RecordNotDestroyed
+  rescue ActiveRecord::RecordInvalid
     log_event(:error, 'Credential Delegate not removed from organization',
               action_context: LoggingConstants::ActionContext::Registration,
               action_type: LoggingConstants::ActionType::CdNotRemovedFromOrg,

--- a/dpc-portal/app/models/cd_org_link.rb
+++ b/dpc-portal/app/models/cd_org_link.rb
@@ -7,7 +7,8 @@ class CdOrgLink < ApplicationRecord
   belongs_to :invitation, required: true
 
   def show_attributes
-    { full_name: "#{user.given_name} #{user.family_name}",
+    { id: id,
+      full_name: "#{user.given_name} #{user.family_name}",
       email: invitation&.invited_email,
       activated_at: created_at.to_s }.with_indifferent_access
   end

--- a/dpc-portal/app/models/cd_org_link.rb
+++ b/dpc-portal/app/models/cd_org_link.rb
@@ -20,4 +20,8 @@ class CdOrgLink < ApplicationRecord
   def ao?
     false
   end
+
+  def disable!
+    update!(disabled_at: Time.now)
+  end
 end

--- a/dpc-portal/config/initializers/logging.rb
+++ b/dpc-portal/config/initializers/logging.rb
@@ -27,6 +27,8 @@ module LoggingConstants
     CdLinkedToOrg = 'CdLinkedToOrg'
     AoAlreadyRegistered = 'AoAlreadyRegistered'
     CdAlreadyRegistered = 'CdAlreadyRegistered'
+    CdRemovedFromOrg = 'CdRemovedFromOrg'
+    CdNotRemovedFromOrg = 'CdNotRemovedFromOrg'
 
     BeginLogin = 'BeginLogin'
     UserLoggedIn = 'UserLoggedIn'

--- a/dpc-portal/config/routes.rb
+++ b/dpc-portal/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :client_tokens, only: [:new, :create, :destroy]
     resources :public_keys, only: [:new, :create, :destroy]
     resources :ip_addresses, only: [:new, :create, :destroy]
+    resources :cd_org_links, only: [:destroy]
     resources :credential_delegate_invitations, only: [:new, :create, :destroy] do
       get 'success', on: :member
     end

--- a/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
       end
       let(:pending_invitations) { [] }
       let(:expired_invitations) { [] }
-      let(:credential_delegates) { [CdOrgLink.new(user:, invitation:)] }
+      let(:credential_delegates) { [CdOrgLink.new(id: 1, user:, invitation:)] }
 
       it 'has a table' do
         expected_html = <<~HTML
@@ -94,6 +94,9 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
                 <th data-sortable scope="col" aria-sort="descending">
                   Active since
                 </th>
+                <th scope="col">
+                    <span class="usa-sr-only">Actions</span>
+                </th>
               </tr>
             </thead>
         HTML
@@ -107,9 +110,15 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
             <td data-sort-value="Bob Hodges">Bob Hodges</td>
             <td data-sort-value="bob@example.com">bob@example.com</td>
             <td data-sort-value="#{activated}">#{activated}</td>
-          </tr>
         HTML
         is_expected.to include(normalize_space(expected_html))
+        remove_cd = <<~HTML
+          <form class="button_to" method="post" action="/organizations/2/cd_org_links/1">
+           <input type="hidden" name="_method" value="delete" autocomplete="off" />
+           <button class="usa-button" type="submit">Yes, remove Credential Delegate</button>
+          </form>
+        HTML
+        is_expected.to include(normalize_space(remove_cd))
       end
 
       it 'has no pending credential delegates' do

--- a/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
+++ b/dpc-portal/spec/components/page/credential_delegate/list_component_spec.rb
@@ -117,6 +117,15 @@ RSpec.describe Page::CredentialDelegate::ListComponent, type: :component do
         is_expected.to include(normalize_space(remove_cd))
       end
 
+      it 'has a delete modal with the CD full name' do
+        expected_html = <<~HTML
+          <h2 class="usa-modal__heading" id="delete-modal-1-heading">
+            Remove [Bob Hodges] as a Credential Delegate?
+          </h2>
+        HTML
+        is_expected.to include(normalize_space(expected_html))
+      end
+
       it 'has no pending credential delegates' do
         expected_html = '<p>You have no pending invites.</p>'
         is_expected.to include(normalize_space(expected_html))

--- a/dpc-portal/spec/requests/cd_org_links_spec.rb
+++ b/dpc-portal/spec/requests/cd_org_links_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'support/login_support'
+
+RSpec.describe CdOrgLinksController, type: :request do
+  include LoginSupport
+
+  let(:provider) { :login_dot_gov }
+  let(:organization) { create(:provider_organization) }
+  let(:ao_user) { create_user_with_csp(csp: provider, given_name: 'Bob', family_name: 'Hoskins') }
+  let(:cd_user) { create_user_with_csp(csp: provider, given_name: 'Lisa', family_name: 'Franklin') }
+  let(:invitation) { create(:invitation, :cd, provider_organization: organization, invited_by: ao_user) }
+  let(:cd_org_link) do
+    create(:cd_org_link, user: cd_user, provider_organization: organization, invitation: invitation)
+  end
+
+  describe 'DELETE /organizations/:organization_id/cd_org_links/:id' do
+    context 'user is signed in' do
+      before do
+        sign_in ao_user, csp: provider
+      end
+
+      context 'when the AO is authorized' do
+        before do
+          create(:ao_org_link, user: ao_user, provider_organization: organization)
+          cd_org_link
+        end
+
+        it 'destroys the CdOrgLink' do
+          expect do
+            delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          end.to change { CdOrgLink.count }.by(-1)
+        end
+
+        it 'shows a success flash with full name' do
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          expect(flash[:success]).to eq('Successfully removed Credential Delegate.')
+        end
+
+        it 'redirects to the organization page' do
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          expect(response).to redirect_to(organization_path(organization))
+        end
+
+        it 'logs the CD removal' do
+          expect_any_instance_of(described_class).to receive(:log_event)
+            .with(:info, 'Credential Delegate removed from organization', hash_including(action_context: LoggingConstants::ActionContext::Registration,
+                                                                                         action_type: LoggingConstants::ActionType::CdRemovedFromOrg,
+                                                                                         csp: provider.to_s))
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+        end
+      end
+
+      context 'when the CD belongs to a different organization' do
+        let(:other_organization) { create(:provider_organization) }
+        let(:other_cd_org_link) do
+          create(:cd_org_link, user: cd_user, provider_organization: other_organization, invitation: invitation)
+        end
+
+        before do
+          create(:ao_org_link, user: ao_user, provider_organization: organization)
+          cd_org_link
+        end
+
+        it 'raises a record not found error' do
+          expect do
+            delete "/organizations/#{organization.path_id}/cd_org_links/#{other_cd_org_link.id}"
+          end.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'when the user is not an AO for the organization' do
+        before do
+          cd_org_link
+        end
+
+        it 'does not destroy the CdOrgLink' do
+          expect do
+            delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          end.to change { CdOrgLink.count }.by(0)
+        end
+
+        it 'redirects with an error' do
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context 'when the destruction fails' do
+        before do
+          create(:ao_org_link, user: ao_user, provider_organization: organization)
+          cd_org_link
+          allow_any_instance_of(CdOrgLink).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+        end
+
+        it 'shows an alert on failure' do
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          expect(flash[:alert]).to eq('Failed to remove Credential Delegate. Please try again later.')
+        end
+
+        it 'redirects to the organization page' do
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          expect(response).to redirect_to(organization_path(organization))
+        end
+
+        it 'logs the CD non-removal' do
+          expect_any_instance_of(described_class).to receive(:log_event)
+            .with(:error, 'Credential Delegate not removed from organization', hash_including(action_context: LoggingConstants::ActionContext::Registration,
+                                                                                              action_type: LoggingConstants::ActionType::CdNotRemovedFromOrg,
+                                                                                              csp: provider.to_s))
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+        end
+
+        it 'does not destroy the CdOrgLink' do
+          expect do
+            delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          end.to change { CdOrgLink.count }.by(0)
+        end
+      end
+    end
+
+    context 'when the user is not signed in' do
+      it 'redirects to the sign in page' do
+        delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+        expect(response).to redirect_to(sign_in_path)
+      end
+
+      it 'does not destroy the CdOrgLink' do
+        cd_org_link
+        expect do
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+        end.to change { CdOrgLink.count }.by(0)
+      end
+    end
+  end
+end

--- a/dpc-portal/spec/requests/cd_org_links_spec.rb
+++ b/dpc-portal/spec/requests/cd_org_links_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CdOrgLinksController, type: :request do
           end.to change { CdOrgLink.count }.by(-1)
         end
 
-        it 'shows a success flash with full name' do
+        it 'shows a success flash' do
           delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
           expect(flash[:success]).to eq('Successfully removed Credential Delegate.')
         end

--- a/dpc-portal/spec/requests/cd_org_links_spec.rb
+++ b/dpc-portal/spec/requests/cd_org_links_spec.rb
@@ -27,10 +27,9 @@ RSpec.describe CdOrgLinksController, type: :request do
               create(:ao_org_link, user: ao_user, provider_organization: organization)
             end
 
-            it 'destroys the CdOrgLink' do
-              expect do
-                delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-              end.to change { CdOrgLink.count }.by(-1)
+            it 'disables the CdOrgLink' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(cd_org_link.reload.disabled_at).not_to be_nil
             end
 
             it 'shows a success flash' do
@@ -70,10 +69,9 @@ RSpec.describe CdOrgLinksController, type: :request do
           end
 
           context 'when the user is not an AO for the organization' do
-            it 'does not destroy the CdOrgLink' do
-              expect do
-                delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-              end.to change { CdOrgLink.count }.by(0)
+            it 'does not disable the CdOrgLink' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(cd_org_link.reload.disabled_at).to be_nil
             end
 
             it 'redirects with an error' do
@@ -82,10 +80,10 @@ RSpec.describe CdOrgLinksController, type: :request do
             end
           end
 
-          context 'when the destruction fails' do
+          context 'when the removal fails' do
             before do
               create(:ao_org_link, user: ao_user, provider_organization: organization)
-              allow_any_instance_of(CdOrgLink).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+              allow_any_instance_of(CdOrgLink).to receive(:update!).and_raise(ActiveRecord::RecordInvalid)
             end
 
             it 'shows an alert on failure' do
@@ -106,10 +104,9 @@ RSpec.describe CdOrgLinksController, type: :request do
               delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
             end
 
-            it 'does not destroy the CdOrgLink' do
-              expect do
-                delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-              end.to change { CdOrgLink.count }.by(0)
+            it 'does not disable the CdOrgLink' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(cd_org_link.reload.disabled_at).to be_nil
             end
           end
         end
@@ -117,16 +114,21 @@ RSpec.describe CdOrgLinksController, type: :request do
     end
 
     context 'when the user is not signed in' do
-      let(:cd_org_link_id) { 1 }
+      let(:ao_user) { create(:user) }
+      let(:cd_user) { create(:user) }
+      let(:invitation) { create(:invitation, :cd, provider_organization: organization, invited_by: ao_user) }
+      let!(:cd_org_link) do
+        create(:cd_org_link, user: cd_user, provider_organization: organization, invitation: invitation)
+      end
+
       it 'redirects to the sign in page' do
-        delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link_id}"
+        delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
         expect(response).to redirect_to(sign_in_path)
       end
 
-      it 'does not destroy the CdOrgLink' do
-        expect do
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link_id}"
-        end.to change { CdOrgLink.count }.by(0)
+      it 'does not remove the CdOrgLink' do
+        delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+        expect(cd_org_link.reload.disabled_at).to be_nil
       end
     end
   end

--- a/dpc-portal/spec/requests/cd_org_links_spec.rb
+++ b/dpc-portal/spec/requests/cd_org_links_spec.rb
@@ -6,122 +6,126 @@ require 'support/login_support'
 RSpec.describe CdOrgLinksController, type: :request do
   include LoginSupport
 
-  let(:provider) { :login_dot_gov }
-  let(:organization) { create(:provider_organization) }
-  let(:ao_user) { create_user_with_csp(csp: provider, given_name: 'Bob', family_name: 'Hoskins') }
-  let(:cd_user) { create_user_with_csp(csp: provider, given_name: 'Lisa', family_name: 'Franklin') }
-  let(:invitation) { create(:invitation, :cd, provider_organization: organization, invited_by: ao_user) }
-  let!(:cd_org_link) do
-    create(:cd_org_link, user: cd_user, provider_organization: organization, invitation: invitation)
-  end
-
   describe 'DELETE /organizations/:organization_id/cd_org_links/:id' do
+    let(:organization) { create(:provider_organization) }
     context 'user is signed in' do
-      before do
-        sign_in ao_user, csp: provider
-      end
+      CspUtils::CODES_TO_DISPLAY.each do |csp_name, display|
+        context "with #{display}" do
+          let(:ao_user) { create_user_with_csp(csp: csp_name, given_name: 'Bob', family_name: 'Hoskins') }
+          let(:cd_user) { create_user_with_csp(csp: csp_name, given_name: 'Lisa', family_name: 'Franklin') }
+          let(:invitation) { create(:invitation, :cd, provider_organization: organization, invited_by: ao_user) }
+          let!(:cd_org_link) do
+            create(:cd_org_link, user: cd_user, provider_organization: organization, invitation: invitation)
+          end
 
-      context 'when the AO is authorized' do
-        before do
-          create(:ao_org_link, user: ao_user, provider_organization: organization)
-        end
+          before do
+            sign_in ao_user, csp: csp_name
+          end
 
-        it 'destroys the CdOrgLink' do
-          expect do
-            delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          end.to change { CdOrgLink.count }.by(-1)
-        end
+          context 'when the AO is authorized' do
+            before do
+              create(:ao_org_link, user: ao_user, provider_organization: organization)
+            end
 
-        it 'shows a success flash' do
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          expect(flash[:success]).to eq('Successfully removed Credential Delegate.')
-        end
+            it 'destroys the CdOrgLink' do
+              expect do
+                delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              end.to change { CdOrgLink.count }.by(-1)
+            end
 
-        it 'redirects to the organization page' do
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          expect(response).to redirect_to(organization_path(organization))
-        end
+            it 'shows a success flash' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(flash[:success]).to eq('Successfully removed Credential Delegate.')
+            end
 
-        it 'logs the CD removal' do
-          expect_any_instance_of(described_class).to receive(:log_event)
-            .with(:info, 'Credential Delegate removed from organization', hash_including(action_context: LoggingConstants::ActionContext::Registration,
-                                                                                         action_type: LoggingConstants::ActionType::CdRemovedFromOrg,
-                                                                                         csp: provider.to_s))
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-        end
-      end
+            it 'redirects to the organization page' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(response).to redirect_to(organization_path(organization))
+            end
 
-      context 'when the CD belongs to a different organization' do
-        let(:other_organization) { create(:provider_organization) }
-        let(:other_cd_org_link) do
-          create(:cd_org_link, user: cd_user, provider_organization: other_organization, invitation: invitation)
-        end
+            it 'logs the CD removal' do
+              expect_any_instance_of(described_class).to receive(:log_event)
+                .with(:info, 'Credential Delegate removed from organization', hash_including(action_context: LoggingConstants::ActionContext::Registration,
+                                                                                             action_type: LoggingConstants::ActionType::CdRemovedFromOrg,
+                                                                                             csp: csp_name.to_s))
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+            end
+          end
 
-        before do
-          create(:ao_org_link, user: ao_user, provider_organization: organization)
-        end
+          context 'when the CD belongs to a different organization' do
+            let(:other_organization) { create(:provider_organization) }
+            let(:other_cd_org_link) do
+              create(:cd_org_link, user: cd_user, provider_organization: other_organization, invitation: invitation)
+            end
 
-        it 'raises a record not found error' do
-          expect do
-            delete "/organizations/#{organization.path_id}/cd_org_links/#{other_cd_org_link.id}"
-          end.to raise_error(ActiveRecord::RecordNotFound)
-        end
-      end
+            before do
+              create(:ao_org_link, user: ao_user, provider_organization: organization)
+            end
 
-      context 'when the user is not an AO for the organization' do
-        it 'does not destroy the CdOrgLink' do
-          expect do
-            delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          end.to change { CdOrgLink.count }.by(0)
-        end
+            it 'raises a record not found error' do
+              expect do
+                delete "/organizations/#{organization.path_id}/cd_org_links/#{other_cd_org_link.id}"
+              end.to raise_error(ActiveRecord::RecordNotFound)
+            end
+          end
 
-        it 'redirects with an error' do
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          expect(response).to have_http_status(:redirect)
-        end
-      end
+          context 'when the user is not an AO for the organization' do
+            it 'does not destroy the CdOrgLink' do
+              expect do
+                delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              end.to change { CdOrgLink.count }.by(0)
+            end
 
-      context 'when the destruction fails' do
-        before do
-          create(:ao_org_link, user: ao_user, provider_organization: organization)
-          allow_any_instance_of(CdOrgLink).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
-        end
+            it 'redirects with an error' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(response).to have_http_status(:redirect)
+            end
+          end
 
-        it 'shows an alert on failure' do
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          expect(flash[:alert]).to eq('Failed to remove Credential Delegate. Please try again later.')
-        end
+          context 'when the destruction fails' do
+            before do
+              create(:ao_org_link, user: ao_user, provider_organization: organization)
+              allow_any_instance_of(CdOrgLink).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
+            end
 
-        it 'redirects to the organization page' do
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          expect(response).to redirect_to(organization_path(organization))
-        end
+            it 'shows an alert on failure' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(flash[:alert]).to eq('Failed to remove Credential Delegate. Please try again later.')
+            end
 
-        it 'logs the CD non-removal' do
-          expect_any_instance_of(described_class).to receive(:log_event)
-            .with(:error, 'Credential Delegate not removed from organization', hash_including(action_context: LoggingConstants::ActionContext::Registration,
-                                                                                              action_type: LoggingConstants::ActionType::CdNotRemovedFromOrg,
-                                                                                              csp: provider.to_s))
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-        end
+            it 'redirects to the organization page' do
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              expect(response).to redirect_to(organization_path(organization))
+            end
 
-        it 'does not destroy the CdOrgLink' do
-          expect do
-            delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
-          end.to change { CdOrgLink.count }.by(0)
+            it 'logs the CD non-removal' do
+              expect_any_instance_of(described_class).to receive(:log_event)
+                .with(:error, 'Credential Delegate not removed from organization', hash_including(action_context: LoggingConstants::ActionContext::Registration,
+                                                                                                  action_type: LoggingConstants::ActionType::CdNotRemovedFromOrg,
+                                                                                                  csp: csp_name.to_s))
+              delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+            end
+
+            it 'does not destroy the CdOrgLink' do
+              expect do
+                delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+              end.to change { CdOrgLink.count }.by(0)
+            end
+          end
         end
       end
     end
 
     context 'when the user is not signed in' do
+      let(:cd_org_link_id) { 1 }
       it 'redirects to the sign in page' do
-        delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+        delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link_id}"
         expect(response).to redirect_to(sign_in_path)
       end
 
       it 'does not destroy the CdOrgLink' do
         expect do
-          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
+          delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link_id}"
         end.to change { CdOrgLink.count }.by(0)
       end
     end

--- a/dpc-portal/spec/requests/cd_org_links_spec.rb
+++ b/dpc-portal/spec/requests/cd_org_links_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CdOrgLinksController, type: :request do
   let(:ao_user) { create_user_with_csp(csp: provider, given_name: 'Bob', family_name: 'Hoskins') }
   let(:cd_user) { create_user_with_csp(csp: provider, given_name: 'Lisa', family_name: 'Franklin') }
   let(:invitation) { create(:invitation, :cd, provider_organization: organization, invited_by: ao_user) }
-  let(:cd_org_link) do
+  let!(:cd_org_link) do
     create(:cd_org_link, user: cd_user, provider_organization: organization, invitation: invitation)
   end
 
@@ -24,7 +24,6 @@ RSpec.describe CdOrgLinksController, type: :request do
       context 'when the AO is authorized' do
         before do
           create(:ao_org_link, user: ao_user, provider_organization: organization)
-          cd_org_link
         end
 
         it 'destroys the CdOrgLink' do
@@ -60,7 +59,6 @@ RSpec.describe CdOrgLinksController, type: :request do
 
         before do
           create(:ao_org_link, user: ao_user, provider_organization: organization)
-          cd_org_link
         end
 
         it 'raises a record not found error' do
@@ -71,10 +69,6 @@ RSpec.describe CdOrgLinksController, type: :request do
       end
 
       context 'when the user is not an AO for the organization' do
-        before do
-          cd_org_link
-        end
-
         it 'does not destroy the CdOrgLink' do
           expect do
             delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
@@ -90,7 +84,6 @@ RSpec.describe CdOrgLinksController, type: :request do
       context 'when the destruction fails' do
         before do
           create(:ao_org_link, user: ao_user, provider_organization: organization)
-          cd_org_link
           allow_any_instance_of(CdOrgLink).to receive(:destroy!).and_raise(ActiveRecord::RecordNotDestroyed)
         end
 
@@ -127,7 +120,6 @@ RSpec.describe CdOrgLinksController, type: :request do
       end
 
       it 'does not destroy the CdOrgLink' do
-        cd_org_link
         expect do
           delete "/organizations/#{organization.path_id}/cd_org_links/#{cd_org_link.id}"
         end.to change { CdOrgLink.count }.by(0)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5628

## 🛠 Changes

Adds delete button to list of active CDs to allow AOs to revoke access.

## ℹ️ Context

As an Authorized official
I'd like DPC Portal to allow me to remove a Credential Delegate. 
So that if the current CD leaves the organization/changes their role OR if I have a new tech vendor handling API integration, I can revoke access and they no longer have access to the portal 

## 🧪 Validation

Tests updated.

<img width="1265" height="865" alt="image" src="https://github.com/user-attachments/assets/6d24870d-58fd-43fa-bebe-6e3cb0b71566" />

<img width="1259" height="860" alt="image" src="https://github.com/user-attachments/assets/71de8dca-35b7-44ab-8225-482ba3660ee8" />
