### PR TITLE
[DPC-5692] add test orgs for validating CSP connections

### DIFF
--- a/dpc-aggregation/src/main/resources/application.yml
+++ b/dpc-aggregation/src/main/resources/application.yml
@@ -125,7 +125,7 @@ exportPath: ${EXPORT_PATH:-"/app/data"}
 # Lookback Settings
 # The number of months to look back for a claim
 lookBackMonths: ${LOOK_BACK_MONTHS:-18}
-lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145"]}
+lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145","a3abaf86-2cd4-4a32-a57e-1bda741ed00d","66e9f10c-31c7-41a4-b88f-4d10e59432d7","97509c9f-4350-4b4f-a9d4-aba4dadffe1c"]}
 
 # base URL for FHIR references to DPC resources (Patients, Organizations, etc) embedded in a Consent resource
 fhirReferenceURL: ${FHIR_REFERENCE_URL:-"http://localhost:3200/api/v1"}

--- a/dpc-aggregation/src/test/resources/test.application.yml
+++ b/dpc-aggregation/src/test/resources/test.application.yml
@@ -102,7 +102,7 @@ exportPath: ${EXPORT_PATH:-"/app/data"}
 # Lookback Settings
 # The number of months to look back for a claim
 lookBackMonths: ${LOOK_BACK_MONTHS:-18}
-lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145"]}
+lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145","a3abaf86-2cd4-4a32-a57e-1bda741ed00d","66e9f10c-31c7-41a4-b88f-4d10e59432d7","97509c9f-4350-4b4f-a9d4-aba4dadffe1c"]}
 
 # base URL for FHIR references to DPC resources (Patients, Organizations, etc) embedded in a Consent resource
 fhirReferenceURL: "http://localhost:3200/api/v1"

--- a/dpc-api/src/main/resources/application.yml
+++ b/dpc-api/src/main/resources/application.yml
@@ -95,7 +95,7 @@ jobTimeoutInSeconds: ${JOB_TIMEOUT_IN_SECONDS:-60}
 # The root URL at which the application is accessible, if necessary, include the port, do not include the application version
 publicURL: ${PUBLIC_URL:-"http://localhost:3002"}
 
-lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145"]}
+lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145","a3abaf86-2cd4-4a32-a57e-1bda741ed00d","66e9f10c-31c7-41a4-b88f-4d10e59432d7","97509c9f-4350-4b4f-a9d4-aba4dadffe1c"]}
 
 bbclient:
   registerHealthCheck: ${BB_REGISTER_HEALTH_CHECK:-true}

--- a/dpc-api/src/test/resources/test.application.yml
+++ b/dpc-api/src/test/resources/test.application.yml
@@ -74,7 +74,7 @@ authdb:
   minSize: 5
   maxSize: 10
 
-lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145"]}
+lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145","a3abaf86-2cd4-4a32-a57e-1bda741ed00d","66e9f10c-31c7-41a4-b88f-4d10e59432d7","97509c9f-4350-4b4f-a9d4-aba4dadffe1c"]}
 
 bbclient:
   registerHealthCheck: ${BB_REGISTER_HEALTH_CHECK:-true}

--- a/dpc-attribution/src/main/resources/application.yml
+++ b/dpc-attribution/src/main/resources/application.yml
@@ -89,7 +89,7 @@ fhir:
 patientLimit: ${PATIENT_LIMIT:--1}
 providerLimit: ${PROVIDER_LIMIT:--1}
 
-lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145"]}
+lookBackExemptOrgs: ${LOOK_BACK_EXEMPT_ORGS:-["0ab352f1-2bf1-44c4-aa7a-3004a1ffef12","69c0d4d4-9c07-4fa8-9053-e10fb1608b48","c7f5247b-4c41-478c-84eb-a6e801bdb145","a3abaf86-2cd4-4a32-a57e-1bda741ed00d","66e9f10c-31c7-41a4-b88f-4d10e59432d7","97509c9f-4350-4b4f-a9d4-aba4dadffe1c"]}
 
 swagger:
   resourcePackage: gov.cms.dpc.attribution.resources

