### PR TITLE
[DPC-5694]: Verify token using kid and download key info as avail…

### DIFF
--- a/dpc-portal/config/initializers/omniauth_openid_connect_patch.rb
+++ b/dpc-portal/config/initializers/omniauth_openid_connect_patch.rb
@@ -4,6 +4,12 @@ require 'openid_connect'
 module OmniAuth
   module Strategies
     class OpenIDConnect
+      # Trusted hosts for CSPs as configured in config/csp.yml, mapped to their discovery URIs. 
+      ALLOWED_IDP_HOSTS_DISCOVERY_URL_MAP = Rails.application.config_for(:csp).values
+                               .select { |value| value.is_a?(Hash) }
+                               .filter_map { |value| [value[:host], value[:discovery_uri]] if value[:host].present? }
+                               .to_h
+
       def user_info
         @user_info ||= ::OpenIDConnect::ResponseObject::UserInfo.new(fetch_userinfo_payload)
       rescue => e
@@ -19,8 +25,9 @@ module OmniAuth
 
       # Calls the userinfo endpoint with the bearer access token and returns
       # the claims as a Hash. If the IdP responds with a signed JWT
-      # (application/jwt), the JWT is decoded without signature verification
-      # and the payload is returned. Otherwise the JSON body is parsed.
+      # (application/jwt), the JWT's signature is verified against the
+      # provider's published JWKS before its payload is trusted. Otherwise
+      # the JSON body is parsed.
       # Fetches and parses the userinfo payload from the OpenID Connect provider.
       #
       # This method retrieves user information from the userinfo endpoint using the access token,
@@ -32,7 +39,7 @@ module OmniAuth
       # - Some providers JSON-encode the JWT, wrapping it as a string: `"<jwt>"`
       #
       # @return [Hash] A hash with indifferent access containing the userinfo payload.
-      #   If the response is a JWT, it is decoded and converted to a hash.
+      #   If the response is a JWT, its signature is verified and the payload is converted to a hash.
       #   If the response is JSON, it is parsed and converted to a hash.
       #   Keys can be accessed with symbols or strings.
       #
@@ -53,15 +60,53 @@ module OmniAuth
 
         if content_type == 'application/jwt' || looks_like_jwt?(body)
           body = body[1..-2] if body.start_with?('"') && body.end_with?('"')
-          ## TODO - consider verifying the JWT signature using the provider's JWKS keys
-          JSON::JWT.decode(body, :skip_verification).to_h.with_indifferent_access
+          decode_verified_jwt(body).with_indifferent_access
         else
           JSON.parse(body).with_indifferent_access
         end
       end
 
+      # Decodes a userinfo JWT, verifying its signature against the key
+      # published by the issuing provider. The signing key set is located via
+      # OpenID Connect Discovery (the provider's well-known configuration
+      # endpoint), and discovery is only ever performed for a host listed as
+      # an identity provider in config/csp.yml.
+      def decode_verified_jwt(jwt_string)
+        JSON::JWT.decode(jwt_string, provider_jwk_set).to_h
+      end
+
+      # Fetches (and caches) the JWK Set published by the current provider,
+      # discovering its jwks_uri via the OIDC well-known configuration
+      # endpoint or using the discovery URI configured in config/csp.yml.
+      def provider_jwk_set
+        host = client_options.host
+        unless ALLOWED_IDP_HOSTS_DISCOVERY_URL_MAP.keys.include?(host)
+          raise ArgumentError, "Refusing to fetch OIDC keys for unlisted identity provider host: #{host}"
+        end
+
+        jwks = Rails.cache.fetch("oidc_jwks/#{host}", expires_in: 1.hour) do
+          well_known_config = fetch_json(well_known_configuration_uri)
+          fetch_json(well_known_config.fetch('jwks_uri'))
+        end
+        JSON::JWK::Set.new(jwks)
+      end
+
+      def fetch_json(uri)
+        response = ::OpenIDConnect.http_client.get(uri)
+        return response.body if response.body.is_a?(Hash)
+
+        JSON.parse(response.body.to_s)
+      end
+
       def userinfo_endpoint_uri
-        endpoint = client_options.userinfo_endpoint
+        provider_uri(client_options.userinfo_endpoint)
+      end
+
+      def well_known_configuration_uri
+        provider_uri(ALLOWED_IDP_HOSTS_DISCOVERY_URL_MAP[client_options.host] || '/.well-known/openid-configuration')
+      end
+
+      def provider_uri(endpoint)
         parsed = URI.parse(endpoint)
         return parsed.to_s if parsed.is_a?(URI::HTTP) || parsed.is_a?(URI::HTTPS)
 

