### PR TITLE
Me/dpc 5653 update portal healthcheck alarms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,13 @@ maven-config:
 psql: ## Run a psql shell
 	@docker compose -f docker-compose.yml exec -it db psql -U postgres
 
-portal-sh: ## Run a portal shell
-	@docker compose -f docker-compose.yml -f docker-compose.portals.yml exec -it dpc_portal bin/sh
+portal-sh: ## Run a portal shell.  If it's not already up, start it without running it's entry point.
+ 		   ## (Comes in handy when you break the portal and it won't start)
+	@if [ -n "$$(docker compose -f docker-compose.yml -f docker-compose.portals.yml ps --status running -q dpc_portal)" ]; then \
+		docker compose -f docker-compose.yml -f docker-compose.portals.yml exec -it dpc_portal bin/sh; \
+	else \
+		docker compose -f docker-compose.yml -f docker-compose.portals.yml run --rm -it --no-deps --entrypoint bin/sh dpc_portal; \
+	fi
 
 portal-console: ## Run a rails console shell
 	@docker compose -f docker-compose.yml -f docker-compose.portals.yml exec -it dpc_portal bin/console

--- a/dpc-portal/app/jobs/verify_resource_health_job.rb
+++ b/dpc-portal/app/jobs/verify_resource_health_job.rb
@@ -11,9 +11,9 @@ class VerifyResourceHealthJob < ApplicationJob
   ENVIRONMENT = ENV.fetch('ENV', 'none')
 
   # Runs all healthchecks if no args provided
-  def perform(check_dpc: true, check_idp: true, check_cpi: true)
+  def perform(check_dpc: true, check_csp: true, check_cpi: true)
     dpc_healthcheck if check_dpc
-    idp_healthcheck if check_idp
+    csp_healthcheck if check_csp
     cpi_gateway_healthcheck if check_cpi
   end
 
@@ -33,7 +33,7 @@ class VerifyResourceHealthJob < ApplicationJob
     )
   end
 
-  def idp_healthcheck
+  def csp_healthcheck
     CspConfig.all.each do |csp|
       csp_host = csp.host
       csp_name = csp.code
@@ -81,25 +81,25 @@ class VerifyResourceHealthJob < ApplicationJob
                   end
     Rails.logger.info(["Healthcheck #{check_name}", { actionContext: LoggingConstants::ActionContext::HealthCheck,
                                                       actionType: action_type, csp_host:, csp_name: }])
-    emit_cloudwatch_metric(check_name, healthy, idp: csp_name)
+    emit_cloudwatch_metric(check_name, healthy, csp: csp_name)
   end
 
-  def dimensions(idp = nil)
+  def dimensions(csp = nil)
     dims = []
     dims << { name: 'Type', value: 'healthcheck' }
     dims << { name: 'environment', value: ENVIRONMENT }
-    dims << { name: 'idp', value: idp } if idp
+    dims << { name: 'csp', value: csp } if csp
     dims
   end
 