--- a/dpc-load-testing/create-persistent-test-orgs.js
+++ b/dpc-load-testing/create-persistent-test-orgs.js
@@ -42,6 +42,11 @@ export default function () {
     const existingOrgResponse = getOrganizationById(token, organization.id);
 
     if (existingOrgResponse.status == 200) {
+      const existingOrganization = existingOrgResponse.json();
+      if (!existingOrganization.identifier.some(identifier => identifier.value === organization.npi)) {
+        console.error(existingOrgResponse.body);
+        exec.test.abort(`org ${organization.id} exists but does not match npi ${organization.npi}`);
+      }
       console.log(`org already exists: ${organization.id}`);
       continue;
     }
@@ -56,7 +61,10 @@ export default function () {
       org,
       {
         'create org response code was 200': res => res.status === 200,
-        'create org response has id': res => res.json().id,
+        'create org response has expected id': res => res.json().id === organization.id,
+        'create org response has expected npi': res => (
+          res.json().identifier.some(identifier => identifier.value === organization.npi)
+        ),
       }
     );
 

--- a/dpc-load-testing/create-persistent-test-orgs.js
+++ b/dpc-load-testing/create-persistent-test-orgs.js
@@ -1,0 +1,70 @@
+/*global console*/
+/* eslint no-console: "off" */
+
+import { check } from 'k6';
+import exec from 'k6/execution';
+import { fetchGoldenMacaroon, generateDPCToken } from './generate-dpc-token.js';
+import {
+  createSmokeTestOrganization,
+  getOrganizationById,
+} from './dpc-api-client.js';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+};
+
+// Synthetic, persistent test fixtures added to lookBackExemptOrgs in application.yml.
+// These UUIDs are generated test IDs
+const syntheticTestOrganizations = [
+  {
+    id: 'a3abaf86-2cd4-4a32-a57e-1bda741ed00d',
+    npi: '0009000122',
+    name: 'Persistent Test Org - Login.gov',
+  },
+  {
+    id: '66e9f10c-31c7-41a4-b88f-4d10e59432d7',
+    npi: '0009000239',
+    name: 'Persistent Test Org - ID.me',
+  },
+  {
+    id: '97509c9f-4350-4b4f-a9d4-aba4dadffe1c',
+    npi: '0009000346',
+    name: 'Persistent Test Org - CLEAR',
+  },
+];
+
+export default function () {
+  const goldenMacaroon = fetchGoldenMacaroon();
+
+  for (const organization of syntheticTestOrganizations) {
+    const token = generateDPCToken(organization.id, goldenMacaroon);
+    const existingOrgResponse = getOrganizationById(token, organization.id);
+
+    if (existingOrgResponse.status == 200) {
+      console.log(`org already exists: ${organization.id}`);
+      continue;
+    }
+
+    if (existingOrgResponse.status != 404) {
+      console.error(existingOrgResponse.body);
+      exec.test.abort(`failed to check org ${organization.id}`);
+    }
+
+    const org = createSmokeTestOrganization(organization.npi, organization.id, goldenMacaroon);
+    const checkOutput = check(
+      org,
+      {
+        'create org response code was 200': res => res.status === 200,
+        'create org response has id': res => res.json().id,
+      }
+    );
+
+    if (!checkOutput) {
+      console.error(org.body);
+      exec.test.abort('failed to create organizations on setup');
+    } else {
+      console.log(`org created: ${organization.id}`);
+    }
+  }
+}

--- a/dpc-portal/app/jobs/sync_organization_job.rb
+++ b/dpc-portal/app/jobs/sync_organization_job.rb
@@ -4,10 +4,10 @@
 class SyncOrganizationJob < ApplicationJob
   queue_as :portal
 