--- a/dpc-portal/spec/config/initializers/omniauth_openid_connect_patch_spec.rb
+++ b/dpc-portal/spec/config/initializers/omniauth_openid_connect_patch_spec.rb
@@ -3,9 +3,25 @@
 require 'rails_helper'
 
 describe OmniAuth::Strategies::OpenIDConnect do
-  let(:strategy) { described_class.new(nil) }
+  let(:idp_host) { 'idp.example.com' }
+  let(:strategy) do
+    described_class.new(nil, client_options: { host: idp_host, userinfo_endpoint: '/userinfo' })
+  end
   let(:payload) do
     { 'sub' => '12345', 'email' => 'test@example.com' }
+  end
+  let(:rsa_key) { OpenSSL::PKey::RSA.generate(2048) }
+  let(:jwk) { JSON::JWK.new(rsa_key) }
+
+  before do
+    stub_const('OmniAuth::Strategies::OpenIDConnect::ALLOWED_IDP_HOSTS_DISCOVERY_URL_MAP',
+               { idp_host => "https://#{idp_host}/.well-known/openid-configuration" })
+  end
+
+  def signed_jwt(claims, key: rsa_key, kid: jwk[:kid])
+    token = JSON::JWT.new(claims)
+    token.kid = kid
+    token.sign(key, :RS256).to_s
   end
 
   describe '#user_info' do
@@ -55,6 +71,134 @@ describe OmniAuth::Strategies::OpenIDConnect do
       it 'returns nil' do
         expect(strategy.user_info).to be_nil
       end