-  def emit_cloudwatch_metric(check_name, healthy, idp: nil)
+  def emit_cloudwatch_metric(check_name, healthy, csp: nil)
     Aws::CloudWatch::Client.new(region: REGION).put_metric_data(
       {
         namespace: METRIC_NAMESPACE,
         metric_data: [
           {
             metric_name: check_name,
-            dimensions: dimensions(idp),
+            dimensions: dimensions(csp),
             value: healthy ? 1 : 0,
             unit: 'None'
           }

--- a/dpc-portal/app/jobs/verify_resource_health_job.rb
+++ b/dpc-portal/app/jobs/verify_resource_health_job.rb
@@ -47,12 +47,12 @@ class VerifyResourceHealthJob < ApplicationJob
       csp_name = csp[:name]
       oidc_discovery_url = csp[:discovery_endpoint]
       if csp_host.nil? || oidc_discovery_url.nil?
-        log_healthcheck('PortalConnectedToIdp', false, csp_host:, csp_name:)
+        log_healthcheck('PortalConnectedToCsp', false, csp_host:, csp_name:)
       else
         # None of our CSPs have a healthcheck, so we'll try the OIDC well-known endpoint
         response = Net::HTTP.get_response(URI("https://#{csp_host}#{oidc_discovery_url}"))
         log_healthcheck(
-          'PortalConnectedToIdp',
+          'PortalConnectedToCsp',
           response.code.to_i.between?(200, 299),
           csp_host:,
           csp_name:

--- a/dpc-portal/app/jobs/verify_resource_health_job.rb
+++ b/dpc-portal/app/jobs/verify_resource_health_job.rb
@@ -10,9 +10,12 @@ class VerifyResourceHealthJob < ApplicationJob
   REGION = 'us-east-1'
   ENVIRONMENT = ENV.fetch('ENV', 'none')
   CSPS = [
-    { name: 'login_gov', host: ENV.fetch('IDP_LOGIN_DOT_GOV_HOST', nil) },
-    { name: 'id_me', host: ENV.fetch('IDP_ID_ME_HOST', nil) },
-    { name: 'clear', host: ENV.fetch('CLEAR_IDP_HOST', nil) }
+    { name: 'login_gov', host: ENV.fetch('IDP_LOGIN_DOT_GOV_HOST', nil),
+      discovery_endpoint: '/.well-known/openid-configuration' },
+    { name: 'id_me', host: ENV.fetch('IDP_ID_ME_HOST', nil),
+      discovery_endpoint: '/oidc/.well-known/openid-configuration' },
+    { name: 'clear', host: ENV.fetch('CLEAR_IDP_HOST', nil),
+      discovery_endpoint: '/integrations/.well-known/openid-configuration' }
   ].freeze
 
   # Runs all healthchecks if no args provided
@@ -42,11 +45,12 @@ class VerifyResourceHealthJob < ApplicationJob
     CSPS.each do |csp|
       csp_host = csp[:host]
       csp_name = csp[:name]
-      if csp_host.nil?
+      oidc_discovery_url = csp[:discovery_endpoint]
+      if csp_host.nil? || oidc_discovery_url.nil?
         log_healthcheck('PortalConnectedToIdp', false, csp_host:, csp_name:)
       else
-        # Login.gov doesn't have a /healthcheck, so we look for a 200 to verify connectivity.
-        response = Net::HTTP.get_response(URI("https://#{csp_host}"))
+        # None of our CSPs have a healthcheck, so we'll try the OIDC well-known endpoint
+        response = Net::HTTP.get_response(URI("https://#{csp_host}#{oidc_discovery_url}"))
         log_healthcheck(
           'PortalConnectedToIdp',
           response.code.to_i.between?(200, 299),
@@ -83,10 +87,8 @@ class VerifyResourceHealthJob < ApplicationJob
                   else
                     LoggingConstants::ActionType::HealthCheckFailed
                   end
-    Rails.logger.info(["Healthcheck #{check_name}",
-                       { actionContext: LoggingConstants::ActionContext::HealthCheck,
-                         actionType: action_type,
-                         csp_host:, csp_name: }.compact])
+    Rails.logger.info(["Healthcheck #{check_name}", { actionContext: LoggingConstants::ActionContext::HealthCheck,
+                                                      actionType: action_type, csp_host:, csp_name: }])
     emit_cloudwatch_metric(check_name, healthy, idp: csp_name)
   end
 

--- a/dpc-portal/app/jobs/verify_resource_health_job.rb
+++ b/dpc-portal/app/jobs/verify_resource_health_job.rb
@@ -9,14 +9,6 @@ class VerifyResourceHealthJob < ApplicationJob
   METRIC_NAMESPACE = 'DPC'
   REGION = 'us-east-1'
   ENVIRONMENT = ENV.fetch('ENV', 'none')
-  CSPS = [
-    { name: 'login_gov', host: ENV.fetch('IDP_LOGIN_DOT_GOV_HOST', nil),
-      discovery_endpoint: '/.well-known/openid-configuration' },
-    { name: 'id_me', host: ENV.fetch('IDP_ID_ME_HOST', nil),
-      discovery_endpoint: '/oidc/.well-known/openid-configuration' },
-    { name: 'clear', host: ENV.fetch('CLEAR_IDP_HOST', nil),
-      discovery_endpoint: '/integrations/.well-known/openid-configuration' }
-  ].freeze
 
   # Runs all healthchecks if no args provided
   def perform(check_dpc: true, check_idp: true, check_cpi: true)
@@ -42,10 +34,10 @@ class VerifyResourceHealthJob < ApplicationJob
   end
 
   def idp_healthcheck
-    CSPS.each do |csp|
-      csp_host = csp[:host]
-      csp_name = csp[:name]
-      oidc_discovery_url = csp[:discovery_endpoint]
+    CspConfig.all.each do |csp|
+      csp_host = csp.host
+      csp_name = csp.code
+      oidc_discovery_url = csp.discovery_uri
       if csp_host.nil? || oidc_discovery_url.nil?
         log_healthcheck('PortalConnectedToCsp', false, csp_host:, csp_name:)
       else

--- a/dpc-portal/app/jobs/verify_resource_health_job.rb
+++ b/dpc-portal/app/jobs/verify_resource_health_job.rb
@@ -9,10 +9,10 @@ class VerifyResourceHealthJob < ApplicationJob
   METRIC_NAMESPACE = 'DPC'
   REGION = 'us-east-1'
   ENVIRONMENT = ENV.fetch('ENV', 'none')
-  IDP_HOSTS = [
-    ENV.fetch('IDP_LOGIN_DOT_GOV_HOST', nil),
-    ENV.fetch('IDP_ID_ME_HOST', nil),
-    ENV.fetch('CLEAR_IDP_HOST', nil)
+  CSPS = [
+    { name: 'login_gov', host: ENV.fetch('IDP_LOGIN_DOT_GOV_HOST', nil) },
+    { name: 'id_me', host: ENV.fetch('IDP_ID_ME_HOST', nil) },
+    { name: 'clear', host: ENV.fetch('CLEAR_IDP_HOST', nil) }
   ].freeze
 
   # Runs all healthchecks if no args provided
@@ -39,16 +39,19 @@ class VerifyResourceHealthJob < ApplicationJob
   end
 
   def idp_healthcheck
-    IDP_HOSTS.each do |idp_host|
-      if idp_host.nil?
-        log_healthcheck('PortalConnectedToIdp', false, csp: idp_host)
+    CSPS.each do |csp|
+      csp_host = csp[:host]
+      csp_name = csp[:name]
+      if csp_host.nil?
+        log_healthcheck('PortalConnectedToIdp', false, csp_host:, csp_name:)
       else
         # Login.gov doesn't have a /healthcheck, so we look for a 200 to verify connectivity.
-        response = Net::HTTP.get_response(URI("https://#{idp_host}"))
+        response = Net::HTTP.get_response(URI("https://#{csp_host}"))
         log_healthcheck(
           'PortalConnectedToIdp',
           response.code.to_i.between?(200, 299),
-          csp: idp_host
+          csp_host:,
+          csp_name:
         )
       end
     end
@@ -74,7 +77,7 @@ class VerifyResourceHealthJob < ApplicationJob
     )
   end
 
-  def log_healthcheck(check_name, healthy, csp: nil)
+  def log_healthcheck(check_name, healthy, csp_host: nil, csp_name: nil)
     action_type = if healthy
                     LoggingConstants::ActionType::HealthCheckPassed
                   else
@@ -83,31 +86,26 @@ class VerifyResourceHealthJob < ApplicationJob
     Rails.logger.info(["Healthcheck #{check_name}",
                        { actionContext: LoggingConstants::ActionContext::HealthCheck,
                          actionType: action_type,
-                         csp: }.compact])
-    emit_cloudwatch_metric(check_name, healthy)
+                         csp_host:, csp_name: }.compact])
+    emit_cloudwatch_metric(check_name, healthy, idp: csp_name)
   end
 
-  def dimensions
-    [
-      {
-        name: 'Type',
-        value: 'healthcheck'
-      },
-      {
-        name: 'environment',
-        value: ENVIRONMENT
-      }
-    ]
+  def dimensions(idp = nil)
+    dims = []
+    dims << { name: 'Type', value: 'healthcheck' }
+    dims << { name: 'environment', value: ENVIRONMENT }
+    dims << { name: 'idp', value: idp } if idp
+    dims
   end
 
-  def emit_cloudwatch_metric(check_name, healthy)
+  def emit_cloudwatch_metric(check_name, healthy, idp: nil)
     Aws::CloudWatch::Client.new(region: REGION).put_metric_data(
       {
         namespace: METRIC_NAMESPACE,
         metric_data: [
           {
             metric_name: check_name,
-            dimensions:,
+            dimensions: dimensions(idp),
             value: healthy ? 1 : 0,
             unit: 'None'
           }

--- a/dpc-portal/app/jobs/verify_resource_health_job.rb
+++ b/dpc-portal/app/jobs/verify_resource_health_job.rb
@@ -19,10 +19,10 @@ class VerifyResourceHealthJob < ApplicationJob
   ].freeze
 
   # Runs all healthchecks if no args provided
-  def perform(args = {})
-    dpc_healthcheck if args.key?('check_dpc') ? args['check_dpc'] : true
-    idp_healthcheck if args.key?('check_idp') ? args['check_idp'] : true
-    cpi_gateway_healthcheck if args.key?('check_cpi') ? args['check_cpi'] : true
+  def perform(check_dpc: true, check_idp: true, check_cpi: true)
+    dpc_healthcheck if check_dpc
+    idp_healthcheck if check_idp
+    cpi_gateway_healthcheck if check_cpi
   end
 
   private

--- a/dpc-portal/app/models/csp_config.rb
+++ b/dpc-portal/app/models/csp_config.rb
@@ -17,6 +17,7 @@ class CspConfig
     @redirect_path = config[:redirect_path]
     @authorize_scope = config[:authorize_scope]
     @acr_values = config[:acr_values]
+    @discovery_uri = config[:discovery_uri]
   end
 
   LOGIN_DOT_GOV = new('login_dot_gov',
@@ -28,7 +29,7 @@ class CspConfig
   private_class_method :new
 
   attr_reader :code, :user_info_endpoint, :log_out_path, :token_expiration_interval, :host, :identifier,
-              :authorization_endpoint, :redirect_path, :authorize_scope, :acr_values
+              :authorization_endpoint, :redirect_path, :authorize_scope, :acr_values, :discovery_uri
 
   def self.for(code)
     case code.to_s
@@ -45,5 +46,9 @@ class CspConfig
 
   def self.list
     [LOGIN_DOT_GOV.code, ID_ME.code, CLEAR.code]
+  end
+
+  def self.all
+    [LOGIN_DOT_GOV, ID_ME, CLEAR]
   end
 end

--- a/dpc-portal/config/csp.yml
+++ b/dpc-portal/config/csp.yml
@@ -14,6 +14,7 @@ development: &development
     authorization_endpoint: <%= "https://#{ENV['IDP_LOGIN_DOT_GOV_HOST']}/openid_connect/authorize" %>
     token_endpoint: <%= "https://#{ENV['IDP_LOGIN_DOT_GOV_HOST']}/api/openid_connect/token" %>
     jwks_uri: <%= "https://#{ENV['IDP_LOGIN_DOT_GOV_HOST']}/api/openid_connect/certs" %>
+    discovery_uri: '/.well-known/openid-configuration'
 
   id_me:
     host: <%= ENV['IDP_ID_ME_HOST'] %>
@@ -27,6 +28,7 @@ development: &development
     authorize_scope: 'openid http://idmanagement.gov/ns/assurance/ial/2/aal/2'
     log_out_path: '/oauth/logout'
     token_expiration_interval: 300
+    discovery_uri: '/oidc/.well-known/openid-configuration'
 
   clear:
     host: <%= ENV['CLEAR_IDP_HOST'] %>
@@ -40,6 +42,7 @@ development: &development
     authorize_scope: 'openid'
     log_out_path: '/integrations/oauth2/sessions/logout'
     token_expiration_interval: 300
+    discovery_uri: '/integrations/.well-known/openid-configuration'
 
 local:
   <<: *development

--- a/dpc-portal/config/recurring.yml
+++ b/dpc-portal/config/recurring.yml
@@ -23,13 +23,19 @@ production:
     schedule: "*/1 * * * *"
     class: "VerifyResourceHealthJob"
     queue: portal
-    args: [ { check_dpc: true, check_cpi: false, check_idp: false } ]
+    args:
+      check_dpc: true
+      check_cpi: false
+      check_idp: false
 
   verify_non_dpc_health_job:
     schedule: "0 * * * *"
     class: "VerifyResourceHealthJob"
     queue: portal
-    args: [ { check_dpc: false, check_cpi: true, check_idp: true } ]
+    args:
+      check_dpc: false
+      check_cpi: true
+      check_idp: true
 
   log_organizations_api_credential_status_job:
     schedule: "0 0 * * *"

--- a/dpc-portal/config/recurring.yml
+++ b/dpc-portal/config/recurring.yml
@@ -24,18 +24,18 @@ production:
     class: "VerifyResourceHealthJob"
     queue: portal
     args:
-      check_dpc: true
-      check_cpi: false
-      check_idp: false
+      - check_dpc: true
+        check_cpi: false
+        check_idp: false
 
   verify_non_dpc_health_job:
     schedule: "0 * * * *"
     class: "VerifyResourceHealthJob"
     queue: portal
     args:
-      check_dpc: false
-      check_cpi: true
-      check_idp: true
+      - check_dpc: false
+        check_cpi: true
+        check_idp: true
 
   log_organizations_api_credential_status_job:
     schedule: "0 0 * * *"

--- a/dpc-portal/config/recurring.yml
+++ b/dpc-portal/config/recurring.yml
@@ -26,7 +26,7 @@ production:
     args:
       - check_dpc: true
         check_cpi: false
-        check_idp: false
+        check_csp: false
 
   verify_non_dpc_health_job:
     schedule: "0 * * * *"
@@ -35,7 +35,7 @@ production:
     args:
       - check_dpc: false
         check_cpi: true
-        check_idp: true
+        check_csp: true
 
   log_organizations_api_credential_status_job:
     schedule: "0 0 * * *"

--- a/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
   end
 
   let(:job) { VerifyResourceHealthJob.new }
-  let(:login_dot_gov_discovery) { 'https://csp.int.identitysandbox.gov/.well-known/openid-configuration' }
+  let(:login_dot_gov_discovery) { 'https://idp.int.identitysandbox.gov/.well-known/openid-configuration' }
   let(:id_me_discovery) { 'https://api.idmelabs.com/oidc/.well-known/openid-configuration' }
   let(:clear_discovery) { 'https://verified.clearme.com/integrations/.well-known/openid-configuration' }
 

--- a/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
   end
 
   let(:job) { VerifyResourceHealthJob.new }
+  let(:login_dot_gov_discovery) { 'https://idp.int.identitysandbox.gov/.well-known/openid-configuration' }
+  let(:id_me_discovery) { 'https://api.idmelabs.com/oidc/.well-known/openid-configuration' }
+  let(:clear_discovery) { 'https://verified.clearme.com/integrations/.well-known/openid-configuration' }
 
   context 'can successfully send metrics' do
     describe 'everything healthy' do
@@ -89,9 +92,9 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
 
   context 'not connected to AWS' do
     it 'should ignore connection error and move on gracefully' do
-      stub_request(:get, 'https://idp.int.identitysandbox.gov').to_return(status: 200)
-      stub_request(:get, 'https://api.idmelabs.com').to_return(status: 200)
-      stub_request(:get, 'https://verified.clearme.com').to_return(status: 200)
+      stub_request(:get, login_dot_gov_discovery).to_return(status: 200)
+      stub_request(:get, id_me_discovery).to_return(status: 200)
+      stub_request(:get, clear_discovery).to_return(status: 200)
 
       expect(mock_dpc_client).to receive(:healthcheck)
       expect(mock_dpc_client).to receive(:response_successful?).and_return(true).twice
@@ -150,9 +153,9 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
   end
 
   def expect_idp(site_status: 200, metric: 1)
-    stub_request(:get, 'https://idp.int.identitysandbox.gov').to_return(status: site_status)
-    stub_request(:get, 'https://api.idmelabs.com').to_return(status: site_status)
-    stub_request(:get, 'https://verified.clearme.com').to_return(status: site_status)
+    stub_request(:get, login_dot_gov_discovery).to_return(status: site_status)
+    stub_request(:get, id_me_discovery).to_return(status: site_status)
+    stub_request(:get, clear_discovery).to_return(status: site_status)
     expect_put_metric('PortalConnectedToIdp', metric, 'login_gov')
     expect_put_metric('PortalConnectedToIdp', metric, 'id_me')
     expect_put_metric('PortalConnectedToIdp', metric, 'clear')

--- a/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
@@ -109,13 +109,13 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
   context 'only runs requested checks' do
     it 'runs dpc-api check' do
       expect_dpc_api
-      job.perform({ 'check_dpc' => true, 'check_cpi' => false, 'check_idp' => false })
+      job.perform(check_dpc: true, check_cpi: false, check_idp: false)
     end
 
     it 'runs idp and cpi checks' do
       expect_cpi
       expect_idp
-      job.perform({ 'check_dpc' => false, 'check_cpi' => true, 'check_idp' => true })
+      job.perform(check_dpc: false, check_cpi: true, check_idp: true)
     end
   end
 

--- a/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
   end
 
   let(:job) { VerifyResourceHealthJob.new }
-  let(:login_dot_gov_discovery) { 'https://idp.int.identitysandbox.gov/.well-known/openid-configuration' }
+  let(:login_dot_gov_discovery) { 'https://csp.int.identitysandbox.gov/.well-known/openid-configuration' }
   let(:id_me_discovery) { 'https://api.idmelabs.com/oidc/.well-known/openid-configuration' }
   let(:clear_discovery) { 'https://verified.clearme.com/integrations/.well-known/openid-configuration' }
 
@@ -28,7 +28,7 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
       it 'should emit healthy metrics' do
         expect_dpc_api
         expect_cpi
-        expect_idp
+        expect_csp
 
         job.perform
       end
@@ -38,7 +38,7 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
       it 'should emit an unhealthy metric' do
         expect_dpc_api(response_successful: false, metric: 0)
         expect_cpi
-        expect_idp
+        expect_csp
 
         job.perform
       end
@@ -48,7 +48,7 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
       it 'should emit an unhealthy metric' do
         expect_dpc_api
         expect_cpi(auth_health: false, metric: 0)
-        expect_idp
+        expect_csp
 
         job.perform
       end
@@ -58,23 +58,23 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
       it 'should emit an unhealthy metric' do
         expect_dpc_api
         expect_cpi(api_health: false, metric: 0)
-        expect_idp
+        expect_csp
 
         job.perform
       end
     end
 
-    describe 'idp is down' do
+    describe 'csp is down' do
       it 'should emit an unhealthy metric' do
         expect_dpc_api
         expect_cpi
-        expect_idp(site_status: 500, metric: 0)
+        expect_csp(site_status: 500, metric: 0)
 
         job.perform
       end
     end
 
-    describe 'idp is not configured' do
+    describe 'csp is not configured' do
       it 'should emit an unhealthy metric when url is not configured' do
         allow(CspConfig).to receive(:all).and_return(
           [
@@ -88,7 +88,7 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
         )
         expect_dpc_api
         expect_cpi
-        expect_idp(metric: 0)
+        expect_csp(metric: 0)
 
         VerifyResourceHealthJob.new.perform
       end
@@ -114,23 +114,23 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
   context 'only runs requested checks' do
     it 'runs dpc-api check' do
       expect_dpc_api
-      job.perform(check_dpc: true, check_cpi: false, check_idp: false)
+      job.perform(check_dpc: true, check_cpi: false, check_csp: false)
     end
 
-    it 'runs idp and cpi checks' do
+    it 'runs csp and cpi checks' do
       expect_cpi
-      expect_idp
-      job.perform(check_dpc: false, check_cpi: true, check_idp: true)
+      expect_csp
+      job.perform(check_dpc: false, check_cpi: true, check_csp: true)
     end
   end
 
   private
 
-  def put_metric_data_parms(namespace, env, check_name, value, idp = nil)
+  def put_metric_data_parms(namespace, env, check_name, value, csp = nil)
     dims = []
     dims << { name: 'Type', value: 'healthcheck' }
     dims << { name: 'environment', value: env }
-    dims << { name: 'idp', value: idp } if idp
+    dims << { name: 'csp', value: csp } if csp
     {
       namespace:,
       metric_data: [
@@ -157,7 +157,7 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
     expect_put_metric('PortalConnectedToCpiApiGateway', metric)
   end
 
-  def expect_idp(site_status: 200, metric: 1)
+  def expect_csp(site_status: 200, metric: 1)
     stub_request(:get, login_dot_gov_discovery).to_return(status: site_status)
     stub_request(:get, id_me_discovery).to_return(status: site_status)
     stub_request(:get, clear_discovery).to_return(status: site_status)
@@ -166,14 +166,14 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
     expect_put_metric('PortalConnectedToCsp', metric, 'clear')
   end
 
-  def expect_put_metric(name, value, idp = nil)
+  def expect_put_metric(name, value, csp = nil)
     expect(mock_cloudwatch_client).to receive(:put_metric_data).with(
       put_metric_data_parms(
         VerifyResourceHealthJob::METRIC_NAMESPACE,
         VerifyResourceHealthJob::ENVIRONMENT,
         name,
         value,
-        idp
+        csp
       )
     )
   end

--- a/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
@@ -73,7 +73,11 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
 
     describe 'idp is not configured' do
       it 'should emit an unhealthy metric when url is not configured' do
-        stub_const('VerifyResourceHealthJob::IDP_HOSTS', [nil, nil, nil])
+        stub_const('VerifyResourceHealthJob::CSPS', [
+                     { name: 'login_gov', host: nil },
+                     { name: 'id_me', host: nil },
+                     { name: 'clear', host: nil }
+                   ])
         expect_dpc_api
         expect_cpi
         expect_idp(metric: 0)
@@ -114,22 +118,17 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
 
   private
 
-  def put_metric_data_parms(namespace, env, check_name, value)
+  def put_metric_data_parms(namespace, env, check_name, value, idp = nil)
+    dims = []
+    dims << { name: 'Type', value: 'healthcheck' }
+    dims << { name: 'environment', value: env }
+    dims << { name: 'idp', value: idp } if idp
     {
       namespace:,
       metric_data: [
         {
           metric_name: check_name,
-          dimensions: [
-            {
-              name: 'Type',
-              value: 'healthcheck'
-            },
-            {
-              name: 'environment',
-              value: env
-            }
-          ],
+          dimensions: dims,
           value:,
           unit: 'None'
         }
@@ -154,16 +153,19 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
     stub_request(:get, 'https://idp.int.identitysandbox.gov').to_return(status: site_status)
     stub_request(:get, 'https://api.idmelabs.com').to_return(status: site_status)
     stub_request(:get, 'https://verified.clearme.com').to_return(status: site_status)
-    expect_put_metric('PortalConnectedToIdp', metric).exactly(3).times
+    expect_put_metric('PortalConnectedToIdp', metric, 'login_gov')
+    expect_put_metric('PortalConnectedToIdp', metric, 'id_me')
+    expect_put_metric('PortalConnectedToIdp', metric, 'clear')
   end
 
-  def expect_put_metric(name, value)
+  def expect_put_metric(name, value, idp = nil)
     expect(mock_cloudwatch_client).to receive(:put_metric_data).with(
       put_metric_data_parms(
         VerifyResourceHealthJob::METRIC_NAMESPACE,
         VerifyResourceHealthJob::ENVIRONMENT,
         name,
-        value
+        value,
+        idp
       )
     )
   end

--- a/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_resource_health_job_spec.rb
@@ -76,11 +76,16 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
 
     describe 'idp is not configured' do
       it 'should emit an unhealthy metric when url is not configured' do
-        stub_const('VerifyResourceHealthJob::CSPS', [
-                     { name: 'login_gov', host: nil },
-                     { name: 'id_me', host: nil },
-                     { name: 'clear', host: nil }
-                   ])
+        allow(CspConfig).to receive(:all).and_return(
+          [
+            instance_double(CspConfig, code: 'login_dot_gov', host: nil,
+                                       discovery_uri: '/.well-known/openid-configuration'),
+            instance_double(CspConfig, code: 'id_me', host: nil,
+                                       discovery_uri: '/oidc/.well-known/openid-configuration'),
+            instance_double(CspConfig, code: 'clear', host: nil,
+                                       discovery_uri: '/integrations/.well-known/openid-configuration')
+          ]
+        )
         expect_dpc_api
         expect_cpi
         expect_idp(metric: 0)
@@ -156,9 +161,9 @@ RSpec.describe VerifyResourceHealthJob, type: :job do
     stub_request(:get, login_dot_gov_discovery).to_return(status: site_status)
     stub_request(:get, id_me_discovery).to_return(status: site_status)
     stub_request(:get, clear_discovery).to_return(status: site_status)
-    expect_put_metric('PortalConnectedToIdp', metric, 'login_gov')
-    expect_put_metric('PortalConnectedToIdp', metric, 'id_me')
-    expect_put_metric('PortalConnectedToIdp', metric, 'clear')
+    expect_put_metric('PortalConnectedToCsp', metric, 'login_dot_gov')
+    expect_put_metric('PortalConnectedToCsp', metric, 'id_me')
+    expect_put_metric('PortalConnectedToCsp', metric, 'clear')
   end
 
   def expect_put_metric(name, value, idp = nil)


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5653

## 🛠 Changes

- Update `verify_resource_health_job` to differentiate between the health checks for each CSP.
- Switched CSP health checks to use the OIDC discover endpoint of each CSP.
- Renamed IDP -> CSP.
- Updated `csp` model and `csp_config` with `discovery_uri`.
- Fixed bug where CSP health checks were executing every minute instead of every hour.
- Added option in makefile to shell into portal container without starting the portal.

## ℹ️ Context

Our CSP health checks were written when we only had one CSP and have never really worked since we moved to three.  The login.gov health check has been passing, while id.me and clear have consistently failed.  Those failures were hidden because the Cloudwatch alarms they trigger were also written when we only had one CSP, and weren't alerting.

There is an associated dpc-ops PR: https://github.com/CMSgov/dpc-ops/pull/975

## 🧪 Validation

Successful deploy [here](https://github.com/CMSgov/dpc-app/actions/runs/33429408131).

New dimensions in Cloudwatch:
<img width="652" height="272" alt="image" src="https://github.com/user-attachments/assets/23389850-93a2-4c5b-b2e1-70459e2466fa" />


New metrics in Cloudwatch:
<img width="1309" height="554" alt="image" src="https://github.com/user-attachments/assets/41c38f2c-7862-4766-bea4-4b3d0c92338e" />