-  PERSISTENT_TEST_ORG_IDS = [
-    'a3abaf86-2cd4-4a32-a57e-1bda741ed00d',
-    '66e9f10c-31c7-41a4-b88f-4d10e59432d7',
-    '97509c9f-4350-4b4f-a9d4-aba4dadffe1c'
+  PERSISTENT_TEST_ORG_IDS = %w[
+    a3abaf86-2cd4-4a32-a57e-1bda741ed00d
+    66e9f10c-31c7-41a4-b88f-4d10e59432d7
+    97509c9f-4350-4b4f-a9d4-aba4dadffe1c
   ].freeze
 
   # rubocop:disable-next Metrics/AbcSize

--- a/dpc-portal/app/jobs/sync_organization_job.rb
+++ b/dpc-portal/app/jobs/sync_organization_job.rb
@@ -4,6 +4,12 @@
 class SyncOrganizationJob < ApplicationJob
   queue_as :portal
 
+  PERSISTENT_TEST_ORG_IDS = [
+    'a3abaf86-2cd4-4a32-a57e-1bda741ed00d',
+    '66e9f10c-31c7-41a4-b88f-4d10e59432d7',
+    '97509c9f-4350-4b4f-a9d4-aba4dadffe1c'
+  ].freeze
+
   # rubocop:disable-next Metrics/AbcSize
   def perform(provider_organization_id)
     begin
@@ -12,6 +18,8 @@ class SyncOrganizationJob < ApplicationJob
       Rails.logger.error "provider_organization #{provider_organization_id} not found"
       raise SyncOrganizationJobError, "provider_organization #{provider_organization_id} not found"
     end
+
+    return if PERSISTENT_TEST_ORG_IDS.include?(po.dpc_api_organization_id)
 
     api_response = api_client.get_organization_by_npi(po.npi)
     if api_response.entry.empty?

--- a/dpc-portal/app/jobs/sync_organization_job.rb
+++ b/dpc-portal/app/jobs/sync_organization_job.rb
@@ -4,12 +4,6 @@
 class SyncOrganizationJob < ApplicationJob
   queue_as :portal
 
-  PERSISTENT_TEST_ORG_IDS = %w[
-    a3abaf86-2cd4-4a32-a57e-1bda741ed00d
-    66e9f10c-31c7-41a4-b88f-4d10e59432d7
-    97509c9f-4350-4b4f-a9d4-aba4dadffe1c
-  ].freeze
-
   # rubocop:disable-next Metrics/AbcSize
   def perform(provider_organization_id)
     begin
@@ -18,8 +12,6 @@ class SyncOrganizationJob < ApplicationJob
       Rails.logger.error "provider_organization #{provider_organization_id} not found"
       raise SyncOrganizationJobError, "provider_organization #{provider_organization_id} not found"
     end
-
-    return if PERSISTENT_TEST_ORG_IDS.include?(po.dpc_api_organization_id)
 
     api_response = api_client.get_organization_by_npi(po.npi)
     if api_response.entry.empty?

--- a/dpc-portal/app/jobs/verify_ao_job.rb
+++ b/dpc-portal/app/jobs/verify_ao_job.rb
@@ -13,7 +13,8 @@ class VerifyAoJob < ApplicationJob
     service = AoVerificationService.new
     links_to_check.each do |link|
       config_attributes(link)
-      check_link(service, link)
+      next if check_link(service, link) == :skipped
+
       update_success(link)
     rescue AoException => e
       handle_error(link, e.message)
@@ -26,6 +27,10 @@ class VerifyAoJob < ApplicationJob
   end
 
   def check_link(service, link)
+    return :skipped if ProviderOrganization::PERSISTENT_TEST_ORG_IDS.include?(
+      link.provider_organization.dpc_api_organization_id
+    )
+
     response = service.check_ao_eligibility(link.provider_organization.npi, :pac_id, link.user.pac_id)
     log_batch_verification_waivers(response)
   end

--- a/dpc-portal/app/jobs/verify_ao_job.rb
+++ b/dpc-portal/app/jobs/verify_ao_job.rb
@@ -13,8 +13,7 @@ class VerifyAoJob < ApplicationJob
     service = AoVerificationService.new
     links_to_check.each do |link|
       config_attributes(link)
-      next if check_link(service, link) == :skipped
-
+      check_link(service, link)
       update_success(link)
     rescue AoException => e
       handle_error(link, e.message)
@@ -27,10 +26,6 @@ class VerifyAoJob < ApplicationJob
   end
 
   def check_link(service, link)
-    return :skipped if ProviderOrganization::PERSISTENT_TEST_ORG_IDS.include?(
-      link.provider_organization.dpc_api_organization_id
-    )
-
     response = service.check_ao_eligibility(link.provider_organization.npi, :pac_id, link.user.pac_id)
     log_batch_verification_waivers(response)
   end
@@ -67,7 +62,10 @@ class VerifyAoJob < ApplicationJob
 
   def links_to_check
     AoOrgLink.where(last_checked_at: ..lookback_hours.hours.ago,
-                    verification_status: true).limit(max_records)
+                    verification_status: true)
+             .joins(:provider_organization)
+             .merge(ProviderOrganization.excluding_persistent_test_orgs)
+             .limit(max_records)
   end
 
   def unverify_all_links_and_orgs(user, message)