+    end
+  end
+
+  describe '#decode_verified_jwt' do
+    let(:jwk_set) { JSON::JWK::Set.new({ 'keys' => [JSON.parse(JSON::JWK.new(rsa_key.public_key).to_json)] }) }
+
+    before do
+      allow(strategy).to receive(:provider_jwk_set).and_return(jwk_set)
+    end
+
+    it 'returns the payload when the signature matches the published key' do
+      result = strategy.send(:decode_verified_jwt, signed_jwt(payload))
+      expect(result).to eq(payload)
+    end
+
+    it 'raises when the JWT is signed by a different key than the one published' do
+      token = signed_jwt(payload, key: OpenSSL::PKey::RSA.generate(2048))
+      expect { strategy.send(:decode_verified_jwt, token) }.to raise_error(JSON::JWT::VerificationFailed)
+    end
+
+    it 'raises when the JWT header kid does not match any published key' do
+      token = signed_jwt(payload, kid: 'unknown-kid')
+      expect { strategy.send(:decode_verified_jwt, token) }.to raise_error(JSON::JWK::Set::KidNotFound)
+    end
+  end
+
+  describe '#provider_jwk_set' do
+    let(:well_known_uri) { "https://#{idp_host}/.well-known/openid-configuration" }
+    let(:jwks_uri) { "https://#{idp_host}/jwks" }
+    let(:jwks_document) { { 'keys' => [JSON.parse(JSON::JWK.new(rsa_key.public_key).to_json)] } }
+
+    before do
+      stub_request(:get, well_known_uri).to_return(
+        body: { 'jwks_uri' => jwks_uri }.to_json, headers: { 'Content-Type' => 'application/json' }
+      )
+      stub_request(:get, jwks_uri).to_return(
+        body: jwks_document.to_json, headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    it 'raises when the client host is not one of the identity providers configured in csp.yml' do
+      stub_const('OmniAuth::Strategies::OpenIDConnect::ALLOWED_IDP_HOSTS_DISCOVERY_URL_MAP',
+                 { 'other-idp.example.com' => 'https://other-idp.example.com/.well-known/openid-configuration' })
+      expect { strategy.send(:provider_jwk_set) }.to raise_error(ArgumentError, /unlisted identity provider host/)
+    end
+
+    it 'discovers the jwks_uri via the well-known configuration endpoint and builds a matching key set' do
+      jwk_set = strategy.send(:provider_jwk_set)
+      expect(jwk_set[jwk[:kid]]).to be_present
+    end
+
+    it 'caches the discovered key set instead of refetching on every call' do
+      allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemoryStore.new)
+
+      strategy.send(:provider_jwk_set)
+      strategy.send(:provider_jwk_set)
+
+      expect(a_request(:get, well_known_uri)).to have_been_made.once
+      expect(a_request(:get, jwks_uri)).to have_been_made.once
+      # expect(OpenIDConnect.http_client).to have_received(:get).with(well_known_uri).once
+      # expect(OpenIDConnect.http_client).to have_received(:get).with(jwks_uri).once
+    end
+  end
+
+  describe '#well_known_configuration_uri' do
+    it 'uses the discovery endpoint as configured in csp.yml file' do
+      expect(strategy.send(:well_known_configuration_uri))
+        .to eq("https://#{idp_host}/.well-known/openid-configuration")
+    end
+    it 'builds the discovery endpoint from the client host, default scheme/port' \
+       'and the default path for well known configuration' do
+      expect(strategy.send(:well_known_configuration_uri))
+        .to eq("https://#{idp_host}/.well-known/openid-configuration")
+    end
+
+    it 'includes a non-default port' do
+      strategy = described_class.new(nil, client_options: { host: idp_host, port: 8443 })
+      stub_const('OmniAuth::Strategies::OpenIDConnect::ALLOWED_IDP_HOSTS_DISCOVERY_URL_MAP',
+                 { idp_host => nil })
+      expect(strategy.send(:well_known_configuration_uri))
+        .to eq("https://#{idp_host}:8443/.well-known/openid-configuration")
+    end
+  end
+
+  describe '#userinfo_endpoint_uri' do
+    it 'builds the endpoint from host/scheme/port when userinfo_endpoint is a path' do
+      expect(strategy.send(:userinfo_endpoint_uri)).to eq("https://#{idp_host}/userinfo")
+    end
+
+    it 'returns the endpoint unchanged when it is already an absolute URL' do
+      strategy = described_class.new(
+        nil, client_options: { host: idp_host, userinfo_endpoint: 'https://other.example.com/userinfo' }
+      )
+      expect(strategy.send(:userinfo_endpoint_uri)).to eq('https://other.example.com/userinfo')
+    end
+  end
+
+  describe '#fetch_userinfo_payload' do
+    let(:userinfo_uri) { "https://#{idp_host}/userinfo" }
+    let(:well_known_uri) { "https://#{idp_host}/.well-known/openid-configuration" }
+    let(:jwks_uri) { "https://#{idp_host}/jwks" }
+    let(:jwks_document) { { 'keys' => [JSON.parse(JSON::JWK.new(rsa_key.public_key).to_json)] } }
+
+    before do
+      allow(strategy).to receive(:access_token).and_return(double(access_token: 'a-token'))
+      stub_request(:get, userinfo_uri)
+        .with(headers: { 'Authorization' => 'Bearer a-token' })
+        .to_return(body: signed_jwt(payload), headers: { 'Content-Type' => 'application/jwt' })
+      stub_request(:get, well_known_uri).to_return(
+        body: { 'jwks_uri' => jwks_uri }.to_json, headers: { 'Content-Type' => 'application/json' }
+      )
+      stub_request(:get, jwks_uri).to_return(
+        body: jwks_document.to_json, headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    it 'verifies the signature and returns the userinfo claims' do
+      result = strategy.send(:fetch_userinfo_payload)
+      expect(result).to include('sub' => '12345', 'email' => 'test@example.com')
+    end
+
+    it 'raises when the userinfo JWT is signed by an untrusted key' do
+      tampered_jwt = signed_jwt(payload, key: OpenSSL::PKey::RSA.generate(2048))
+      stub_request(:get, userinfo_uri)
+        .with(headers: { 'Authorization' => 'Bearer a-token' })
+        .to_return(status: 200, body: tampered_jwt, headers: { 'Content-Type' => 'application/jwt' })
+
+      expect { strategy.send(:fetch_userinfo_payload) }.to raise_error(JSON::JWT::VerificationFailed)
     end
   end
 end


### PR DESCRIPTION
Verify the token as returned in the user info endpoint by utilizing the public key information as available through the jwks url published via .well-known/openid-configuration endpoint
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-5684


## 🛠 Changes

<!-- What was added, updated, or removed in this PR? -->
Updated the patch we created earlier to not just decode the token but verify the signature in the token through the kid and public key. Added additional constraint to verify the host as used for configuring strategy is one of the three host configured in csp.yml.
Accounted for the fact that the convention for using /well-known/openid-configuration might not be followed, and in that case the discovery_uri should be configured in csp.yml and that would trump the default well known open id configuration derived by adding /well-known/openid-configuration  to host.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->
Using JWT for user info respnose payload is uncommon, but since one of the CSP utilizes this mechanism, we'd like to verify the token before deciding to use it.
<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
Added tests to ensure the following:
a) We hit the /well-known/openid-configuration  to retrieve JWKS uri.
b) We hit the JWKs uri to download the public key
c) Tempered JWTs are rejected