--- a/dpc-portal/app/jobs/verify_provider_organization_job.rb
+++ b/dpc-portal/app/jobs/verify_provider_organization_job.rb
@@ -12,8 +12,6 @@ class VerifyProviderOrganizationJob < ApplicationJob
     service = AoVerificationService.new
     @start = Time.now
     orgs_to_check.each do |org|
-      next if ProviderOrganization::PERSISTENT_TEST_ORG_IDS.include?(org.dpc_api_organization_id)
-
       CurrentAttributes.save_organization_attributes(org, nil)
       enrollments_and_waivers = service.get_approved_enrollments(org.npi)
       log_batch_verification_waivers(enrollments_and_waivers)
@@ -34,6 +32,8 @@ class VerifyProviderOrganizationJob < ApplicationJob
 
   def orgs_to_check
     ProviderOrganization.where(last_checked_at: ..lookback_hours.hours.ago,
-                               verification_status: 'approved').limit(max_records)
+                               verification_status: 'approved')
+                        .excluding_persistent_test_orgs
+                        .limit(max_records)
   end
 end

--- a/dpc-portal/app/jobs/verify_provider_organization_job.rb
+++ b/dpc-portal/app/jobs/verify_provider_organization_job.rb
@@ -12,6 +12,8 @@ class VerifyProviderOrganizationJob < ApplicationJob
     service = AoVerificationService.new
     @start = Time.now
     orgs_to_check.each do |org|
+      next if ProviderOrganization::PERSISTENT_TEST_ORG_IDS.include?(org.dpc_api_organization_id)
+
       CurrentAttributes.save_organization_attributes(org, nil)
       enrollments_and_waivers = service.get_approved_enrollments(org.npi)
       log_batch_verification_waivers(enrollments_and_waivers)

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -83,7 +83,7 @@ class Invitation < ApplicationRecord
     check_missing_user_info(user_info, 'social_security_number', 'SSN', check_all_keys: false)
     ssn = user_info['social_security_number']&.tr('-', '') || user_info['SSN']&.tr('-', '')
 
-    if SyncOrganizationJob::PERSISTENT_TEST_ORG_IDS.include?(provider_organization.dpc_api_organization_id)
+    if ProviderOrganization::PERSISTENT_TEST_ORG_IDS.include?(provider_organization.dpc_api_organization_id)
       return { success: true, ao_role: { 'pacId' => ssn, 'roleCode' => '10', 'ssn' => ssn },
                has_org_waiver: false, has_ao_waiver: false }
     end

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -82,6 +82,12 @@ class Invitation < ApplicationRecord
   def ao_match?(user_info)
     check_missing_user_info(user_info, 'social_security_number', 'SSN', check_all_keys: false)
     ssn = user_info['social_security_number']&.tr('-', '') || user_info['SSN']&.tr('-', '')
+
+    if SyncOrganizationJob::PERSISTENT_TEST_ORG_IDS.include?(provider_organization.dpc_api_organization_id)
+      return { success: true, ao_role: { 'pacId' => ssn, 'roleCode' => '10', 'ssn' => ssn },
+               has_org_waiver: false, has_ao_waiver: false }
+    end
+
     service = AoVerificationService.new
     result = service.check_eligibility(provider_organization.npi, ssn)
 

--- a/dpc-portal/app/models/invitation.rb
+++ b/dpc-portal/app/models/invitation.rb
@@ -79,7 +79,7 @@ class Invitation < ApplicationRecord
     invitation
   end
 
-  def ao_match?(user_info)
+  def ao_match?(user_info) # rubocop:disable Naming/PredicateMethod
     check_missing_user_info(user_info, 'social_security_number', 'SSN', check_all_keys: false)
     ssn = user_info['social_security_number']&.tr('-', '') || user_info['SSN']&.tr('-', '')
 

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -2,10 +2,11 @@
 
 # Link class to dpc-api Organization
 class ProviderOrganization < ApplicationRecord
-  PERSISTENT_TEST_ORG_IDS = %w[
-    a3abaf86-2cd4-4a32-a57e-1bda741ed00d
-    66e9f10c-31c7-41a4-b88f-4d10e59432d7
-    97509c9f-4350-4b4f-a9d4-aba4dadffe1c
+  # rubocop:disable-next Style/WordArray
+  PERSISTENT_TEST_ORG_IDS = [
+    'a3abaf86-2cd4-4a32-a57e-1bda741ed00d',
+    '66e9f10c-31c7-41a4-b88f-4d10e59432d7',
+    '97509c9f-4350-4b4f-a9d4-aba4dadffe1c'
   ].freeze
 
   audited only: %i[verification_reason verification_status], on: :update
@@ -18,6 +19,8 @@ class ProviderOrganization < ApplicationRecord
 
   enum :verification_reason, %i[org_med_sanction_waived ao_med_sanctions no_approved_enrollment org_med_sanctions]
   enum :verification_status, %i[approved rejected]
+
+  scope :excluding_persistent_test_orgs, -> { where.not(dpc_api_organization_id: PERSISTENT_TEST_ORG_IDS) }
 
   belongs_to :terms_of_service_accepted_by, class_name: 'User', required: false
 

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -20,7 +20,9 @@ class ProviderOrganization < ApplicationRecord
   enum :verification_reason, %i[org_med_sanction_waived ao_med_sanctions no_approved_enrollment org_med_sanctions]
   enum :verification_status, %i[approved rejected]
 
-  scope :excluding_persistent_test_orgs, -> { where.not(dpc_api_organization_id: PERSISTENT_TEST_ORG_IDS) }
+  scope :excluding_persistent_test_orgs, lambda {
+    where(dpc_api_organization_id: nil).or(where.not(dpc_api_organization_id: PERSISTENT_TEST_ORG_IDS))
+  }
 
   belongs_to :terms_of_service_accepted_by, class_name: 'User', required: false
 

--- a/dpc-portal/app/models/provider_organization.rb
+++ b/dpc-portal/app/models/provider_organization.rb
@@ -2,6 +2,12 @@
 
 # Link class to dpc-api Organization
 class ProviderOrganization < ApplicationRecord
+  PERSISTENT_TEST_ORG_IDS = %w[
+    a3abaf86-2cd4-4a32-a57e-1bda741ed00d
+    66e9f10c-31c7-41a4-b88f-4d10e59432d7
+    97509c9f-4350-4b4f-a9d4-aba4dadffe1c
+  ].freeze
+
   audited only: %i[verification_reason verification_status], on: :update
 
   validates :npi, presence: true

--- a/dpc-portal/scripts/create_persistent_test_orgs.rb
+++ b/dpc-portal/scripts/create_persistent_test_orgs.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-environment = ENV['ENV']
+environment = ENV.fetch('ENV', nil)
 
 invite_emails = {
   clear: {

--- a/dpc-portal/scripts/create_persistent_test_orgs.rb
+++ b/dpc-portal/scripts/create_persistent_test_orgs.rb
@@ -62,6 +62,6 @@ organizations.each do |organization_data|
   invitation = service.create_invitation('Test', 'User', email, organization_data[:npi])
   puts "created AO invitation #{invitation.id} for #{email}"
   if Rails.env.development?
-    puts "http://localhost:3100/organizations/#{invitation.provider_organization.id}/invitations/#{invitation.id}/accept"
+    puts "http://localhost:3100/organizations/#{invitation.provider_organization.id}/invitations/#{invitation.id}/#{invitation.token}/accept"
   end
 end

--- a/dpc-portal/scripts/create_persistent_test_orgs.rb
+++ b/dpc-portal/scripts/create_persistent_test_orgs.rb
@@ -44,12 +44,6 @@ organizations = [
 service = AoInvitationService.new
 
 organizations.each do |organization_data|
-  email = invite_emails.fetch(organization_data[:csp]).fetch(environment)
-  if email.nil?
-    puts "skipping #{organization_data[:csp]} persistent test org creation for ENV=#{environment.inspect}"
-    next
-  end
-
   provider_organization = ProviderOrganization.find_or_create_by!(
     npi: organization_data[:npi],
     dpc_api_organization_id: organization_data[:dpc_api_organization_id]
@@ -58,6 +52,12 @@ organizations.each do |organization_data|
   end
 
   puts "got provider organization #{provider_organization.id}, #{provider_organization.dpc_api_organization_id}"
+
+  email = invite_emails.fetch(organization_data[:csp]).fetch(environment)
+  if email.nil?
+    puts "skipping #{organization_data[:csp]} persistent test org creation for ENV=#{environment.inspect}"
+    next
+  end
 
   invitation = service.create_invitation('Test', 'User', email, organization_data[:npi])
   puts "created AO invitation #{invitation.id} for #{email}"

--- a/dpc-portal/scripts/create_persistent_test_orgs.rb
+++ b/dpc-portal/scripts/create_persistent_test_orgs.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+environment = ENV['ENV']
+
+invite_emails = {
+  clear: {
+    'dev' => 'ahackett@gmail.com',
+    'test' => 'ahackett@gmail.com',
+    'prod' => nil
+  },
+  login_dot_gov: {
+    'dev' => 'luke+lowerenvtesting@verdance.co',
+    'test' => 'luke+lowerenvtesting@verdance.co',
+    'prod' => nil
+  },
+  id_me: {
+    'dev' => 'luke+lowerenvtesting@verdance.co',
+    'test' => 'luke+lowerenvtesting@verdance.co',
+    'prod' => nil
+  }
+}
+
+organizations = [
+  {
+    csp: :login_dot_gov,
+    dpc_api_organization_id: 'a3abaf86-2cd4-4a32-a57e-1bda741ed00d',
+    npi: '0009000122',
+    name: 'Login.gov test org'
+  },
+  {
+    csp: :id_me,
+    dpc_api_organization_id: '66e9f10c-31c7-41a4-b88f-4d10e59432d7',
+    npi: '0009000239',
+    name: 'ID.me test org'
+  },
+  {
+    csp: :clear,
+    dpc_api_organization_id: '97509c9f-4350-4b4f-a9d4-aba4dadffe1c',
+    npi: '0009000346',
+    name: 'CLEAR test org'
+  }
+]
+
+service = AoInvitationService.new
+
+organizations.each do |organization_data|
+  email = invite_emails.fetch(organization_data[:csp]).fetch(environment)
+  if email.nil?
+    puts "skipping #{organization_data[:csp]} persistent test org creation for ENV=#{environment.inspect}"
+    next
+  end
+
+  provider_organization = ProviderOrganization.find_or_create_by!(
+    npi: organization_data[:npi],
+    dpc_api_organization_id: organization_data[:dpc_api_organization_id]
+  ) do |org|
+    org.name = organization_data[:name]
+  end
+
+  puts "got provider organization #{provider_organization.id}, #{provider_organization.dpc_api_organization_id}"
+
+  invitation = service.create_invitation('Test', 'User', email, organization_data[:npi])
+  puts "created AO invitation #{invitation.id} for #{email}"
+  if Rails.env.development?
+    puts "http://localhost:3100/organizations/#{invitation.provider_organization.id}/invitations/#{invitation.id}/accept"
+  end
+end

--- a/dpc-portal/spec/jobs/verify_ao_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_ao_job_spec.rb
@@ -107,18 +107,18 @@ RSpec.describe VerifyAoJob, type: :job do
         end
         VerifyAoJob.perform_now
       end
-      it 'should not select persistent test organization links' do
-        user = create(:user, pac_id: '900111111', verification_status: :approved)
-        test_org = create(:provider_organization,
-                          dpc_api_organization_id: 'a3abaf86-2cd4-4a32-a57e-1bda741ed00d')
-        link_to_test_org = create(:ao_org_link, user:, provider_organization: test_org,
-                                                last_checked_at: 8.days.ago)
-        regular_org = create(:provider_organization, npi: '900111111', verification_status: :approved)
-        regular_link = create(:ao_org_link, user:, last_checked_at: 8.days.ago, provider_organization: regular_org)
+    end
+    it 'should not select persistent test organization links' do
+      user = create(:user, pac_id: '900111111', verification_status: :approved)
+      test_org = create(:provider_organization,
+                        dpc_api_organization_id: 'a3abaf86-2cd4-4a32-a57e-1bda741ed00d')
+      link_to_test_org = create(:ao_org_link, user:, provider_organization: test_org,
+                                              last_checked_at: 8.days.ago)
+      regular_org = create(:provider_organization, npi: '900111111', verification_status: :approved)
+      regular_link = create(:ao_org_link, user:, last_checked_at: 8.days.ago, provider_organization: regular_org)
 
-        expect(VerifyAoJob.new.links_to_check).not_to include(link_to_test_org)
-        expect(VerifyAoJob.new.links_to_check).to include(regular_link)
-      end
+      expect(VerifyAoJob.new.links_to_check).not_to include(link_to_test_org)
+      expect(VerifyAoJob.new.links_to_check).to include(regular_link)
     end
     context :ao_has_waiver do
       let(:user) { create(:user, pac_id: '900777777', verification_status: :approved) }

--- a/dpc-portal/spec/jobs/verify_ao_job_spec.rb
+++ b/dpc-portal/spec/jobs/verify_ao_job_spec.rb
@@ -107,6 +107,18 @@ RSpec.describe VerifyAoJob, type: :job do
         end
         VerifyAoJob.perform_now
       end
+      it 'should not select persistent test organization links' do
+        user = create(:user, pac_id: '900111111', verification_status: :approved)
+        test_org = create(:provider_organization,
+                          dpc_api_organization_id: 'a3abaf86-2cd4-4a32-a57e-1bda741ed00d')
+        link_to_test_org = create(:ao_org_link, user:, provider_organization: test_org,
+                                                last_checked_at: 8.days.ago)
+        regular_org = create(:provider_organization, npi: '900111111', verification_status: :approved)
+        regular_link = create(:ao_org_link, user:, last_checked_at: 8.days.ago, provider_organization: regular_org)
+
+        expect(VerifyAoJob.new.links_to_check).not_to include(link_to_test_org)
+        expect(VerifyAoJob.new.links_to_check).to include(regular_link)
+      end
     end
     context :ao_has_waiver do
       let(:user) { create(:user, pac_id: '900777777', verification_status: :approved) }

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -447,7 +447,7 @@ RSpec.describe Invitation, type: :model do
       end
       it 'should skip AO Verification for persistent test orgs' do
         persistent_test_org = create(:provider_organization,
-                                dpc_api_organization_id: ProviderOrganization::PERSISTENT_TEST_ORG_IDS.first)
+                                     dpc_api_organization_id: ProviderOrganization::PERSISTENT_TEST_ORG_IDS.first)
         test_org_invite = create(:invitation, :ao, provider_organization: persistent_test_org)
 
         expect(AoVerificationService).not_to receive(:new)

--- a/dpc-portal/spec/models/invitation_spec.rb
+++ b/dpc-portal/spec/models/invitation_spec.rb
@@ -436,6 +436,24 @@ RSpec.describe Invitation, type: :model do
         user_info = { 'SSN' => '999999999' }
         expect(ao_invite.ao_match?(user_info)).to be_truthy
       end
+      it 'should check against AO Verification service' do
+        service = instance_double(AoVerificationService)
+        expect(AoVerificationService).to receive(:new).and_return(service)
+        expect(service).to receive(:check_eligibility)
+          .with(ao_invite.provider_organization.npi, '123456789')
+          .and_return(success: true)
+
+        ao_invite.ao_match?({ 'social_security_number' => '123-45-6789' })
+      end
+      it 'should skip AO Verification for persistent test orgs' do
+        persistent_test_org = create(:provider_organization,
+                                dpc_api_organization_id: ProviderOrganization::PERSISTENT_TEST_ORG_IDS.first)
+        test_org_invite = create(:invitation, :ao, provider_organization: persistent_test_org)
+
+        expect(AoVerificationService).not_to receive(:new)
+
+        test_org_invite.ao_match?({ 'social_security_number' => '123-45-6789' })
+      end
       it 'should raise with bad ssn' do
         user_info = { 'social_security_number' => '900666666' }
         expect do


### PR DESCRIPTION
## 🎫 Ticket

[DPC-5692](https://jira.cms.gov/browse/DPC-5692)

## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
 - adds two new standalone scripts for creating test data (Organization, ProviderOrganization, Invitation)
 - adds new organization id's to be exempt from lookback

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->
 - After some discussion, team has landed on using synthetic identities for all CSP in order to validate connections with all CSP's in upper evnrionments
   - Additional follow-up will be required with CSP's in order to get access to these accounts in prod
   - For CLEAR csp in non-prod environments, we can use their provided [Synthetic Test Identities & Patients](https://docs.clearme.com/docs/synthetic-test-users)
   - For Login.gov + ID.me, I used a new `+string` with the email I have for https://developers.idmelabs.com/  

 - For organizations to not impact production, we'll need to make sure that lookback checks are not performed on them
   - smoketests already do that [HERE](https://github.com/CMSgov/dpc-app/blob/main/dpc-load-testing/smoke-test.js#L39-L41)
   - Because smoketest organizations are built and destroyed each run, I opted to add three new id's and make them lookback-exempt: `"a3abaf86-2cd4-4a32-a57e-1bda741ed00d","66e9f10c-31c7-41a4-b88f-4d10e59432d7","97509c9f-4350-4b4f-a9d4-aba4dadffe1c"`


 - new scripts can be run with the following commands
 ### k6 script:
```
kion stak

export ENVIRONMENT=dev
export AWS_REGION="us-east-1"
export GOLDEN_MACAROON=<manually-pulled-from-parameter-store>

cd dpc-load-testing

k6 run ./create-persistent-test-orgs.js
```

### Rails script:
```
<create SSH shell to dev>

rails runner scripts/create_persistent_test_orgs.rb
```
 - See also [Running commands in AWS FARGATE containers](https://confluence.cms.gov/spaces/DAPC/pages/1013327823/Running+commands+in+AWS+FARGATE+containers) for more information on connecting to AWS

## Next steps
 - Following this, we still need to perform client demo's to all three CSP's before we can get prod integrations set up.
 - We will need to work with all three CSP's in order to obtain synthetic identities for us in `prod`
 - Script needs to be updated to cover invitation email [HERE](https://github.com/CMSgov/dpc-app/pull/3138/changes#diff-73fc3e76b6e7080985ae289813ad9a649dbd319013a47a0c237bfcc7a80e4779R9). Depending on where the discussion goes, we may move these to SSM or somewhere else if they are considered secret

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
 - example output from running in `dev`:
 - <img width="754" height="773" alt="Screenshot 2026-09-09 at 5 51 07 PM" src="https://github.com/user-attachments/assets/e817becc-eafe-4c5c-bbb1-33bf78b833a0" />
 - <img width="1855" height="484" alt="Screenshot 2026-09-10 at 10 26 13 AM" src="https://github.com/user-attachments/assets/ead5b14c-76dc-4068-b02a-8f3a52a86d24" />

